### PR TITLE
Support preprocessor expressions in includes

### DIFF
--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppGrammarTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppGrammarTest.java
@@ -229,6 +229,9 @@ public class CppGrammarTest {
     assertThat(p).matches("#include /**/ <ace/config-all.h>");
     assertThat(p).matches("#include <math.h> /**/ /**/");
     assertThat(p).matches("#include USER_CONFIG");
+    assertThat(p).matches("#include macro(a,b,c)");
+    assertThat(p).matches("#include BOOST_PP_STRINGIZE(boost/mpl/aux_/preprocessed/AUX778076_PREPROCESSED_HEADER)");
+    assertThat(p).matches("#include BOOST_PP_TUPLE_ELEM_2(0,10,<boost/utility/detail/result_of_iterate.hpp>,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
   }
 
   @Test

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/squid/CxxSquidSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/squid/CxxSquidSensorTest.java
@@ -96,10 +96,10 @@ public class CxxSquidSensorTest {
     sensor.analyse(project, context);
 
     verify(context).saveMeasure((org.sonar.api.resources.File) anyObject(), eq(CoreMetrics.FILES), eq(1.0));
-    verify(context).saveMeasure((org.sonar.api.resources.File) anyObject(), eq(CoreMetrics.LINES), eq(27.0));
-    verify(context).saveMeasure((org.sonar.api.resources.File) anyObject(), eq(CoreMetrics.NCLOC), eq(8.0));
+    verify(context).saveMeasure((org.sonar.api.resources.File) anyObject(), eq(CoreMetrics.LINES), eq(29.0));
+    verify(context).saveMeasure((org.sonar.api.resources.File) anyObject(), eq(CoreMetrics.NCLOC), eq(9.0));
     verify(context).saveMeasure((org.sonar.api.resources.File) anyObject(), eq(CoreMetrics.STATEMENTS), eq(0.0));
-    verify(context).saveMeasure((org.sonar.api.resources.File) anyObject(), eq(CoreMetrics.FUNCTIONS), eq(8.0));
+    verify(context).saveMeasure((org.sonar.api.resources.File) anyObject(), eq(CoreMetrics.FUNCTIONS), eq(9.0));
     verify(context).saveMeasure((org.sonar.api.resources.File) anyObject(), eq(CoreMetrics.CLASSES), eq(0.0));
   }
 

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/include-directories-project/include/widget.hh
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/include-directories-project/include/widget.hh
@@ -1,0 +1,1 @@
+#define WIDGET void widget(){}

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/include-directories-project/src/main.cc
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/include-directories-project/src/main.cc
@@ -15,6 +15,8 @@
 // 7. ... but it does in the 'free' form of the include statement
 #define LOCATION "bar.hh"
 #include LOCATION
+#define MACRO(p) p
+#include MACRO("widget.hh")
 
 INCLUDE1
 INCLUDE2
@@ -24,3 +26,4 @@ INCLUDE_SND_SUBFOLDER_1
 HEADER1
 HEADER2
 BAR //void bar(){}
+WIDGET //void widget(){}


### PR DESCRIPTION
- test of include body free form use cases
- add some new test cases
- found no bugs
- related to #227

test cases:
# define FILE "file.h"
# include FILE
# define MACRO(p) p
# include MACRO("file.h")
