### PR TITLE
cppcheck refactoring

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParser.java
@@ -28,8 +28,4 @@ public interface CppcheckParser {
   void processReport(Project project, SensorContext context, File report)
     throws javax.xml.stream.XMLStreamException;
   
-  /**
-   * @return returns true if parser is able to read the file
-   */
-  boolean hasParsed();
 }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV1.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV1.java
@@ -36,7 +36,6 @@ import org.sonar.plugins.cxx.utils.EmptyReportException;
 public class CppcheckParserV1 implements CppcheckParser {
 
   private CxxCppCheckSensor sensor;
-  private boolean parsed = false;
 
   public CppcheckParserV1(CxxCppCheckSensor sensor) {
     this.sensor = sensor;
@@ -54,7 +53,6 @@ public class CppcheckParserV1 implements CppcheckParser {
        * {@inheritDoc}
        */
       public void stream(SMHierarchicCursor rootCursor) throws XMLStreamException {
-        parsed = true;
 
         try {
           rootCursor.advance(); // results
@@ -77,7 +75,6 @@ public class CppcheckParserV1 implements CppcheckParser {
             }
           }
         } catch (RuntimeException e) {
-          parsed = false;
           throw new XMLStreamException();
         }
       }
@@ -88,10 +85,6 @@ public class CppcheckParserV1 implements CppcheckParser {
     });
 
     parser.parse(report);
-  }
-
-  public boolean hasParsed() {
-    return parsed;
   }
   
   @Override

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV2.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV2.java
@@ -36,7 +36,6 @@ import org.sonar.plugins.cxx.utils.EmptyReportException;
 public class CppcheckParserV2 implements CppcheckParser {
 
   private CxxCppCheckSensor sensor;
-  private boolean parsed = false;
 
   public CppcheckParserV2(CxxCppCheckSensor sensor) {
     this.sensor = sensor;
@@ -54,7 +53,7 @@ public class CppcheckParserV2 implements CppcheckParser {
        * {@inheritDoc}
        */
       public void stream(SMHierarchicCursor rootCursor) throws XMLStreamException {
-        parsed = true;
+        boolean parsed = false;
 
         try {
           rootCursor.advance();
@@ -67,6 +66,7 @@ public class CppcheckParserV2 implements CppcheckParser {
           if (version.equals("2")) {
             SMInputCursor errorsCursor = rootCursor.childElementCursor("errors");
             if (errorsCursor.getNext() != null) {
+              parsed = true;
               SMInputCursor errorCursor = errorsCursor.childElementCursor("error");
               while (errorCursor.getNext() != null) {
                 String id = errorCursor.getAttrValue("id");
@@ -89,7 +89,10 @@ public class CppcheckParserV2 implements CppcheckParser {
             }
           }
         } catch (RuntimeException e) {
-          parsed = false;
+          throw new XMLStreamException();
+        }
+
+        if (!parsed) {
           throw new XMLStreamException();
         }
       }
@@ -102,10 +105,6 @@ public class CppcheckParserV2 implements CppcheckParser {
     parser.parse(report);
   }
 
-  public boolean hasParsed() {
-    return parsed;
-  }
-  
   @Override
   public String toString() {
     return getClass().getSimpleName();

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckSensor.java
@@ -80,14 +80,13 @@ public class CxxCppCheckSensor extends CxxReportSensor {
   protected void processReport(final Project project, final SensorContext context, File report)
     throws javax.xml.stream.XMLStreamException {
     boolean parsed = false;
+    
     for (CppcheckParser parser : parsers) {
       try {
         parser.processReport(project, context, report);
-        if (parser.hasParsed()) {
-          CxxUtils.LOG.info("Added report '{}' (parsed by: {})", report, parser);
-          parsed = true;
-          break;
-        }
+        CxxUtils.LOG.info("Added report '{}' (parsed by: {})", report, parser);
+        parsed = true;
+        break;
       } catch (XMLStreamException e) {
         CxxUtils.LOG.trace("Report {} cannot be parsed by {}", report, parser);
       }


### PR DESCRIPTION
- unify error handling
- V2: attribute version must be 2; tag 'errors' must exist
