### PR TITLE
Remove duplicate rule declaration (compatibility with newer SQ versions)

### DIFF
--- a/sonar-cxx-plugin/src/main/resources/cppcheck.xml
+++ b/sonar-cxx-plugin/src/main/resources/cppcheck.xml
@@ -1124,14 +1124,6 @@
     </description>
   </rule>
   <rule>
-    <key>assignmentInAssert</key>
-    <configkey>assignmentInAssert</configkey>
-    <name>Assert statement modifies variable</name>
-    <description>
-      Assert statement modifies variable.
-    </description>
-  </rule>
-  <rule>
     <key>invalidscanf</key>
     <configkey>invalidscanf</configkey>
     <name>scanf without field width limits can crash with huge input data</name>

--- a/sonar-cxx-plugin/src/main/resources/default-profile.xml
+++ b/sonar-cxx-plugin/src/main/resources/default-profile.xml
@@ -1475,11 +1475,6 @@
     </rule>
     <rule>
       <repositoryKey>cppcheck</repositoryKey>
-      <key>assignmentInAssert</key>
-      <priority>MINOR</priority>
-    </rule>
-    <rule>
-      <repositoryKey>cppcheck</repositoryKey>
       <key>pointerArithBool</key>
       <priority>MAJOR</priority>
     </rule>

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckRuleRepositoryTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckRuleRepositoryTest.java
@@ -32,6 +32,6 @@ public class CxxCppCheckRuleRepositoryTest {
   public void createRulesTest() {
     CxxCppCheckRuleRepository rulerep = new CxxCppCheckRuleRepository(
         mock(ServerFileSystem.class), new XMLRuleParser(), new Settings());
-    assertEquals(298, rulerep.createRules().size());
+    assertEquals(297, rulerep.createRules().size());
   }
 }


### PR DESCRIPTION
In the latest versions of SonarQube, a check is done on startup to prevent a rule from being declared twice. Another check is done on quality profiles to prevent a rule from being enabled twice.

With the current master, a SQ 4.3 instance refuses to start when sonar-cxx is installed. Hence these changes on the cppcheck repository and on the default quality profile.
