### PR TITLE
Remove module restriction on CxxXunitSensor

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/xunit/CxxXunitSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/xunit/CxxXunitSensor.java
@@ -110,21 +110,6 @@ public class CxxXunitSensor extends CxxReportSensor {
   public Class<?> dependsUponCoverageSensors() {
     return CoverageExtension.class;
   }
-  
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public boolean shouldExecuteOnProject(Project project) {
-    if (conf.hasKey(reportPathKey())) {
-      if (!conf.getBoolean(PROVIDE_DETAILS_KEY)) {
-        return !project.isModule();
-      } else {
-        return fs.hasFiles(fs.predicates().hasLanguage(CxxLanguage.KEY));
-      }
-    }
-    return false;
-  }
 
   /**
    * {@inheritDoc}


### PR DESCRIPTION
Allow the test execution report sensor to run in the same way as other
sensors, rather than limited to "non-modules" in simple mode.