### PR TITLE
Add rules for switch 'default' case; 'present' and 'is last'

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/CheckList.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/CheckList.java
@@ -55,6 +55,7 @@ public final class CheckList {
         ParsingErrorRecoveryCheck.class,
         ReservedNamesCheck.class,
         StringLiteralDuplicatedCheck.class,
+        SwitchLastCaseIsDefaultCheck.class,
         TabCharacterCheck.class,
         TodoTagPresenceCheck.class,
         TooLongLineCheck.class,

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/SwitchLastCaseIsDefaultCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/SwitchLastCaseIsDefaultCheck.java
@@ -1,0 +1,90 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2011 Waleri Enns and CONTACT Software GmbH
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.cxx.checks;
+
+import java.util.List;
+
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.cxx.parser.CxxGrammarImpl;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.sonar.sslr.api.AstNode;
+import com.sonar.sslr.api.AstNodeType;
+import com.sonar.sslr.api.Grammar;
+import com.sonar.sslr.squid.checks.SquidCheck;
+
+@Rule(key = "SwitchLastCaseIsDefaultCheck",
+    description = "Each switch statement shall have a 'default' case in the last position.",
+    priority = Priority.MAJOR)
+public class SwitchLastCaseIsDefaultCheck extends SquidCheck<Grammar> {
+
+  private static final AstNodeType[] CHECKED_TYPES = new AstNodeType[] {
+      CxxGrammarImpl.switchStatement
+  };
+
+  private static final String MISSING_DEFAULT_CASE_MESSAGE = "Add a default case to this switch.";
+  private static final String DEFAULT_CASE_IS_NOT_LAST_MESSAGE = "Move this default to the end of the switch.";
+  private static final String DEFAULT_CASE_TOKENVALUE = "default";
+
+  private static final Predicate<AstNode> DEFAULT_CASE_NODE_FILTER = new Predicate<AstNode>() {
+    public boolean apply(AstNode childNode) {
+      return childNode.getTokenValue().equals(DEFAULT_CASE_TOKENVALUE);
+    }
+  };
+
+  @Override
+  public void init() {
+    subscribeTo(CHECKED_TYPES);
+  }
+
+  @Override
+  public void visitNode(AstNode node) {
+    List<AstNode> switchCases = getSwitchCases(node);
+    int defaultCaseIndex = Iterables.indexOf(switchCases, DEFAULT_CASE_NODE_FILTER);
+
+    if (defaultCaseIndex == -1) {
+      getContext().createLineViolation(this, MISSING_DEFAULT_CASE_MESSAGE, node);
+    } else {
+      AstNode defaultCase = Iterables.get(switchCases, defaultCaseIndex);
+
+      if (!defaultCase.equals(Iterables.getLast(switchCases))) {
+        getContext().createLineViolation(this, DEFAULT_CASE_IS_NOT_LAST_MESSAGE, defaultCase);
+      }
+    }
+  }
+
+  private List<AstNode> getSwitchCases(AstNode node) {
+    List<AstNode> cases = Lists.newArrayList();
+
+    for (AstNode stmtGroups : node.getChildren(CxxGrammarImpl.switchBlockStatementGroups)) {
+       for (AstNode stmtGroup: stmtGroups.getChildren(CxxGrammarImpl.switchBlockStatementGroup)) {
+         for (AstNode label : stmtGroup.getChildren(CxxGrammarImpl.switchLabelStatement)) {
+           cases.add(label);
+         }
+       }
+    }
+
+    return cases;
+  }
+
+}

--- a/cxx-checks/src/main/resources/org/sonar/l10n/cxx.properties
+++ b/cxx-checks/src/main/resources/org/sonar/l10n/cxx.properties
@@ -33,6 +33,7 @@ rule.cxx.ParsingErrorRecoveryCheck.name=C++ skip parser error
 rule.cxx.ReservedNamesCheck.name=Reserved names should not be used for preprocessor macros
 rule.cxx.StringLiteralDuplicated.name=String literals should not be duplicated
 rule.cxx.StringLiteralDuplicated.param.minimalLiteralLength=The minimal literal length.
+rule.cxx.SwitchLastCaseIsDefaultCheck.name=Switch statements should end with a default case
 rule.cxx.SafetyTagCheck.name=Risk mitigation implementation shall be defined in separate file
 rule.cxx.SafetyTagCheck.param.regularExpression=Comment regular expression rule
 rule.cxx.SafetyTagCheck.param.suffix=The appropriate file name suffix

--- a/cxx-checks/src/main/resources/org/sonar/l10n/cxx/rules/cxx/SwitchLastCaseIsDefaultCheck.html
+++ b/cxx-checks/src/main/resources/org/sonar/l10n/cxx/rules/cxx/SwitchLastCaseIsDefaultCheck.html
@@ -1,0 +1,36 @@
+<p>
+The requirement for a final default clause is defensive programming.
+This clause should either take appropriate action or contain a suitable comment as to why no action is taken.
+</p>
+
+<p>
+The following code snippet illustrates this rule:
+</p>
+
+<pre>
+switch (state) {                       // Non-Compliant - must have a default case
+  case 0:
+  case 1:
+    printf("0 or 1!");
+    break;
+}
+
+switch (state) {
+  default:                             // Non-Compliant - must be last for better readability
+    printf("Default");
+    break;
+  case 0:
+  case 1:
+    printf("0 or 1!");
+    break;
+}
+
+switch (state) {
+  case 0:
+  case 1:
+    printf("0 or 1!");
+    break;
+  default:                             // Compliant
+    printf("Default");
+    break;
+</pre>

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/CheckListTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/CheckListTest.java
@@ -27,6 +27,6 @@ public class CheckListTest {
 
   @Test
   public void count() {
-    assertThat(CheckList.getChecks().size()).isEqualTo(33);
+    assertThat(CheckList.getChecks().size()).isEqualTo(34);
   }
 }

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/SwitchLastCaseIsDefaultCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/SwitchLastCaseIsDefaultCheckTest.java
@@ -1,0 +1,46 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2011 Waleri Enns and CONTACT Software GmbH
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.cxx.checks;
+
+import com.sonar.sslr.squid.checks.CheckMessagesVerifierRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.cxx.CxxAstScanner;
+import org.sonar.squid.api.SourceFile;
+
+import java.io.File;
+
+public class SwitchLastCaseIsDefaultCheckTest {
+
+  @Rule
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  public void detected() {
+    SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/SwitchLastCaseIsDefaultCheck.cc"), new SwitchLastCaseIsDefaultCheck());
+    checkMessagesVerifier.verify(file.getCheckMessages())
+        .next().atLine(6).withMessage("Add a default case to this switch.")
+        .next().atLine(13).withMessage("Move this default to the end of the switch.")
+        .next().atLine(33).withMessage("Add a default case to this switch.")
+        .next().atLine(43).withMessage("Add a default case to this switch.")
+        .next().atLine(48).withMessage("Move this default to the end of the switch.");
+  }
+
+}

--- a/cxx-checks/src/test/resources/checks/SwitchLastCaseIsDefaultCheck.cc
+++ b/cxx-checks/src/test/resources/checks/SwitchLastCaseIsDefaultCheck.cc
@@ -1,0 +1,57 @@
+class A {
+  public:
+    void f( ) {
+      int var = 0;
+
+      switch (var) {
+        case '0':
+          printf("Missing default");
+          break;
+      }
+
+      switch (var) {
+        default:
+          printf("Wrong position");
+          break;
+        case '0':
+          printf("Has default not in last position");
+          break;
+      }
+
+      switch (var) {
+        case '0':
+          printf("Has default in last position");
+          break;
+        default:
+          printf("Compliant");
+          break;
+      }
+
+      switch (var) {
+        case '0':
+          int var2 = 1;
+          switch (var2) {
+            case '0':
+              printf("Missing default (nested)");
+              break;
+          }
+        default:
+          printf("Compliant");
+          break;
+      }
+
+      switch (var) {
+        case '0':
+          printf("Missing default");
+          int var2 = 1;
+          switch (var2) {
+            default:
+              printf("Wrong position");
+              break;
+            case '0':
+              printf("Has default not in last position");
+              break;
+          }
+      }
+    }
+};


### PR DESCRIPTION
Migrate the SwitchLastCaseIsDefaultCheck logic over from the Sonar-Java
plugin. The new rule tests that a switch statement has 'default' label,
and that the 'default' is the final case.
