### PR TITLE
Support MSTest summary report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,12 @@
         <artifactId>sslr-squid-bridge</artifactId>
         <version>2.3</version>
       </dependency>
-
+    <dependency>
+      <groupId>org.codehaus.sonar.dotnet.tests</groupId>
+      <artifactId>sonar-dotnet-tests-library</artifactId>
+      <version>1.1.2</version>
+    </dependency>
+      
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>

--- a/sonar-cxx-plugin/pom.xml
+++ b/sonar-cxx-plugin/pom.xml
@@ -37,7 +37,11 @@
       <artifactId>sonar-ws-client</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.codehaus.sonar.dotnet.tests</groupId>
+      <artifactId>sonar-dotnet-tests-library</artifactId>
+    </dependency>
+    
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>cxx-squid</artifactId>

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -47,6 +47,9 @@ import org.sonar.plugins.cxx.valgrind.CxxValgrindSensor;
 import org.sonar.plugins.cxx.veraxx.CxxVeraxxRuleRepository;
 import org.sonar.plugins.cxx.veraxx.CxxVeraxxSensor;
 import org.sonar.plugins.cxx.xunit.CxxXunitSensor;
+import org.sonar.plugins.cxx.mstest.MSTestResultsProvider;
+import org.sonar.plugins.cxx.mstest.MSTestResultsProvider.MSTestResultsAggregator;
+import org.sonar.plugins.cxx.mstest.MSTestResultsProvider.MSTestResultsImportSensor;
 
 import com.google.common.collect.ImmutableList;
 
@@ -345,6 +348,14 @@ public final class CxxPlugin extends SonarPlugin {
       .subCategory(subcateg)
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
       .index(5)
+      .build(),
+
+      PropertyDefinition.builder(MSTestResultsProvider.VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY)
+      .name("Visual Studio Test Reports Paths")
+      .description("Example: \"report.trx\", \"report1.trx,report2.trx\" or \"C:/report.trx\"")
+      .subCategory(subcateg)
+      .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+      .index(6)
       .build()
       );
   }
@@ -381,6 +392,8 @@ public final class CxxPlugin extends SonarPlugin {
     l.add(CxxExternalRulesSensor.class);
     l.add(CxxExternalRuleRepository.class);
     l.add(CxxRuleRepository.class);
+    l.add(MSTestResultsAggregator.class);
+    l.add(MSTestResultsImportSensor.class);
 
     l.addAll(generalProperties());
     l.addAll(codeAnalysisProperties());

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/mstest/MSTestResultsProvider.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/mstest/MSTestResultsProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010 Neticoa SAS France
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.cxx.mstest;
+
+import org.sonar.api.config.Settings;
+import org.sonar.plugins.dotnet.tests.UnitTestConfiguration;
+import org.sonar.plugins.dotnet.tests.UnitTestResultsAggregator;
+import org.sonar.plugins.dotnet.tests.UnitTestResultsImportSensor;
+
+public class MSTestResultsProvider {
+
+  public static final String VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY = "sonar.cxx.vstest.reportsPaths";
+  private static final UnitTestConfiguration UNIT_TEST_CONF = new UnitTestConfiguration(VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY);
+  
+  private MSTestResultsProvider() {
+  }
+
+  public static class MSTestResultsAggregator extends UnitTestResultsAggregator {
+
+    public MSTestResultsAggregator(Settings settings) {
+      super(UNIT_TEST_CONF, settings);
+    }
+
+  }
+
+  public static class MSTestResultsImportSensor extends UnitTestResultsImportSensor {
+    
+    public MSTestResultsImportSensor(MSTestResultsAggregator unitTestResultsAggregator) {
+      super(unitTestResultsAggregator);
+
+    }
+  }
+
+}

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -27,6 +27,6 @@ public class CxxPluginTest {
   @Test
   public void testGetExtensions() throws Exception {
     CxxPlugin plugin = new CxxPlugin();
-    assertEquals(56, plugin.getExtensions().size());
+    assertEquals(59, plugin.getExtensions().size());
   }
 }


### PR DESCRIPTION
reuse org.sonar.plugins.dotnet.tests.UnitTestResultsImportSensor to support Visual Studio Test results
