### PR TITLE
Fix reserved name check.

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/ReservedNamesCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/ReservedNamesCheck.java
@@ -56,19 +56,24 @@ public class ReservedNamesCheck extends SquidCheck<Grammar> implements CxxCharse
     } catch (IOException e) {
       throw new SonarException(e);
     }
-    String[] name = null;
     int nr= 0;
     for (String line : lines) {
       nr++;
-      String[] sub = line.split("^.*#define\\s+", 2);
+      String[] sub = line.split("^\\s*#define\\s+", 2);
       if (sub.length>1) {
-        name = sub[1].toLowerCase().split("\\s",2);
-        for (String keyword : keywords) {
-          if (name[0].startsWith("_"+keyword) || (name[0].startsWith("__"+keyword))  ) {
-            getContext().createLineViolation(this, "Reserved name used for macro (incorrect use of underscore)", nr);
-          } else {
-            if (name[0].contains(keyword)) {
+        String name = sub[1].split("[\\s(]",2)[0];
+        if (name.startsWith("_") && Character.isUpperCase(name.charAt(1))) {
+          getContext().createLineViolation(this, "Reserved name used for macro (begins with underscore followed by a capital letter)", nr);
+        }
+        else if (name.contains("__")) {
+          getContext().createLineViolation(this, "Reserved name used for macro (contains two consecutive underscores)", nr);
+        }
+        else {
+          name = name.toLowerCase();
+          for (String keyword : keywords) {
+            if (name.equals(keyword)) {
               getContext().createLineViolation(this, "Reserved name used for macro (keyword or alternative token redefined)", nr);
+              break;
             }
           }
         }

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/ReservedNamesCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/ReservedNamesCheckTest.java
@@ -38,9 +38,13 @@ public class ReservedNamesCheckTest {
     checkMessagesVerifier.verify(file.getCheckMessages())
         .next().atLine(3).withMessage("Reserved name used for macro (keyword or alternative token redefined)")
         .next().atLine(4)
-        .next().atLine(12).withMessage("Reserved name used for macro (incorrect use of underscore)")
-        .next().atLine(13)
+        .next().atLine(5)
+        .next().atLine(6)
+        .next().atLine(14).withMessage("Reserved name used for macro (begins with underscore followed by a capital letter)")
+        .next().atLine(15)
         .next().atLine(16)
-        .next().atLine(17);
+        .next().atLine(18).withMessage("Reserved name used for macro (contains two consecutive underscores)")
+        .next().atLine(19)
+        .next().atLine(20);
   }
 }

--- a/cxx-checks/src/test/resources/checks/ReservedNamesCheck.cc
+++ b/cxx-checks/src/test/resources/checks/ReservedNamesCheck.cc
@@ -2,6 +2,8 @@
 
 #define TRUE 1
 #define FALSE 0
+#define SWITCH(x) (x!=0)
+#define AUTO
 
 #define     NULL 0
 class myData {
@@ -11,10 +13,16 @@ public:
 
 #define _TRUE 1
 #define _FALSE 0
-
+#define _FOO
 
 #define __TRUE 1
 #define __FALSE 0
+#define FOO__BAR
+
+//These are ok:
+#define _test
+#define TRUE_TEST
+/*#define TRUE this is not an error...*/
 
 int main()
 {


### PR DESCRIPTION
- According to the standard, reserved names that either begin with underscore
  followed by a capital letter and a capital letter, contain 2 consecutive
  underscores, or are part of the reserved keywords.
- The check was not working for function-like macros.
- The check could report errors if #define is used in commnets.
