### PR TITLE
Support case-insensitive file systems in all sensors

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CxxCompilerSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CxxCompilerSensor.java
@@ -32,7 +32,6 @@ import org.sonar.api.scan.filesystem.ModuleFileSystem;
 import java.io.File;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -129,7 +128,7 @@ public class CxxCompilerSensor extends CxxReportSensor {
       parser.ParseReport(report, reportCharset, reportRegEx, warnings);
       for(CompilerParser.Warning w : warnings) {
         // get filename from file system - e.g. VC writes case insensitive file name to html
-        String filename = getCaseSensitiveFileName(w.filename, fs.sourceDirs());
+        String filename = CxxUtils.getCaseSensitiveFileName(w.filename, fs.sourceDirs());
         if (isInputValid(filename, w.line, w.id, w.msg)) {
           if (saveUniqueViolation(project, context, parser.rulesRepositoryKey(), filename, w.line, w.id, w.msg)) {
             countViolations++;
@@ -150,40 +149,5 @@ public class CxxCompilerSensor extends CxxReportSensor {
     return !StringUtils.isEmpty(file) && !StringUtils.isEmpty(line)
       && !StringUtils.isEmpty(id) && !StringUtils.isEmpty(msg);
   }
-
-  /**
-   *  Supports full path and relative path in report.xml file.
-   */     
-  private String getCaseSensitiveFileName(String file, List<java.io.File> sourceDirs) {
-    // check whether the report file uses absolute path
-    File targetfile = new java.io.File(file);
-    if (targetfile.exists()) {
-      file = getRealFileName(targetfile);
-    } else {
-      Iterator<java.io.File> iterator = sourceDirs.iterator();
-      while (iterator.hasNext()) {              
-           targetfile = new java.io.File(iterator.next().getPath() + java.io.File.separatorChar + file);
-           if (targetfile.exists()) {
-               file = getRealFileName(targetfile);
-               break;
-           }
-      }
-    }
-    return file;      
-  }
-     
-  /**
-   * Find the case sensitive file name - tools might use different naming schema
-   * e.g. VC HTML or build log report uses case insensitive file name (lower case on windows)
-   */      
-  private String getRealFileName( File filename){
-     try {
-         return filename.getCanonicalFile().getAbsolutePath();
-     } catch (java.io.IOException e) {
-       CxxUtils.LOG.error("SaveViolation GetRealFileName failed '{}'", e.toString());
-       }
-     return filename.getName();
-  }
-
-  
+ 
 }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/BullseyeParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/BullseyeParser.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import org.sonar.api.scan.filesystem.ModuleFileSystem;
 
 /**
  * {@inheritDoc}
@@ -44,7 +45,12 @@ public class BullseyeParser implements CoverageParser {
   private int totalcovereddecisions;
   private int totalconditions;
   private int totalcoveredconditions;
-
+  private ModuleFileSystem fs;
+    
+  public BullseyeParser(ModuleFileSystem fs) {
+    this.fs = fs;
+  }
+  
   /**
    * {@inheritDoc}
    */
@@ -124,7 +130,8 @@ public class BullseyeParser implements CoverageParser {
         }     
         CoverageMeasuresBuilder fileMeasuresBuilderIn = CoverageMeasuresBuilder.create();
         fileWalk(child, fileMeasuresBuilderIn);
-        coverageData.put(refPath + fileName, fileMeasuresBuilderIn);
+        String csPath = CxxUtils.getCaseSensitiveFileName(refPath + fileName, fs.sourceDirs());
+        coverageData.put(csPath, fileMeasuresBuilderIn);
 
       } else {
         recTreeWalk(refPath, child, path, coverageData);

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CoberturaParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CoberturaParser.java
@@ -30,11 +30,18 @@ import javax.xml.stream.XMLStreamException;
 
 import java.io.File;
 import java.util.Map;
+import org.sonar.api.scan.filesystem.ModuleFileSystem;
 
 /**
  * {@inheritDoc}
  */
 public class CoberturaParser implements CoverageParser {
+  private ModuleFileSystem fs;
+    
+  public CoberturaParser(ModuleFileSystem fs) {
+    this.fs = fs;
+  }
+  
   /**
    * {@inheritDoc}
    */
@@ -68,6 +75,7 @@ public class CoberturaParser implements CoverageParser {
   {
     while (clazz.getNext() != null) {
       String fileName = clazz.getAttrValue("filename");
+      fileName = CxxUtils.getCaseSensitiveFileName(fileName, fs.sourceDirs());
       CoverageMeasuresBuilder builder = coverageData.get(fileName);
       if (builder == null) {
         builder = CoverageMeasuresBuilder.create();

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
@@ -62,8 +62,8 @@ public class CxxCoverageSensor extends CxxReportSensor {
   public CxxCoverageSensor(Settings settings, ModuleFileSystem fs) {
     super(settings, fs);
     
-    parsers.add(new CoberturaParser());
-    parsers.add(new BullseyeParser());
+    parsers.add(new CoberturaParser(fs));
+    parsers.add(new BullseyeParser(fs));
   }
 
   /**

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/CxxReportSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/CxxReportSensor.java
@@ -31,7 +31,6 @@ import org.sonar.api.rules.Violation;
 import org.sonar.api.utils.SonarException;
 import org.sonar.plugins.cxx.CxxLanguage;
 import org.sonar.api.scan.filesystem.ModuleFileSystem;
-import org.sonar.plugins.cxx.CxxPlugin;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -171,6 +170,7 @@ public abstract class CxxReportSensor implements Sensor {
       Violation violation = null;
       // handles file="" situation
       if ((file != null) && (file.length() > 0)){
+        file = CxxUtils.getCaseSensitiveFileName(file, fs.sourceDirs());
         org.sonar.api.resources.File resource =
           org.sonar.api.resources.File.fromIOFile(new File(file), project);
         if (context.getResource(resource) != null) {

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/utils/CxxUtilsTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/utils/CxxUtilsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010 Neticoa SAS France
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
+package org.sonar.plugins.cxx.utils;
+
+import java.io.File;
+import java.util.LinkedList;
+import org.junit.Test;
+
+public class CxxUtilsTest {
+
+  @Test
+  public void testIsSystemCaseSensitive() {
+    boolean isWindows = System.getProperty("os.name").toLowerCase().indexOf("win") >= 0;
+    boolean result = CxxUtils.isSystemCaseSensitive();
+
+    // Windows OS is case insensitive
+    assert (result == !isWindows);
+  }
+  
+  @Test
+  public void testCaseSensitiveFileName() {
+    try {
+      File fileUpperCase = new java.io.File(System.getProperty("java.io.tmpdir") +
+                                            java.io.File.separatorChar +
+                                            "CXX.TEST.testCaseSensitiveFileName.TXT");
+      String realFileName = fileUpperCase.getCanonicalFile().getAbsolutePath();
+      fileUpperCase.createNewFile();
+      String result = CxxUtils.getCaseSensitiveFileName(realFileName.toLowerCase(),
+                                                        new LinkedList<java.io.File>());
+      fileUpperCase.delete();
+      
+      if (CxxUtils.isSystemCaseSensitive()) {
+        assert (realFileName == result);
+      } else {
+        assert (realFileName != result);
+      }
+      
+    } catch (java.io.IOException e) {
+      assert (false);
+    }
+  }
+  
+  @Test
+  public void testCaseSensitiveFileNameWithDirList() {
+    try {
+      File fileUpperCase = new java.io.File(System.getProperty("java.io.tmpdir") +
+                                            java.io.File.separatorChar +
+                                            "CXX.TEST.testCaseSensitiveFileNameWithDirList.TXT");
+      String realFileName = fileUpperCase.getCanonicalFile().getAbsolutePath();
+      fileUpperCase.createNewFile();
+      LinkedList<java.io.File> sourceDirs = new LinkedList<java.io.File>();
+      sourceDirs.add(new java.io.File(fileUpperCase.getParent().toLowerCase()));
+      String result = CxxUtils.getCaseSensitiveFileName(fileUpperCase.getName().toLowerCase(),
+                                                        sourceDirs);
+      fileUpperCase.delete();
+      
+      if (CxxUtils.isSystemCaseSensitive()) {
+        assert (realFileName == result);
+      } else {
+        assert (realFileName != result);
+      }
+      
+    } catch (java.io.IOException e) {
+      assert (false);
+    }
+  }
+  
+}

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/utils/CxxUtilsTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/utils/CxxUtilsTest.java
@@ -17,11 +17,11 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-
 package org.sonar.plugins.cxx.utils;
 
 import java.io.File;
 import java.util.LinkedList;
+import static org.junit.Assert.*;
 import org.junit.Test;
 
 public class CxxUtilsTest {
@@ -32,55 +32,56 @@ public class CxxUtilsTest {
     boolean result = CxxUtils.isSystemCaseSensitive();
 
     // Windows OS is case insensitive
-    assert (result == !isWindows);
+    assertTrue(result == !isWindows);
   }
-  
+
   @Test
   public void testCaseSensitiveFileName() {
     try {
-      File fileUpperCase = new java.io.File(System.getProperty("java.io.tmpdir") +
-                                            java.io.File.separatorChar +
-                                            "CXX.TEST.testCaseSensitiveFileName.TXT");
+      File fileUpperCase = new java.io.File(System.getProperty("java.io.tmpdir")
+        + java.io.File.separatorChar
+        + "CXX_TEST_CS.TXT");
       String realFileName = fileUpperCase.getCanonicalFile().getAbsolutePath();
       fileUpperCase.createNewFile();
-      String result = CxxUtils.getCaseSensitiveFileName(realFileName.toLowerCase(),
-                                                        new LinkedList<java.io.File>());
+      String result = CxxUtils.getCaseSensitiveFileName(
+        realFileName.toLowerCase(),
+        new LinkedList<java.io.File>());
       fileUpperCase.delete();
-      
+
       if (CxxUtils.isSystemCaseSensitive()) {
-        assert (realFileName == result);
+        assertFalse("isSystemCaseSensitive=true", realFileName.equals(result));
       } else {
-        assert (realFileName != result);
+        assertTrue("isSystemCaseSensitive=false", realFileName.equals(result));
       }
-      
-    } catch (java.io.IOException e) {
-      assert (false);
+
+    } catch (Exception e) {
+      fail(e.toString());
     }
   }
-  
+
   @Test
   public void testCaseSensitiveFileNameWithDirList() {
     try {
-      File fileUpperCase = new java.io.File(System.getProperty("java.io.tmpdir") +
-                                            java.io.File.separatorChar +
-                                            "CXX.TEST.testCaseSensitiveFileNameWithDirList.TXT");
+      File fileUpperCase = new java.io.File(System.getProperty("java.io.tmpdir")
+        + java.io.File.separatorChar
+        + "CXX_TEST_CS.TXT");
       String realFileName = fileUpperCase.getCanonicalFile().getAbsolutePath();
       fileUpperCase.createNewFile();
       LinkedList<java.io.File> sourceDirs = new LinkedList<java.io.File>();
       sourceDirs.add(new java.io.File(fileUpperCase.getParent().toLowerCase()));
       String result = CxxUtils.getCaseSensitiveFileName(fileUpperCase.getName().toLowerCase(),
-                                                        sourceDirs);
+        sourceDirs);
       fileUpperCase.delete();
-      
+
       if (CxxUtils.isSystemCaseSensitive()) {
-        assert (realFileName == result);
+        assertFalse("isSystemCaseSensitive=true", realFileName.equals(result));
       } else {
-        assert (realFileName != result);
+        assertTrue("isSystemCaseSensitive=false",realFileName.equals(result));
       }
-      
-    } catch (java.io.IOException e) {
-      assert (false);
+
+    } catch (Exception e) {
+      fail(e.toString());
     }
   }
-  
+
 }


### PR DESCRIPTION
Windows OS is case preserving but case-insensitive. Use the solution from CxxCompilerSensor for all other sensors.

Hints:
- I'm only able to test this on Windows. Maybe someone else can test it on Linux?
- Reconstruct case-sensitive path is time consuming. Not sure if this patch is a performance problem?

Changes:
- see #134
- call getCaseSensitiveFileName for all from CxxReportSensor derived classes (inside of saveViolation)
- add getCaseSensitiveFileName to CxxCoverageSensor
- add isSystemCaseSensitive to CxxUtils
- add test cases for isSystemCaseSensitive and getCaseSensitiveFileName
