### PR TITLE
Ignore C++ keywords when parsing C files.

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
@@ -34,6 +34,7 @@ public class CxxConfiguration extends SquidConfiguration {
   private List<String> forceIncludeFiles = new ArrayList<String>();
   private String baseDir;
   private boolean errorRecoveryEnabled = true;
+  private List<String> cFilesPatterns = new ArrayList<String>();
 
   public CxxConfiguration() {
   }
@@ -107,4 +108,15 @@ public class CxxConfiguration extends SquidConfiguration {
   public boolean getErrorRecoveryEnabled(){
     return this.errorRecoveryEnabled;
   }
+
+  public List<String> getCFilesPatterns() {
+    return cFilesPatterns;
+  }
+
+  public void setCFilesPatterns(String[] cFilesPatterns) {
+    if (this.cFilesPatterns != null) {
+      this.cFilesPatterns = Arrays.asList(cFilesPatterns);
+    }
+  }
+
 }

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/StandardDefinitions.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/StandardDefinitions.java
@@ -36,7 +36,46 @@ public final class StandardDefinitions {
       .put("__TIME__", "\"??:??:??\"")     // indicates 'time unknown'. should suffice
       .put("__STDC__", "1")
       .put("__STDC_HOSTED__", "1")
-      .put("__cplusplus", "1")
+      .put("__cplusplus", "201103L")
+      .build();
+  }
+
+  public static Map<String, String> compatibilityMacros(){
+    // This is a collection of macros used to let C code be parsed by C++ parser
+    return ImmutableMap.<String, String>builder()
+      .put("alignas", "__alignas")
+      .put("alignof", "__alignof")
+      .put("catch", "__catch")
+      .put("class", "__class")
+      .put("constexpr", "__constexpr")
+      .put("const_cast", "__const_cast")
+      .put("decltype", "__decltype")
+      .put("delete", "__delete")
+      .put("dynamic_cast", "__dynamic_cast")
+      .put("explicit", "__explicit")
+      .put("export", "__export")
+      .put("friend", "__friend")
+      .put("mutable", "__mutable")
+      .put("namespace", "__namespace")
+      .put("new", "__new")
+      .put("noexcept", "__noexcept")
+      .put("nullptr", "__nullptr")
+      .put("operator", "__operator")
+      .put("override", "__override")
+      .put("private", "__private")
+      .put("protected", "__protected")
+      .put("public", "__public")
+      .put("reinterpret_cast", "__reinterpret_cast")
+      .put("static_assert", "__static_assert")
+      .put("static_cast", "__static_cast")
+      .put("thread_local", "__thread_local")
+      .put("throw", "__throw")
+      .put("try", "__try")
+      .put("typeid", "__typeid")
+      .put("typename", "__typename")
+      .put("using", "__using")
+      .put("template", "__template")
+      .put("virtual", "__virtual")
       .build();
   }
 }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxLanguage.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxLanguage.java
@@ -30,6 +30,7 @@ import org.sonar.api.scan.filesystem.FileQuery;
 public class CxxLanguage extends AbstractLanguage {
   public static final String DEFAULT_SOURCE_SUFFIXES = ".cxx,.cpp,.cc,.c";
   public static final String DEFAULT_HEADER_SUFFIXES = ".hxx,.hpp,.hh,.h";
+  public static final String DEFAULT_C_FILES = "*.c,*.C";
   public static final String KEY = "c++";
 
   private String[] sourceSuffixes;

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -60,6 +60,7 @@ public final class CxxPlugin extends SonarPlugin {
   public static final String INCLUDE_DIRECTORIES_KEY = "sonar.cxx.includeDirectories";
   public static final String ERROR_RECOVERY_KEY = "sonar.cxx.errorRecoveryEnabled";
   public static final String FORCE_INCLUDE_FILES_KEY = "sonar.cxx.forceIncludes";
+  public static final String C_FILES_PATTERNS_KEY = "sonar.cxx.cFilesPatterns";
 
   public static List<PropertyDefinition> generalProperties() {
     String subcateg = "(1) General";
@@ -106,6 +107,15 @@ public final class CxxPlugin extends SonarPlugin {
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
       .type(PropertyType.TEXT)
       .index(5)
+      .build(),
+
+      PropertyDefinition.builder(C_FILES_PATTERNS_KEY)
+      .defaultValue(CxxLanguage.DEFAULT_C_FILES)
+      .name("C source files patterns")
+      .description("Comma-separated list of wildcard patterns used to detect C files. When a file matches any of the patterns, it is parsed as a standard C file.")
+      .subCategory(subcateg)
+      .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+      .index(6)
       .build(),
 
       PropertyDefinition.builder(CxxPlugin.ERROR_RECOVERY_KEY)

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxSquidSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxSquidSensor.java
@@ -116,6 +116,7 @@ public final class CxxSquidSensor implements Sensor {
     cxxConf.setIncludeDirectories(conf.getStringArray(CxxPlugin.INCLUDE_DIRECTORIES_KEY));
     cxxConf.setErrorRecoveryEnabled(conf.getBoolean(CxxPlugin.ERROR_RECOVERY_KEY));
     cxxConf.setForceIncludeFiles(conf.getStringArray(CxxPlugin.FORCE_INCLUDE_FILES_KEY));
+    cxxConf.setCFilesPatterns(conf.getStringArray(CxxPlugin.C_FILES_PATTERNS_KEY));
     return cxxConf;
   }
 

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -27,6 +27,6 @@ public class CxxPluginTest {
   @Test
   public void testGetExtensions() throws Exception {
     CxxPlugin plugin = new CxxPlugin();
-    assertEquals(56, plugin.getExtensions().size());
+    assertEquals(57, plugin.getExtensions().size());
   }
 }


### PR DESCRIPTION
C files sometimes use reserved C++ keywords, and thus cannot be parsed directly.
The usual solution is to create macros manually (in sonar.cxx.defines) to replace them with non-reserved keywords. This however
does not work for mixed C/C++ projects.

To overcome this, this patch lets the plugin automatically add the macros depending on the type of the file. The plugin also resets
the __cplusplus macro according to the type of the file.
