### PR TITLE
Support GCC case range extension.

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -607,6 +607,8 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
 
     b.rule(switchLabelStatement).is(b.firstOf(
         b.sequence(CxxKeyword.CASE, constantExpression, ":"),
+        // EXTENSION: gcc's case range
+        b.sequence(CxxKeyword.CASE, constantExpression, "...", constantExpression, ":"),
         b.sequence(CxxKeyword.DEFAULT, ":")));
 
     b.rule(condition).is(

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/StatementTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/StatementTest.java
@@ -133,6 +133,8 @@ public class StatementTest extends ParserBaseTest {
     assertThat(p).matches("switch ( condition ) { default : ; }");
     assertThat(p).matches("switch ( condition ) { default : break; }");
     assertThat(p).matches("switch ( condition ) { case constantExpression : statement break; default : break; }");
+    // EXTENSION: gcc's case range
+    assertThat(p).matches("switch ( condition ) { case constantExpression ... constantExpression : break; }");
   }
 
   @Test

--- a/cxx-squid/src/test/resources/parser/own/conditions.cc
+++ b/cxx-squid/src/test/resources/parser/own/conditions.cc
@@ -3,6 +3,9 @@ int main(){
     switch(i){
     case 1:
         break;
+    // EXTENSION: gcc's case range
+    case 2 ... 3:
+        break;
     default:
         break;
     }


### PR DESCRIPTION
With GCC, you can specify a range of consecutive values in a single case label, like this:

```
 case low ... high:
```

This has the same effect as the proper number of individual case labels, one for each integer value from low to high, inclusive.
