### PR TITLE
bug/duplicated-violations

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CxxCompilerSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CxxCompilerSensor.java
@@ -49,7 +49,6 @@ public class CxxCompilerSensor extends CxxReportSensor {
   public static final String DEFAULT_PARSER_DEF = CxxCompilerVcParser.KEY;
 
   private final RulesProfile profile;
-  private final HashSet<String> uniqueIssues = new HashSet<String>();
   private final HashMap<String, CompilerParser> parsers = new HashMap<String, CompilerParser>();
 
   /**
@@ -132,8 +131,7 @@ public class CxxCompilerSensor extends CxxReportSensor {
         // get filename from file system - e.g. VC writes case insensitive file name to html
         String filename = getCaseSensitiveFileName(w.filename, fs.sourceDirs());
         if (isInputValid(filename, w.line, w.id, w.msg)) {
-          if (uniqueIssues.add(filename + w.line + w.id + w.msg)) {
-            saveViolation(project, context, parser.rulesRepositoryKey(), filename, w.line, w.id, w.msg);
+          if (saveUniqueViolation(project, context, parser.rulesRepositoryKey(), filename, w.line, w.id, w.msg)) {
             countViolations++;
           }
         } else {

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV1.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV1.java
@@ -72,7 +72,7 @@ public class CppcheckParserV1 implements CppcheckParser {
             String msg = errorCursor.getAttrValue("msg");
 
             if (isInputValid(file, line, id, msg)) {
-              sensor.saveViolation(project, context, CxxCppCheckRuleRepository.KEY, file, line, id, msg);
+              sensor.saveUniqueViolation(project, context, CxxCppCheckRuleRepository.KEY, file, line, id, msg);
             } else {
               CxxUtils.LOG.warn("Skipping invalid violation: '{}'", msg);
             }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV2.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV2.java
@@ -74,8 +74,8 @@ public class CppcheckParserV2 implements CppcheckParser {
                 String msg = errorCursor.getAttrValue("msg");
                 //String verbose = errorCursor.getAttrValue("verbose");
                 //String inconclusive = errorCursor.getAttrValue("inconclusive");
-                String file = "";
-                String line = "";
+                String file = null;
+                String line = null;
 
                 SMInputCursor locationCursor = errorCursor.childElementCursor("location"); // location
                 if (locationCursor.getNext() != null) {
@@ -84,7 +84,7 @@ public class CppcheckParserV2 implements CppcheckParser {
                 }
 
                 if (isInputValid(file, line, id, msg)) {
-                  sensor.saveViolation(project, context, CxxCppCheckRuleRepository.KEY, file, line, id, msg);
+                  sensor.saveUniqueViolation(project, context, CxxCppCheckRuleRepository.KEY, file, line, id, msg);
                 } else {
                   CxxUtils.LOG.warn("Skipping invalid violation: '{}'", msg);
                 }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckSensor.java
@@ -43,7 +43,7 @@ public class CxxCppCheckSensor extends CxxReportSensor {
   private static final String DEFAULT_REPORT_PATH = "cppcheck-reports/cppcheck-result-*.xml";
   
   private final RulesProfile profile;
-  private static List<CppcheckParser> parsers = new LinkedList<CppcheckParser>();
+  private final List<CppcheckParser> parsers = new LinkedList<CppcheckParser>();
   
   /**
    * {@inheritDoc}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/externalrules/CxxExternalRulesSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/externalrules/CxxExternalRulesSensor.java
@@ -89,7 +89,7 @@ public class CxxExternalRulesSensor extends CxxReportSensor {
           String id = errorCursor.getAttrValue("id");
           String msg = errorCursor.getAttrValue("msg");
 
-          saveViolation(project, context, CxxExternalRuleRepository.KEY, file, line, id, msg);
+          saveUniqueViolation(project, context, CxxExternalRuleRepository.KEY, file, line, id, msg);
         }
       }
     });

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/pclint/CxxPCLintSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/pclint/CxxPCLintSensor.java
@@ -52,7 +52,6 @@ public class CxxPCLintSensor extends CxxReportSensor {
   public static final String REPORT_PATH_KEY = "sonar.cxx.pclint.reportPath";
   private static final String DEFAULT_REPORT_PATH = "pclint-reports/pclint-result-*.xml";
   private RulesProfile profile;
-  private HashSet<String> uniqueIssues = new HashSet<String>();
 
   /**
    * {@inheritDoc}
@@ -112,10 +111,9 @@ public class CxxPCLintSensor extends CxxReportSensor {
               if(msg.contains("MISRA 2004") || msg.contains("MISRA 2008")) {
                   id = mapMisraRulesToUniqueSonarRules(msg);
               }
-              if (uniqueIssues.add(file + line + id + msg)) {
-                  saveViolation(project, context, CxxPCLintRuleRepository.KEY,
-                      file, line, id, msg);
-                  countViolations++;
+              if (saveUniqueViolation(project, context, CxxPCLintRuleRepository.KEY,
+                                      file, line, id, msg)) {
+                countViolations++;
               }
             } else {
               CxxUtils.LOG.warn("PC-lint warning ignored: {}", msg);

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/rats/CxxRatsSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/rats/CxxRatsSensor.java
@@ -94,7 +94,7 @@ public final class CxxRatsSensor extends CxxReportSensor {
           List<Element> lines = file.getChildren("line");
           for (Element lineElem : lines) {
             String line = lineElem.getTextTrim();
-            saveViolation(project, context, CxxRatsRuleRepository.KEY,
+            saveUniqueViolation(project, context, CxxRatsRuleRepository.KEY,
                 fileName, line, type, message);
           }
         }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/CxxReportSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/CxxReportSensor.java
@@ -45,6 +45,7 @@ public abstract class CxxReportSensor implements Sensor {
   private RuleFinder ruleFinder;
   protected Settings conf;
   private HashSet<String> uniqueFileName = new HashSet<String>();
+  private HashSet<String> uniqueIssues = new HashSet<String>();
   protected ModuleFileSystem fs;
   
   /**
@@ -139,6 +140,20 @@ public abstract class CxxReportSensor implements Sensor {
     return reports;
   }
 
+  /**
+   * Saves code violation only if unique.
+   * Compares file, line, ruleId and msg.
+   */  
+  protected boolean saveUniqueViolation(Project project, SensorContext context, String ruleRepoKey,
+                                        String file, String line, String ruleId, String msg) {
+  
+    if (uniqueIssues.add(file + line + ruleId + msg)) {
+      saveViolation(project, context, ruleRepoKey, file, line, ruleId, msg);
+      return true;
+    }
+    return false;
+  }
+  
   /**
    * Saves a code violation which is detected in the given file/line
    * and has given ruleId and message. Saves it to the given project and context.

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/CxxReportSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/CxxReportSensor.java
@@ -144,7 +144,7 @@ public abstract class CxxReportSensor implements Sensor {
    * Saves code violation only if unique.
    * Compares file, line, ruleId and msg.
    */  
-  protected boolean saveUniqueViolation(Project project, SensorContext context, String ruleRepoKey,
+  public boolean saveUniqueViolation(Project project, SensorContext context, String ruleRepoKey,
                                         String file, String line, String ruleId, String msg) {
   
     if (uniqueIssues.add(file + line + ruleId + msg)) {

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/valgrind/CxxValgrindSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/valgrind/CxxValgrindSensor.java
@@ -78,8 +78,8 @@ public class CxxValgrindSensor extends CxxReportSensor {
     for (ValgrindError error : valgrindErrors) {
       ValgrindFrame frame = error.getLastOwnFrame(fs.baseDir().getPath());
       if (frame != null) {
-        saveViolation(project, context, CxxValgrindRuleRepository.KEY,
-                      frame.getPath(), frame.getLine(), error.getKind(), error.toString());
+        saveUniqueViolation(project, context, CxxValgrindRuleRepository.KEY,
+                            frame.getPath(), frame.getLine(), error.getKind(), error.toString());
       }
       else{
         CxxUtils.LOG.warn("Cannot find a project file to assign the valgrind error '{}' to", error);

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/veraxx/CxxVeraxxSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/veraxx/CxxVeraxxSensor.java
@@ -99,9 +99,10 @@ public class CxxVeraxxSensor extends CxxReportSensor {
                 String message = errorCursor.getAttrValue("message");
                 String source = errorCursor.getAttrValue("source");
 
-                saveViolation(project, context, CxxVeraxxRuleRepository.KEY,
-                    name, line, source, message);
-                countIssues++;
+                if( saveUniqueViolation(project, context, CxxVeraxxRuleRepository.KEY,
+                                        name, line, source, message)) {
+                  countIssues++;
+                }
               } else {
                 CxxUtils.LOG.debug("Error in file '{}', with message '{}'",
                     errorCursor.getAttrValue("line"),

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckSensorTest.java
@@ -64,7 +64,7 @@ public class CxxCppCheckSensorTest {
   @Test
   public void shouldReportCorrectViolations() {
     sensor.analyse(project, context);
-    verify(context, times(8)).saveViolation(any(Violation.class));
+    verify(context, times(5)).saveViolation(any(Violation.class));
   }
 
   @Test

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/externalrules/CxxExternalRulesSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/externalrules/CxxExternalRulesSensorTest.java
@@ -111,4 +111,13 @@ public class CxxExternalRulesSensorTest {
     sensor = new CxxExternalRulesSensor(ruleFinder, settings, fs, profile);
     sensor.analyse(project, context);
   }
+  
+  @Test
+  public void shouldReportOnlyOneViolationAndRemoveDuplicates() {
+    settings = new Settings();
+    settings.setProperty(CxxExternalRulesSensor.REPORT_PATH_KEY, "externalrules-reports/externalrules-with-duplicates.xml");
+    sensor = new CxxExternalRulesSensor(ruleFinder, settings, fs, profile);
+    sensor.analyse(project, context);
+    verify(context, times(1)).saveViolation(any(Violation.class));
+  }
 }

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/cppcheck-reports/cppcheck-result-SAMPLE-V2.xml
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/cppcheck-reports/cppcheck-result-SAMPLE-V2.xml
@@ -6,7 +6,7 @@
              verbose="long error text" inconclusive="true">
       <location file="sources/utils/code_chunks.cpp" line="1"/>
     </error>
-    <error id="unusedFunction" severity="style" msg="The function 'foo' is never used"
+    <error id="unusedFunction" severity="style" msg="The function 'utils' is never used"
              verbose="long error text" inconclusive="true">
       <location file="sources/utils/utils.cpp" line="1"/>
     </error>

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/externalrules-reports/externalrules-with-duplicates.xml
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/externalrules-reports/externalrules-with-duplicates.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<results>
+<error file="sources/utils/code_chunks.cpp" line="1" id="cxxexternal-unusedFunction" msg="The function 'foo' is never used"/>
+<error file="sources/utils/code_chunks.cpp" line="1" id="cxxexternal-unusedFunction" msg="The function 'foo' is never used"/>
+</results>


### PR DESCRIPTION
Move check for unique violations to base class CxxReportSensor: saveUniqueViolation.
- Design decision: Create new method saveUniqueViolation to give derived classes the chance to call saveUniqueViolation or saveViolation.
- Add saveUniqueViolation to all from CxxReportSensor derived sensors.
- Add test for duplicated external rule violations.
- see #110
