### PR TITLE
Support C99 compound literals.

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -514,6 +514,8 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
 
     b.rule(castExpression).is(
       b.firstOf(
+        // C-COMPATIBILITY: C99 compound literals
+        b.sequence("(", typeId, ")", bracedInitList ),
         b.sequence(
           b.next("(", typeId, ")"), "(", typeId, ")", castExpression),
         unaryExpression

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/ExpressionTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/ExpressionTest.java
@@ -519,10 +519,14 @@ public class ExpressionTest extends ParserBaseTest {
     p.setRootRule(g.rule(CxxGrammarImpl.pmExpression));
     g.rule(CxxGrammarImpl.unaryExpression).mock();
     g.rule(CxxGrammarImpl.typeId).mock();
+    g.rule(CxxGrammarImpl.bracedInitList).mock();
 
     assertThat(p).matches("unaryExpression");
     assertThat(p).matches("(typeId) unaryExpression");
     assertThat(p).matches("(typeId)(typeId) unaryExpression");
+
+    // C-COMPATIBILITY: C99 compound literals
+    assertThat(p).matches("(typeId) bracedInitList");
   }
 
   @Test
@@ -532,5 +536,9 @@ public class ExpressionTest extends ParserBaseTest {
     assertThat(p).matches("(istream_iterator<string>(cin))");
     assertThat(p).matches("(Color)c");
     assertThat(p).matches("CDB::mask");
+
+    // C-COMPATIBILITY: C99 compound literals
+    assertThat(p).matches("(Point){ 400, 200 }");
+    assertThat(p).matches("(int []){ 1, 2, 4, 8 }");
   }
 }

--- a/cxx-squid/src/test/resources/parser/own/misc.cc
+++ b/cxx-squid/src/test/resources/parser/own/misc.cc
@@ -45,3 +45,13 @@ struct Point { int x, y; };
 Point p = { .y = 45, .x = 72 };
 int a[6] = { [4] = 29, [2] = 15 };
 int widths[200] = { [0 ... 9] = 1, [10 ... 99] = 2, [100] = 3 };
+
+// C-COMPATIBILITY: C99 compound literals
+void compoundLiteral()
+{
+  struct foo {int a; char b[2];} structure;
+  structure = (struct foo) {x + y, 'a', 0};
+
+  int * array;
+  array = (int []) { 1, 2, 3, 4, 5};
+}


### PR DESCRIPTION
ISO C99 supports compound literals. A compound literal looks like a cast
containing an initializer. Its value is an object of the type specified
in the cast, containing the elements specified in the initializer; it is
an lvalue.

For example,

```
struct foo {int a; char b[2];} structure;
structure = ((struct foo) {x + y, 'a', 0});
```
