### PR TITLE
Better handling on unit tests, now it flags files with correct qualifier...

### DIFF
--- a/src/main/java/org/sonar/plugins/cxx/CxxLanguage.java
+++ b/src/main/java/org/sonar/plugins/cxx/CxxLanguage.java
@@ -30,6 +30,7 @@ public final class CxxLanguage extends AbstractLanguage {
   public static final String DEFAULT_SOURCE_SUFFIXES = "cxx,cpp,cc,c";
   public static final String DEFAULT_HEADER_SUFFIXES = "hxx,hpp,hh,h";
   public static final String KEY = "c++";
+  public static final CxxLanguage INSTANCE = new CxxLanguage();
   
   private String[] sourceSuffixes;
   private String[] headerSuffixes;

--- a/src/main/java/org/sonar/plugins/cxx/xunit/TestCase.java
+++ b/src/main/java/org/sonar/plugins/cxx/xunit/TestCase.java
@@ -22,86 +22,91 @@ package org.sonar.plugins.cxx.xunit;
 import org.apache.commons.lang.StringEscapeUtils;
 
 /**
- * Represents a unit test case. Has a couple of data items like name,
- * status, time etc. associated. Reports testcase details in sonar-conform XML
+ * Represents a unit test case. Has a couple of data items like name, status,
+ * time etc. associated. Reports testcase details in sonar-conform XML
  */
 public class TestCase {
+
   private static final String STATUS_OK = "ok";
   private static final String STATUS_ERROR = "error";
   private static final String STATUS_FAILURE = "failure";
   private static final String STATUS_SKIPPED = "skipped";
-  
-  private String name;
-  private String status = STATUS_OK;
-  private String stackTrace;
-  private String errorMessage;
+  private final String name;
+  private final String status;
+  private final String stackTrace;
+  private final String errorMessage;
   private int time = 0;
-  
+
   /**
    * Constructs a testcase instance out of following parameters
+   *
    * @params name The name of this testcase
    * @params time The execution time in milliseconds
    * @params status The execution status of the testcase
    * @params stack The stack trace occurred while executing of this testcase;
-   *               pass "" if the testcase passed/skipped.
-   * @params msg The error message accosiated with this testcase of the execution
-   *             was errouneous; pass "" if not.
+   * pass "" if the testcase passed/skipped.
+   * @params msg The error message accosiated with this testcase of the
+   * execution was errouneous; pass "" if not.
    */
-  public TestCase(String name, int time, String status, String stack, String msg){
+  public TestCase(String name, int time, String status, String stack, String msg) {
     this.name = name;
     this.time = time;
     this.stackTrace = stack;
     this.errorMessage = msg;
     this.status = status;
   }
-  
+
   /**
    * Returns true if this testcase is an error, false otherwise
    */
-  public boolean isError(){
+  public boolean isError() {
     return STATUS_ERROR.equals(status);
   }
-  
+
   /**
    * Returns true if this testcase is a failure, false otherwise
    */
-  public boolean isFailure(){
+  public boolean isFailure() {
     return STATUS_FAILURE.equals(status);
   }
 
   /**
    * Returns true if this testcase has been skipped, failure, false otherwise
    */
-  public boolean isSkipped(){
+  public boolean isSkipped() {
     return STATUS_SKIPPED.equals(status);
   }
 
   public int getTime() {
     return time;
   }
-  
+
+  public String getName() {
+    return name;
+  }
+
   /**
    * Returns execution details as sonar-conform XML
    */
-  public String getDetails(){
+  public String getDetails() {
     StringBuilder details = new StringBuilder();
     details.append("<testcase status=\"")
-      .append(status)
-      .append("\" time=\"")
-      .append(time)
-      .append("\" name=\"")
-      .append(name)
-      .append("\"");
+            .append(status)
+            .append("\" time=\"")
+            .append(time)
+            .append("\" name=\"")
+            .append(name)
+            .append("\"");
     if (isError() || isFailure()) {
       details.append(">")
-        .append(isError() ? "<error message=\"" : "<failure message=\"")
-        .append(StringEscapeUtils.escapeXml(errorMessage))
-        .append("\">")
-        .append("<![CDATA[")
-        .append(StringEscapeUtils.escapeXml(stackTrace))
-        .append("]]>")
-        .append(isError() ? "</error>" : "</failure>")
-        .append("</testcase>");
+              .append(isError() ? "<error message=\"" : "<failure message=\"")
+              .append(StringEscapeUtils.escapeXml(errorMessage))
+              .append("\">")
+              .append("<![CDATA[")
+              .append(StringEscapeUtils.escapeXml(stackTrace))
+              .append("]]>")
+              .append(isError() ? "</error>" : "</failure>")
+              .append("</testcase>");
     } else {
       details.append("/>");
     }

--- a/src/main/java/org/sonar/plugins/cxx/xunit/TestSuite.java
+++ b/src/main/java/org/sonar/plugins/cxx/xunit/TestSuite.java
@@ -21,6 +21,7 @@ package org.sonar.plugins.cxx.xunit;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.sonar.plugins.cxx.xunit.TestCase;
 
 /**
  * Represents a unit test suite. Contains testcases, maintains some statistics.
@@ -28,31 +29,44 @@ import java.util.List;
  */
 public class TestSuite {
 
-  private String key;
+  private final String testSuiteName;
+  private final String path;
   private int errors = 0;
   private int skipped = 0;
   private int tests = 0;
   private int time = 0;
   private int failures = 0;
   private List<TestCase> testCases;
-  
+
   /**
-   * Creates a testsuite instance uniquely identified by the given key
-   * @param key The key to construct a testsuite for
+   * Creates a testsuite instance uniquely identified by the given testSuiteName
+   *
+   * @param testSuiteName The testSuiteName to construct a testsuite for
    */
-  public TestSuite(String key) {
-    this.key = key;
+  public TestSuite(String testSuiteName, String path) {
+    this.testSuiteName = testSuiteName;
+    this.path = path;
     this.testCases = new ArrayList<TestCase>();
   }
-  
-  public String getKey() {
-    return key;
+
+  public String getTestFileName() {
+    if (path == null) {
+      return testSuiteName;
+    }
+    if (!path.equals("")) {
+      return path;
+    }
+    return testSuiteName;
+  }
+
+  public String getTestSuiteName() {
+    return testSuiteName;
   }
 
   public int getErrors() {
     return errors;
   }
-  
+
   public int getSkipped() {
     return skipped;
   }
@@ -68,7 +82,7 @@ public class TestSuite {
   public int getFailures() {
     return failures;
   }
-  
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -77,21 +91,23 @@ public class TestSuite {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    
+
     TestSuite that = (TestSuite) o;
-    return key.equals(that.key);
+    return testSuiteName.equals(that.testSuiteName);
   }
 
   @Override
   public int hashCode() {
-    return key.hashCode();
+    return testSuiteName.hashCode();
   }
-  
+
   /**
-   * Adds the given test case to this testsuite maintaining the internal statistics
+   * Adds the given test case to this testsuite maintaining the internal
+   * statistics
+   *
    * @param tc the test case to add
    */
-  public void addTestCase(TestCase tc){ 
+  public void addTestCase(TestCase tc) {
     if (tc.isSkipped()) {
       skipped++;
     } else if (tc.isFailure()) {
@@ -107,10 +123,10 @@ public class TestSuite {
   /**
    * Returns execution details as sonar-conform XML
    */
-  public String getDetails() { 
+  public String getDetails() {
     StringBuilder details = new StringBuilder();
     details.append("<tests-details>");
-    for (TestCase tc: testCases) {
+    for (TestCase tc : testCases) {
       details.append(tc.getDetails());
     }
     details.append("</tests-details>");

--- a/src/test/java/org/sonar/plugins/cxx/xunit/CxxXunitSensorTest.java
+++ b/src/test/java/org/sonar/plugins/cxx/xunit/CxxXunitSensorTest.java
@@ -34,6 +34,7 @@ import org.sonar.api.batch.SensorContext;
 import org.sonar.api.config.Settings;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.Measure;
+import org.sonar.api.profiles.RulesProfile;
 import org.sonar.api.resources.Project;
 import org.sonar.api.resources.Resource;
 import org.sonar.plugins.cxx.TestUtils;
@@ -42,16 +43,17 @@ public class CxxXunitSensorTest {
   private CxxXunitSensor sensor;
   private SensorContext context;
   private Project project;
-
+      
   @Before
   public void setUp() {
     project = TestUtils.mockProject();
-    sensor = new CxxXunitSensor(new Settings(), TestUtils.mockCxxLanguage());
     context = mock(SensorContext.class);
   }
 
   @Test
   public void shouldReportCorrectViolations() {
+
+    sensor = new CxxXunitSensor(new Settings());
     sensor.analyse(project, context);
 
     verify(context, times(3)).saveMeasure((Resource) anyObject(),
@@ -71,8 +73,8 @@ public class CxxXunitSensorTest {
   public void shouldReportZeroTestWhenNoReportFound() {
     Settings config = new Settings();
     config.setProperty(CxxXunitSensor.REPORT_PATH_KEY, "notexistingpath");
-    
-    sensor = new CxxXunitSensor(config, TestUtils.mockCxxLanguage());
+        
+    sensor = new CxxXunitSensor(config);
     
     sensor.analyse(project, context);
     
@@ -83,8 +85,8 @@ public class CxxXunitSensorTest {
   public void shouldThrowWhenGivenInvalidTime() {
     Settings config = new Settings();
     config.setProperty(CxxXunitSensor.REPORT_PATH_KEY, "xunit-reports/invalid-time-xunit-report.xml");    
-    sensor = new CxxXunitSensor(config, TestUtils.mockCxxLanguage());
-    
+
+    sensor = new CxxXunitSensor(config);   
     sensor.analyse(project, context);
   }
   
@@ -93,9 +95,8 @@ public class CxxXunitSensorTest {
     throws java.io.IOException, javax.xml.transform.TransformerException 
   {
     Settings config = new Settings();
-    config.setProperty(CxxXunitSensor.XSLT_URL_KEY, "whatever");  
-
-    sensor = new CxxXunitSensor(config, TestUtils.mockCxxLanguage());
+    config.setProperty(CxxXunitSensor.XSLT_URL_KEY, "whatever");      
+    sensor = new CxxXunitSensor(config);
     
     sensor.transformReport(cppunitReport());
   }
@@ -105,9 +106,9 @@ public class CxxXunitSensorTest {
     throws java.io.IOException, javax.xml.transform.TransformerException 
   {
     Settings config = new Settings();
-    config.setProperty(CxxXunitSensor.XSLT_URL_KEY, "cppunit-1.x-to-junit-1.0.xsl");  
-    
-    sensor = new CxxXunitSensor(config, TestUtils.mockCxxLanguage());
+    config.setProperty(CxxXunitSensor.XSLT_URL_KEY, "cppunit-1.x-to-junit-1.0.xsl");      
+      
+    sensor = new CxxXunitSensor(config);
     File reportBefore = cppunitReport();
     
     File reportAfter = sensor.transformReport(reportBefore);

--- a/src/test/java/org/sonar/plugins/cxx/xunit/TestSuiteTest.java
+++ b/src/test/java/org/sonar/plugins/cxx/xunit/TestSuiteTest.java
@@ -20,12 +20,11 @@
 
 package org.sonar.plugins.cxx.xunit;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.junit.Assert.assertEquals;
-
 import org.junit.Before;
 import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestSuiteTest {
   TestSuite suite;
@@ -34,9 +33,9 @@ public class TestSuiteTest {
   
   @Before
   public void setUp() {
-    suite = new TestSuite("key");
-    equalSuite = new TestSuite("key");
-    otherSuite = new TestSuite("otherkey");
+    suite = new TestSuite("key","");
+    equalSuite = new TestSuite("key","");
+    otherSuite = new TestSuite("otherkey","");
   }
 
   @Test


### PR DESCRIPTION
The fallback behavior remains, i left the filename option since i want to open the possibility to find the test in the future using sslr. 

I guess we can improve this by searching the all filesystem but IMO this is to expensive
