### PR TITLE
fix macro parameter replacement

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -62,6 +62,7 @@ import static org.sonar.cxx.api.CppKeyword.IFDEF;
 import static org.sonar.cxx.api.CppKeyword.IFNDEF;
 import static org.sonar.cxx.api.CppPunctuator.COMMA;
 import static org.sonar.cxx.api.CppPunctuator.LT;
+import static org.sonar.cxx.api.CppPunctuator.HASHHASH;
 import static org.sonar.cxx.api.CxxTokenType.NUMBER;
 import static org.sonar.cxx.api.CxxTokenType.PREPROCESSOR;
 import static org.sonar.cxx.api.CxxTokenType.STRING;
@@ -820,6 +821,11 @@ public class CxxPreprocessor extends Preprocessor {
         Token curr = body.get(i);
         int index = defParamValues.indexOf(curr.getValue());
         if (index == -1) {
+          if (tokenPastingRightOp) {
+            if (curr.getType() != WS && curr.getType() != HASHHASH) {
+              tokenPastingRightOp = false;
+            }
+          }
           newTokens.add(curr);
         } else if (index == arguments.size()) {
           // EXTENSION: GCC's special meaning of token paste operator

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/PreprocessorDirectivesTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/PreprocessorDirectivesTest.java
@@ -298,6 +298,11 @@ public class PreprocessorDirectivesTest extends ParserBaseTest {
       + "#define FB1(arg) FB(arg)\n"
       + "string s = FB1(F/B);"))
       .equals("string s = \"abc/def\" ; EOF"));
+    
+    assert (serialize(p.parse(
+      "#define SC_METHOD(func) declare_method_process( func ## _handle, #func, func )\n"
+      + "SC_METHOD(test);"))
+      .equals("declare_method_process ( test_handle , \"test\" , test ) ; EOF"));
   }
 
   @Test


### PR DESCRIPTION
```C++
#define SC_METHOD(func) declare_method_process( func ## _handle, #func, func )
SC_METHOD(test); // declare_method_process( test_handle, "test", test );
```

close #705