### PR TITLE
Add template rule to each profile

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/externalrules/CxxExternalRuleRepository.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/externalrules/CxxExternalRuleRepository.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.plugins.cxx.externalrules;
 
+import java.io.InputStream;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,6 +52,9 @@ public class CxxExternalRuleRepository extends RuleRepository {
   public List<Rule> createRules() {
     List<Rule> rules = new ArrayList<Rule>();
 
+    final InputStream xmlStream = getClass().getResourceAsStream("/external-rule.xml");
+    rules.addAll(this.xmlRuleParser.parse(xmlStream));
+    
     for(String ruleDefs : settings.getStringArray(RULES_KEY)){
       if (StringUtils.isNotBlank(ruleDefs)) {
         try {
@@ -62,5 +66,5 @@ public class CxxExternalRuleRepository extends RuleRepository {
     }
 
     return rules;
-  }
+  } 
 }

--- a/sonar-cxx-plugin/src/main/resources/compiler-gcc.xml
+++ b/sonar-cxx-plugin/src/main/resources/compiler-gcc.xml
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rules>
+  <rule key="CustomRuleTemplate">
+    <cardinality>MULTIPLE</cardinality>
+    <priority>MAJOR</priority>
+    <name><![CDATA[Template for custom Custom rules]]></name>
+    <description>
+      <![CDATA[
+<p>
+Follow these steps to make your custom Custom rules available in SonarQube:
+</p>
+
+<ol>
+  <ol>
+    <li>Create a new rule in SonarQube by "copying" this rule template and specify the <code>CheckId</code> of your custom rule, a title, a description, and a default severity.</li>
+    <li>Enable the newly created rule in your quality profile</li>
+  </ol>
+  <li>Relaunch an analysis on your projects, et voilà, your custom rules are executed!</li>
+</ol>
+      ]]>
+    </description>
+  </rule>    
   <rule>
     <key>enabled by default</key>
     <configkey>enabled by default</configkey>

--- a/sonar-cxx-plugin/src/main/resources/compiler-vc.xml
+++ b/sonar-cxx-plugin/src/main/resources/compiler-vc.xml
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rules>
+  <rule key="CustomRuleTemplate">
+    <cardinality>MULTIPLE</cardinality>
+    <priority>MAJOR</priority>
+    <name><![CDATA[Template for custom Custom rules]]></name>
+    <description>
+      <![CDATA[
+<p>
+Follow these steps to make your custom Custom rules available in SonarQube:
+</p>
+
+<ol>
+  <ol>
+    <li>Create a new rule in SonarQube by "copying" this rule template and specify the <code>CheckId</code> of your custom rule, a title, a description, and a default severity.</li>
+    <li>Enable the newly created rule in your quality profile</li>
+  </ol>
+  <li>Relaunch an analysis on your projects, et voilà, your custom rules are executed!</li>
+</ol>
+      ]]>
+    </description>
+  </rule>    
   <rule>
     <key>C4001</key>
     <configkey>C4001</configkey>

--- a/sonar-cxx-plugin/src/main/resources/cppcheck.xml
+++ b/sonar-cxx-plugin/src/main/resources/cppcheck.xml
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="us-ascii"?>
 <rules>
+  <rule key="CustomRuleTemplate">
+    <cardinality>MULTIPLE</cardinality>
+    <priority>MAJOR</priority>
+    <name><![CDATA[Template for custom Custom rules]]></name>
+    <description>
+      <![CDATA[
+<p>
+Follow these steps to make your custom Custom rules available in SonarQube:
+</p>
+
+<ol>
+  <ol>
+    <li>Create a new rule in SonarQube by "copying" this rule template and specify the <code>CheckId</code> of your custom rule, a title, a description, and a default severity.</li>
+    <li>Enable the newly created rule in your quality profile</li>
+  </ol>
+  <li>Relaunch an analysis on your projects, et voilà, your custom rules are executed!</li>
+</ol>
+      ]]>
+    </description>
+  </rule>    
   <rule>
     <key>AssignmentAddressToInteger</key>
     <configkey>AssignmentAddressToInteger</configkey>

--- a/sonar-cxx-plugin/src/main/resources/external-rule.xml
+++ b/sonar-cxx-plugin/src/main/resources/external-rule.xml
@@ -1,0 +1,22 @@
+<rules>
+  <rule key="CustomRuleTemplate">
+    <cardinality>MULTIPLE</cardinality>
+    <priority>MAJOR</priority>
+    <name><![CDATA[Template for custom Custom rules]]></name>
+    <description>
+      <![CDATA[
+<p>
+Follow these steps to make your custom Custom rules available in SonarQube:
+</p>
+
+<ol>
+  <ol>
+    <li>Create a new rule in SonarQube by "copying" this rule template and specify the <code>CheckId</code> of your custom rule, a title, a description, and a default severity.</li>
+    <li>Enable the newly created rule in your quality profile</li>
+  </ol>
+  <li>Relaunch an analysis on your projects, et voilà, your custom rules are executed!</li>
+</ol>
+      ]]>
+    </description>
+  </rule>    
+</rules>

--- a/sonar-cxx-plugin/src/main/resources/pclint.xml
+++ b/sonar-cxx-plugin/src/main/resources/pclint.xml
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rules>
+  <rule key="CustomRuleTemplate">
+    <cardinality>MULTIPLE</cardinality>
+    <priority>MAJOR</priority>
+    <name><![CDATA[Template for custom Custom rules]]></name>
+    <description>
+      <![CDATA[
+<p>
+Follow these steps to make your custom Custom rules available in SonarQube:
+</p>
+
+<ol>
+  <ol>
+    <li>Create a new rule in SonarQube by "copying" this rule template and specify the <code>CheckId</code> of your custom rule, a title, a description, and a default severity.</li>
+    <li>Enable the newly created rule in your quality profile</li>
+  </ol>
+  <li>Relaunch an analysis on your projects, et voilà, your custom rules are executed!</li>
+</ol>
+      ]]>
+    </description>
+  </rule>    
   <rule>
     <key>1</key>
     <configkey>1</configkey>

--- a/sonar-cxx-plugin/src/main/resources/rats.xml
+++ b/sonar-cxx-plugin/src/main/resources/rats.xml
@@ -1,4 +1,24 @@
 <rules>
+  <rule key="CustomRuleTemplate">
+    <cardinality>MULTIPLE</cardinality>
+    <priority>MAJOR</priority>
+    <name><![CDATA[Template for custom Custom rules]]></name>
+    <description>
+      <![CDATA[
+<p>
+Follow these steps to make your custom Custom rules available in SonarQube:
+</p>
+
+<ol>
+  <ol>
+    <li>Create a new rule in SonarQube by "copying" this rule template and specify the <code>CheckId</code> of your custom rule, a title, a description, and a default severity.</li>
+    <li>Enable the newly created rule in your quality profile</li>
+  </ol>
+  <li>Relaunch an analysis on your projects, et voilà, your custom rules are executed!</li>
+</ol>
+      ]]>
+    </description>
+  </rule>    
   <rule>
     <key>drand48</key>
     <name>drand48</name>

--- a/sonar-cxx-plugin/src/main/resources/valgrind.xml
+++ b/sonar-cxx-plugin/src/main/resources/valgrind.xml
@@ -1,4 +1,24 @@
 <rules>
+  <rule key="CustomRuleTemplate">
+    <cardinality>MULTIPLE</cardinality>
+    <priority>MAJOR</priority>
+    <name><![CDATA[Template for custom Custom rules]]></name>
+    <description>
+      <![CDATA[
+<p>
+Follow these steps to make your custom Custom rules available in SonarQube:
+</p>
+
+<ol>
+  <ol>
+    <li>Create a new rule in SonarQube by "copying" this rule template and specify the <code>CheckId</code> of your custom rule, a title, a description, and a default severity.</li>
+    <li>Enable the newly created rule in your quality profile</li>
+  </ol>
+  <li>Relaunch an analysis on your projects, et voilà, your custom rules are executed!</li>
+</ol>
+      ]]>
+    </description>
+  </rule>    
   <rule>
     <key>InvalidFree</key>
     <name>Invalid free</name>

--- a/sonar-cxx-plugin/src/main/resources/vera++.xml
+++ b/sonar-cxx-plugin/src/main/resources/vera++.xml
@@ -1,4 +1,24 @@
 <rules>
+  <rule key="CustomRuleTemplate">
+    <cardinality>MULTIPLE</cardinality>
+    <priority>MAJOR</priority>
+    <name><![CDATA[Template for custom Custom rules]]></name>
+    <description>
+      <![CDATA[
+<p>
+Follow these steps to make your custom Custom rules available in SonarQube:
+</p>
+
+<ol>
+  <ol>
+    <li>Create a new rule in SonarQube by "copying" this rule template and specify the <code>CheckId</code> of your custom rule, a title, a description, and a default severity.</li>
+    <li>Enable the newly created rule in your quality profile</li>
+  </ol>
+  <li>Relaunch an analysis on your projects, et voilà, your custom rules are executed!</li>
+</ol>
+      ]]>
+    </description>
+  </rule>    
   <rule>
     <key>F001</key>
     <configKey>F001</configKey>

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/compiler/CxxCompilerRuleRepositoryTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/compiler/CxxCompilerRuleRepositoryTest.java
@@ -33,7 +33,7 @@ public class CxxCompilerRuleRepositoryTest {
     CxxCompilerVcRuleRepository rulerep = new CxxCompilerVcRuleRepository(
         mock(ServerFileSystem.class),
         new XMLRuleParser(), new Settings());
-    assertThat(rulerep.createRules()).hasSize(692);
+    assertThat(rulerep.createRules()).hasSize(693);
   }
 
   @Test
@@ -41,6 +41,6 @@ public class CxxCompilerRuleRepositoryTest {
     CxxCompilerGccRuleRepository rulerep = new CxxCompilerGccRuleRepository(
         mock(ServerFileSystem.class),
         new XMLRuleParser(), new Settings());
-    assertThat(rulerep.createRules()).hasSize(159);
+    assertThat(rulerep.createRules()).hasSize(160);
   }
 }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensorTest.java
@@ -55,7 +55,7 @@ public class CxxCoverageSensorTest {
   @Test
   public void shouldReportCorrectCoverage() {
     sensor.analyse(project, context);
-    verify(context, times(219)).saveMeasure((File) anyObject(), any(Measure.class));
+    verify(context, times(212)).saveMeasure((File) anyObject(), any(Measure.class));
   }
 
   @Test

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckRuleRepositoryTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/cppcheck/CxxCppCheckRuleRepositoryTest.java
@@ -32,6 +32,6 @@ public class CxxCppCheckRuleRepositoryTest {
   public void createRulesTest() {
     CxxCppCheckRuleRepository rulerep = new CxxCppCheckRuleRepository(
         mock(ServerFileSystem.class), new XMLRuleParser(), new Settings());
-    assertEquals(322, rulerep.createRules().size());
+    assertEquals(323, rulerep.createRules().size());
   }
 }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/externalrules/CxxExternalRuleRepositoryTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/externalrules/CxxExternalRuleRepositoryTest.java
@@ -43,10 +43,10 @@ public class CxxExternalRuleRepositoryTest {
           "    </rule></rules>";
 
   @Test
-  public void createEmptyRulesTest() {
+  public void verifyTemplateRuleIsFound() {
     CxxExternalRuleRepository rulerep = new CxxExternalRuleRepository(
         new XMLRuleParser(), new Settings());
-    assertThat(rulerep.createRules()).hasSize(0);
+    assertThat(rulerep.createRules()).hasSize(1);
   }
 
   @Test
@@ -55,7 +55,7 @@ public class CxxExternalRuleRepositoryTest {
     settings.appendProperty(CxxExternalRuleRepository.RULES_KEY, profile);
     CxxExternalRuleRepository rulerep = new CxxExternalRuleRepository(
       new XMLRuleParser(), settings);
-    assertThat(rulerep.createRules()).hasSize(2);
+    assertThat(rulerep.createRules()).hasSize(3);
   }
 
   @Test
@@ -64,6 +64,6 @@ public class CxxExternalRuleRepositoryTest {
     settings.appendProperty(CxxExternalRuleRepository.RULES_KEY, null);
     CxxExternalRuleRepository rulerep = new CxxExternalRuleRepository(
       new XMLRuleParser(), settings);
-    assertThat(rulerep.createRules()).hasSize(0);
+    assertThat(rulerep.createRules()).hasSize(1);
   }
 }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/pclint/CxxPCLintRuleRepositoryTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/pclint/CxxPCLintRuleRepositoryTest.java
@@ -34,6 +34,6 @@ public class CxxPCLintRuleRepositoryTest {
     CxxPCLintRuleRepository rulerep = new CxxPCLintRuleRepository(
         mock(ServerFileSystem.class),
         new XMLRuleParser(), new Settings());
-    assertEquals(1442, rulerep.createRules().size());
+    assertEquals(1443, rulerep.createRules().size());
   }
 }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/rats/CxxRatsRuleRepositoryTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/rats/CxxRatsRuleRepositoryTest.java
@@ -32,6 +32,6 @@ public class CxxRatsRuleRepositoryTest {
   public void createRulesTest() {
     CxxRatsRuleRepository rulerep = new CxxRatsRuleRepository(
         mock(ServerFileSystem.class), new XMLRuleParser(), new Settings());
-    assertThat(rulerep.createRules()).hasSize(300);
+    assertThat(rulerep.createRules()).hasSize(301);
   }
 }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/valgrind/CxxValgrindRuleRepositoryTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/valgrind/CxxValgrindRuleRepositoryTest.java
@@ -36,7 +36,7 @@ public class CxxValgrindRuleRepositoryTest {
   @Test
   public void shouldContainProperNumberOfRules() {
     CxxValgrindRuleRepository repo = new CxxValgrindRuleRepository(mock(ServerFileSystem.class), new XMLRuleParser(), new Settings());
-    assertEquals(repo.createRules().size(), 15);
+    assertEquals(repo.createRules().size(), 16);
   }
 
   @Test
@@ -46,7 +46,7 @@ public class CxxValgrindRuleRepositoryTest {
     extensionFile.add(TestUtils.loadResource("/org/sonar/plugins/cxx/rules-repository/CustomRulesOldFormat.xml"));
     when(filesystem.getExtensions(CxxValgrindRuleRepository.KEY, "xml")).thenReturn(extensionFile);
     CxxValgrindRuleRepository repo = new CxxValgrindRuleRepository(filesystem, new XMLRuleParser(), new Settings());
-    assertEquals(repo.createRules().size(), 17);
+    assertEquals(repo.createRules().size(), 18);
   }
 
   @Test
@@ -56,7 +56,7 @@ public class CxxValgrindRuleRepositoryTest {
     extensionFile.add(TestUtils.loadResource("/org/sonar/plugins/cxx/rules-repository/CustomRulesNewFormat.xml"));
     when(filesystem.getExtensions(CxxValgrindRuleRepository.KEY, "xml")).thenReturn(extensionFile);
     CxxValgrindRuleRepository repo = new CxxValgrindRuleRepository(filesystem, new XMLRuleParser(), new Settings());
-    assertEquals(repo.createRules().size(), 16);
+    assertEquals(repo.createRules().size(), 17);
   }
 
   @Test(expected = org.sonar.api.utils.SonarException.class)

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/veraxx/CxxVeraxxRuleRepositoryTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/veraxx/CxxVeraxxRuleRepositoryTest.java
@@ -34,6 +34,6 @@ public class CxxVeraxxRuleRepositoryTest {
     CxxVeraxxRuleRepository rulerep = new CxxVeraxxRuleRepository(
         mock(ServerFileSystem.class),
         new XMLRuleParser(), new Settings());
-    assertThat(rulerep.createRules()).hasSize(27);
+    assertThat(rulerep.createRules()).hasSize(28);
   }
 }


### PR DESCRIPTION
from the rest api, the only way to create rules is to have custom rules defined in the default profiles. This pr provides that implementation. Basically it just adds a multi cardinality rule to the profile.

This way is the now recommended way of defining rules. to be discussed if the xml defined rules can be deprecated at some point
