### PR TITLE
Improve preprocessor rescan

### DIFF
--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/PreprocessorDirectivesTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/PreprocessorDirectivesTest.java
@@ -132,10 +132,10 @@ public class PreprocessorDirectivesTest extends ParserBaseTest {
         .equals("c_init ( ) ; EOF"));
 
     assert (serialize(p.parse(
-        "#define lang_init(x) std_init\n"
+        "#define lang_init(x) x = std_init\n"
             + "#define std_init() c_init()\n"
-            + "lang_init(0)();"))
-        .equals("c_init ( ) ; EOF"));
+            + "lang_init(c)();"))
+        .equals("c = c_init ( ) ; EOF"));
 
     /*assert (serialize(p.parse(
         "#define PAIR(x,y) x, y\n"


### PR DESCRIPTION
Implement more complete rescan after some macros after expanded.
This should fix the original issue in https://github.com/wenns/sonar-cxx/issues/302, though the argument parsing issue is not adressed.

NOTE: the original rescanning code, i.e. the calls to `expandMacro(macro.name, serialize(replTokens))`, is still needed as it handles other cases (e.g. removes whitespace tokens, ...)
