### PR TITLE
Report zero coverage for all files not found in the coverage report

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
@@ -25,6 +25,7 @@ import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.CoverageMeasuresBuilder;
 import org.sonar.api.measures.Measure;
 import org.sonar.api.measures.Metric;
+import org.sonar.api.resources.InputFile;
 import org.sonar.api.resources.Project;
 import org.sonar.plugins.cxx.utils.CxxReportSensor;
 import org.sonar.plugins.cxx.utils.CxxUtils;
@@ -65,6 +66,30 @@ public class CxxCoverageSensor extends CxxReportSensor {
     parsers.add(new BullseyeParser());
   }
 
+  private void reportZeroCoverageForUncoveredFiles(Project project, SensorContext context) {
+    List<InputFile> sourceFiles = project.getFileSystem().mainFiles(new String("c++"));
+
+    for(InputFile source : sourceFiles) {
+
+      org.sonar.api.resources.File cxxfile = org.sonar.api.resources.File.fromIOFile(source.getFile(), project);
+
+      Measure statementsMeasure = context.getMeasure(cxxfile, CoreMetrics.STATEMENTS);
+
+      if(statementsMeasure != null) {
+
+        double value = statementsMeasure.getValue();
+
+        if(context.getMeasure(cxxfile, CoreMetrics.LINES_TO_COVER) == null) {
+          context.saveMeasure(cxxfile, new Measure(CoreMetrics.LINES_TO_COVER, value));
+        }
+
+        if(context.getMeasure(cxxfile, CoreMetrics.UNCOVERED_LINES) == null) {
+          context.saveMeasure(cxxfile, new Measure(CoreMetrics.UNCOVERED_LINES, value));
+        }
+      }
+    }
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -87,6 +112,8 @@ public class CxxCoverageSensor extends CxxReportSensor {
         OVERALL_REPORT_PATH_KEY, OVERALL_DEFAULT_REPORT_PATH);
     Map<String, CoverageMeasuresBuilder> overallCoverageMeasures = parseReports(overallReports);
     saveMeasures(project, context, overallCoverageMeasures, OVERALL_TEST_COVERAGE);
+
+    reportZeroCoverageForUncoveredFiles(project, context);
   }
 
   private Map<String, CoverageMeasuresBuilder> parseReports(List<File> reports) {


### PR DESCRIPTION
I found that the plugin does not report any coverage statistics for any file which has no measurements in the XML coverage report. This is causing Sonar to report misleading results for me.

Take the following example:

code1.cxx (File 100% tested in my unittest)
code2.cxx (File not tested in the unittest. Therefore, it is not found in the coverage report)
Both files selected in "sonar.sources"

Results:

code1.cxx: 100% coverage
code2.cxx: ---
Overall coverage: 100%

100% overall coverage? This is misleading! There is one file that is not tested at all. Assuming that code1.cxx and code2.cxx have exactly the same number of statement, I would expect a 50% overall coverage.

Find here a patch that will fix this issue. It sets the line coverage to zero for any file found in "sonar.sources" but not in the coverage XML report.
