### PR TITLE
Visual studio coverage fix null ref exception

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
@@ -156,7 +156,9 @@ public class CxxCoverageSensor extends CxxReportSensor {
       String filePath = entry.getKey();
       InputFile cxxFile = fs.inputFile(fs.predicates().hasPath(filePath));
       if (cxxFile != null) {
-        Collection<Measure> measures = entry.getValue().createMeasures();
+        CxxUtils.LOG.debug("Saving for file '{}'", filePath);
+        CoverageMeasuresBuilder builder = entry.getValue();
+        Collection<Measure> measures = builder.createMeasures();
         CxxUtils.LOG.debug("Saving '{}' coverage measures for file '{}'", measures.size(), filePath);
         for (Measure measure : measures) {
           Measure convertedMeasure = measure;
@@ -179,7 +181,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
           }            
         }
       } else {
-        CxxUtils.LOG.warn("Cannot find the file '{}', ignoring coverage measures", filePath);
+        CxxUtils.LOG.debug("Cannot find the file '{}', ignoring coverage measures", filePath);
       }
     }
   }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/VisualStudioParser.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/VisualStudioParser.java
@@ -87,6 +87,12 @@ public class VisualStudioParser extends CxxCoverageParser {
     SMInputCursor sourceFile = sourceFiles.childElementCursor("source_file");
     while (sourceFile.getNext() != null) {
       String id = sourceFile.getAttrValue("id");
+      
+      if (!coverageData.containsKey(id)) {
+        // source_file without any covered lines
+        continue;
+      }
+      
       String normalPath = CxxUtils.normalizePath(sourceFile.getAttrValue("path"));
       CoverageMeasuresBuilder builder = coverageData.remove(id);
       if (normalPath != null) {


### PR DESCRIPTION
fix nullref exception for VisualStudio Coverage, where a complete file is not covered by tests:
CxxCoverageSensor
entry.getValue().createMeasures()
entry.getValue() would be be null.

VisualStudioParser:
therfore ignore files which are not in coverageData.

CoverageMeasuresBuilder builder = coverageData.remove(id);
would return null if id does not exists in coverageData