### PR TITLE
Issue #300: Fix parsing of named variable arguments.

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppGrammar.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppGrammar.java
@@ -166,7 +166,7 @@ public enum CppGrammar implements GrammarRuleKey {
         )
         );
 
-    b.rule(parameterList).is(IDENTIFIER, b.zeroOrMore(b.zeroOrMore(WS), ",", b.zeroOrMore(WS), IDENTIFIER));
+    b.rule(parameterList).is(IDENTIFIER, b.zeroOrMore(b.zeroOrMore(WS), ",", b.zeroOrMore(WS), IDENTIFIER, b.nextNot(b.sequence(b.zeroOrMore(WS), "..."))));
     b.rule(argumentList).is(argument, b.zeroOrMore(b.zeroOrMore(WS), ",", b.zeroOrMore(WS), argument));
 
     b.rule(argument).is(

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/PreprocessorDirectivesTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/PreprocessorDirectivesTest.java
@@ -153,6 +153,11 @@ public class PreprocessorDirectivesTest extends ParserBaseTest {
       + "eprintf(\"%s:%d: \", input_file, lineno);"))
       .equals("fprintf ( stderr , \"%s:%d: \" , input_file , lineno ) ; EOF"));
 
+    assert (serialize(p.parse(
+        "#define eprintf(format, args...) fprintf (stderr, format, args)\n"
+            + "eprintf(\"%s:%d: \", input_file, lineno);"))
+        .equals("fprintf ( stderr , \"%s:%d: \" , input_file , lineno ) ; EOF"));
+
     // FIXME: can this actually be swallowed by GCC?? My experiments showed the opposite, so far...
     // GNU CPP: Vou are allowed to leave the variable argument out entirely
     // assert (serialize(p.parse(


### PR DESCRIPTION
ParameterList was too greedy, and would eat the name of the variable argument, thus parsing a variadic macro as an object like macro.
