### PR TITLE
Visual Studio attributed ATL support

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -122,6 +122,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
   attributeDeclaration,
   declSpecifier,
   recoveredDeclaration,
+  vcAtlDeclaration,
 
   conditionDeclSpecifierSeq,
   forrangeDeclSpecifierSeq,
@@ -176,6 +177,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
   attributeArgumentClause,
   balancedTokenSeq,
   balancedToken,
+  vcAtlAttribute,
 
   // Declarators
   initDeclaratorList,
@@ -288,6 +290,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
     exceptionHandling(b);
 
     misc(b);
+    vcAttributedAtl(b);
     
     b.setRootRule(translationUnit);
 
@@ -307,7 +310,14 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
         BOOL,
         NULLPTR));
   }
-  
+
+  private static void vcAttributedAtl(LexerfulGrammarBuilder b) {
+    b.rule(vcAtlAttribute).is(
+      "[", b.oneOrMore(b.anyTokenButNot("]")), "]"
+    );
+    b.rule(vcAtlDeclaration).is(vcAtlAttribute, ";");
+  }
+    
   private static void toplevel(LexerfulGrammarBuilder b, CxxConfiguration conf) {
     if (conf.getErrorRecoveryEnabled() == true) {
       b.rule(translationUnit).is(b.zeroOrMore(b.firstOf(declaration, recoveredDeclaration)), EOF);
@@ -579,7 +589,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
     b.rule(labeledStatement).is(b.optional(attributeSpecifierSeq), IDENTIFIER, ":", statement);
 
     b.rule(expressionStatement).is(b.optional(expression), ";");
-    
+            
     b.rule(compoundStatement).is("{", statementSeq, "}");
     
 
@@ -673,7 +683,8 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
             linkageSpecification,
             namespaceDefinition,
             emptyDeclaration,
-            attributeDeclaration
+            attributeDeclaration,
+            vcAtlDeclaration
         )
         );
 
@@ -800,7 +811,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
 
 //    b.rule(enumSpecifier).is(b.sequence(enumHead, "{", b.optional(enumeratorList), "}"));
     
-    b.rule(enumHead).is(enumKey, b.optional(attributeSpecifierSeq), b.firstOf(b.sequence(nestedNameSpecifier, IDENTIFIER), b.optional(IDENTIFIER)), b.optional(enumBase));
+    b.rule(enumHead).is(b.optional(vcAtlAttribute), enumKey, b.optional(attributeSpecifierSeq), b.firstOf(b.sequence(nestedNameSpecifier, IDENTIFIER), b.optional(IDENTIFIER)), b.optional(enumBase));
 
     b.rule(opaqueEnumDeclaration).is(enumKey, b.optional(attributeSpecifierSeq), IDENTIFIER, b.optional(enumBase), ";");
 
@@ -1015,7 +1026,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
 
     b.rule(parameterDeclaration).is(
         b.firstOf(
-            b.sequence(b.optional(attributeSpecifierSeq), parameterDeclSpecifierSeq, declarator, b.optional("=", initializerClause)),
+            b.sequence(b.optional(attributeSpecifierSeq), b.optional(vcAtlAttribute), parameterDeclSpecifierSeq, declarator, b.optional("=", initializerClause)),
             b.sequence(b.optional(attributeSpecifierSeq), parameterDeclSpecifierSeq, b.optional(abstractDeclarator), b.optional("=", initializerClause)))
         );
 
@@ -1084,8 +1095,8 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
 
     b.rule(classHead).is(
         b.firstOf(
-            b.sequence(classKey, b.optional(attributeSpecifierSeq), classHeadName, b.optional(classVirtSpecifier), b.optional(baseClause)),
-            b.sequence(classKey, b.optional(attributeSpecifierSeq), b.optional(baseClause))
+            b.sequence(b.optional(vcAtlAttribute), classKey, b.optional(attributeSpecifierSeq), classHeadName, b.optional(classVirtSpecifier), b.optional(baseClause)),
+            b.sequence(b.optional(vcAtlAttribute), classKey, b.optional(attributeSpecifierSeq), b.optional(baseClause))
         )
         );
 
@@ -1108,7 +1119,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
 
     b.rule(memberDeclaration).is(
         b.firstOf(
-          b.sequence(b.optional(attributeSpecifierSeq), b.optional(memberDeclSpecifierSeq), b.optional(memberDeclaratorList), ";"),
+          b.sequence(b.optional(attributeSpecifierSeq), b.optional(vcAtlAttribute), b.optional(memberDeclSpecifierSeq), b.optional(memberDeclaratorList), ";"),
             b.sequence(functionDefinition, b.optional(";")),
             b.sequence(b.optional("::"), nestedNameSpecifier, b.optional(CxxKeyword.TEMPLATE), unqualifiedId, ";"),
             usingDeclaration,

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/AttributedAtlTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/AttributedAtlTest.java
@@ -1,0 +1,86 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2011 Waleri Enns and CONTACT Software GmbH
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.cxx.parser;
+
+import com.sonar.sslr.api.Grammar;
+import com.sonar.sslr.impl.Parser;
+import com.sonar.sslr.squid.SquidAstVisitorContext;
+import org.junit.Test;
+
+import static org.sonar.sslr.tests.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class AttributedAtlTest {
+
+  Parser<Grammar> p = CxxParser.create(mock(SquidAstVisitorContext.class));
+  Grammar g = p.getGrammar();
+
+  @Test
+  public void vcAtlDeclaration() {
+    p.setRootRule(g.rule(CxxGrammarImpl.declaration));
+
+    assertThat(p).matches("[x];");
+  }
+
+  @Test
+  public void vcAtlEnum() {
+    p.setRootRule(g.rule(CxxGrammarImpl.enumSpecifier));
+
+    assertThat(p).matches("[x] enum X {}");
+  }
+
+  @Test
+  public void vcAtlClass() {
+    p.setRootRule(g.rule(CxxGrammarImpl.classSpecifier));
+
+    assertThat(p).matches("[x] class X {}");
+    assertThat(p).matches("[x] struct X {}");
+  }
+
+  @Test
+  public void vcAtlMember() {
+    p.setRootRule(g.rule(CxxGrammarImpl.memberSpecification));
+
+    assertThat(p).matches("[x] int m([y] int p);");
+  }
+
+  @Test
+  public void vcAtlRealWorldExample() {
+    p.setRootRule(g.rule(CxxGrammarImpl.translationUnit));
+
+    assertThat(p).matches(
+      "  [module(name=\"MyModule\")];"
+      + "[emitidl(false)];"
+      + "[export, helpstring(\"description\")] enum MyEnum {};"
+      + "["
+      + "  dispinterface,"
+      + "  nonextensible,"
+      + "  hidden,"
+      + "  uuid(\"0815\"),"
+      + "  helpstring(\"description\")"
+      + "]"
+      + "struct IMyInterface"
+      + "{"
+      + "  [id(1), helpstring(\"description\")] HRESULT M1(int p1);"
+      + "  [propget, id(DISPID_VALUE), helpstring(\"description\")] HRESULT M2([in] VARIANT p1, [out, retval] MyService** p2);"
+      + "};"
+    );
+  }
+}


### PR DESCRIPTION
- extend grammar: Visual Studio attributed ATL support
- add unit tests
- see #174

Because of usage of squared brackets for attributes there is no possibility to mock this with macro directives.

Example:

``` C++
[module(name="MyModule")];
[emitidl(false)];

[export, helpstring("description")] enum MyEnum {};

[
    dispinterface,
    nonextensible,
    hidden,
    uuid("0815"),
    helpstring("description")
]
struct IMyInterface
{
    [id(1), helpstring("description")] HRESULT M1(int p1);
    [propget, id(DISPID_VALUE), helpstring("description")] HRESULT M2([in] VARIANT p1, [out, retval] MyService** p2);
};
```
