### PR TITLE
CollapsibleIfCheck: suppress false positives for if statatements containing variable declarations.

### DIFF
--- a/cxx-checks/src/test/resources/checks/CollapsibleIfCandidateCheck.cc
+++ b/cxx-checks/src/test/resources/checks/CollapsibleIfCandidateCheck.cc
@@ -82,5 +82,16 @@ int main(void)
             }
 
         }
+
+        void declarations( )  {
+            if (false) { // Compliant
+                if (bool aValue = false) { // Compliant
+                }
+            }
+            if (bool aValue = false) { // Compliant
+                if (false) {           // Compliant
+                }
+            }
+        }
     };
 }


### PR DESCRIPTION
Verify if the ifStatement's condition is actually a variable declaration, as in :
    if (void \* ptr = f()) {
    }

This prevents collapsing multiple if', since multiple definitions and expressions cannot be combined.
