### PR TITLE
Bug: Bullseye Parser fails to retrieve coverage if coverage file is set ...

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/BullseyeParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/BullseyeParser.java
@@ -24,6 +24,7 @@ import org.codehaus.staxmate.in.SMInputCursor;
 import org.sonar.api.measures.CoverageMeasuresBuilder;
 import org.sonar.api.utils.StaxParser;
 import org.sonar.plugins.cxx.utils.CxxUtils;
+import org.apache.commons.lang.StringUtils;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -58,7 +59,7 @@ public class BullseyeParser implements CoverageParser {
        */
       public void stream(SMHierarchicCursor rootCursor) throws XMLStreamException {
         rootCursor.advance();
-        collectCoverage2(rootCursor.getAttrValue("dir"), rootCursor.childElementCursor("folder"), coverageData);
+        collectCoverage2(rootCursor.getAttrValue("dir") + "/", rootCursor.childElementCursor("folder"), coverageData);
       }
     });
     parser.parse(xmlFile);
@@ -113,8 +114,12 @@ public class BullseyeParser implements CoverageParser {
         String fileName = "";
         Iterator<String> iterator = path.iterator();
         while (iterator.hasNext()) {
-          fileName += "/" + iterator.next();
+          fileName += iterator.next() + "/";
         }
+        fileName = StringUtils.chomp(fileName);
+        if ((new File(fileName)).isAbsolute()) {
+          refPath = "";
+        }     
         CoverageMeasuresBuilder fileMeasuresBuilderIn = CoverageMeasuresBuilder.create();
         fileWalk(child, fileMeasuresBuilderIn);
         coverageData.put(refPath + fileName, fileMeasuresBuilderIn);

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensorTest.java
@@ -52,7 +52,7 @@ public class CxxCoverageSensorTest {
   @Test
   public void shouldReportCorrectCoverage() {
     sensor.analyse(project, context);
-    verify(context, times(189)).saveMeasure((File) anyObject(), any(Measure.class));
+    verify(context, times(196)).saveMeasure((File) anyObject(), any(Measure.class));
   }
 
   @Test

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/coverage-reports/coverage-result-bullseye-cov-in-different-drive.xml
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/coverage-reports/coverage-result-bullseye-cov-in-different-drive.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- BullseyeCoverage 8.7.47 Windows License 2656 -->
+<BullseyeCoverage name="coverage.cov" dir="c:/Users/user/" buildId="4c01d04e, 2013-03-07 23:10:15" version="4" xmlns="http://www.bullseye.com/covxml">
+<folder name="e:" fn_cov="1" fn_total="1" cd_cov="1" cd_total="10" d_cov="1" d_total="2">
+<folder name="jenkins-builder" fn_cov="1" fn_total="1" cd_cov="1" cd_total="10" d_cov="1" d_total="2">
+<folder name="workspace" fn_cov="1" fn_total="1" cd_cov="1" cd_total="10" d_cov="1" d_total="2">
+<folder name="AnalyseBinaryTree" fn_cov="1" fn_total="1" cd_cov="1" cd_total="10" d_cov="1" d_total="2">
+<folder name="dummy" fn_cov="1" fn_total="1" cd_cov="1" cd_total="10" d_cov="1" d_total="2">
+<folder name="dummy" fn_cov="1" fn_total="1" cd_cov="1" cd_total="10" d_cov="1" d_total="2">
+<src name="dummy.c" mtime="1362690563" fn_cov="1" fn_total="1" cd_cov="5" cd_total="10" d_cov="1" d_total="2">
+<fn name="dummy(bintree_t*,int(*)(void**,void**,void*),int(*)(void*,void*),int(*)(void**))" fn_cov="1" fn_total="1" cd_cov="5" cd_total="10" d_cov="1" d_total="2">
+<probe line="14" column="6" kind="function" event="full"/>
+<probe line="20" kind="decision" event="true"/>
+<probe line="20" column="3" kind="condition" event="true"/>
+<probe line="20" column="16" kind="condition" event="true"/>
+<probe line="20" column="29" kind="condition" event="true"/>
+<probe line="20" column="45" kind="condition" event="true"/>
+</fn>
+</src>
+</folder>
+</folder>
+</folder>
+</folder>
+</folder>
+</folder>
+</BullseyeCoverage>


### PR DESCRIPTION
Bug: Bullseye Parser fails to retrieve coverage if coverage file is set to a different drive than the build is executed

Ive detected this recently. 

Here goes the patch and the test
