### PR TITLE
Provide a new implementation to cases where the bullseye coverage files ...

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/BullseyeParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/BullseyeParser.java
@@ -24,6 +24,7 @@ import org.codehaus.staxmate.in.SMInputCursor;
 import org.sonar.api.measures.CoverageMeasuresBuilder;
 import org.sonar.api.utils.StaxParser;
 import org.sonar.plugins.cxx.utils.CxxUtils;
+import org.apache.commons.lang.StringUtils;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -113,8 +114,14 @@ public class BullseyeParser implements CoverageParser {
         String fileName = "";
         Iterator<String> iterator = path.iterator();
         while (iterator.hasNext()) {
-          fileName += "/" + iterator.next();
+          fileName += iterator.next() + "/";
         }
+        
+        fileName = StringUtils.chop(fileName);
+        
+        if ((new File(fileName)).isAbsolute()) {
+          refPath = "";
+        }     
         CoverageMeasuresBuilder fileMeasuresBuilderIn = CoverageMeasuresBuilder.create();
         fileWalk(child, fileMeasuresBuilderIn);
         coverageData.put(refPath + fileName, fileMeasuresBuilderIn);

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensorTest.java
@@ -52,7 +52,7 @@ public class CxxCoverageSensorTest {
   @Test
   public void shouldReportCorrectCoverage() {
     sensor.analyse(project, context);
-    verify(context, times(189)).saveMeasure((File) anyObject(), any(Measure.class));
+    verify(context, times(198)).saveMeasure((File) anyObject(), any(Measure.class));
   }
 
   @Test

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/coverage-reports/it-coverage-result-bullseye-another-drive.xml
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/coverage-reports/it-coverage-result-bullseye-another-drive.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- BullseyeCoverage 8.7.48 Windows License 2656 -->
+<BullseyeCoverage name="covfile.cov" dir="c:/Users/jocs/" buildId="9b33970f, 2013-03-14 21:52:40" version="4" xmlns="http://www.bullseye.com/covxml">
+<folder name="e:" fn_cov="3" fn_total="5" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<folder name="Development" fn_cov="3" fn_total="5" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<folder name="sonar-cxx" fn_cov="3" fn_total="5" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<folder name="sonar-cxx" fn_cov="3" fn_total="5" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<folder name="sonar-cxx-plugin" fn_cov="3" fn_total="5" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<folder name="target" fn_cov="3" fn_total="5" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<folder name="test-classes" fn_cov="3" fn_total="5" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<folder name="org" fn_cov="3" fn_total="5" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<folder name="sonar" fn_cov="3" fn_total="5" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<folder name="plugins" fn_cov="3" fn_total="5" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<folder name="cxx" fn_cov="3" fn_total="5" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<folder name="SampleProjectWindows" fn_cov="3" fn_total="5" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<folder name="sample.test" fn_cov="1" fn_total="1" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<src name="SampleTest.cpp" mtime="1363288130" fn_cov="1" fn_total="1" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<fn name="main()" fn_cov="1" fn_total="1" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<probe line="6" column="4" kind="function" event="full"/>
+</fn>
+</src>
+</folder>
+<folder name="sample" fn_cov="2" fn_total="4" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<src name="sampleclass.cpp" mtime="1363286548" fn_cov="2" fn_total="3" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<fn name="SampleClass::SampleClass(string,int)" fn_cov="1" fn_total="1" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<probe line="3" kind="function" event="full"/>
+</fn>
+<fn name="SampleClass::GetAge()" fn_cov="0" fn_total="1" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<probe line="7" column="3" kind="function" event="none"/>
+</fn>
+<fn name="SampleClass::GetName()" fn_cov="1" fn_total="1" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<probe line="12" column="6" kind="function" event="full"/>
+</fn>
+</src>
+<src name="sampleclass.h" mtime="1363286562" fn_cov="0" fn_total="1" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<fn name="SampleClass::SampleClass()" fn_cov="0" fn_total="1" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+<probe line="15" kind="function" event="none"/>
+</fn>
+</src>
+</folder>
+</folder>
+</folder>
+</folder>
+</folder>
+</folder>
+</folder>
+</folder>
+</folder>
+</folder>
+</folder>
+</folder>
+</folder>
+</BullseyeCoverage>


### PR DESCRIPTION
...is in a different drive than the source files. Dir property in xml file can have a absolute path, so combining this with another aboslute path of the downstream folders will cause sonar to display 0 coverage
