### PR TITLE
Support C99 designed initializers.

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -1072,14 +1072,21 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
       );
     
     b.rule(initializerClause).is(
-      b.firstOf(
-        assignmentExpression,
-        bracedInitList
+      b.sequence(
+        // C-COMPATIBILITY: C99 designated initializers
+        b.optional(b.firstOf(b.sequence(".", IDENTIFIER, "="),
+                             // EXTENSION: gcc's designated initializers range
+                             b.sequence("[", constantExpression, "...", constantExpression, "]", "="),
+                             b.sequence("[", constantExpression, "]", "="))),
+        b.firstOf(
+          assignmentExpression,
+          bracedInitList
+          )
         )
       );
     
     b.rule(initializerList).is(initializerClause, b.optional("..."), b.zeroOrMore(",", initializerClause, b.optional("...")));
-    
+
     b.rule(bracedInitList).is("{", b.optional(initializerList), b.optional(","), "}");
   }
   

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/DeclaratorsTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/DeclaratorsTest.java
@@ -451,6 +451,37 @@ public class DeclaratorsTest extends ParserBaseTest {
 
     assertThat(p).matches("(istream_iterator<string>(cin))");
     assertThat(p).matches("istream_iterator<string>()");
+
+    // C-COMPATIBILITY: C99 designated initializers
+    assertThat(p).matches(".name = string(\"Something\")");
+    assertThat(p).matches("[5] = {}");
+    assertThat(p).matches(".values = { [4] = 5, [5 ... 7] = 1, [2] = 0 }");
+  }
+
+  @Test
+  public void initializerClause() {
+    p.setRootRule(g.rule(CxxGrammarImpl.initializerClause));
+
+    g.rule(CxxGrammarImpl.assignmentExpression).mock();
+    g.rule(CxxGrammarImpl.initializerList).mock();
+    g.rule(CxxGrammarImpl.constantExpression).mock();
+
+    assertThat(p).matches("{}");
+    assertThat(p).matches("{ initializerList }");
+    assertThat(p).matches("assignmentExpression");
+
+    // C-COMPATIBILITY: C99 designated initializers
+    assertThat(p).matches(".fieldName = {}");
+    assertThat(p).matches(".fieldName = { initializerList }");
+    assertThat(p).matches(".fieldName = assignmentExpression");
+    assertThat(p).matches("[constantExpression] = {}");
+    assertThat(p).matches("[constantExpression] = { initializerList }");
+    assertThat(p).matches("[constantExpression] = assignmentExpression");
+
+    // C-COMPATIBILITY: EXTENSION: gcc's designated initializers range
+    assertThat(p).matches("[constantExpression ... constantExpression] = {}");
+    assertThat(p).matches("[constantExpression ... constantExpression] = { initializerList }");
+    assertThat(p).matches("[constantExpression ... constantExpression] = assignmentExpression");
   }
 
   @Test

--- a/cxx-squid/src/test/resources/parser/own/misc.cc
+++ b/cxx-squid/src/test/resources/parser/own/misc.cc
@@ -39,3 +39,9 @@ int main(int argc, char** argv)
     
     return foo()->i;
 }
+
+//C-COMPATIBILITY: C99 designated initializers
+struct Point { int x, y; };
+Point p = { .y = 45, .x = 72 };
+int a[6] = { [4] = 29, [2] = 15 };
+int widths[200] = { [0 ... 9] = 1, [10 ... 99] = 2, [100] = 3 };


### PR DESCRIPTION
Standard C89 and C++ require the elements of an initializer to appear in a fixed order, the same as the order of the elements in the array or structure being initialized.

In ISO C99 you can give the elements in any order, specifying the array indices or structure field names they apply to.
To specify an array index, write `[index] =' before the element value. For example,

```
 int a[6] = { [4] = 29, [2] = 15 };
```

Gcc also adds an extension to initialize a range of elements to the same value, by writing `[first ... last] = value'. For example,

```
 int widths[] = { [0 ... 9] = 1, [10 ... 99] = 2, [100] = 3 };
```

In a structure initializer, specify the name of a field to initialize with `.fieldname =' before the element value. For example,

```
 struct point { int x, y; };
 struct point p = { .y = yvalue, .x = xvalue };
```
