### PR TITLE
Indentation checker fixes

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/IndentationCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/IndentationCheck.java
@@ -49,8 +49,7 @@ public class IndentationCheck extends SquidCheck<Grammar> {
 
   private static final AstNodeType[] CHECKED_TYPES = new AstNodeType[] {
       CxxGrammarImpl.statement,
-      CxxGrammarImpl.simpleTypeSpecifier,
-      CxxGrammarImpl.memberSpecification,
+      CxxGrammarImpl.memberDeclaration,
       CxxGrammarImpl.enumeratorDefinition,
   };
 

--- a/cxx-checks/src/test/resources/checks/IndentationCheck.cc
+++ b/cxx-checks/src/test/resources/checks/IndentationCheck.cc
@@ -78,4 +78,14 @@ class Foo {
       default: ;
     }
   };
+  void foo()         {}    // Compliant
+  Foo();                   // Compliant
+  enum Code {              // Compliant
+    CODE_OK,
+    CODE_ERROR,
+  }
+  bool       variable;     // Compliant
+  void       Test1();      // Compliant
+  virtual void ReportError(); // Compliant
+  virtual void Test()=0;   // Compliant
 };


### PR DESCRIPTION
Check if member definitions are aligned, instead of simple types: this used to cause problems e.g. with 'virtual' members.
