### PR TITLE
Remove redundant rules in Cppcheck profile

### DIFF
--- a/sonar-cxx-plugin/src/main/resources/default-profile.xml
+++ b/sonar-cxx-plugin/src/main/resources/default-profile.xml
@@ -951,11 +951,6 @@
     <!-- ########### New in cppcheck 1.52 ########### -->
     <rule>
       <repositoryKey>cppcheck</repositoryKey>
-      <key>simplePatternError</key>
-      <priority>MINOR</priority>
-    </rule>
-    <rule>
-      <repositoryKey>cppcheck</repositoryKey>
       <key>complexPatternError</key>
       <priority>MAJOR</priority>
     </rule>
@@ -1370,11 +1365,6 @@
     <rule>
       <repositoryKey>cppcheck</repositoryKey>
       <key>redundantCopyInSwitch</key>
-      <priority>MINOR</priority>
-    </rule>
-    <rule>
-      <repositoryKey>cppcheck</repositoryKey>
-      <key>redundantNextPrevious</key>
       <priority>MINOR</priority>
     </rule>
     <rule>


### PR DESCRIPTION
@wenns, it seems the current version of the plugin is not compatible with sonar 4.2. We will need to make a new release soon after 4.2 is release. It seems duplicated rules make the server to fail to initialized with message

2014.03.15 18:12:00 ERROR [o.s.s.p.PlatformLifecycleListener]  Fail to start server
org.sonar.api.utils.MessageException: The definition of the profile 'Sonar way' (language 'c++') contains multiple occurrences of the 'cppcheck:simplePatternError' rule. The plugin which declares this profile should fix this.
2014.03.15 18:12:00 INFO  [o.s.s.n.NotificationService]  Notification service stopped
2014.03.15 18:12:00 INFO  [o.elasticsearch.node]  [sonarqube] stopping ...
2014.03.15 18:12:00 INFO  [o.elasticsearch.node]  [sonarqube] stopped
2014.03.15 18:12:00 INFO  [o.elasticsearch.node]  [sonarqube] closing ...
2014.03.15 18:12:00 INFO  [o.elasticsearch.node]  [sonarqube] closed
<-- Wrapper Stopped
--> Wrapper Started as Console

So now we need to make a release at least with this fix.
