### PR TITLE
Improve the comment regarding the public api limitations

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxPublicApiVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxPublicApiVisitor.java
@@ -49,7 +49,9 @@ import com.sonar.sslr.api.Token;
  * This visitor should be applied only on header files.<br>
  * Currently, no filtering is applied using preprocessing directive.<br>
  * <p>
- * Limitation: only "in front of the declaration" comments are considered.
+ * Limitation: only "in front of the declaration" comments and inline 
+ * comments (for members) are considered. Documenting public API by name 
+ * (\struct Foo for instance) in other files is not supported. 
  *
  * @see <a href="http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html">
  *      Doxygen Manual: Documenting the code</a>


### PR DESCRIPTION
The previous comment seemed to indicate that inline comments were not supported, but they are perfectly. This update makes the comment clearer by indicating that only comments by name in other files are not supported.