### PR TITLE
reduce logging

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -575,8 +575,6 @@ public class CxxPreprocessor extends Preprocessor {
       } finally {
         currentFileState = globalStateStack.pop();
       }
-    } else {
-      LOG.debug("[{}:{}]: skipping already included file '{}'", new Object[]{filename, token.getLine(), includedFile});
     }
 
     return new PreprocessorAction(1, Lists.newArrayList(Trivia.createSkippedText(token)), new ArrayList<Token>());
@@ -748,7 +746,7 @@ public class CxxPreprocessor extends Preprocessor {
 
       rest = match(rest, ")");
     } catch (MismatchException me) {
-      LOG.error("{}", me);
+      LOG.error("MismatchException : '{}' rest: '{}'", me.getMessage(), rest);
       return 0;
     }
 
@@ -757,6 +755,7 @@ public class CxxPreprocessor extends Preprocessor {
 
   private List<Token> match(List<Token> tokens, String str) throws MismatchException {
     if (!tokens.get(0).getValue().equals(str)) {
+      LOG.error("Mismatch: expected '" + str + "' got: '" + tokens.get(0).getValue() + "'");
       throw new MismatchException("Mismatch: expected '" + str + "' got: '"
         + tokens.get(0).getValue() + "'");
     }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/BullseyeParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/BullseyeParser.java
@@ -57,8 +57,7 @@ public class BullseyeParser extends CxxCoverageParser {
   @Override
   public void processReport(final Project project, final SensorContext context, File report, final Map<String, CoverageMeasuresBuilder> coverageData)
     throws XMLStreamException {
-    CxxUtils.LOG.info("Parsing 'Bullseye' format");
-
+    CxxUtils.LOG.debug("Parsing 'Bullseye' format");
     StaxParser topLevelparser = new StaxParser(new StaxParser.XmlStreamHandler() {
       /**
        * {@inheritDoc}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CoberturaParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CoberturaParser.java
@@ -48,8 +48,7 @@ public class CoberturaParser extends CxxCoverageParser {
   @Override
   public void processReport(final Project project, final SensorContext context, File report, final Map<String, CoverageMeasuresBuilder> coverageData)
     throws XMLStreamException {
-    CxxUtils.LOG.info("Parsing 'Cobertura' format");
-
+    CxxUtils.LOG.debug("Parsing 'Cobertura' format");
     StaxParser parser = new StaxParser(new StaxParser.XmlStreamHandler() {
       /**
        * {@inheritDoc}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
@@ -179,7 +179,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
           }            
         }
       } else {
-        CxxUtils.LOG.warn("Cannot find the file '{}', ignoring coverage measures", filePath);
+        CxxUtils.LOG.debug("Cannot find the file '{}', ignoring coverage measures", filePath);
       }
     }
   }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/VisualStudioParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/VisualStudioParser.java
@@ -47,8 +47,7 @@ public class VisualStudioParser extends CxxCoverageParser {
   @Override
   public void processReport(final Project project, final SensorContext context, File report, final Map<String, CoverageMeasuresBuilder> coverageData)
     throws XMLStreamException {
-    CxxUtils.LOG.info("Parsing 'Visual Studio' format");
-
+    CxxUtils.LOG.debug("Parsing 'Visual Studio' format");
     StaxParser parser = new StaxParser(new StaxParser.XmlStreamHandler() {
       /**
        * {@inheritDoc}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV1.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV1.java
@@ -49,8 +49,7 @@ public class CppcheckParserV1 implements CppcheckParser {
   @Override
   public void processReport(final Project project, final SensorContext context, File report)
     throws javax.xml.stream.XMLStreamException {
-    CxxUtils.LOG.info("Parsing 'Cppckeck V1' format");
-
+    CxxUtils.LOG.debug("Parsing 'Cppcheck V1' format");
     StaxParser parser = new StaxParser(new StaxParser.XmlStreamHandler() {
       /**
        * {@inheritDoc}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV2.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/cppcheck/CppcheckParserV2.java
@@ -49,8 +49,7 @@ public class CppcheckParserV2 implements CppcheckParser {
   @Override
   public void processReport(final Project project, final SensorContext context, File report)
     throws javax.xml.stream.XMLStreamException {
-    CxxUtils.LOG.info("Parsing 'Cppcheck V2' format");
-
+    CxxUtils.LOG.debug("Parsing 'Cppcheck V2' format");
     StaxParser parser = new StaxParser(new StaxParser.XmlStreamHandler() {
       /**
        * {@inheritDoc}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/externalrules/CxxExternalRulesSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/externalrules/CxxExternalRulesSensor.java
@@ -70,8 +70,8 @@ public class CxxExternalRulesSensor extends CxxReportSensor {
 
   @Override
   protected void processReport(final Project project, final SensorContext context, File report) throws javax.xml.stream.XMLStreamException {
-    CxxUtils.LOG.info("Parsing 'other' format");
-
+    CxxUtils.LOG.debug("Parsing 'other' format");
+    
     StaxParser parser = new StaxParser(new StaxParser.XmlStreamHandler() {
 
       /**

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/pclint/CxxPCLintSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/pclint/CxxPCLintSensor.java
@@ -78,8 +78,8 @@ public class CxxPCLintSensor extends CxxReportSensor {
   @Override
   protected void processReport(final Project project, final SensorContext context, File report)
     throws javax.xml.stream.XMLStreamException {
-    CxxUtils.LOG.info("Parsing 'PC-Lint' format");
-
+    CxxUtils.LOG.debug("Parsing 'PC-Lint' format");
+    
     StaxParser parser = new StaxParser(new StaxParser.XmlStreamHandler() {
       /**
        * {@inheritDoc}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/rats/CxxRatsSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/rats/CxxRatsSensor.java
@@ -68,8 +68,8 @@ public final class CxxRatsSensor extends CxxReportSensor {
   @Override
   protected void processReport(final Project project, final SensorContext context, File report)
     throws org.jdom.JDOMException, java.io.IOException {
-    CxxUtils.LOG.info("Parsing 'RATS' format");
-
+    CxxUtils.LOG.debug("Parsing 'RATS' format");
+    
     try {
       SAXBuilder builder = new SAXBuilder(false);
       Element root = builder.build(report).getRootElement();

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxSquidSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxSquidSensor.java
@@ -133,7 +133,6 @@ public final class CxxSquidSensor implements Sensor {
       visitors.toArray(new SquidAstVisitor[visitors.size()]));
 
     scanner.scanFiles(Lists.newArrayList(fs.files(mainFilePredicate)));
-
     Collection<SourceCode> squidSourceFiles = scanner.getIndex().search(new QueryByType(SourceFile.class));
     save(squidSourceFiles);
   }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/valgrind/CxxValgrindSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/valgrind/CxxValgrindSensor.java
@@ -65,7 +65,7 @@ public class CxxValgrindSensor extends CxxReportSensor {
   @Override
   protected void processReport(final Project project, final SensorContext context, File report)
     throws javax.xml.stream.XMLStreamException {
-    CxxUtils.LOG.info("Parsing 'Valgrind' format");
+    CxxUtils.LOG.debug("Parsing 'Valgrind' format");
     ValgrindReportParser parser = new ValgrindReportParser();
     saveErrors(project, context, parser.processReport(project, context, report));
   }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/veraxx/CxxVeraxxSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/veraxx/CxxVeraxxSensor.java
@@ -68,8 +68,7 @@ public class CxxVeraxxSensor extends CxxReportSensor {
   @Override
   protected void processReport(final Project project, final SensorContext context, File report)
     throws javax.xml.stream.XMLStreamException {
-    CxxUtils.LOG.info("Parsing 'Vera++' format");
-
+    CxxUtils.LOG.debug("Parsing 'Vera++' format");
     try {
       StaxParser parser = new StaxParser(new StaxParser.XmlStreamHandler() {
         /**
@@ -87,7 +86,6 @@ public class CxxVeraxxSensor extends CxxReportSensor {
           while (fileCursor.getNext() != null) {
             String name = fileCursor.getAttrValue("name");
 
-            CxxUtils.LOG.info("Vera++ processes file = {}", name);
             SMInputCursor errorCursor = fileCursor.childElementCursor("error");
             while (errorCursor.getNext() != null) {
               if (!"error".equals(name)) {


### PR DESCRIPTION
. silence parse stacktrace  and instead print more meaningful information for the analysis
. clean some duplicated logging

@guwirth the current logging is printing stacktraces that are not meaninfull or not working. ex:

[14:39:57] :		 [Step 3/3] 14:39:57.857 ERROR - {}
[14:39:57] :		 [Step 3/3] org.sonar.cxx.preprocessor.CxxPreprocessor$MismatchException: null
[14:39:57] :		 [Step 3/3] 	at org.sonar.cxx.preprocessor.CxxPreprocessor.matchArgument(CxxPreprocessor.java:795) [cxx-squid-0.9.6-SNAPSHOT.jar:na]
[14:39:57] :		 [Step 3/3] 	at org.sonar.cxx.preprocessor.CxxPreprocessor.matchArguments(CxxPreprocessor.java:739) [cxx-squid-0.9.6-SNAPSHOT.jar:na]

For some reason when doing this:

throw new EvaluationException("Unknown expression type '" + nodeType + "'");

those dont show up in stacktrace. instead a 200 lines stack trace is printed, with this change a debug log of 160 MB went to 26 MB