### PR TITLE
add cxxlint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ target
 **/Debug/**
 **/Release/**
 *.log.server
+
+nbactions.xml
+nb-configuration.xml

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/TooManyLinesOfCodeInFileCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/TooManyLinesOfCodeInFileCheck.java
@@ -52,7 +52,7 @@ public class TooManyLinesOfCodeInFileCheck extends SquidCheck<Grammar> {
     defaultValue = "" + DEFAULT_MAXIMUM)
   private int max = DEFAULT_MAXIMUM;
 
-  public void SetMax(int max) {
+  public void setMax(int max) {
     this.max = max;
   }
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/TooManyLinesOfCodeInFileCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/TooManyLinesOfCodeInFileCheckTest.java
@@ -32,7 +32,7 @@ public class TooManyLinesOfCodeInFileCheckTest {
 
   @Test
   public void test() {
-    check.SetMax(1);
+    check.setMax(1);
     SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/checks/complexity.cc"), check);
     CheckMessagesVerifier.verify(file.getCheckMessages())
       .next().withMessage("This file has 22 lines of code, which is greater than 1 authorized. Split it into smaller files.")

--- a/cxx-lint/pom.xml
+++ b/cxx-lint/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.codehaus.sonar-plugins.cxx</groupId>
+        <artifactId>cxx</artifactId>
+        <version>0.9.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>cxx-lint</artifactId>
+    <name>Cxx :: Lint</name>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cxx-checks</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+          <version>2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.sonar</groupId>
+            <artifactId>sonar-check-api</artifactId>
+            <version>4.5.2</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.sonar</groupId>
+            <artifactId>sonar-plugin-api</artifactId>
+            <version>4.5.2</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.3.1</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    
+  <build>
+    <plugins>
+<plugin>
+  <artifactId>maven-assembly-plugin</artifactId>
+  <configuration>
+    <archive>
+      <manifest>
+              <addClasspath>true</addClasspath>
+              <mainClass>org.codehaus.sonarplugins.cxx.cxxlint.CxxLint</mainClass>
+              <classpathPrefix>lib/</classpathPrefix>
+      </manifest>
+    </archive>
+    <descriptorRefs>
+      <descriptorRef>jar-with-dependencies</descriptorRef>
+      
+    </descriptorRefs>
+    <finalName>cxx-lint-${version}</finalName>
+    <appendAssemblyId>false</appendAssemblyId>
+  </configuration>
+  <executions>
+    <execution>
+      <id>make-assembly</id> <!-- this is used for inheritance merges -->
+      <phase>package</phase> <!-- bind to the packaging phase -->
+      <goals>
+        <goal>single</goal>
+      </goals>
+    </execution>
+  </executions>
+</plugin>
+        
+      
+   
+    </plugins>
+  </build>
+      
+</project>

--- a/cxx-lint/src/main/java/org/codehaus/sonarplugins/cxx/cxxlint/CheckerData.java
+++ b/cxx-lint/src/main/java/org/codehaus/sonarplugins/cxx/cxxlint/CheckerData.java
@@ -1,0 +1,32 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2011 Waleri Enns
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.codehaus.sonarplugins.cxx.cxxlint;
+
+import java.util.HashMap;
+
+/**
+ *
+ * @author jocs
+ */
+public class CheckerData {
+    public String id = "";
+    public Boolean enabled = true;
+    public HashMap<String, String> parameterData = new HashMap<String, String>();
+}

--- a/cxx-lint/src/main/java/org/codehaus/sonarplugins/cxx/cxxlint/CxxLint.java
+++ b/cxx-lint/src/main/java/org/codehaus/sonarplugins/cxx/cxxlint/CxxLint.java
@@ -1,0 +1,286 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2011 Waleri Enns
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.codehaus.sonarplugins.cxx.cxxlint;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import com.sonar.sslr.api.Grammar;
+import java.beans.Statement;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
+import org.sonar.cxx.CxxAstScanner;
+import org.sonar.cxx.CxxConfiguration;
+import org.sonar.cxx.CxxVCppBuildLogParser;
+import org.sonar.cxx.checks.CheckList;
+import org.sonar.squidbridge.SquidAstVisitor;
+import org.sonar.squidbridge.api.CheckMessage;
+import org.sonar.squidbridge.api.SourceFile;
+
+/**
+ *
+ * @author jocs
+ */
+public class CxxLint {
+
+  private static Options CreateCommandLineOptions() {
+    Options options = new Options();
+    options.addOption("s", true, "settings file");
+    options.addOption("f", true, "file to analyse - required");
+    return options;
+  }
+
+  public static String readFile(String filename) throws IOException {
+    String content = null;
+    File file = new File(filename); //for ex foo.txt
+    try (FileReader reader = new FileReader(file)) {
+      char[] chars = new char[(int) file.length()];
+      reader.read(chars);
+      content = new String(chars);
+      reader.close();
+    } catch (IOException e) {
+    }
+    return content;
+  }
+
+  /**
+   * @param args the command line arguments
+   * @throws java.lang.InstantiationException
+   * @throws java.lang.IllegalAccessException
+   * @throws java.io.IOException
+   */
+  public static void main(String[] args)
+          throws InstantiationException, IllegalAccessException, IOException, Exception {
+
+    CommandLineParser commandlineParser = new DefaultParser();
+    Options options = CreateCommandLineOptions();
+    CommandLine parsedArgs;
+    String settingsFile = "";
+    String fileToAnalyse = "";
+    CxxConfiguration configuration = new CxxConfiguration();
+
+    try {
+      parsedArgs = commandlineParser.parse(CreateCommandLineOptions(), args);
+      if (!parsedArgs.hasOption("f")) {
+        throw new ParseException("f option mandatory");
+      } else {
+        fileToAnalyse = parsedArgs.getOptionValue("f");
+        File f = new File(fileToAnalyse);
+        if (!f.exists()) {
+          throw new ParseException("file to analysis not found");
+        }
+      }
+
+      if (parsedArgs.hasOption("s")) {
+        settingsFile = parsedArgs.getOptionValue("s");
+        File f = new File(settingsFile);
+        if (!f.exists()) {
+          throw new ParseException("optional settings file given with -s, however file was not found");
+        }
+      }
+    } catch (ParseException exp) {
+      System.err.println("Parsing Command line Failed.  Reason: " + exp.getMessage());
+      HelpFormatter formatter = new HelpFormatter();
+      formatter.printHelp("java -jar CxxLint-<sersion>.jar -f filetoanalyse", options);
+      throw exp;
+    }
+
+    HashMap<String, CheckerData> rulesData = new HashMap<>();
+    if (!"".equals(settingsFile)) {
+      JsonParser parser = new JsonParser();
+      String fileContent = readFile(settingsFile);
+      
+      // get basic information
+      String platformToolset = GetJsonStringValue(parser, fileContent, "platformToolset");     
+      String platform = GetJsonStringValue(parser, fileContent, "platform");
+      String projectFile = GetJsonStringValue(parser, fileContent, "projectFile");       
+      
+      JsonElement rules = parser.parse(fileContent).getAsJsonObject().get("rules");
+      if (rules != null) {
+        for (JsonElement rule : rules.getAsJsonArray()) {
+          JsonObject data = rule.getAsJsonObject();
+          String ruleId = data.get("ruleId").getAsString();
+          String enabled = data.get("status").getAsString();
+          if (rulesData.containsKey(ruleId)) {
+            continue;
+          }
+
+          CheckerData check = new CheckerData();
+          check.id = ruleId;
+          check.enabled = enabled.equals("Enabled");
+          JsonElement region = data.get("properties");
+          if (region != null) {
+            for (Entry parameter : region.getAsJsonObject().entrySet()) {
+              JsonElement elem = (JsonElement) parameter.getValue();
+              check.parameterData.put(parameter.getKey().toString(), elem.getAsString());
+            }
+          }
+
+          rulesData.put(ruleId, check);
+        }
+      }
+      
+      JsonElement includes = parser.parse(fileContent).getAsJsonObject().get("includes");
+      if (includes != null) {
+        for (JsonElement include : includes.getAsJsonArray()) {
+          configuration.addOverallIncludeDirectory(include.getAsString());
+        }
+      }
+
+      JsonElement defines = parser.parse(fileContent).getAsJsonObject().get("defines");
+      if (defines != null) {
+        for (JsonElement define : defines.getAsJsonArray()) {
+          configuration.addOverallDefine(define.getAsString());
+        }
+      }
+      
+      JsonElement additionalOptions = parser.parse(fileContent).getAsJsonObject().get("additionalOptions");
+      String elementsOfAdditionalOptions = "";
+      if (additionalOptions != null) {
+        for (JsonElement option : additionalOptions.getAsJsonArray()) {
+          elementsOfAdditionalOptions = elementsOfAdditionalOptions + " " + option.getAsString();
+        }
+      }
+      
+      HandleVCppAdditionalOptions(platformToolset, platform, elementsOfAdditionalOptions + " ", projectFile, fileToAnalyse, configuration);
+    }
+
+    List<Class> checks = CheckList.getChecks();
+    List<SquidAstVisitor<Grammar>> visitors = new ArrayList<>();
+    HashMap<String, String> KeyData = new HashMap<String, String>();
+
+    for (Class check : checks) {
+      Rule rule = (Rule) check.getAnnotation(Rule.class);
+      if (rule == null) {
+        continue;
+      }
+
+      SquidAstVisitor<Grammar> element = (SquidAstVisitor<Grammar>) check.newInstance();
+
+      KeyData.put(check.getCanonicalName(), rule.key());
+      
+      if (!parsedArgs.hasOption("s")) {
+        visitors.add(element);
+        continue;
+      }
+      
+      if (!rulesData.containsKey(rule.key())) {
+        continue;
+      }
+
+      CheckerData data = rulesData.get(rule.key());
+
+      if (!data.enabled) {
+        continue;
+      }
+
+      for (Field f : check.getDeclaredFields()) {
+        for (Annotation a : f.getAnnotations()) {
+          RuleProperty ruleProp = (RuleProperty) a;
+          if (ruleProp != null) {
+            if (data.parameterData.containsKey(ruleProp.key())) {
+              if (f.getType().equals(int.class)) {
+                String cleanData = data.parameterData.get(ruleProp.key());
+                int value = Integer.parseInt(cleanData);
+                if (f.toString().startsWith("public ")) {
+                  f.set(element, value);
+                } else {
+                  char first = Character.toUpperCase(ruleProp.key().charAt(0));
+                  Statement stmt = new Statement(element, "set" + first + ruleProp.key().substring(1), new Object[]{value});
+                  stmt.execute();
+                }
+              }
+
+              if (f.getType().equals(String.class)) {
+                String cleanData = data.parameterData.get(ruleProp.key());
+
+                if (f.toString().startsWith("public ")) {
+                  f.set(element, cleanData);
+                } else {
+                  char first = Character.toUpperCase(ruleProp.key().charAt(0));
+                  Statement stmt = new Statement(element, "set" + first + ruleProp.key().substring(1), new Object[]{cleanData});
+                  stmt.execute();
+                }
+              }
+            }
+          }
+        }
+      }
+      visitors.add(element);
+    }
+
+    System.out.println("Analyse with : " + visitors.size() + " checks");
+    SourceFile file = CxxAstScanner.scanSingleFileConfig(
+            new File(fileToAnalyse),
+            configuration,
+            visitors.toArray(new SquidAstVisitor[visitors.size()]));
+    for (CheckMessage message : file.getCheckMessages()) {
+      String key = KeyData.get(message.getCheck().getClass().getCanonicalName());      
+      // E:\TSSRC\Core\Common\libtools\tool_archive.cpp(390): Warning : sscanf can be ok, but is slow and can overflow buffers.  [runtime/printf-5] [1]
+      System.out.println(message.getSourceCode() + "(" + message.getLine() + "): Warning : " + message.formatDefaultMessage() + " [" + key + "]");
+    }
+  }
+
+  private static String GetJsonStringValue(JsonParser parser, String fileContent, String id) throws JsonSyntaxException {
+    JsonElement element = parser.parse(fileContent).getAsJsonObject().get(id);
+    if (element != null) {
+      return element.getAsString();
+    }
+    return "";
+  }
+
+  private static void HandleVCppAdditionalOptions(String platformToolset, String platform, String elementsOfAdditionalOptions, String project, String fileToAnalyse, CxxConfiguration configuration) {
+    if(platformToolset.equals("V100") ||
+            platformToolset.equals("V110") ||
+            platformToolset.equals("V120") ||
+            platformToolset.equals("V140")) {
+      
+      HashMap<String, List<String>> uniqueIncludes = new HashMap<>();
+      HashMap<String, Set<String>> uniqueDefines = new HashMap<>();
+      uniqueDefines.put(fileToAnalyse, new HashSet<String>());
+      uniqueIncludes.put(fileToAnalyse, new ArrayList<String>());
+      CxxVCppBuildLogParser lineOptionsParser = new CxxVCppBuildLogParser(uniqueIncludes, uniqueDefines);
+      lineOptionsParser.setPlatform(platform);
+      lineOptionsParser.setPlatformToolset(platformToolset);
+      lineOptionsParser.parseVCppLine(elementsOfAdditionalOptions, project, fileToAnalyse);
+      for(String define : uniqueDefines.get(fileToAnalyse)) {
+        configuration.addOverallDefine(define);
+      }
+    }
+  }
+}

--- a/cxx-lint/src/test/java/org/codehaus/sonarplugins/cxx/cxxlint/CxxLintTest.java
+++ b/cxx-lint/src/test/java/org/codehaus/sonarplugins/cxx/cxxlint/CxxLintTest.java
@@ -1,0 +1,81 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2011 Waleri Enns
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.codehaus.sonarplugins.cxx.cxxlint;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author jocs
+ */
+public class CxxLintTest {
+  
+  /**
+   * Test of main method, of class CxxLint.
+   */
+  @Test
+  public void runsToolWithoutSettingsWithoutExceptions() {
+    ClassLoader classLoader = getClass().getClassLoader();
+	File fileToAnalyse = new File(classLoader.getResource("PathHandle.cpp").getFile());
+    
+    String[] args = new String[2];
+    args[0] = "-f";
+    args[1] = fileToAnalyse.getAbsolutePath();
+    
+    try {
+      CxxLint.main(args);
+      assertTrue(true);
+    } catch (Exception ex) {
+      assertTrue("Exception Found: " + ex.getMessage(), false);
+    }
+  }  
+  
+  /**
+   * Test of main method, of class CxxLint.
+   */
+  @Test
+  public void runsToolWithSettingsWithoutExceptions() {
+    ClassLoader classLoader = getClass().getClassLoader();
+	File fileToAnalyse = new File(classLoader.getResource("PathHandle.cpp").getFile());
+    File settingsFile = new File(classLoader.getResource("4b4b9c5c-05f3-42e1-b94f-4c74b53241e3.json").getFile());
+    
+    String[] args = new String[4];
+    args[0] = "-f";
+    args[1] = fileToAnalyse.getAbsolutePath();
+    args[2] = "-s";
+    args[3] = settingsFile.getAbsolutePath();
+    
+    try {
+      CxxLint.main(args);
+      assertTrue(true);
+    } catch (Exception ex) {
+      assertTrue("Exception Found: " + ex.getMessage(), false);
+    }
+  }  
+}

--- a/cxx-lint/src/test/resources/4b4b9c5c-05f3-42e1-b94f-4c74b53241e3.json
+++ b/cxx-lint/src/test/resources/4b4b9c5c-05f3-42e1-b94f-4c74b53241e3.json
@@ -1,0 +1,253 @@
+{
+  "platformToolset": "V120",
+  "platform": "Win32",
+  "projectFile": "D:/prod/structures/Core/Common/libexternaldatabase/libexternaldatabase.vcxproj",
+  "includes": [
+    "C:/Program Files (x86)/Microsoft Visual Studio 12.0/VC/INCLUDE",
+    "C:/Program Files (x86)/Microsoft Visual Studio 12.0/VC/ATLMFC/INCLUDE",
+    "C:/Program Files (x86)/Windows Kits/8.1/include/shared",
+    "C:/Program Files (x86)/Windows Kits/8.1/include/um",
+    "C:/Program Files (x86)/Windows Kits/8.1/include/winrt",
+    "D:/prod/structures/Packages/gtestmock.1.7.5/build/native/include/",
+    "D:/prod/structures/Packages/gtestmock.1.7.5/build/native/include/googletest"
+  ],
+  "defines": [
+    "_MBCS",
+    "ZKIT_USE_STRICT_TYPES",
+    "GTEST_LINKED_AS_SHARED_LIBRARY=1",
+    "NO_WARN_MBCS_MFC_DEPRECATION",
+    "NT",
+    "OS_NT",
+    "WIN32",
+    "_WIN32_WINNT=0x0601",
+    "WINVER=0x0601"
+  ],
+  "additionalOptions": [
+    "/Zc:strictStrings",
+    "-Zm200",
+    "-D_CRT_SECURE_NO_DEPRECATE",
+    "-w34063",
+    "-w34189",
+    "-w34206",
+    "-w34327",
+    "-w34701",
+    "/Zc:rvalueCast",
+    "/Zc:inline"
+  ],
+  "rules": [
+    {
+      "ruleId": "ParsingErrorRecovery",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "CollapsibleIfCandidate",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "FileName",
+      "status": "Enabled",
+      "properties": {
+        "format": "(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$"
+      }
+    },
+    {
+      "ruleId": "FixmeTagPresence",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "TabCharacter",
+      "status": "Enabled",
+      "properties": {
+        "createLineViolation": "false"
+      }
+    },
+    {
+      "ruleId": "HardcodedAccount",
+      "status": "Enabled",
+      "properties": {
+        "regularExpression": "\\bDSN\\b.*=.*;\\b(UID|PWD)\\b=.*;"
+      }
+    },
+    {
+      "ruleId": "HardcodedIp",
+      "status": "Enabled",
+      "properties": {
+        "regularExpression": "^.*((?<![\\d|\\.])(?:\\b(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\b\\.){3}\\b(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\b(?!\\d|\\.)).*$"
+      }
+    },
+    {
+      "ruleId": "MissingCurlyBraces",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "UselessParentheses",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "FunctionName",
+      "status": "Enabled",
+      "properties": {
+        "format": "^[a-z_][a-z0-9_]{2,30}$"
+      }
+    },
+    {
+      "ruleId": "UndocumentedApi",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "ClassName",
+      "status": "Enabled",
+      "properties": {
+        "format": "^[A-Z_][a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "ruleId": "FileComplexity",
+      "status": "Enabled",
+      "properties": {
+        "max": "200"
+      }
+    },
+    {
+      "ruleId": "ReservedNames",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "MethodName",
+      "status": "Enabled",
+      "properties": {
+        "format": "^[A-Z][A-Za-z0-9]{2,30}$"
+      }
+    },
+    {
+      "ruleId": "FileHeader",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "DuplicatedInclude",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "BooleanEqualityComparison",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "UnnamedNamespaceInHeader",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "UseCorrectInclude",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "TooLongLine",
+      "status": "Enabled",
+      "properties": {
+        "maximumLineLength": "200",
+        "tabWidth": "4"
+      }
+    },
+    {
+      "ruleId": "TodoTagPresence",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "MissingNewLineAtEndOfFile",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "Indentation",
+      "status": "Enabled",
+      "properties": {
+        "indentLinkageSpecification": "false",
+        "indentationLevel": "2",
+        "tabWidth": "8",
+        "indentSwitchCase": "true",
+        "indentNamespace": "true"
+      }
+    },
+    {
+      "ruleId": "CommentedCode",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "CycleBetweenPackages",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "TooManyStatementsPerLine",
+      "status": "Enabled",
+      "properties": {
+        "excludeCaseBreak": "true"
+      }
+    },
+    {
+      "ruleId": "UsingNamespaceInHeader",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "FunctionComplexity",
+      "status": "Enabled",
+      "properties": {
+        "max": "16"
+      }
+    },
+    {
+      "ruleId": "MissingIncludeFile",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "ParsingError",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "NestedStatements",
+      "status": "Enabled",
+      "properties": {
+        "max": "6"
+      }
+    },
+    {
+      "ruleId": "StringLiteralDuplicated",
+      "status": "Enabled",
+      "properties": {
+        "minimalLiteralLength": "7"
+      }
+    },
+    {
+      "ruleId": "NoSonar",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "TooManyLinesOfCodeInFile",
+      "status": "Enabled",
+      "properties": {
+        "max": "2000"
+      }
+    },
+    {
+      "ruleId": "SafetyTag",
+      "status": "Enabled",
+      "properties": {
+        "regularExpression": "<Safetykey>.*</Safetykey>",
+        "message": "Source files implementing risk mitigations shall use special name suffix '_SAFETY'",
+        "suffix": "_SAFETY"
+      }
+    },
+    {
+      "ruleId": "FileEncoding",
+      "status": "Enabled"
+    },
+    {
+      "ruleId": "MagicNumber",
+      "status": "Enabled",
+      "properties": {
+        "exceptions": "0,1,0x0,0x00,.0,.1,0.0,1.0,0u,1u,0ul,1ul,1.0f,0.0f,0LL,1LL,0ULL,1ULL"
+      }
+    },
+    {
+      "ruleId": "SwitchLastCaseIsDefault",
+      "status": "Enabled"
+    }
+  ]
+}

--- a/cxx-lint/src/test/resources/PathHandle.cpp
+++ b/cxx-lint/src/test/resources/PathHandle.cpp
@@ -1,0 +1,26 @@
+#include "PathHandle.h"
+
+
+PathHandle::PathHandle()
+{
+}
+
+
+PathHandle::~PathHandle()
+{
+}
+
+std::string PathHandle::CompinePaths(std::string path1, std::string path2)
+{
+    char *pFile = getenv("TEAMCITY_PROJECT_NAME");
+
+    int i = 0;
+    char ch = path1.back();
+
+    if(ch == '/')
+    {
+        return path1.append(path2);
+    }
+
+    return path1.append("/").append(path2);
+}

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
@@ -100,6 +100,13 @@ public class CxxConfiguration extends SquidConfiguration {
       }
     }
   }
+  
+  public void addOverallDefine(String define) {
+    Set<String> overallDefs = uniqueDefines.get(OverallDefineKey);
+    if (!overallDefs.contains(define)) {
+      overallDefs.add(define);
+    }
+  }  
 
   public void setDefines(String[] defines) {
     if (defines != null) {
@@ -130,6 +137,14 @@ public class CxxConfiguration extends SquidConfiguration {
       }
     }
   }
+  
+  public void addOverallIncludeDirectory(String includeDirectory) {
+    List<String> overallIncludes = uniqueIncludes.get(OverallIncludeKey);
+    if (!overallIncludes.contains(includeDirectory)) {
+      LOG.debug("setIncludeDirectories() adding dir '{}'", includeDirectory);
+      overallIncludes.add(includeDirectory);
+    }
+  }  
 
   public void setIncludeDirectories(String[] includeDirectories) {
     if (includeDirectories != null) {

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxVCppBuildLogParser.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxVCppBuildLogParser.java
@@ -38,17 +38,12 @@ import org.slf4j.LoggerFactory;
 
 public class CxxVCppBuildLogParser {
 
-  private enum VSVersion {
-
-    V100, V110, V120, V140
-  };
-
   private static final org.slf4j.Logger LOG = LoggerFactory.getLogger("CxxVCppBuildLogParser");
 
   private final HashMap<String, List<String>> uniqueIncludes;
   private final HashMap<String, Set<String>> uniqueDefines;
 
-  private VSVersion platformToolset = VSVersion.V120;
+  private String platformToolset = "V120";
   private String platform = "Win32";
 
   public CxxVCppBuildLogParser(HashMap<String, List<String>> uniqueIncludesIn,
@@ -56,7 +51,30 @@ public class CxxVCppBuildLogParser {
     uniqueIncludes = uniqueIncludesIn;
     uniqueDefines = uniqueDefinesIn;
   }
+  
+  public void setPlatform(String platform) {
+    this.platform = platform;
+  }
 
+  /**
+   *
+   * @param platformToolset
+   */
+  public void setPlatformToolset(String platformToolset) {
+    this.platformToolset = platformToolset;
+  }
+  
+  /**
+   * Can be used to creat a list of includes, defines and options for a single line
+   * If it follows the format of Vcpp
+   * @param line
+   * @param projectPath
+   * @param compilationFile
+   */
+  public void parseVCppLine(String line, String projectPath, String compilationFile) {
+    this.parseVCppCompilerCLLine(line, projectPath, compilationFile);
+  }
+  
   public void parseVCppLog(File buildLog, String baseDir, String charsetName) {
 
     try {
@@ -91,13 +109,13 @@ public class CxxVCppBuildLogParser {
         }
 
         if (line.contains("\\V100\\Microsoft.CppBuild.targets") || line.contains("Microsoft Visual Studio 10.0\\VC\\bin\\CL.exe")) {
-          platformToolset = VSVersion.V100;
+          platformToolset = "V100";
         } else if (line.contains("\\V110\\Microsoft.CppBuild.targets") || line.contains("Microsoft Visual Studio 11.0\\VC\\bin\\CL.exe")) {
-          platformToolset = VSVersion.V110;
+          platformToolset = "V110";
         } else if (line.contains("\\V120\\Microsoft.CppBuild.targets") || line.contains("Microsoft Visual Studio 12.0\\VC\\bin\\CL.exe")) {
-          platformToolset = VSVersion.V120;
+          platformToolset = "V120";
         } else if (line.contains("\\V140\\Microsoft.CppBuild.targets") || line.contains("Microsoft Visual Studio 14.0\\VC\\bin\\CL.exe")) {
-          platformToolset = VSVersion.V140;
+          platformToolset = "V140";
         }
 
           // 1>Task "Message"
@@ -130,7 +148,6 @@ public class CxxVCppBuildLogParser {
             LOG.error("Bug in parser, please report: '{}' - '{}'", ex.getMessage(), data + " @ " + currentProjectPath);
             LOG.error("StackTrace: '{}'", ex.getStackTrace());
           }
-
         }
       }
       br.close();
@@ -163,13 +180,13 @@ public class CxxVCppBuildLogParser {
     // https://msdn.microsoft.com/en-us/library/vstudio/b0084kay(v=vs.140).aspx
     ParseCommonCompilerOptions(line, fileElement);
 
-    if (platformToolset.equals(VSVersion.V100)) {
+    if (platformToolset.equals("V100")) {
       ParseV100CompilerOptions(line, fileElement);
-    } else if (platformToolset.equals(VSVersion.V110)) {
+    } else if (platformToolset.equals("V110")) {
       ParseV110CompilerOptions(line, fileElement);
-    } else if (platformToolset.equals(VSVersion.V120)) {
+    } else if (platformToolset.equals("V120")) {
       ParseV120CompilerOptions(line, fileElement);
-    } else if (platformToolset.equals(VSVersion.V140)) {
+    } else if (platformToolset.equals("V140")) {
       ParseV140CompilerOptions(line, fileElement);
     }
   }

--- a/integration-tests/features/common.py
+++ b/integration-tests/features/common.py
@@ -122,7 +122,7 @@ def analyseloglines(lines, toignore=None):
             badlines.append(line)
             errors += 1
         elif isSonarWarning(line, toingore_re):
-            if "JOURNAL_FLUSHER" not in line:
+            if "JOURNAL_FLUSHER" not in line and "high disk watermark" not in line and "shards will be relocated away from this node" not in line:
                 sys.stdout.write("found warning '%s'" % line)
                 badlines.append(line)
                 warnings += 1

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
   <modules>
     <module>cxx-squid</module>
     <module>cxx-checks</module>
+    <module>cxx-lint</module>    
     <module>sonar-cxx-plugin</module>
     <module>sslr-cxx-toolkit</module>
   </modules>

--- a/sonar-cxx-plugin/pom.xml
+++ b/sonar-cxx-plugin/pom.xml
@@ -100,6 +100,13 @@
           <exclude>external/*</exclude>
         </excludes>
       </resource>
+      <resource>
+        <targetPath>static</targetPath>
+        <directory>../cxx-lint/target</directory>
+        <includes>
+          <include>cxx-lint-${project.version}.jar</include>
+        </includes>
+      </resource>
     </resources>
   </build>
 </project>


### PR DESCRIPTION
@guwirth @Bertk one of the things of using clang was that it could be made into a standalone analyser and reuse in local analysis before files are commit.

in fact, there is not reason why we cant do the same for the cxx plugin as it us. ive create a small console application that can be run to generate issues using the current cxx checks. 

the sintax is easy:
java -jar E:\Development\SonarQube\cxx\sonar-cxx\CxxLint\target\CxxLint-0.9.5-SNAPSHOT.jar -f d:\prod\structures\Core\Common\common\Common.cpp -s e:\CxxLintConfig.json

where CxxLintConfig.json is optional and is meant to give more info to the analysis:

```
{
  "version": "0.1",
  "includes": [
	"abc",
	"adc"
  ],
  "defines": [
	"abc",
	"adc"
  ],  
  "rules": [
    {
      "ruleId": "FileComplexity",
	  "status": "Enabled",
      "properties": {
        "max": "1"
      }
    },
    {
      "ruleId": "ClassName",
	  "status": "Enabled",
      "properties": {
        "format": "^sdasa[A-Z_][a-zA-Z0-9]+$"
      }
    },
    {
      "ruleId": "OtherName",
	  "status": "Disabled"
    }
  ]
}
```

this will provide issues like this:
```
d:\prod\structures\Core\Common\common\Common.cpp:40:Unable to find the source for '#include "tool_date.hpp"'.
d:\prod\structures\Core\Common\common\Common.cpp:56:The regular expression matches this line
d:\prod\structures\Core\Common\common\Common.cpp:87:Rename function "LibMain" to match the regular expression ^[a-z_][a-z0-9_]{2,30}$.
```

ive change this plugin to embeed the jar so, users can download from sonar like this:

http://localhost:9000/static/cxx/CxxLint-0.9.5-SNAPSHOT.jar

i was thinking now to include this in my visual studio extension so i can report all missing issues also from the cxx plugin and not only for vera , cppcheck and so on

what do you guys think?


