### PR TITLE
Extend XPathCheck with path filter

### DIFF
--- a/cxx-checks/src/main/resources/org/sonar/l10n/cxx.properties
+++ b/cxx-checks/src/main/resources/org/sonar/l10n/cxx.properties
@@ -55,6 +55,7 @@ rule.cxx.UselessParentheses.name=Useless parentheses around expressions should b
 rule.cxx.UsingNamespaceInHeader.name=Using namespace directives are not allowed in header files
 rule.cxx.UseCorrectInclude.name=#include directive shall not use relative path
 rule.cxx.XPath.name=XPath rule
+rule.cxx.XPath.param.matchFilePattern=Ant-style matching patterns for path
 rule.cxx.XPath.param.message=The violation message
 rule.cxx.XPath.param.xpathQuery=The XPath query
 rule.cxx.InvalidFileEncoding.name=Verify that all characters of the file can be encoded with the predefined charset

--- a/cxx-checks/src/main/resources/org/sonar/l10n/cxx/rules/cxx/XPath.html
+++ b/cxx-checks/src/main/resources/org/sonar/l10n/cxx/rules/cxx/XPath.html
@@ -12,5 +12,33 @@ Violations are created depending on the return value of the XPath expression. If
 </ul>
 
 <p>
+matchFilePattern allows Ant-style matching patterns for the path. If no matchFilePattern is defined all files are evaluated.
+</p>
+
+<p>
+Following rules are applied:
+</p>
+<ul>
+  <li>? matches single character</li>
+  <li>* matches zero or more characters</li>
+  <li>** matches zero or more 'directories'</li>
+  <li>use always '/' as a directory separator</li>
+  <li>there must always be a root directory</li>
+</ul>
+
+<p>
+Some examples of patterns:
+</p>
+<ul>
+  <li>/**/*.cpp - matches all .cpp files in all directories (you have to define the root directory '/'), e.g. org/Foo.cpp or org/foo/Bar.cpp or org/foo/bar/Baz.cpp</li>
+  <li>/**/test/**/Foo.cpp - matches all 'Foo.cpp' files in directories with one 'test' directory in the path, e.g. org/test/Foo.cpp or org/bar/test/bar/Foo.cpp</li>
+  <li>org/T?st.cpp - matches org/Test.cpp and also org/Tost.cpp</li>
+  <li>org/*.cpp - matches all .cpp files in the org directory, e.g. org/Foo.cpp or org/Bar.cpp</li>
+  <li>org/** - matches all files underneath the org directory, e.g. org/Foo.cpp or org/foo/bar.jsp</li>
+  <li>org/**/Test.cpp - matches all Test.cpp files underneath the org directory, e.g. org/Test.cpp or org/foo/Test.cpp or org/foo/bar/Test.cpp</li>
+  <li>org/**/*.cpp - matches all .cpp files underneath the org directory, e.g. org/Foo.cpp or org/foo/Bar.cpp or org/foo/bar/Baz.cpp</li>
+</ul>
+
+<p>
 Here is an example of an XPath expression to log a violation on each declaration : //declaration
 </p>

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/XPathCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/XPathCheckTest.java
@@ -29,15 +29,53 @@ import org.sonar.squidbridge.checks.CheckMessagesVerifier;
 public class XPathCheckTest {
 
   @Test
-  public void check() {
+  public void xpathWithoutFilePattern() {
     XPathCheck check = new XPathCheck();
     check.xpathQuery = "//declaration";
     check.message = "Avoid declarations!! ";
 
     SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/xpath.cc"), check);
     CheckMessagesVerifier.verify(file.getCheckMessages())
-        .next().atLine(1).withMessage(check.message)
-        .noMore();
+      .next().atLine(1).withMessage(check.message)
+      .noMore();
+  }
+
+  @Test
+  public void xpathWithFilePattern1() {
+    XPathCheck check = new XPathCheck();
+    check.matchFilePattern = "/**/*.cc"; // all files with .cc file extension
+    check.xpathQuery = "//declaration";
+    check.message = "Avoid declarations!! ";
+
+    SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/xpath.cc"), check);
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(1).withMessage(check.message)
+      .noMore();
+  }
+
+  @Test
+  public void xpathWithFilePattern2() {
+    XPathCheck check = new XPathCheck();
+    check.matchFilePattern = "/**/test/**/xpath.cc"; // all files with filename xpath.cc in a subdirectory with name test
+    check.xpathQuery = "//declaration";
+    check.message = "Avoid declarations!! ";
+
+    SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/xpath.cc"), check);
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(1).withMessage(check.message)
+      .noMore();
+  }
+
+  @Test
+  public void xpathWithFilePattern3() {
+    XPathCheck check = new XPathCheck();
+    check.matchFilePattern = "/**/*.xxx"; // all files with .xxx file extension
+    check.xpathQuery = "//declaration";
+    check.message = "Avoid declarations!! ";
+
+    SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/xpath.cc"), check);
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+      .noMore();
   }
 
 }


### PR DESCRIPTION
- matchFilePattern allows Ant-style matching patterns for the path.
- If no matchFilePattern is defined all files are evaluated.

Main idea of this extension is to restrict a check to special:
- file extension
- filename
- path
