### PR TITLE
NUnit support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
       <dependency>
       <groupId>org.codehaus.sonar.dotnet.tests</groupId>
       <artifactId>sonar-dotnet-tests-library</artifactId>
-      <version>1.1.2</version>
+      <version>1.2</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -45,10 +45,10 @@ import org.sonar.plugins.cxx.valgrind.CxxValgrindRuleRepository;
 import org.sonar.plugins.cxx.valgrind.CxxValgrindSensor;
 import org.sonar.plugins.cxx.veraxx.CxxVeraxxRuleRepository;
 import org.sonar.plugins.cxx.veraxx.CxxVeraxxSensor;
-import org.sonar.plugins.cxx.xunit.CxxXunitSensor;
-import org.sonar.plugins.cxx.xunit.MSTestResultsProvider;
-import org.sonar.plugins.cxx.xunit.MSTestResultsProvider.MSTestResultsAggregator;
-import org.sonar.plugins.cxx.xunit.MSTestResultsProvider.MSTestResultsImportSensor;
+import org.sonar.plugins.cxx.tests.xunit.CxxXunitSensor;
+import org.sonar.plugins.cxx.tests.dotnet.CxxUnitTestResultsProvider;
+import org.sonar.plugins.cxx.tests.dotnet.CxxUnitTestResultsProvider.CxxUnitTestResultsAggregator;
+import org.sonar.plugins.cxx.tests.dotnet.CxxUnitTestResultsProvider.CxxUnitTestResultsImportSensor;
 import org.sonar.plugins.cxx.utils.CxxMetrics;
 
 import com.google.common.collect.ImmutableList;
@@ -374,12 +374,19 @@ public final class CxxPlugin extends SonarPlugin {
       .type(PropertyType.BOOLEAN)
       .index(7)
       .build(),
-      PropertyDefinition.builder(MSTestResultsProvider.VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY)
+      PropertyDefinition.builder(CxxUnitTestResultsProvider.VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY)
       .name("Visual Studio Test Reports Paths")
       .description("Example: \"report.trx\", \"report1.trx,report2.trx\" or \"C:/report.trx\"")
       .subCategory(subcateg)
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
       .index(8)
+      .build(),
+      PropertyDefinition.builder(CxxUnitTestResultsProvider.NUNIT_TEST_RESULTS_PROPERTY_KEY)
+      .name("Nunit Test Reports Paths")
+      .description("Example: \"nunit.xml\", \"nunit1.xml,nunit2.xml\" or \"C:/nunit.xml\"")
+      .subCategory(subcateg)
+      .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+      .index(9)
       .build()
     );
   }
@@ -415,8 +422,8 @@ public final class CxxPlugin extends SonarPlugin {
     l.add(CxxExternalRulesSensor.class);
     l.add(CxxExternalRuleRepository.class);
     l.add(CxxRuleRepository.class);
-    l.add(MSTestResultsAggregator.class);
-    l.add(MSTestResultsImportSensor.class);
+    l.add(CxxUnitTestResultsAggregator.class);
+    l.add(CxxUnitTestResultsImportSensor.class);
     l.add(CxxSourceCodeColorizer.class);
 
     l.addAll(generalProperties());

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/dotnet/CxxUnitTestResultsProvider.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/dotnet/CxxUnitTestResultsProvider.java
@@ -17,32 +17,33 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.cxx.xunit;
+package org.sonar.plugins.cxx.tests.dotnet;
 
 import org.sonar.api.config.Settings;
 import org.sonar.plugins.dotnet.tests.UnitTestConfiguration;
 import org.sonar.plugins.dotnet.tests.UnitTestResultsAggregator;
 import org.sonar.plugins.dotnet.tests.UnitTestResultsImportSensor;
 
-public class MSTestResultsProvider {
+public class CxxUnitTestResultsProvider {
 
   public static final String VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY = "sonar.cxx.vstest.reportsPaths";
-  private static final UnitTestConfiguration UNIT_TEST_CONF = new UnitTestConfiguration(VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY);
-
-  private MSTestResultsProvider() {
+  public static final String NUNIT_TEST_RESULTS_PROPERTY_KEY = "sonar.cxx.nunit.reportsPaths";
+  private static final UnitTestConfiguration UNIT_TEST_CONF = new UnitTestConfiguration(VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY, NUNIT_TEST_RESULTS_PROPERTY_KEY);
+  
+  private CxxUnitTestResultsProvider() {
   }
 
-  public static class MSTestResultsAggregator extends UnitTestResultsAggregator {
+  public static class CxxUnitTestResultsAggregator extends UnitTestResultsAggregator {
 
-    public MSTestResultsAggregator(Settings settings) {
+    public CxxUnitTestResultsAggregator(Settings settings) {
       super(UNIT_TEST_CONF, settings);
     }
 
   }
 
-  public static class MSTestResultsImportSensor extends UnitTestResultsImportSensor {
-
-    public MSTestResultsImportSensor(MSTestResultsAggregator unitTestResultsAggregator) {
+  public static class CxxUnitTestResultsImportSensor extends UnitTestResultsImportSensor {
+    
+    public CxxUnitTestResultsImportSensor(CxxUnitTestResultsAggregator unitTestResultsAggregator) {
       super(unitTestResultsAggregator);
     }
 

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/dotnet/package-info.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/dotnet/package-info.java
@@ -22,6 +22,6 @@
  * Package with sensor to evaluate Unit Test specific report files.
  */
 @ParametersAreNonnullByDefault
-package org.sonar.plugins.cxx.xunit;
+package org.sonar.plugins.cxx.tests.dotnet;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/xunit/CxxXunitSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/xunit/CxxXunitSensor.java
@@ -17,7 +17,7 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.cxx.xunit;
+package org.sonar.plugins.cxx.tests.xunit;
 
 import java.io.File;
 import java.io.InputStream;

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/xunit/TestCase.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/xunit/TestCase.java
@@ -17,7 +17,7 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.cxx.xunit;
+package org.sonar.plugins.cxx.tests.xunit;
 
 import org.apache.commons.lang.StringEscapeUtils;
 

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/xunit/TestFile.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/xunit/TestFile.java
@@ -17,7 +17,7 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.cxx.xunit;
+package org.sonar.plugins.cxx.tests.xunit;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/xunit/XunitReportParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/xunit/XunitReportParser.java
@@ -17,7 +17,7 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.cxx.xunit;
+package org.sonar.plugins.cxx.tests.xunit;
 
 import java.text.ParseException;
 import java.util.LinkedList;

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/xunit/package-info.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/xunit/package-info.java
@@ -17,17 +17,11 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.cxx;
 
-import static org.junit.Assert.assertEquals;
+/**
+ * Package with sensor to evaluate Unit Test specific report files.
+ */
+@ParametersAreNonnullByDefault
+package org.sonar.plugins.cxx.tests.xunit;
 
-import org.junit.Test;
-
-public class CxxPluginTest {
-
-  @Test
-  public void testGetExtensions() throws Exception {
-    CxxPlugin plugin = new CxxPlugin();
-    assertEquals(64, plugin.getExtensions().size());
-  }
-}
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/tests/dotnet/CxxUnitTestResultsProviderTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/tests/dotnet/CxxUnitTestResultsProviderTest.java
@@ -17,7 +17,7 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.cxx.xunit;
+package org.sonar.plugins.cxx.tests.dotnet;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -32,19 +32,21 @@ import org.sonar.api.resources.Project;
 import org.sonar.api.batch.SensorContext;
 import org.sonar.api.batch.fs.internal.DefaultFileSystem;
 import org.sonar.plugins.cxx.TestUtils;
-import org.sonar.plugins.cxx.xunit.MSTestResultsProvider.MSTestResultsAggregator;
-import org.sonar.plugins.cxx.xunit.MSTestResultsProvider.MSTestResultsImportSensor;
+import org.sonar.plugins.cxx.tests.dotnet.CxxUnitTestResultsProvider.CxxUnitTestResultsAggregator;
+import org.sonar.plugins.cxx.tests.dotnet.CxxUnitTestResultsProvider.CxxUnitTestResultsImportSensor;
 import org.sonar.plugins.dotnet.tests.UnitTestResults;
 import org.sonar.plugins.dotnet.tests.UnitTestResultsImportSensor;
+import org.sonar.plugins.dotnet.tests.WildcardPatternFileProvider;
 
 import com.google.common.collect.ImmutableList;
 
-public class MSTestResultsProviderTest {
+public class CxxUnitTestResultsProviderTest {
+
 
   private Project project;
   private SensorContext context;
-  private MSTestResultsAggregator resultsAggregator;
-  private MSTestResultsImportSensor sensor;
+  private CxxUnitTestResultsAggregator resultsAggregator;
+  private CxxUnitTestResultsImportSensor sensor;
 
   @Before
   public void setUp() {
@@ -56,7 +58,7 @@ public class MSTestResultsProviderTest {
   @Test
   public void should_execute_on_project() {
 
-    resultsAggregator = mock(MSTestResultsAggregator.class);
+    resultsAggregator = mock(CxxUnitTestResultsAggregator.class);
 
     when(resultsAggregator.hasUnitTestResultsProperty()).thenReturn(true);
     assertThat(new UnitTestResultsImportSensor(resultsAggregator).shouldExecuteOnProject(project)).isTrue();
@@ -67,11 +69,11 @@ public class MSTestResultsProviderTest {
 
   @Test
   public void should_not_analyze_on_reactor_project() {
-    when(project.isRoot()).thenReturn(true);
+    when(project.isRoot()).thenReturn(false);
     when(project.getModules()).thenReturn(ImmutableList.of(mock(Project.class)));
 
-    resultsAggregator = mock(MSTestResultsAggregator.class);
-    sensor = new MSTestResultsImportSensor(resultsAggregator);
+    resultsAggregator = mock(CxxUnitTestResultsAggregator.class);
+    sensor = new CxxUnitTestResultsImportSensor(resultsAggregator);
     sensor.analyse(project, context);
 
     verify(context, Mockito.never()).saveMeasure(Mockito.any(Metric.class), Mockito.anyDouble());
@@ -79,19 +81,19 @@ public class MSTestResultsProviderTest {
 
   @Test
   public void should_analyze_on_multi_module_modules() {
-    when(project.isRoot()).thenReturn(false);
+    when(project.isRoot()).thenReturn(true);
 
-    resultsAggregator = mock(MSTestResultsAggregator.class);
+    resultsAggregator = mock(CxxUnitTestResultsAggregator.class);
 
     UnitTestResults results = mock(UnitTestResults.class);
     when(results.tests()).thenReturn(1.0);
     when(results.passedPercentage()).thenCallRealMethod();
     when(results.skipped()).thenReturn(0.0);
-    when(results.failed()).thenReturn(1.0);
+    when(results.failures()).thenReturn(1.0);
     when(results.errors()).thenReturn(0.0);
 
-    when(resultsAggregator.aggregate(Mockito.any(UnitTestResults.class))).thenReturn(results);
-    sensor = new MSTestResultsImportSensor(resultsAggregator);
+    when(resultsAggregator.aggregate(Mockito.any(WildcardPatternFileProvider.class), Mockito.any(UnitTestResults.class))).thenReturn(results);
+    sensor = new CxxUnitTestResultsImportSensor(resultsAggregator);
     sensor.analyse(project, context);
 
     verify(context, Mockito.atLeastOnce()).saveMeasure(Mockito.any(Metric.class), Mockito.anyDouble());

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/tests/xunit/CxxXunitSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/tests/xunit/CxxXunitSensorTest.java
@@ -17,7 +17,7 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.cxx.xunit;
+package org.sonar.plugins.cxx.tests.xunit;
 
 import static org.hamcrest.core.AnyOf.anyOf;
 import static org.hamcrest.core.Is.is;

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/tests/xunit/TestCaseTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/tests/xunit/TestCaseTest.java
@@ -17,7 +17,7 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.cxx.xunit;
+package org.sonar.plugins.cxx.tests.xunit;
 
 import static org.junit.Assert.assertEquals;
 

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/tests/xunit/TestFileTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/tests/xunit/TestFileTest.java
@@ -17,7 +17,7 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.cxx.xunit;
+package org.sonar.plugins.cxx.tests.xunit;
 
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/tests/xunit/XunitReportParserTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/tests/xunit/XunitReportParserTest.java
@@ -17,7 +17,7 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.cxx.xunit;
+package org.sonar.plugins.cxx.tests.xunit;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
update sonar-dotnet-tests-library to 1.2
use "sonar.cxx.nunit.reportsPaths" for NUnit reports
rename derived classes from MSTestXxx to CxxUnitTestXxx
clean-up folder structure (xunit => tests/xunit and tests/dotnet)
close #722
