### PR TITLE
Do expand the macro arguments before expanding the macro body

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -32,7 +32,6 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.cxx.CxxConfiguration;
-//import org.sonar.cxx.api.CxxGrammar;
 import com.sonar.sslr.api.Grammar;
 
 import org.sonar.cxx.lexer.CxxLexer;
@@ -646,11 +645,8 @@ public class CxxPreprocessor extends Preprocessor {
         else if (index < arguments.size()) {
           Token replacement = arguments.get(index);
 
-          // TODO: maybe we should pipe the argument through the whole expansion
-          // engine before doing the replacement
+          // The arguments have to be fully expanded before expanding the body of the macro
           String newValue = serialize(expandMacro("", replacement.getValue()));
-
-          //String newValue = replacement.getValue();
 
           if (i > 0 && body.get(i - 1).getValue().equals("#")) {
             newTokens.remove(newTokens.size() - 1);

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/PreprocessorDirectivesTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/PreprocessorDirectivesTest.java
@@ -114,7 +114,7 @@ public class PreprocessorDirectivesTest {
 //    assert (serialize(p.parse(
 //      "#define A_B A/*Comment*/B\n"
 //      +" A_B;"))
-//      .equals("A B ; EOF"));    
+//      .equals("A B ; EOF"));
   }
 
   @Test
@@ -166,7 +166,7 @@ public class PreprocessorDirectivesTest {
 //    assert (serialize(p.parse(
 //      "#define eprintf(format, ...) fprintf (stderr, format, ##__VA_ARGS__)\n"
 //      + "eprintf(\"success!\");"))
-//      .equals("fprintf ( stderr , \"success!\" ) ; EOF"));    
+//      .equals("fprintf ( stderr , \"success!\" ) ; EOF"));
   }
 
   @Test
@@ -207,7 +207,7 @@ public class PreprocessorDirectivesTest {
 //      + "#define B 0x##n\n"
 //      + "A")
 //      .getTokenValue().equals("0xn(cf)"));
-    
+
 //    @todo
 //    assert (p.parse(
 //      "#define A B(cf)\n"
@@ -266,7 +266,7 @@ public class PreprocessorDirectivesTest {
 
   @Test
   public void self_referential_macros() {
-//    @todo         
+//    @todo
 //    assert (p.parse(
 //      "#define EPERM EPERM"
 //      + "EPERM")


### PR DESCRIPTION
Reactivate prescanning and expanding macro arguments. Should solve the issue:

Improper whitespace handling when hashhash'ing functionlike macro arguments #58
