### PR TITLE
Microsoft specific asm support

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -875,8 +875,13 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
 
     b.rule(usingDirective).is(b.optional(attributeSpecifier), CxxKeyword.USING, CxxKeyword.NAMESPACE, b.optional("::"), b.optional(nestedNameSpecifier), namespaceName, ";");
 
-    b.rule(asmDefinition).is(CxxKeyword.ASM, "(", STRING, ")", ";");
-
+    b.rule(asmDefinition).is(
+      b.firstOf(
+        b.sequence(CxxKeyword.ASM, "(", STRING, ")", ";"),
+        b.sequence(CxxKeyword.ASM, "{", b.oneOrMore(b.nextNot(b.firstOf("}", EOF)), b.anyToken()), "}", b.optional(";")),
+        b.sequence(CxxKeyword.ASM, b.oneOrMore(b.nextNot(b.firstOf(";", EOF)), b.anyToken()), ";")
+      ));
+    
     b.rule(linkageSpecification).is(CxxKeyword.EXTERN, STRING, b.firstOf(b.sequence("{", b.optional(declarationSeq), "}"), declaration));
 
     b.rule(attributeSpecifierSeq).is(b.oneOrMore(attributeSpecifier));

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/AssemblerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/AssemblerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2011 Waleri Enns and CONTACT Software GmbH
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.cxx.parser;
+
+import static org.sonar.sslr.tests.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class AssemblerTest extends ParserBaseTest {
+
+  @Test
+  public void asmIsoStandard() {
+    p.setRootRule(g.rule(CxxGrammarImpl.asmDefinition));
+    assertThat(p).matches("asm(\"mov eax, num\");");
+  }
+
+  @Test
+  public void asmVcAssemblyInstruction1() {
+    p.setRootRule(g.rule(CxxGrammarImpl.asmDefinition));
+    assertThat(p).matches("asm mov eax, num ;");
+  }
+  
+  @Test
+  public void asmVcAssemblyInstructionList1() {
+    p.setRootRule(g.rule(CxxGrammarImpl.asmDefinition));
+    assertThat(p).matches("asm { mov eax, num }");
+  }
+
+  @Test
+  public void asmVcAssemblyInstructionList2() {
+    p.setRootRule(g.rule(CxxGrammarImpl.asmDefinition));
+    assertThat(p).matches("asm { mov eax, num };");
+  }
+
+  @Test
+  public void asmVcAssemblyInstructionList3() {
+    p.setRootRule(g.rule(CxxGrammarImpl.asmDefinition));
+    assertThat(p).matches(
+      "asm {\n"
+      + "mov eax, num    ; Get first argument\n"
+      + "mov ecx, power  ; Get second argument\n"
+      + "shl eax, cl     ; EAX = EAX * ( 2 to the power of CL )\n"
+      + "}"
+    );
+  }
+
+}


### PR DESCRIPTION
- solution for #262
- precondition: keyword __asm must be replaced by preprocessor with asm
- grammar 1: `asm assembly-instruction ;`
  - not supported: asm assembly-instruction // without ;
- grammar 2: `asm { assembly-instruction-list } [ ; ]`
- add unit tests for inline assembler
