### PR TITLE
Support GCC's statement expression.

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -324,7 +324,9 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
                 CxxKeyword.THIS,
                 par_expression,
                 idExpression,
-                lambdaExpression)
+                lambdaExpression,
+                // EXTENSION: gcc's statement expression: a compound statement enclosed in parentheses may appear as an expression
+                b.sequence("(", compoundStatement, ")"))
       ).skipIfOneChild();
     
     b.rule(par_expression).is(b.sequence("(", expression, ")"));

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/ExpressionTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/ExpressionTest.java
@@ -38,6 +38,7 @@ public class ExpressionTest {
     
     g.rule(CxxGrammarImpl.LITERAL).mock();
     g.rule(CxxGrammarImpl.expression).mock();
+    g.rule(CxxGrammarImpl.compoundStatement).mock();
     g.rule(CxxGrammarImpl.idExpression).mock();
     g.rule(CxxGrammarImpl.lambdaExpression).mock();
     
@@ -46,7 +47,8 @@ public class ExpressionTest {
       .matches("this")
       .matches("( expression )")
       .matches("idExpression")
-      .matches("lambdaExpression");
+      .matches("lambdaExpression")
+      .matches("( compoundStatement )");
   }
 
   @Test
@@ -54,6 +56,7 @@ public class ExpressionTest {
     p.setRootRule(g.rule(CxxGrammarImpl.primaryExpression));
     
     assertThat(p).matches("(istream_iterator<string>(cin))");
+    assertThat(p).matches("({ int i = 0; a = i++; })");
   }
   
   @Test


### PR DESCRIPTION
A compound statement enclosed in parentheses may appear as an expression in GNU C. This allows you to use loops, switches, and local variables within an expression.
