### PR TITLE
Fix scoped enum support (C++11)

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -553,7 +553,7 @@ public class CxxGrammarImpl extends CxxGrammar {
 
     opaqueEnumDeclaration.is(enumKey, opt(attributeSpecifierSeq), IDENTIFIER, opt(enumBase), ";");
 
-    enumKey.is(CxxKeyword.ENUM, opt(CxxKeyword.CLASS, CxxKeyword.STRUCT));
+    enumKey.is(CxxKeyword.ENUM, opt(or(CxxKeyword.CLASS, CxxKeyword.STRUCT)));
 
     enumBase.is(":", typeSpecifierSeq);
 

--- a/cxx-squid/src/test/resources/parser/own/enums.cc
+++ b/cxx-squid/src/test/resources/parser/own/enums.cc
@@ -1,0 +1,25 @@
+
+#include <cstdio>
+
+enum class my_enum
+{
+   value1 = 1,
+   value2 = 2
+};
+
+enum struct my_enum2
+{
+   value1 = 10,
+   value2 = 20
+};
+
+int main(int argc, char** argv)
+{
+   my_enum a = my_enum::value1;
+   my_enum2 b = my_enum2::value1;
+
+   printf("a=%d\n", static_cast<int>(a));
+   printf("b=%d\n", static_cast<int>(b));
+
+   return 0;
+}


### PR DESCRIPTION
C++11 scoped enums are specified as either
"enum class" or "enum struct", not "enum class struct"
