### PR TITLE
rats: add missing rules strncat/sscanf

### DIFF
--- a/sonar-cxx-plugin/src/main/resources/rats.xml
+++ b/sonar-cxx-plugin/src/main/resources/rats.xml
@@ -945,6 +945,20 @@ Follow these steps to make your custom Custom rules available in SonarQube:
   </rule>
 
   <rule>
+    <key>strncat</key>
+    <name>strncat</name>
+    <description>
+      Double check that your buffer is as big as you specify. When
+      using functions that accept a number n of bytes to copy, such as
+      strncpy, be aware that if the destination buffer size = n it may not
+      NULL-terminate the string.
+    </description>
+    <priority>MAJOR</priority>
+    <configKey>config/StrNCat</configKey>
+    <tag>security</tag>
+  </rule>
+
+  <rule>
     <key>StrNCat</key>
     <name>StrNCat</name>
     <description>
@@ -2619,6 +2633,21 @@ Follow these steps to make your custom Custom rules available in SonarQube:
   <rule>
     <key>sscanf</key>
     <name>sscanf</name>
+    <description>
+      Check to be sure that the format string passed as argument 2 to
+      this function call does not come from an untrusted source that could
+      have added formatting characters that the code is not prepared to
+      handle. Additionally, the format string could contain `%s' without
+      precision that could result in a buffer overflow.
+    </description>
+    <priority>MAJOR</priority>
+    <configKey>config/sscanf</configKey>
+    <tag>security</tag>
+  </rule>
+
+  <rule>
+    <key>swscanf</key>
+    <name>swscanf</name>
     <description>
       Check to be sure that the format string passed as argument 2 to
       this function call does not come from an untrusted source that could

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/rats/CxxRatsRuleRepositoryTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/rats/CxxRatsRuleRepositoryTest.java
@@ -39,6 +39,6 @@ public class CxxRatsRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxRatsRuleRepository.KEY);
-    assertThat(repo.rules()).hasSize(301);
+    assertThat(repo.rules()).hasSize(303);
   }
 }


### PR DESCRIPTION
SQ is case sensitive and swscanf rule was not available