### PR TITLE
correct search order of dirs specified via 'sonar.cxx.includeDirectories'

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
@@ -40,7 +40,7 @@ public class CxxConfiguration extends SquidConfiguration {
   public static final String OverallDefineKey = "CxxOverallDefine";
 
   private boolean ignoreHeaderComments = false;
-  private final HashMap<String, Set<String>> uniqueIncludes = new HashMap<>();
+  private final HashMap<String, List<String>> uniqueIncludes = new HashMap<>();
   private final HashMap<String, Set<String>> uniqueDefines = new HashMap<>();
   private List<String> forceIncludeFiles = new ArrayList<>();
   private List<String> headerFileSuffixes = new ArrayList<>();
@@ -54,14 +54,14 @@ public class CxxConfiguration extends SquidConfiguration {
   private final CxxVCppBuildLogParser cxxVCppParser;
 
   public CxxConfiguration() {
-    uniqueIncludes.put(OverallIncludeKey, new HashSet<String>());
+    uniqueIncludes.put(OverallIncludeKey, new ArrayList<String>());
     uniqueDefines.put(OverallDefineKey, new HashSet<String>());
     cxxVCppParser = new CxxVCppBuildLogParser(uniqueIncludes, uniqueDefines);
   }
 
   public CxxConfiguration(Charset encoding) {
     super(encoding);
-    uniqueIncludes.put(OverallIncludeKey, new HashSet<String>());
+    uniqueIncludes.put(OverallIncludeKey, new ArrayList<String>());
     uniqueDefines.put(OverallDefineKey, new HashSet<String>());
     cxxVCppParser = new CxxVCppBuildLogParser(uniqueIncludes, uniqueDefines);
   }
@@ -69,7 +69,7 @@ public class CxxConfiguration extends SquidConfiguration {
   public CxxConfiguration(FileSystem fs) {
     super(fs.encoding());
     this.fs = fs;
-    uniqueIncludes.put(OverallIncludeKey, new HashSet<String>());
+    uniqueIncludes.put(OverallIncludeKey, new ArrayList<String>());
     uniqueDefines.put(OverallDefineKey, new HashSet<String>());
     cxxVCppParser = new CxxVCppBuildLogParser(uniqueIncludes, uniqueDefines);
   }
@@ -79,7 +79,7 @@ public class CxxConfiguration extends SquidConfiguration {
     super(fs.encoding());
     this.fs = fs;
     perspectives = perspectivesIn;
-    uniqueIncludes.put(OverallIncludeKey, new HashSet<String>());
+    uniqueIncludes.put(OverallIncludeKey, new ArrayList<String>());
     uniqueDefines.put(OverallDefineKey, new HashSet<String>());
     cxxVCppParser = new CxxVCppBuildLogParser(uniqueIncludes, uniqueDefines);
   }
@@ -122,9 +122,10 @@ public class CxxConfiguration extends SquidConfiguration {
   }
 
   public void setIncludeDirectories(List<String> includeDirectories) {
-    Set<String> overallIncludes = uniqueIncludes.get(OverallIncludeKey);
+    List<String> overallIncludes = uniqueIncludes.get(OverallIncludeKey);
     for (String include : includeDirectories) {
       if (!overallIncludes.contains(include)) {
+        LOG.debug("setIncludeDirectories() adding dir '{}'", include);
         overallIncludes.add(include);
       }
     }
@@ -137,17 +138,17 @@ public class CxxConfiguration extends SquidConfiguration {
   }
 
   public List<String> getIncludeDirectories() {
-    Set<String> allIncludes = new HashSet<>();
+    List<String> allIncludes = new ArrayList<>();
 
-    for (Set<String> elemSet : uniqueIncludes.values()) {
-      for (String value : elemSet) {
+    for (List<String> elemList : uniqueIncludes.values()) {
+      for (String value : elemList) {
         if (!allIncludes.contains(value)) {
           allIncludes.add(value);
         }
       }
     }
 
-    return new ArrayList<>(allIncludes);
+    return allIncludes;
   }
 
   public void setForceIncludeFiles(List<String> forceIncludeFiles) {

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxVCppBuildLogParser.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxVCppBuildLogParser.java
@@ -45,13 +45,13 @@ public class CxxVCppBuildLogParser {
 
   private static final org.slf4j.Logger LOG = LoggerFactory.getLogger("CxxVCppBuildLogParser");
 
-  private final HashMap<String, Set<String>> uniqueIncludes;
+  private final HashMap<String, List<String>> uniqueIncludes;
   private final HashMap<String, Set<String>> uniqueDefines;
 
   private VSVersion platformToolset = VSVersion.V120;
   private String platform = "Win32";
 
-  public CxxVCppBuildLogParser(HashMap<String, Set<String>> uniqueIncludesIn,
+  public CxxVCppBuildLogParser(HashMap<String, List<String>> uniqueIncludesIn,
     HashMap<String, Set<String>> uniqueDefinesIn) {
     uniqueIncludes = uniqueIncludesIn;
     uniqueDefines = uniqueDefinesIn;
@@ -65,7 +65,7 @@ public class CxxVCppBuildLogParser {
       LOG.debug("build log parser baseDir='{}'", baseDir);
       Path currentProjectPath = Paths.get(baseDir);
 
-      Set<String> overallIncludes = uniqueIncludes.get(CxxConfiguration.OverallIncludeKey);
+      List<String> overallIncludes = uniqueIncludes.get(CxxConfiguration.OverallIncludeKey);
 
       while ((line = br.readLine()) != null) {
         if (line.startsWith("  INCLUDE=")) { // handle environment includes 
@@ -116,7 +116,7 @@ public class CxxVCppBuildLogParser {
             }
 
             if (!uniqueIncludes.containsKey(fileElement)) {
-              uniqueIncludes.put(fileElement, new HashSet<String>());
+              uniqueIncludes.put(fileElement, new ArrayList<String>());
             }
 
             parseVCppCompilerCLLine(line, currentProjectPath.toAbsolutePath().toString(), fileElement);
@@ -181,7 +181,7 @@ public class CxxVCppBuildLogParser {
 
   private void ParseInclude(String element, String project, String fileElement) {
 
-    Set<String> includesPerUnit = uniqueIncludes.get(fileElement);
+    List<String> includesPerUnit = uniqueIncludes.get(fileElement);
 
     try {
       File includeRoot = new File(element.replace("\"", ""));


### PR DESCRIPTION
Previously, the include directories specified via 'sonar.cxx.includeDirectories'
were not necessarily searched in the order specified.  This patch corrects the
problem by storing the include paths as a list instead of a hash.

This toy project illustrates the problem, and verifies the fix:
```
[selltc@mac src]$ l
total 60
drwxr-xr-x  6 selltc selltc  4096 Jan  5 09:08 .
drwxrwxrwt 67 root   root   20480 Jan  5 09:08 ..
drwxr-xr-x  2 selltc selltc  4096 Jan  5 09:06 inc1
drwxr-xr-x  2 selltc selltc  4096 Jan  5 09:08 inc2
drwxr-xr-x  2 selltc selltc  4096 Jan  5 09:08 inc3
-rw-r--r--  1 selltc selltc   172 Jan  5 08:52 sonar-project.properties
-rw-r--r--  1 selltc selltc    30 Jan  5 09:08 x.c
[selltc@mac src]$ cat sonar-project.properties
sonar.projectKey=proj
sonar.projectName=proj
sonar.sources=x.c
sonar.log.level=DEBUG
sonar.cxx.cppcheck.reportPath=cppcheck.xml
sonar.cxx.includeDirectories=inc1,inc2,inc3
[selltc@mac src]$ cat x.c
#include "x.h"

int main() {}
[selltc@mac src]$ l inc1
total 8
drwxr-xr-x 2 selltc selltc 4096 Jan  5 09:06 .
drwxr-xr-x 6 selltc selltc 4096 Jan  5 09:08 ..
[selltc@mac src]$ l inc2
total 12
drwxr-xr-x 2 selltc selltc 4096 Jan  5 09:08 .
drwxr-xr-x 6 selltc selltc 4096 Jan  5 09:08 ..
-rw-r--r-- 1 selltc selltc   38 Jan  5 08:39 x.h
[selltc@mac src]$ l inc3
total 12
drwxr-xr-x 2 selltc selltc 4096 Jan  5 09:08 .
drwxr-xr-x 6 selltc selltc 4096 Jan  5 09:08 ..
-rw-r--r-- 1 selltc selltc   38 Jan  5 08:39 x.h
[selltc@mac src]$ cat inc2/x.h
int f2()
{
    char *p2;
    *p2=0;
}
[selltc@mac src]$ cat inc3/x.h
int f3()
{
    char *p3;
    *p3=0;
}
[selltc@mac src]$ cppcheck --enable=all --xml -Iinc1 -Iinc2 -Iinc3 x.c 2>cppcheck.xml
Checking x.c...
[selltc@mac src]$ cat cppcheck.xml
<?xml version="1.0" encoding="UTF-8"?>
<results>
    <error file="inc2/x.h" line="3" id="unassignedVariable" severity="style" msg="Variable &apos;p2&apos; is not assigned a value."/>
    <error file="inc2/x.h" line="4" id="uninitvar" severity="error" msg="Uninitialized variable: p2"/>
</results>
```

Running sonar-runner withOUT this patch yields the following output (note the expected search order of inc2 and inc3 is reversed):
```
...
09:10:46.583 INFO  - Sensor CxxSquidSensor
09:10:46.589 DEBUG - setIncludeDirectories() adding dir 'inc1'
09:10:46.589 DEBUG - setIncludeDirectories() adding dir 'inc2'
09:10:46.590 DEBUG - setIncludeDirectories() adding dir 'inc3'
09:10:46.644 DEBUG - storing include root: '/var/tmp/src/inc1'
09:10:46.645 DEBUG - storing include root: '/var/tmp/src/inc3'
09:10:46.645 DEBUG - storing include root: '/var/tmp/src/inc2'
09:10:46.704 DEBUG - [/var/tmp/src/x.c:1]: processing #include "x.h", resolved to file '/var/tmp/src/inc3/x.h'
09:10:46.720 DEBUG - finished preprocessing '/var/tmp/src/x.c'
...
```

This patch corrects the problem of the include directories being searched in
the wrong order (as the above example shows inc3 being searched before inc2).

Running sonar-runner WITH this patch yields the following output:
```
09:21:33.507 INFO  - Sensor CxxSquidSensor
09:21:33.510 DEBUG - setIncludeDirectories() adding dir 'inc1'
09:21:33.510 DEBUG - setIncludeDirectories() adding dir 'inc2'
09:21:33.510 DEBUG - setIncludeDirectories() adding dir 'inc3'
09:21:33.553 DEBUG - storing include root: '/var/tmp/src/inc1'
09:21:33.553 DEBUG - storing include root: '/var/tmp/src/inc2'
09:21:33.553 DEBUG - storing include root: '/var/tmp/src/inc3'
09:21:33.603 DEBUG - [/var/tmp/src/x.c:1]: processing #include "x.h", resolved to file '/var/tmp/src/inc2/x.h'
```

See also https://github.com/SonarOpenCommunity/sonar-cxx/issues/745.