### PR TITLE
File RegEx rule

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/CheckList.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/CheckList.java
@@ -42,6 +42,7 @@ public final class CheckList {
         FileComplexityCheck.class,
         FileHeaderCheck.class,
         FileEncodingCheck.class,
+        FileRegularExpressionCheck.class,
         FixmeTagPresenceCheck.class,
         FunctionComplexityCheck.class,
         HardcodedAccountCheck.class,

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/FileRegularExpressionCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/FileRegularExpressionCheck.java
@@ -1,0 +1,122 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2011 Waleri Enns and CONTACT Software GmbH
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.cxx.checks;
+
+import com.sonar.sslr.api.AstNode;
+import org.sonar.check.Cardinality;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
+import com.sonar.sslr.api.Grammar;
+import org.sonar.api.utils.SonarException;
+import org.sonar.cxx.visitors.CxxCharsetAwareVisitor;
+import org.sonar.squidbridge.checks.SquidCheck;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.sonar.api.utils.PathUtils;
+import org.sonar.api.utils.WildcardPattern;
+
+@Rule(
+  key = "FileRegularExpression",
+  cardinality = Cardinality.MULTIPLE,
+  priority = Priority.MAJOR)
+
+public class FileRegularExpressionCheck extends SquidCheck<Grammar> implements CxxCharsetAwareVisitor {
+
+  private static final String DEFAULT_MATCH_FILE_PATTERN = "";
+  private static final String DEFAULT_REGULAR_EXPRESSION = "";
+  private static final String DEFAULT_MESSAGE = "The regular expression matches this file";
+
+  private Charset charset;
+  private Pattern pattern;
+
+  @RuleProperty(
+    key = "matchFilePattern",
+    defaultValue = DEFAULT_MATCH_FILE_PATTERN)
+  public String matchFilePattern = DEFAULT_MATCH_FILE_PATTERN;
+
+  @RuleProperty(
+    key = "regularExpression",
+    defaultValue = DEFAULT_REGULAR_EXPRESSION)
+  public String regularExpression = DEFAULT_REGULAR_EXPRESSION;
+
+  @RuleProperty(
+    key = "message",
+    defaultValue = DEFAULT_MESSAGE)
+  public String message = DEFAULT_MESSAGE;
+
+  @Override
+  public void init() {
+    try {
+      pattern = Pattern.compile(regularExpression);
+    } catch (PatternSyntaxException e) {
+      throw new SonarException(e);
+    }
+  }
+
+  @Override
+  public void setCharset(Charset charset) {
+    this.charset = charset;
+  }
+
+  @Override
+  public void visitFile(AstNode fileNode) {
+    if (fileNode != null) {
+      try {
+        if (!matchFile()) {
+          return;
+        }
+        Matcher matcher = pattern.matcher(fromFile(getContext().getFile(), charset));
+        if (matcher.find()) {
+          getContext().createFileViolation(this, message);
+        }
+      } catch (IOException e) {
+        throw new SonarException(e);
+      }
+    }
+  }
+
+  private boolean matchFile() {
+    if (!matchFilePattern.isEmpty()) {
+      WildcardPattern filePattern = WildcardPattern.create(matchFilePattern);
+      String path = PathUtils.sanitize(getContext().getFile().getPath());
+      return filePattern.match(path);
+    }
+    return true;
+  }
+
+  private static CharSequence fromFile(File file, Charset charset) throws IOException {
+    FileInputStream input = new FileInputStream(file);
+    FileChannel channel = input.getChannel();
+    ByteBuffer bbuf = channel.map(FileChannel.MapMode.READ_ONLY, 0, (int) channel.size());
+    CharBuffer cbuf = charset.newDecoder().decode(bbuf);
+    return cbuf;
+  }
+
+}

--- a/cxx-checks/src/main/resources/org/sonar/l10n/cxx.properties
+++ b/cxx-checks/src/main/resources/org/sonar/l10n/cxx.properties
@@ -59,3 +59,7 @@ rule.cxx.XPath.param.matchFilePattern=Ant-style matching patterns for path
 rule.cxx.XPath.param.message=The violation message
 rule.cxx.XPath.param.xpathQuery=The XPath query
 rule.cxx.InvalidFileEncoding.name=Verify that all characters of the file can be encoded with the predefined charset
+rule.cxx.FileRegularExpression.name=File RegEx rule
+rule.cxx.FileRegularExpression.param.matchFilePattern=Ant-style matching patterns for path
+rule.cxx.FileRegularExpression.param.message=The violation message
+rule.cxx.FileRegularExpression.param.regularExpression=The regular expression

--- a/cxx-checks/src/main/resources/org/sonar/l10n/cxx/rules/cxx/FileRegularExpression.html
+++ b/cxx-checks/src/main/resources/org/sonar/l10n/cxx/rules/cxx/FileRegularExpression.html
@@ -1,0 +1,33 @@
+<p>
+This rule template can be used to create rules which will be triggered when a file matches a given regular expression.
+Additional a Ant-style matching pattern for the path can be defined.
+</p>
+
+<p>
+matchFilePattern allows Ant-style matching patterns for the path. If no matchFilePattern is defined all files are evaluated.
+</p>
+
+<p>
+Following rules are applied:
+</p>
+<ul>
+  <li>? matches single character</li>
+  <li>* matches zero or more characters</li>
+  <li>** matches zero or more 'directories'</li>
+  <li>use always '/' as a directory separator</li>
+  <li>there must always be a root directory</li>
+</ul>
+
+<p>
+Some examples of patterns:
+</p>
+<ul>
+  <li>/**/*.cpp - matches all .cpp files in all directories (you have to define the root directory '/'), e.g. org/Foo.cpp or org/foo/Bar.cpp or org/foo/bar/Baz.cpp</li>
+  <li>/**/test/**/Foo.cpp - matches all 'Foo.cpp' files in directories with one 'test' directory in the path, e.g. org/test/Foo.cpp or org/bar/test/bar/Foo.cpp</li>
+  <li>org/T?st.cpp - matches org/Test.cpp and also org/Tost.cpp</li>
+  <li>org/*.cpp - matches all .cpp files in the org directory, e.g. org/Foo.cpp or org/Bar.cpp</li>
+  <li>org/** - matches all files underneath the org directory, e.g. org/Foo.cpp or org/foo/bar.jsp</li>
+  <li>org/**/Test.cpp - matches all Test.cpp files underneath the org directory, e.g. org/Test.cpp or org/foo/Test.cpp or org/foo/bar/Test.cpp</li>
+  <li>org/**/*.cpp - matches all .cpp files underneath the org directory, e.g. org/Foo.cpp or org/foo/Bar.cpp or org/foo/bar/Baz.cpp</li>
+</ul>
+

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/CheckListTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/CheckListTest.java
@@ -27,6 +27,6 @@ public class CheckListTest {
 
   @Test
   public void count() {
-    assertThat(CheckList.getChecks().size()).isEqualTo(36);
+    assertThat(CheckList.getChecks().size()).isEqualTo(37);
   }
 }

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/FileRegularExpressionCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/FileRegularExpressionCheckTest.java
@@ -1,0 +1,56 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2011 Waleri Enns and CONTACT Software GmbH
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.cxx.checks;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.sonar.cxx.CxxAstScanner;
+import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifier;
+
+public class FileRegularExpressionCheckTest {
+
+  @Test
+  public void fileRegExWithoutFilePattern() {
+    FileRegularExpressionCheck check = new FileRegularExpressionCheck();
+    check.regularExpression = "stdafx\\.h";
+    check.message = "Found 'stdafx.h' in file!";
+
+    SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/FileRegEx.cc"), check);
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+      .next().withMessage(check.message)
+      .noMore();
+  }
+
+  @Test
+  public void fileRegExWithFilePattern() {
+    FileRegularExpressionCheck check = new FileRegularExpressionCheck();
+    check.matchFilePattern = "/**/*.cc"; // all files with .cc file extension
+    check.regularExpression = "#include\\s+\"stdafx\\.h\"";
+    check.message = "Found '#include \"stdafx.h\"' in a .cc file!";
+
+    SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/FileRegEx.cc"), check);
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+      .next().withMessage(check.message)
+      .noMore();
+  }
+
+}

--- a/cxx-checks/src/test/resources/checks/FileRegEx.cc
+++ b/cxx-checks/src/test/resources/checks/FileRegEx.cc
@@ -1,0 +1,5 @@
+// Comment
+   #include      "stdafx.h"
+int i;
+void func() {}
+


### PR DESCRIPTION
This rule template can be used to create rules which will be triggered when a file matches a given regular expression. Additional a Ant-style matching pattern for the path can be defined.

Also a solution for #179.
