### PR TITLE
Fix correct include check if comment is right after file string.

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectIncludeCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectIncludeCheck.java
@@ -41,7 +41,7 @@ import java.util.List;
 
 public class UseCorrectIncludeCheck extends SquidCheck<Grammar> implements CxxCharsetAwareVisitor {
     
-  private static final String DEFAULT_REGULAR_EXPRESSION = "#include.*(?>\"|\\<)[\\\\/\\.]+";
+  private static final String DEFAULT_REGULAR_EXPRESSION = "#include\\s+(?>\"|\\<)[\\\\/\\.]+";
   private static final String DEFAULT_MESSAGE = "Use correct #include directives";
   
   public String regularExpression = DEFAULT_REGULAR_EXPRESSION;

--- a/cxx-checks/src/test/resources/checks/UseCorrectIncludeCheck.cc
+++ b/cxx-checks/src/test/resources/checks/UseCorrectIncludeCheck.cc
@@ -6,6 +6,7 @@
 #include "\apath/string" // Non-Compliant
 #include "..\apath/string" // Non-Compliant
 #include "apath/string" // Compliant
+#include "string"// Compliant
 
 
 class A {


### PR DESCRIPTION
The checker was incorrectly reporting issues if the name is specified in quotes,
and followed immediately (no space) by a comment.
