### PR TITLE
Creating a GCC+MAKE log analyser

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -28,6 +28,7 @@ import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
 import org.sonar.plugins.cxx.compiler.CxxCompilerGccParser;
 import org.sonar.plugins.cxx.compiler.CxxCompilerGccRuleRepository;
+import org.sonar.plugins.cxx.compiler.CxxCompilerGccMakeParser;
 import org.sonar.plugins.cxx.compiler.CxxCompilerSensor;
 import org.sonar.plugins.cxx.compiler.CxxCompilerVcParser;
 import org.sonar.plugins.cxx.compiler.CxxCompilerVcRuleRepository;
@@ -268,8 +269,8 @@ public final class CxxPlugin extends SonarPlugin {
       .defaultValue(CxxCompilerSensor.DEFAULT_PARSER_DEF)
       .name("Format")
       .type(PropertyType.SINGLE_SELECT_LIST)
-      .options(CxxCompilerVcParser.KEY, CxxCompilerGccParser.KEY)
-      .description("The format of the warnings file. Currently supported are Visual C++ and GCC.")
+      .options(CxxCompilerVcParser.KEY, CxxCompilerGccParser.KEY, CxxCompilerGccMakeParser.KEY)
+      .description("The format of the warnings file. Currently supported are Visual C++, GCC and GCC+MAKE.")
       .subCategory(subcateg)
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
       .index(2)

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CxxCompilerGccMakeParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CxxCompilerGccMakeParser.java
@@ -1,0 +1,123 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010 Neticoa SAS France
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.cxx.compiler;
+
+import java.io.File;
+import java.util.List;
+import java.util.Stack;
+import java.util.Scanner;
+import java.util.regex.Pattern;
+import java.util.regex.MatchResult;
+import org.sonar.api.batch.SensorContext;
+import org.sonar.api.resources.Project;
+
+import org.sonar.plugins.cxx.utils.CxxUtils;
+
+/**
+ * {@inheritDoc}
+ */
+public class CxxCompilerGccMakeParser implements CompilerParser {
+
+  public static final String KEY = "GCC-MAKE";
+  // search for single line with compiler warning message - order for groups: 1 = file, 2 = line, 3 = message, 4=id
+  public static final String DEFAULT_REGEX_DEF = "^(.*):(?:(?:([0-9]+):[0-9]+: warning: (.*)\\[(.*)\\])|(?:\\s*(Entering|Leaving)\\s+\\w*\\s+[\"`'](.*?)[\"`']))$";
+  // ToDo: as long as java 7 API is not used the support of named groups for regular expression is not possible
+  // sample regex: "^.*[\\\\,/](?<filename>.*)\\((?<line>[0-9]+)\\)\\x20:\\x20warning\\x20(?<id>C\\d\\d\\d\\d):(?<message>.*)$";
+  // get value with e.g. scanner.match().group("filename");
+  public static final String DEFAULT_CHARSET_DEF = "UTF-8";
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String key() {
+    return KEY;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String rulesRepositoryKey() {
+    return CxxCompilerGccRuleRepository.KEY;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String defaultRegexp() {
+    return DEFAULT_REGEX_DEF;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String defaultCharset() {
+    return DEFAULT_CHARSET_DEF;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void processReport(final Project project, final SensorContext context, File report, String charset, String reportRegEx, List<Warning> warnings) throws java.io.FileNotFoundException {
+    CxxUtils.LOG.info("Parsing 'GCC-MAKE' format");
+
+    Scanner scanner = new Scanner(report, charset);
+    Pattern p = Pattern.compile(reportRegEx, Pattern.MULTILINE);
+    CxxUtils.LOG.debug("Using pattern : '{}'", p);
+    Stack<String> dirpath = new Stack<String>();
+    MatchResult matchres = null;
+    while (scanner.findWithinHorizon(p, 0) != null) {
+      matchres = scanner.match();
+      String type = matchres.group(5);
+
+      if (type != null) {
+        if (type.equals("Entering")) {
+          String path = matchres.group(6);
+          dirpath.push(path);
+          CxxUtils.LOG.debug("Push path '{}'", path);
+        } else if (type.equals("Leaving")) {
+          String path = matchres.group(6);
+          dirpath.pop();
+          // Maybe throw exception if it is not equal?
+          CxxUtils.LOG.debug("Pop path '{}'", path);
+        }
+      } else {
+        String filename = CxxUtils.normalizePathFull(matchres.group(1), dirpath.peek());
+        String line = matchres.group(2);
+        String msg = matchres.group(3);
+        String id = matchres.group(4).replaceAll("=$", "");
+        CxxUtils.LOG.debug("Scanner-matches file='{}' line='{}' id='{}' msg={}",
+          new Object[]{filename, line, id, msg});
+        warnings.add(new Warning(filename, line, id, msg));
+      }
+    }
+
+    scanner.close();
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CxxCompilerSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/compiler/CxxCompilerSensor.java
@@ -63,6 +63,7 @@ public class CxxCompilerSensor extends CxxReportSensor {
 
     addCompilerParser(new CxxCompilerVcParser());
     addCompilerParser(new CxxCompilerGccParser());
+    addCompilerParser(new CxxCompilerGccMakeParser());
   }
 
   /**

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/compiler/CxxCompilerSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/compiler/CxxCompilerSensorTest.java
@@ -28,6 +28,7 @@ import org.sonar.api.issue.Issue;
 import org.sonar.api.profiles.RulesProfile;
 import org.sonar.api.resources.Project;
 import org.sonar.plugins.cxx.TestUtils;
+import org.sonar.plugins.cxx.utils.CxxUtils;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -75,6 +76,19 @@ public class CxxCompilerSensorTest {
     settings.setProperty(CxxCompilerSensor.REPORT_PATH_KEY, "compiler-reports/build.log");
     settings.setProperty(CxxCompilerSensor.REPORT_CHARSET_DEF, "UTF-8");
     TestUtils.addInputFile(fs, perspectives, issuable, "/home/test/src/zip/src/zipmanager.cpp");
+    CxxCompilerSensor sensor = new CxxCompilerSensor(perspectives, settings, fs, profile);
+    sensor.analyse(project, context);
+    verify(issuable, times(4)).addIssue(any(Issue.class));
+  }
+
+  @Test
+  public void shouldReportCorrectGccMakeViolations() {
+    Settings settings = new Settings();
+    String fullpath = CxxUtils.normalizePath("/home/test/src/zip/src/zipmanager.cpp");
+    settings.setProperty("sonar.cxx.compiler.parser", CxxCompilerGccMakeParser.KEY);
+    settings.setProperty(CxxCompilerSensor.REPORT_PATH_KEY, "compiler-reports/build_make.log");
+    settings.setProperty(CxxCompilerSensor.REPORT_CHARSET_DEF, "UTF-8");
+    TestUtils.addInputFile(fs, perspectives, issuable, fullpath);
     CxxCompilerSensor sensor = new CxxCompilerSensor(perspectives, settings, fs, profile);
     sensor.analyse(project, context);
     verify(issuable, times(4)).addIssue(any(Issue.class));

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/compiler-reports/build_make.log
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/compiler-reports/build_make.log
@@ -1,0 +1,13 @@
+make[1]: Entering directory '/home/test/src/zip'
+make[2]: Entering directory '/home/test/src/zip/src'
+zipmanager.cpp: In function 'int unzip(char *, int)'
+../src/zipmanager.cpp:141:10: warning: conversion to 'unsigned char' from 'unsigned int' may alter its value [-Wconversion]
+zipmanager.cpp:222:9: warning: enumeration value 'Type_Deflate' not handled in switch [-Wswitch-enum]
+zipmanager.cpp:268:15: warning: enumeration value 'Type_Deflate' not handled in switch [-Wswitch-enum]
+zipmanager.cpp: In member function 'bool getRatio(int*) const':
+zipmanager.cpp:271:75: warning: comparing floating point with == or != is unsafe [-Wfloat-equal]
+make[2]: Leaving directory '/home/test/src/zip/src'
+make[1]: Leaving directory '/home/test/src/zip'
+make: Entering directory '/home/test/src/test'
+make: Nothing to be done for 'all'.
+make: Leaving directory '/home/test/src/test'


### PR DESCRIPTION
GCC+Make allows to filter for Entering/Leaving directory to have a better location of files.