### PR TITLE
Ignore doxygen comments in CommentedCode checker.

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/CommentedCodeCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/CommentedCodeCheck.java
@@ -66,7 +66,11 @@ public class CommentedCodeCheck extends SquidCheck<Grammar> implements AstAndTok
 
   public void visitToken(Token token) {
     for (Trivia trivia : token.getTrivia()) {
-      if (trivia.isComment() && !trivia.getToken().getOriginalValue().startsWith("///")) {
+      if (trivia.isComment() &&
+          !trivia.getToken().getOriginalValue().startsWith("///") &&
+          !trivia.getToken().getOriginalValue().startsWith("//!") &&
+          !trivia.getToken().getOriginalValue().startsWith("/**") &&
+          !trivia.getToken().getOriginalValue().startsWith("/*!")) {
         String lines[] = regexpToDivideStringByLine.split(getContext().getCommentAnalyser().getContents(
             trivia.getToken().getOriginalValue()));
 

--- a/cxx-checks/src/test/resources/checks/commentedCode.cc
+++ b/cxx-checks/src/test/resources/checks/commentedCode.cc
@@ -28,6 +28,22 @@ class Program
     /// </example>
     /// <param name="task">The task.</param>
 
+    /** This is some doxygen documentation
+     * @{
+     * - List item 1;
+     * - List item 2;
+     * @}
+     * @code
+     * void myFunction() { return 0; }
+     * @endcode
+     */
+
+    /*! Alternative doxygen syntax
+     * void myFunction() { return 0; }
+     */
+
+    //! This is as well: void myFunction() { return 0; }
+
     void foo()
     {
     }


### PR DESCRIPTION
Doxygen comments can start with either /*_, /_!, /// or //!.
