### PR TITLE
Allow one-line case: break; constructs.

### DIFF
--- a/cxx-checks/src/main/resources/org/sonar/l10n/cxx.properties
+++ b/cxx-checks/src/main/resources/org/sonar/l10n/cxx.properties
@@ -39,6 +39,7 @@ rule.cxx.TooLongLine.param.tabWidth=Number of spaces in a 'tab' character
 rule.cxx.TooManyLinesOfCodeInFile.name=Avoid too many code lines in source file
 rule.cxx.TooManyLinesOfCodeInFile.param.max=Maximum code lines allowed.
 rule.cxx.TooManyStatementsPerLine.name=Statements should be on separate lines
+rule.cxx.TooManyStatementsPerLine.param.excludeCaseBreak=Exclude 'break' statement if it is on the same line as the switch label (case: or default:).
 rule.cxx.UnnamedNamespaceInHeader.name=Unnamed namespaces are not allowed in header files
 rule.cxx.UseCorrectType.name=C++ type(s) shall be used 
 rule.cxx.UseCorrectType.param.message=Use C++ types whenever possible

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/TooManyStatementsPerLineCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/TooManyStatementsPerLineCheckTest.java
@@ -20,6 +20,7 @@
 package org.sonar.cxx.checks;
 
 import com.sonar.sslr.squid.checks.CheckMessagesVerifier;
+import junit.framework.Assert;
 import org.junit.Test;
 import org.sonar.cxx.CxxAstScanner;
 import org.sonar.squid.api.SourceFile;
@@ -28,16 +29,38 @@ import java.io.File;
 
 public class TooManyStatementsPerLineCheckTest {
 
-  private TooManyStatementsPerLineCheck check = new TooManyStatementsPerLineCheck();
-
   @Test
   public void test() {
+    TooManyStatementsPerLineCheck check = new TooManyStatementsPerLineCheck();
+    check.excludeCaseBreak = false;
     SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/TooManyStatementsPerLine.cc"), check);
     CheckMessagesVerifier.verify(file.getCheckMessages())
         .next().atLine(10).withMessage("At most one statement is allowed per line, but 2 statements were found on this line.")
         .next().atLine(13)
         .next().atLine(16)
         .next().atLine(20)
+        .next().atLine(22)
+        .next().atLine(24)
+        .noMore();
+  }
+
+  @Test
+  public void testDefaultExcludeCaseBreak() {
+    TooManyStatementsPerLineCheck check = new TooManyStatementsPerLineCheck();
+    Assert.assertEquals(check.excludeCaseBreak, false);
+  }
+
+  @Test
+  public void testExcludeCaseBreak() {
+    TooManyStatementsPerLineCheck check = new TooManyStatementsPerLineCheck();
+    check.excludeCaseBreak = true;
+    SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/TooManyStatementsPerLine.cc"), check);
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+        .next().atLine(10).withMessage("At most one statement is allowed per line, but 2 statements were found on this line.")
+        .next().atLine(13)
+        .next().atLine(16)
+        .next().atLine(20)
+        .next().atLine(24)
         .noMore();
   }
 

--- a/cxx-checks/src/test/resources/checks/TooManyStatementsPerLine.cc
+++ b/cxx-checks/src/test/resources/checks/TooManyStatementsPerLine.cc
@@ -15,8 +15,13 @@ class TooManyStatementsPerLine {
         TEST(a,b) // OK
         if (a) {  } TEST(a,b) // NOK
     label: while (condition) { // OK
-        break; // OK
-    }
-           int a = 0; a++; // NOK
+            break; // OK
+        }
+        int a = 0; a++; // NOK
+        switch(x) {
+        case 0: x++; break; //(N)OK, depending on parameters
+        case 1:
+            x++; break;     //NOK
+        }
     }
 };


### PR DESCRIPTION
Ignore the 'break' statement if it is on the same line as the case:/default: label, to support code which looks like this:

switch(i) {
case 0: action0(); break;
case 1: action1(); break;
default: defaultAction(); break;
}
