### PR TITLE
End of support for Java 7 as a runtime environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ language: java
 
 jdk:
         - oraclejdk8
-        - openjdk7
 
 env:
-        - SONARHOME=/tmp/sonarqube-5.3
         - SONARHOME=/tmp/sonarqube-5.4
   
 matrix:


### PR DESCRIPTION
This will allow us to benefit from new construct and APIs of Java 8, both on the platform and on plugins.
As a reminder, Oracle stopped public support of Java 7 in April 2015.
https://jira.sonarsource.com/browse/SONAR-7225