### PR TITLE
Support GCC's conditionals with omitted operands.

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -521,7 +521,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
 
     b.rule(conditionalExpression).is(
       b.firstOf(
-        b.sequence(logicalOrExpression, "?", expression, ":", assignmentExpression),
+        b.sequence(logicalOrExpression, "?", b.optional(expression), ":", assignmentExpression),
         logicalOrExpression
         )
       ).skipIfOneChild();

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppGrammar.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppGrammar.java
@@ -238,7 +238,7 @@ public enum CppGrammar implements GrammarRuleKey {
 
     b.rule(conditionalExpression).is(
         b.firstOf(
-            b.sequence(logicalOrExpression, b.zeroOrMore(WS), "?", b.zeroOrMore(WS), expression, b.zeroOrMore(WS), ":", b.zeroOrMore(WS), conditionalExpression),
+            b.sequence(logicalOrExpression, b.zeroOrMore(WS), "?", b.zeroOrMore(WS), b.optional(expression), b.zeroOrMore(WS), ":", b.zeroOrMore(WS), conditionalExpression),
             logicalOrExpression
         )
         ).skipIfOneChild();

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/ExpressionEvaluator.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/ExpressionEvaluator.java
@@ -378,10 +378,18 @@ public final class ExpressionEvaluator {
   }
 
   long evalConditionalExpression(AstNode exprAst) {
-    AstNode decisionOperand = exprAst.getChild(0);
-    AstNode trueCaseOperand = exprAst.getChild(2);
-    AstNode falseCaseOperand = exprAst.getChild(4);
-    return eval(decisionOperand) ? evalToInt(trueCaseOperand) : evalToInt(falseCaseOperand);
+    if (exprAst.getNumberOfChildren() == 5) {
+        AstNode decisionOperand = exprAst.getChild(0);
+        AstNode trueCaseOperand = exprAst.getChild(2);
+        AstNode falseCaseOperand = exprAst.getChild(4);
+        return eval(decisionOperand) ? evalToInt(trueCaseOperand) : evalToInt(falseCaseOperand);
+    }
+    else {
+        AstNode decisionOperand = exprAst.getChild(0);
+        AstNode falseCaseOperand = exprAst.getChild(3);
+        long decision = evalToInt(decisionOperand);
+        return decision != 0 ? decision : evalToInt(falseCaseOperand);
+    }
   }
 
   long evalPrimaryExpression(AstNode exprAst) {

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/ExpressionTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/ExpressionTest.java
@@ -326,6 +326,7 @@ public class ExpressionTest {
     assertThat(p).matches("( y > 4)");
     assertThat(p).matches("( x== 8) && (c=='U')");
     assertThat(p).matches("(a > b) ? a : b");
+    assertThat(p).matches("a ? : b");
     assertThat(p).matches("m = 1");
     assertThat(p).matches("cout << endl");
     assertThat(p).matches("numeric_limits<char>::is_signed");

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppGrammarTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppGrammarTest.java
@@ -367,6 +367,7 @@ public class CppGrammarTest {
 
     assertThat(p).matches("logicalOrExpression");
     assertThat(p).matches("logicalOrExpression ? expression : logicalOrExpression");
+    assertThat(p).matches("logicalOrExpression ? : logicalOrExpression");
   }
 
   @Test

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/ExpressionEvaluatorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/ExpressionEvaluatorTest.java
@@ -71,6 +71,9 @@ public class ExpressionEvaluatorTest {
 
     assertFalse(evaluator.eval("1 ? 0 : 1"));
     assertFalse(evaluator.eval("0 ? 1 : 0"));
+
+    assertTrue(evaluator.eval("1 ? : 0"));
+    assertTrue(evaluator.eval("0 ? : 1"));
   }
 
   @Test


### PR DESCRIPTION
There is a GCC extension which allows the middle operand in a conditional
expression to be omitted. Therefore, the expression "x ? : y" has the value of x
if that is nonzero; otherwise, the value of y.
