### PR TITLE
remove final and override from keyword list

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/api/CxxKeyword.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/api/CxxKeyword.java
@@ -24,8 +24,13 @@ import com.sonar.sslr.api.TokenType;
 
 /**
  * C++ Standard, Section 2.12 "Keywords"
+ *
+ * In this list are only C++ keywords allowed.
+ * All other extensions must be handled as identifiers
+ * (e.g. final, override, ...)
  */
 public enum CxxKeyword implements TokenType {
+  
   ALIGNAS("alignas"),
   ALIGNOF("alignof"),
   ASM("asm"),
@@ -57,7 +62,6 @@ public enum CxxKeyword implements TokenType {
   FLOAT("float"),
   FOR("for"),
   FRIEND("friend"),
-  FINAL("final"),
   GOTO("goto"),
   IF("if"),
   INLINE("inline"),
@@ -69,7 +73,6 @@ public enum CxxKeyword implements TokenType {
   NOEXCEPT("noexcept"),
   NULLPTR("nullptr"),
   OPERATOR("operator"),
-  OVERRIDE("override"),
   PRIVATE("private"),
   PROTECTED("protected"),
   PUBLIC("public"),
@@ -116,7 +119,6 @@ public enum CxxKeyword implements TokenType {
   
   // C++/CLI keywords
   GCNEW("gcnew");
-
   private final String value;
 
   private CxxKeyword(String value) {

--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -1221,7 +1221,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
 
     b.rule(classHeadName).is(b.optional(nestedNameSpecifier), className);
 
-    b.rule(classVirtSpecifier).is(b.firstOf(CxxKeyword.FINAL, "sealed", "abstract"));
+    b.rule(classVirtSpecifier).is(b.firstOf("final", "sealed", "abstract"));
 
     b.rule(classKey).is(
         b.firstOf(b.sequence(b.optional(b.firstOf("ref", "value", "interface")), CxxKeyword.CLASS),
@@ -1300,13 +1300,13 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
     b.rule(cliFunctionModifiers).is(b.oneOrMore(cliFunctionModifier));
 
     b.rule(cliFunctionModifier).is(
-        b.firstOf( "abstract", CxxKeyword.NEW, "sealed", CxxKeyword.OVERRIDE)
+        b.firstOf( "abstract", CxxKeyword.NEW, "sealed", "override")
         );
 
     b.rule(virtSpecifierSeq).is(b.oneOrMore(virtSpecifier));
 
     b.rule(virtSpecifier).is(
-        b.firstOf(CxxKeyword.OVERRIDE, CxxKeyword.FINAL)
+        b.firstOf("override", "final")
         );
 
     b.rule(pureSpecifier).is(b.sequence("=", "0"));

--- a/cxx-squid/src/test/java/org/sonar/cxx/api/CxxKeywordTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/api/CxxKeywordTest.java
@@ -27,7 +27,7 @@ public class CxxKeywordTest {
 
   @Test
   public void test() {
-    assertThat(CxxKeyword.values()).hasSize(86);
+    assertThat(CxxKeyword.values()).hasSize(84);
     assertThat(CxxKeyword.keywordValues()).hasSize(CxxKeyword.values().length);
   }
 


### PR DESCRIPTION
* final and override have a special meaning: http://en.cppreference.com/w/cpp/keyword and are no keywords
* close #673