### PR TITLE
Count TAB characters properly in TooLongLineCheck.

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/TooLongLineCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/TooLongLineCheck.java
@@ -22,6 +22,7 @@ package org.sonar.cxx.checks;
 import com.google.common.io.Files;
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.squid.checks.SquidCheck;
+import org.apache.commons.lang.StringUtils;
 import org.sonar.api.utils.SonarException;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
@@ -41,11 +42,17 @@ import java.util.List;
 public class TooLongLineCheck extends SquidCheck<Grammar> implements CxxCharsetAwareVisitor {
 
   private static final int DEFAULT_MAXIMUM_LINE_LENHGTH = 160;
+  private static final int DEFAULT_TAB_WIDTH = 8;
 
   @RuleProperty(
     key = "maximumLineLength",
     defaultValue = "" + DEFAULT_MAXIMUM_LINE_LENHGTH)
   public int maximumLineLength = DEFAULT_MAXIMUM_LINE_LENHGTH;
+
+  @RuleProperty(
+      key = "tabWidth",
+      defaultValue = "" + DEFAULT_TAB_WIDTH)
+  public int tabWidth = DEFAULT_TAB_WIDTH;
 
   private Charset charset;
 
@@ -63,8 +70,9 @@ public class TooLongLineCheck extends SquidCheck<Grammar> implements CxxCharsetA
     }
     for (int i = 0; i < lines.size(); i++) {
       String line = lines.get(i);
-      if (line.length() > maximumLineLength) {
-        getContext().createLineViolation(this, "Split this {0} characters long line (which is greater than {1} authorized).", i + 1, line.length(), maximumLineLength);
+      int length = line.length() + StringUtils.countMatches(line, "\t") * (tabWidth - 1);
+      if (length > maximumLineLength) {
+        getContext().createLineViolation(this, "Split this {0} characters long line (which is greater than {1} authorized).", i + 1, length, maximumLineLength);
       }
     }
   }

--- a/cxx-checks/src/main/resources/org/sonar/l10n/cxx.properties
+++ b/cxx-checks/src/main/resources/org/sonar/l10n/cxx.properties
@@ -35,6 +35,7 @@ rule.cxx.SafetyTagCheck.param.regularExpression=Comment regular expression rule
 rule.cxx.SafetyTagCheck.param.suffix=The appropriate file name suffix
 rule.cxx.TooLongLine.name=Lines of code should not be too long
 rule.cxx.TooLongLine.param.maximumLineLength=The maximum authorized line length.
+rule.cxx.TooLongLine.param.tabWidth=Number of spaces in a 'tab' character
 rule.cxx.TooManyLinesOfCodeInFile.name=Avoid too many code lines in source file
 rule.cxx.TooManyLinesOfCodeInFile.param.max=Maximum code lines allowed.
 rule.cxx.TooManyStatementsPerLine.name=Statements should be on separate lines


### PR DESCRIPTION
The TooLongLineCheck now has a tab width setting, which allows to properly compute the length of the line when TAB characters are used.
