### PR TITLE
Ignore macro expansions in one-statement-per-line check.

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/TooManyStatementsPerLineCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/TooManyStatementsPerLineCheck.java
@@ -43,6 +43,17 @@ public class TooManyStatementsPerLineCheck extends AbstractOneStatementPerLineCh
     subscribeTo(CxxGrammarImpl.statement);
   }
 
+  /** Exclude subsequent generated nodes, if they are consecutive and on the same line.
+   */
+  private boolean isGeneratedNodeExcluded(AstNode astNode)
+  {
+    AstNode prev = astNode.getPreviousAstNode();
+    return prev != null &&
+           prev.getTokenLine() == astNode.getTokenLine() &&
+           prev.getTokenLine() == astNode.getTokenLine() &&
+           prev.isCopyBookOrGeneratedNode();
+  }
+
   @Override
   public boolean isExcluded(AstNode astNode) {
     AstNode statementNode = astNode.getFirstChild();
@@ -50,6 +61,7 @@ public class TooManyStatementsPerLineCheck extends AbstractOneStatementPerLineCh
       || statementNode.is(CxxGrammarImpl.emptyStatement)
       || statementNode.is(CxxGrammarImpl.iterationStatement)
       || statementNode.is(CxxGrammarImpl.labeledStatement)
-      || statementNode.is(CxxGrammarImpl.declaration);
+      || statementNode.is(CxxGrammarImpl.declaration)
+      || (statementNode.isCopyBookOrGeneratedNode() && isGeneratedNodeExcluded(statementNode));
  }
 }

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/TooManyStatementsPerLineCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/TooManyStatementsPerLineCheckTest.java
@@ -34,9 +34,10 @@ public class TooManyStatementsPerLineCheckTest {
   public void test() {
     SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/TooManyStatementsPerLine.cc"), check);
     CheckMessagesVerifier.verify(file.getCheckMessages())
-        .next().atLine(7).withMessage("At most one statement is allowed per line, but 2 statements were found on this line.")
-        .next().atLine(10)
-        .next().atLine(15)
+        .next().atLine(10).withMessage("At most one statement is allowed per line, but 2 statements were found on this line.")
+        .next().atLine(13)
+        .next().atLine(16)
+        .next().atLine(20)
         .noMore();
   }
 

--- a/cxx-checks/src/test/resources/checks/TooManyStatementsPerLine.cc
+++ b/cxx-checks/src/test/resources/checks/TooManyStatementsPerLine.cc
@@ -1,6 +1,9 @@
 int doSomething();
 int doSomethingElse();
 bool condition = true;
+#define TEST(a,b) if (a) {    \
+                  } if (b) {  \
+                  }
 class TooManyStatementsPerLine {
     int a; int b; // OK - not a statement
     void myfunc() {
@@ -9,6 +12,8 @@ class TooManyStatementsPerLine {
         if (a) {  } // OK
         if (a) {  } if (b) {  } // NOK
         while (condition); // OK
+        TEST(a,b) // OK
+        if (a) {  } TEST(a,b) // NOK
     label: while (condition) { // OK
         break; // OK
     }


### PR DESCRIPTION
Many macros expand to more than one statement, making this check quite unusable.
This patch ignores all but the first generated statement in a sequence.
