### PR TITLE
Support plugins with custom rules

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/api/CustomCxxRulesDefinition.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/api/CustomCxxRulesDefinition.java
@@ -1,0 +1,59 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010 Neticoa SAS France
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.cxx.api;
+
+import org.sonar.api.BatchExtension;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.plugins.cxx.CxxLanguage;
+import org.sonar.squidbridge.annotations.AnnotationBasedRulesDefinition;
+
+import com.google.common.collect.ImmutableList;
+
+public abstract class CustomCxxRulesDefinition implements RulesDefinition, BatchExtension {
+    
+  @Override
+  public void define(RulesDefinition.Context context) {
+    RulesDefinition.NewRepository repo = context.createRepository(repositoryKey(), CxxLanguage.KEY)
+          .setName(repositoryName());
+
+    // Load metadata from check classes' annotations
+    new AnnotationBasedRulesDefinition(repo, CxxLanguage.KEY).addRuleClasses(false,
+          ImmutableList.copyOf(checkClasses()));
+
+    repo.done();
+  }
+
+  /**
+   * Name of the custom rule repository.
+   */
+  public abstract String repositoryName();
+
+  /**
+   * Key of the custom rule repository.
+   */
+  public abstract String repositoryKey();
+
+  /**
+   * Array of the custom rules classes.
+   */
+  @SuppressWarnings("rawtypes")
+  public abstract Class[] checkClasses();
+
+}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxChecks.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxChecks.java
@@ -1,0 +1,93 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010 Neticoa SAS France
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.cxx.squid;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import org.sonar.api.batch.rule.CheckFactory;
+import org.sonar.api.batch.rule.Checks;
+import org.sonar.api.rule.RuleKey;
+import org.sonar.plugins.cxx.api.CustomCxxRulesDefinition;
+import org.sonar.squidbridge.SquidAstVisitor;
+
+import com.google.common.collect.Lists;
+import com.sonar.sslr.api.Grammar;
+
+public class CxxChecks {
+
+  private final CheckFactory checkFactory;
+  private Set<Checks<SquidAstVisitor<Grammar>>> checksByRepository = new HashSet<>();
+
+  private CxxChecks(CheckFactory checkFactory) {
+    this.checkFactory = checkFactory;
+  }
+
+  public static CxxChecks createCxxCheck(CheckFactory checkFactory) {
+    return new CxxChecks(checkFactory);
+  }
+
+  @SuppressWarnings("rawtypes")
+  public CxxChecks addChecks(String repositoryKey, List<Class> checkClass) {
+    checksByRepository.add(checkFactory
+      .<SquidAstVisitor<Grammar>>create(repositoryKey)
+      .addAnnotatedChecks(checkClass));
+
+    return this;
+  }
+
+  public CxxChecks addCustomChecks(@Nullable CustomCxxRulesDefinition[] customRulesDefinitions) {
+    if (customRulesDefinitions != null) {
+      for (CustomCxxRulesDefinition rulesDefinition : customRulesDefinitions) {
+        addChecks(rulesDefinition.repositoryKey(), Lists.newArrayList(rulesDefinition.checkClasses()));
+      }
+    }
+
+    return this;
+  }
+
+  public List<SquidAstVisitor<Grammar>> all() {
+    List<SquidAstVisitor<Grammar>> allVisitors = new ArrayList<>();
+
+    for (Checks<SquidAstVisitor<Grammar>> checks : checksByRepository) {
+      allVisitors.addAll(checks.all());
+    }
+
+    return allVisitors;
+  }
+
+  @Nullable
+  public RuleKey ruleKey(SquidAstVisitor<Grammar> check) {
+    RuleKey ruleKey;
+
+    for (Checks<SquidAstVisitor<Grammar>> checks : checksByRepository) {
+      ruleKey = checks.ruleKey(check);
+
+      if (ruleKey != null) {
+        return ruleKey;
+      }
+    }
+    return null;
+  }
+}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxChecks.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxChecks.java
@@ -32,6 +32,7 @@ import org.sonar.api.rule.RuleKey;
 import org.sonar.plugins.cxx.api.CustomCxxRulesDefinition;
 import org.sonar.squidbridge.SquidAstVisitor;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.sonar.sslr.api.Grammar;
 
@@ -89,5 +90,10 @@ public class CxxChecks {
       }
     }
     return null;
+  }
+  
+  @VisibleForTesting
+  public Set<Checks<SquidAstVisitor<Grammar>>> getChecks() {
+    return checksByRepository;
   }
 }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/api/CustomCxxRulesDefinitionTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/api/CustomCxxRulesDefinitionTest.java
@@ -1,0 +1,97 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010 Neticoa SAS France
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.cxx.api;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.api.server.rule.RulesDefinition.Param;
+import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
+import org.sonar.plugins.cxx.CxxLanguage;
+import org.sonar.squidbridge.checks.SquidCheck;
+
+import com.sonar.sslr.api.Grammar;
+
+public class CustomCxxRulesDefinitionTest {
+
+  private static final String REPOSITORY_NAME = "Custom Rule Repository";
+  private static final String REPOSITORY_KEY = "CustomRuleRepository";
+
+  private static final String RULE_NAME = "This is my custom rule";
+  private static final String RULE_KEY = "MyCustomRule";
+
+  @Test
+  public void test() {
+    MyCustomPlSqlRulesDefinition rulesDefinition = new MyCustomPlSqlRulesDefinition();
+    RulesDefinition.Context context = new RulesDefinition.Context();
+    rulesDefinition.define(context);
+    RulesDefinition.Repository repository = context.repository(REPOSITORY_KEY);
+
+    assertThat(repository.name()).isEqualTo(REPOSITORY_NAME);
+    assertThat(repository.language()).isEqualTo(CxxLanguage.KEY);
+    assertThat(repository.rules()).hasSize(1);
+
+    RulesDefinition.Rule alertUseRule = repository.rule(RULE_KEY);
+    assertThat(alertUseRule).isNotNull();
+    assertThat(alertUseRule.name()).isEqualTo(RULE_NAME);
+
+    for (RulesDefinition.Rule rule : repository.rules()) {
+      for (Param param : rule.params()) {
+        assertThat(param.description()).as("description for " + param.key()).isNotEmpty();
+      }
+    }
+  }
+
+  @Rule(
+    key = RULE_KEY,
+    name = RULE_NAME,
+    description = "desc",
+    tags = { "bug" })
+  public class MyCustomRule extends SquidCheck<Grammar> {
+      @RuleProperty(
+        key = "customParam",
+        description = "Custom parameter",
+        defaultValue = "value")
+      public String customParam = "value";
+  }
+
+  public static class MyCustomPlSqlRulesDefinition extends CustomCxxRulesDefinition {
+
+    @Override
+    public String repositoryName() {
+      System.out.println(REPOSITORY_NAME);
+      return REPOSITORY_NAME;
+    }
+
+    @Override
+    public String repositoryKey() {
+      return REPOSITORY_KEY;
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Class[] checkClasses() {
+      return new Class[] { MyCustomRule.class };
+    }
+  }
+  
+}

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/squid/CxxChecksTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/squid/CxxChecksTest.java
@@ -1,0 +1,144 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010 Neticoa SAS France
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.cxx.squid;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.api.batch.rule.ActiveRules;
+import org.sonar.api.batch.rule.CheckFactory;
+import org.sonar.api.batch.rule.Checks;
+import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
+import org.sonar.api.rule.RuleKey;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.check.Rule;
+import org.sonar.plugins.cxx.api.CustomCxxRulesDefinition;
+import org.sonar.squidbridge.SquidAstVisitor;
+import org.sonar.squidbridge.checks.SquidCheck;
+
+import com.google.common.collect.ImmutableList;
+import com.sonar.sslr.api.Grammar;
+
+public class CxxChecksTest {
+  private static final String DEFAULT_REPOSITORY_KEY = "DefaultRuleRepository";
+  private static final String DEFAULT_RULE_KEY = "MyRule";
+  private static final String CUSTOM_REPOSITORY_KEY = "CustomRuleRepository";
+  private static final String CUSTOM_RULE_KEY = "MyCustomRule";
+  
+  private MyCustomPlSqlRulesDefinition customRulesDefinition;
+  private CheckFactory checkFactory;
+  
+  @Before
+  public void setUp() {
+    ActiveRules activeRules = (new ActiveRulesBuilder())
+        .create(RuleKey.of(DEFAULT_REPOSITORY_KEY, DEFAULT_RULE_KEY)).activate()
+        .create(RuleKey.of(CUSTOM_REPOSITORY_KEY, CUSTOM_RULE_KEY)).activate()
+        .build();
+    checkFactory = new CheckFactory(activeRules);
+    
+    customRulesDefinition = new MyCustomPlSqlRulesDefinition();
+    RulesDefinition.Context context = new RulesDefinition.Context();
+    customRulesDefinition.define(context);
+  }
+  
+  @SuppressWarnings("rawtypes")
+  @Test
+  public void shouldReturnDefaultChecks() {
+    CxxChecks checks = CxxChecks.createCxxCheck(checkFactory);
+    checks.addChecks(DEFAULT_REPOSITORY_KEY, ImmutableList.<Class>of(MyRule.class));
+    
+    SquidAstVisitor<Grammar> defaultCheck = check(checks, DEFAULT_REPOSITORY_KEY, DEFAULT_RULE_KEY);
+    
+    assertThat(checks.all()).hasSize(1);
+    assertThat(checks.ruleKey(defaultCheck)).isNotNull();
+    assertThat(checks.ruleKey(defaultCheck).rule()).isEqualTo(DEFAULT_RULE_KEY);
+    assertThat(checks.ruleKey(defaultCheck).repository()).isEqualTo(DEFAULT_REPOSITORY_KEY);
+  }
+  
+  @Test
+  public void shouldReturnCustomChecks() {
+    CxxChecks checks = CxxChecks.createCxxCheck(checkFactory);
+    checks.addCustomChecks(new CustomCxxRulesDefinition[] { customRulesDefinition });
+    
+    SquidAstVisitor<Grammar> customCheck = check(checks, CUSTOM_REPOSITORY_KEY, CUSTOM_RULE_KEY);
+    
+    assertThat(checks.all()).hasSize(1);
+    assertThat(checks.ruleKey(customCheck)).isNotNull();
+    assertThat(checks.ruleKey(customCheck).rule()).isEqualTo(CUSTOM_RULE_KEY);
+    assertThat(checks.ruleKey(customCheck).repository()).isEqualTo(CUSTOM_REPOSITORY_KEY);
+  }
+  
+  @Test
+  public void shouldWorkWithoutCustomChecks() {
+    CxxChecks checks = CxxChecks.createCxxCheck(checkFactory);
+    checks.addCustomChecks(null);
+    assertThat(checks.all()).hasSize(0);
+  }
+  
+  @SuppressWarnings("rawtypes")
+  @Test
+  public void shouldNotReturnRuleKeyIfCheckDoesNotExists() {
+    CxxChecks checks = CxxChecks.createCxxCheck(checkFactory);
+    checks.addChecks(DEFAULT_REPOSITORY_KEY, ImmutableList.<Class>of(MyRule.class));
+    assertThat(checks.ruleKey(new MyCustomRule())).isNull();
+  }
+  
+  public SquidAstVisitor<Grammar> check(CxxChecks cxxChecks, String repository, String rule) {
+    RuleKey key = RuleKey.of(repository, rule);
+    
+    SquidAstVisitor<Grammar> check;
+    for (Checks<SquidAstVisitor<Grammar>> checks : cxxChecks.getChecks()) {
+      check = (SquidAstVisitor<Grammar>)checks.of(key);
+
+      if (check != null) {
+        return check;
+      }
+    }
+    return null;
+  }
+
+  @Rule(key = DEFAULT_RULE_KEY, name = "This is the default rule", description = "desc")
+  public static class MyRule extends SquidCheck<Grammar> {
+  }
+  
+  @Rule(key = CUSTOM_RULE_KEY, name = "This is the custom rule", description = "desc")
+  public static class MyCustomRule extends SquidCheck<Grammar> {
+  }
+
+  public static class MyCustomPlSqlRulesDefinition extends CustomCxxRulesDefinition {
+
+    @Override
+    public String repositoryName() {
+      return "Custom Rule Repository";
+    }
+
+    @Override
+    public String repositoryKey() {
+      return CUSTOM_REPOSITORY_KEY;
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Class[] checkClasses() {
+      return new Class[] { MyCustomRule.class };
+    }
+  }
+}


### PR DESCRIPTION
As I mentioned in https://github.com/SonarOpenCommunity/sonar-cxx/issues/527#issuecomment-153189197, these are the changes necessary to allow custom checks in external plugins.

The grammar classes had to be moved to org.sonar.plugins.cxx.api due the SonarQube plugin classloader (http://docs.sonarqube.org/display/DEV/Plugin+Class+Loader).

The CustomCxxRulesDefinition class is the extension point. All plugins must extends this class to add new checks.

Instances of CustomCxxRulesDefinition are injected automatically by SonarQube in CxxSquidSensor.

I consider this a WIP because:
- needs more discussion, of course
- I don't like to hardcode the sonar-cxx-plugin version in the example plugin. Can I make this project a submodule of sonar-cxx (to compile with the project) or should I create a new kind of integration tests for it?