### PR TITLE
Introduce our own source parser to differentiate between source files an...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,11 @@
           <header>src/license-header.txt</header>
         </configuration>
       </plugin>
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.12.4</version>
+      </plugin>      
     </plugins>
   </build>
 </project>

--- a/src/main/java/org/sonar/plugins/cxx/CxxLanguage.java
+++ b/src/main/java/org/sonar/plugins/cxx/CxxLanguage.java
@@ -30,6 +30,7 @@ public final class CxxLanguage extends AbstractLanguage {
   public static final String DEFAULT_SOURCE_SUFFIXES = "cxx,cpp,cc,c";
   public static final String DEFAULT_HEADER_SUFFIXES = "hxx,hpp,hh,h";
   public static final String KEY = "c++";
+  public static final CxxLanguage INSTANCE = new CxxLanguage();
   
   private String[] sourceSuffixes;
   private String[] headerSuffixes;

--- a/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -109,6 +109,13 @@ import org.sonar.plugins.cxx.xunit.CxxXunitSensor;
       global = false,
       project = true),
     @Property(
+      key = CxxPlugin.TEST_DIRECTORY_PATTERN,
+      name = "Source directory",
+      description = "Directories to be considered as test directories, will override source dirs",
+      defaultValue = "",
+      global = false,
+      project = true),  
+  @Property(        
       key = CxxXunitSensor.REPORT_PATH_KEY,
       defaultValue = "",
       name = "Path to unit test execution report(s)",
@@ -126,6 +133,7 @@ import org.sonar.plugins.cxx.xunit.CxxXunitSensor;
 public final class CxxPlugin extends SonarPlugin {
   static final String SOURCE_FILE_SUFFIXES_KEY = "sonar.cxx.suffixes.sources";
   static final String HEADER_FILE_SUFFIXES_KEY = "sonar.cxx.suffixes.headers";
+  static final String TEST_DIRECTORY_PATTERN = "sonar.cxx.testdir";
 
   /**
    * {@inheritDoc}

--- a/src/main/java/org/sonar/plugins/cxx/CxxSourceImporter.java
+++ b/src/main/java/org/sonar/plugins/cxx/CxxSourceImporter.java
@@ -19,22 +19,70 @@
  */
 package org.sonar.plugins.cxx;
 
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
 import org.sonar.api.batch.AbstractSourceImporter;
+import org.sonar.api.batch.SensorContext;
+import org.sonar.api.config.Settings;
+import org.sonar.api.resources.Project;
+import org.sonar.api.resources.Qualifiers;
+import org.sonar.api.resources.Resource;
+import org.sonar.api.utils.SonarException;
+import org.sonar.plugins.cxx.utils.CxxUtils;
 
-/**
- * {@inheritDoc}
- */
 public final class CxxSourceImporter extends AbstractSourceImporter {
-  
-  /**
-   * {@inheritDoc}
-   */
-  public CxxSourceImporter(CxxLanguage lang) {
-    super(lang);
+
+  private final Project project;
+  private final CxxLanguage language;
+  private final String testPatterns;
+
+  public CxxSourceImporter(CxxLanguage language, Project project, Settings settings) {
+    super(language);
+    this.project = project;
+    this.language = language;
+    this.testPatterns = settings.getString(CxxPlugin.TEST_DIRECTORY_PATTERN);
+  }
+
+  @Override
+  protected Resource createResource(File file, List<File> sourceDirs, boolean unitTest) {
+
+    org.sonar.api.resources.File resource = org.sonar.api.resources.File.fromIOFile(file, project);
+    resource.setLanguage(language);
+
+    if (CxxUtils.isATestFile(testPatterns, file.getPath())) {
+      resource.setQualifier(Qualifiers.UNIT_TEST_FILE);
+    }
+
+    return resource;
+  }
+
+  @Override
+  protected void parseDirs(SensorContext context, List<File> files, List<File> sourceDirs, boolean unitTest, Charset sourcesEncoding) {
+
+    for (File file : files) {
+
+      Resource resource = createResource(file, sourceDirs, CxxUtils.isATestFile(testPatterns, file.getPath()));
+      if (resource != null) {
+        try {
+          context.index(resource);
+          if (isEnabled(project)) {
+
+            String source = FileUtils.readFileToString(file, sourcesEncoding.name());
+            context.saveSource(resource, source);
+          }
+        } catch (Exception e) {
+          throw new SonarException("Unable to read and import the source file : '" + file.getAbsolutePath() + "' with the charset : '"
+                  + sourcesEncoding.name() + "'.", e);
+        }
+      }
+    }
   }
 
   @Override
   public String toString() {
     return getClass().getSimpleName();
   }
+
 }

--- a/src/main/java/org/sonar/plugins/cxx/utils/CxxUtils.java
+++ b/src/main/java/org/sonar/plugins/cxx/utils/CxxUtils.java
@@ -20,19 +20,20 @@
 package org.sonar.plugins.cxx.utils;
 
 import java.io.File;
-
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonar.api.config.Settings;
+import org.sonar.api.utils.WildcardPattern;
 
 /**
  * Utility class holding various, well, utilities
  */
 public final class CxxUtils {
-  
+
   private CxxUtils() {
     // only static methods
   }
-
   /**
    * Default logger.
    */
@@ -43,9 +44,38 @@ public final class CxxUtils {
    * @return Returns file path of provided file, or "null" if file == null
    */
   public static String fileToAbsolutePath(File file) {
-    if(file == null) {
+    if (file == null) {
       return "null";
     }
     return file.getAbsolutePath();
-  }  
+  }
+
+  /**
+   * @param file
+   * @return Returns file path of provided file, or "null" if file == null
+   */
+  public static boolean isATestFile(String data, String file) {
+    boolean isTest = false;
+    String[] patterns = CxxUtils.createStringArray(data, "");
+    for (int i = 0; i < patterns.length; i++) {
+      if (WildcardPattern.create(patterns[i]).match(file.replace("\\", "/"))) {
+        isTest = true;
+        break;
+      }
+    }
+    return isTest;
+  }
+
+  /**
+   * @param values
+   * @param defaultValues
+   * @return creates a array of strings, from string delimited by semi-colon
+   */
+  public static String[] createStringArray(String values, String defaultValues) {
+    String[] data = new String[0];
+    if (values != null && !values.equals("")) {
+      data = StringUtils.split(values, ",");
+    }
+    return data;
+  }
 }

--- a/src/test/java/org/sonar/plugins/cxx/CxxSourceImporterTest.java
+++ b/src/test/java/org/sonar/plugins/cxx/CxxSourceImporterTest.java
@@ -39,12 +39,12 @@ import static junit.framework.Assert.assertTrue;
 public class CxxSourceImporterTest {
   @Test
   public void testSourceImporter() {
-    SensorContext context = mock(SensorContext.class);
+    SensorContext context = mock(SensorContext.class);           
     Project project = mockProject();
     Settings config = new Settings(new PropertyDefinitions(CxxPlugin.class));
     config.setProperty(CoreProperties.CORE_IMPORT_SOURCES_PROPERTY, true);    
-    CxxSourceImporter importer = new CxxSourceImporter(TestUtils.mockCxxLanguage());
-
+    CxxSourceImporter importer = new CxxSourceImporter(TestUtils.mockCxxLanguage(), project, config);
+    assertTrue(importer.shouldExecuteOnProject(project));    
     importer.analyse(project, context);
 
     verify(context).saveSource((Resource) anyObject(), eq("<c++ source>\n"));

--- a/src/test/java/org/sonar/plugins/cxx/utils/CxxUtilsTest.java
+++ b/src/test/java/org/sonar/plugins/cxx/utils/CxxUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Sonar Cxx Plugin, open source software quality management tool.
+ * Copyright (C) 2010 - 2011, Neticoa SAS France - Tous droits reserves.
+ * Author(s) : Franck Bonin, Neticoa SAS France.
+ *
+ * Sonar Cxx Plugin is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * Sonar Cxx Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Sonar Cxx Plugin; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.cxx.utils;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ *
+ * @author Jorge Costa
+ */
+public class CxxUtilsTest {
+
+  @Test
+  public void testIsATest() throws Exception {
+    assertEquals(true, CxxUtils.isATestFile("**/EnvironmentTests/**,**/test/**", "EnvironmentTests/file1.cpp"));
+    assertEquals(true, CxxUtils.isATestFile("**/EnvironmentTests/**,**/test/**", "src1/test/file2.cpp"));
+    assertEquals(true, CxxUtils.isATestFile("**/EnvironmentTests/**,**/test/**", "e:/src1/test/file2.cpp"));
+    assertEquals(true, CxxUtils.isATestFile("**/Tests/**,**/test/**", "E:\\SRC\\Tests\\filex.cpp"));
+  }
+}


### PR DESCRIPTION
I need your opinion on this one, this patch overrides what maven defined as unit test. Because in maven we cannot have a folder structure like this

sources\dir1
sources\dir1\test
sources\dir2
sources\dir2\test

so if defining in maven sources sources\dir2, the sources\dir2\test will also be considered as source files so there will be duplicated files going to the sensor. 

To overcome this, ive introduced the property sonar.cxx.testdir so that users can specify **/test/** so all these are considered correctly as test files

However it might be a good idea to check the unittest flag, so if true than we still consider as true? 

what do you think?
