### PR TITLE
Enhancement/error recovery declaration

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/CheckList.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/CheckList.java
@@ -49,6 +49,7 @@ public final class CheckList {
         MissingNewLineAtEndOfFileCheck.class,
         NoSonarCheck.class,
         ParsingErrorCheck.class,
+        ParsingErrorRecoveryCheck.class,
         ReservedNamesCheck.class,
         StringLiteralDuplicatedCheck.class,
         TabCharacterCheck.class,

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/ParsingErrorRecoveryCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/ParsingErrorRecoveryCheck.java
@@ -1,0 +1,46 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2011 Waleri Enns and CONTACT Software GmbH
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.cxx.checks;
+
+import com.sonar.sslr.api.AstNode;
+import com.sonar.sslr.api.Grammar;
+import com.sonar.sslr.squid.checks.SquidCheck;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.cxx.parser.CxxGrammarImpl;
+
+@Rule(
+  key = "ParsingErrorRecovery",
+  name = "C++ skip parser error", //todo: why not working in cxx.properties?
+  description = "C++ Parser can't read code. Code is skipped.",
+  priority = Priority.INFO)
+
+public class ParsingErrorRecoveryCheck extends SquidCheck<Grammar> {
+  
+  @Override
+  public void init() {
+    subscribeTo(CxxGrammarImpl.recoveredDeclaration);
+  }
+   
+  @Override
+  public void visitNode(AstNode node) {
+    getContext().createLineViolation(this, "C++ Parser can't read code. Declaration is skipped.", node.getToken().getLine());
+  }  
+}

--- a/cxx-checks/src/main/resources/org/sonar/l10n/cxx.properties
+++ b/cxx-checks/src/main/resources/org/sonar/l10n/cxx.properties
@@ -22,6 +22,7 @@ rule.cxx.NoTabCharacter.name=Tabulation characters should not be used
 rule.cxx.NotAllowedFixMeTag.name=FIXME tags should be handled
 rule.cxx.NotAllowedToDoTag.name=TODO tags should be handled
 rule.cxx.ParsingError.name=C++ parser failure
+rule.cxx.ParsingErrorRecoveryCheck.name=C++ skip parser error
 rule.cxx.ReservedNamesCheck.name=Reserved names should not be used for preprocessor macros
 rule.cxx.StringLiteralDuplicated.name=String literals should not be duplicated
 rule.cxx.StringLiteralDuplicated.param.minimalLiteralLength=The minimal literal length.

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/CheckListTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/CheckListTest.java
@@ -27,6 +27,6 @@ public class CheckListTest {
 
   @Test
   public void count() {
-    assertThat(CheckList.getChecks().size()).isEqualTo(29);
+    assertThat(CheckList.getChecks().size()).isEqualTo(30);
   }
 }

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/ParsingErrorCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/ParsingErrorCheckTest.java
@@ -23,6 +23,7 @@ import com.sonar.sslr.squid.checks.CheckMessagesVerifier;
 import org.junit.Test;
 import org.sonar.cxx.CxxAstScanner;
 import org.sonar.squid.api.SourceFile;
+import org.sonar.cxx.CxxConfiguration;
 
 import java.io.File;
 
@@ -32,7 +33,9 @@ public class ParsingErrorCheckTest {
 
   @Test
   public void test_syntax_error_recognition() {
-    SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/parsingError1.cc"), new ParsingErrorCheck());
+    CxxConfiguration config = new CxxConfiguration();
+    config.setErrorRecoveryEnabled(false);
+    SourceFile file = CxxAstScanner.scanSingleFileConfig(new File("src/test/resources/checks/parsingError1.cc"), config, new ParsingErrorCheck());
     CheckMessagesVerifier.verify(file.getCheckMessages())
       .next().atLine(4).withMessageThat(containsString("Parse error"))
       .noMore();
@@ -40,7 +43,9 @@ public class ParsingErrorCheckTest {
 
   @Test
   public void test_syntax_error_pperror() {
-    SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/parsingError2.cc"), new ParsingErrorCheck());
+    CxxConfiguration config = new CxxConfiguration();  
+    config.setErrorRecoveryEnabled(false);
+    SourceFile file = CxxAstScanner.scanSingleFileConfig(new File("src/test/resources/checks/parsingError2.cc"), config, new ParsingErrorCheck());
     CheckMessagesVerifier.verify(file.getCheckMessages())
       .next().atLine(2).withMessageThat(containsString("Parse error"))
       .noMore();

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/ParsingErrorRecoveryCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/ParsingErrorRecoveryCheckTest.java
@@ -1,0 +1,42 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2011 Waleri Enns and CONTACT Software GmbH
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.cxx.checks;
+
+import com.sonar.sslr.squid.checks.CheckMessagesVerifier;
+import java.io.File;
+import org.junit.Test;
+import org.sonar.cxx.CxxAstScanner;
+import org.sonar.cxx.CxxConfiguration;
+import org.sonar.squid.api.SourceFile;
+
+public class ParsingErrorRecoveryCheckTest {
+    
+  @Test
+  public void test_syntax_error_recovery() {
+    CxxConfiguration config = new CxxConfiguration();
+    config.setErrorRecoveryEnabled(true);
+    SourceFile file = CxxAstScanner.scanSingleFileConfig(new File("src/test/resources/checks/parsingError3.cc"), config, new ParsingErrorRecoveryCheck());
+    
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(2).withMessage("C++ Parser can't read code. Declaration is skipped.")
+      .noMore();
+  }    
+  
+}

--- a/cxx-checks/src/test/resources/checks/parsingError3.cc
+++ b/cxx-checks/src/test/resources/checks/parsingError3.cc
@@ -1,0 +1,6 @@
+void f1(){int i1;}
+void f2(){int i2 }
+void f3(){int i3;}
+
+
+

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxAstScanner.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxAstScanner.java
@@ -43,6 +43,7 @@ import org.sonar.cxx.parser.CxxGrammarImpl;
 import org.sonar.cxx.visitors.CxxCharsetAwareVisitor;
 import org.sonar.cxx.visitors.CxxFileVisitor;
 import org.sonar.cxx.visitors.CxxLinesOfCodeVisitor;
+import org.sonar.cxx.visitors.CxxParseErrorLoggerVisitor;
 import org.sonar.squid.api.SourceClass;
 import org.sonar.squid.api.SourceCode;
 import org.sonar.squid.api.SourceFile;
@@ -189,6 +190,9 @@ public final class CxxAstScanner {
 
     // to emit a 'new file' event to the internals of the plugin
     builder.withSquidAstVisitor(new CxxFileVisitor(context));
+    
+    // log syntax errors
+    builder.withSquidAstVisitor(new CxxParseErrorLoggerVisitor(context));
     
     /* External visitors (typically Check ones) */
     for (SquidAstVisitor<Grammar> visitor : visitors) {

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
@@ -32,6 +32,7 @@ public class CxxConfiguration extends SquidConfiguration {
   private List<String> defines = new ArrayList<String>();
   private List<String> includeDirectories = new ArrayList<String>();
   private String baseDir;
+  private boolean errorRecoveryEnabled = true;
 
   public CxxConfiguration() {
   }
@@ -82,5 +83,13 @@ public class CxxConfiguration extends SquidConfiguration {
 
   public String getBaseDir() {
     return baseDir;
+  }
+
+  public void setErrorRecoveryEnabled(boolean errorRecoveryEnabled){
+    this.errorRecoveryEnabled = errorRecoveryEnabled;
+  }
+
+  public boolean getErrorRecoveryEnabled(){
+    return this.errorRecoveryEnabled;
   }
 }

--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxParser.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxParser.java
@@ -55,7 +55,7 @@ public final class CxxParser {
   public static Parser<Grammar> create(SquidAstVisitorContext<Grammar> context,
                                        CxxConfiguration conf) {
     cxxpp = new CxxPreprocessor(context, conf);
-    return Parser.builder(CxxGrammarImpl.create())
+    return Parser.builder(CxxGrammarImpl.create(conf))
       .withLexer(CxxLexer.create(conf, cxxpp, new JoinStringsPreprocessor()))
       .build();
   }

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitor.java
@@ -1,0 +1,55 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2011 Waleri Enns and CONTACT Software GmbH
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.cxx.visitors;
+
+import org.sonar.cxx.parser.CxxGrammarImpl;
+        
+import com.sonar.sslr.api.AstAndTokenVisitor;
+import com.sonar.sslr.api.AstNode;
+import com.sonar.sslr.api.GenericTokenType;
+import com.sonar.sslr.api.Grammar;
+import com.sonar.sslr.api.Token;
+import com.sonar.sslr.squid.SquidAstVisitor;
+import com.sonar.sslr.squid.SquidAstVisitorContext;
+
+public class CxxParseErrorLoggerVisitor <GRAMMAR extends Grammar> extends SquidAstVisitor<GRAMMAR> implements AstAndTokenVisitor {
+
+  private SquidAstVisitorContext context = null;
+  
+  public CxxParseErrorLoggerVisitor(SquidAstVisitorContext context){
+    this.context = context;
+  }
+  
+  @Override
+  public void init() {
+    subscribeTo(CxxGrammarImpl.recoveredDeclaration);
+  }
+
+  @Override
+  public void visitNode(AstNode node) {
+    AstNode identifierAst = node.getFirstChild(GenericTokenType.IDENTIFIER);
+    if( identifierAst != null ) {
+      CxxGrammarImpl.LOG.warn("[{}:{}]: syntax error, skip '{}'", new Object[] {context.getFile(), node.getToken().getLine(), identifierAst.getTokenValue()});
+    }
+  }
+
+  public void visitToken(Token token) {
+  }
+}

--- a/cxx-squid/src/test/java/org/sonar/cxx/CxxAstScannerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/CxxAstScannerTest.java
@@ -87,4 +87,9 @@ public class CxxAstScannerTest {
   //   assertThat(file.getInt(CxxMetric.COMPLEXITY)).isEqualTo(14);
   // }
 
+   @Test
+   public void error_recovery_declaration() {
+     SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/parser/own/error_recovery_declaration.cc"));
+     assertThat(file.getInt(CxxMetric.FUNCTIONS)).isEqualTo(2);
+   }
 }

--- a/cxx-squid/src/test/resources/parser/own/error_recovery_declaration.cc
+++ b/cxx-squid/src/test/resources/parser/own/error_recovery_declaration.cc
@@ -1,0 +1,19 @@
+int function_1()
+{
+    return 1;
+}
+
+int function_2()
+{
+    return 2//; <= syntax error
+}
+
+int function_3()
+{
+    return 3;
+}
+
+int function_4()
+{
+    return 4;
+//} <= syntax error

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -165,14 +165,23 @@ import java.util.List;
     name = "URL of the xslt transformer",
     description = "TODO",
     global = false,
+    project = true),
+  @Property(
+    key = CxxPlugin.ERROR_RECOVERY_KEY,
+    defaultValue = "true",
+    name = "Parse error recovery control",
+    description = "Enables/disables the parse error recovery. For development purposes.",
+    type = PropertyType.BOOLEAN,
+    global = false,
     project = true)
-})
+    })
 public final class CxxPlugin extends SonarPlugin {
   static final String SOURCE_FILE_SUFFIXES_KEY = "sonar.cxx.suffixes.sources";
   static final String HEADER_FILE_SUFFIXES_KEY = "sonar.cxx.suffixes.headers";
   public static final String DEFINES_KEY = "sonar.cxx.defines";
   public static final String INCLUDE_DIRECTORIES_KEY = "sonar.cxx.include_directories";
-
+  public static final String ERROR_RECOVERY_KEY = "sonar.cxx.errorRecoveryEnabled";
+  
   /**
    * {@inheritDoc}
    */

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxSquidSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxSquidSensor.java
@@ -107,6 +107,7 @@ public final class CxxSquidSensor implements Sensor {
       cxxConf.setDefines(Arrays.asList(lines));
     }
     cxxConf.setIncludeDirectories(conf.getStringArray(CxxPlugin.INCLUDE_DIRECTORIES_KEY));
+    cxxConf.setErrorRecoveryEnabled(conf.getBoolean(CxxPlugin.ERROR_RECOVERY_KEY));
     return cxxConf;
   }
 


### PR DESCRIPTION
Handle error recovery on global declaration level: skip syntax errors and proceed with next declaration.
This is a very coarse error handling but as a result all files are able to read.
- add new property to enable/disable error recovery: sonar.cxx.errorRecoveryEnabled=true/false (idea wenns for debugging purpose)
- add a rule to report on every recoveredDeclaration (C++ skip parser error)
- add logging
- see #45
