### PR TITLE
remove CxxMetric.LINES

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxAstScanner.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxAstScanner.java
@@ -47,7 +47,6 @@ import org.sonar.squidbridge.indexer.QueryByType;
 import org.sonar.squidbridge.metrics.CommentsVisitor;
 import org.sonar.squidbridge.metrics.ComplexityVisitor;
 import org.sonar.squidbridge.metrics.CounterVisitor;
-import org.sonar.squidbridge.metrics.LinesVisitor;
 
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.AstNodeType;
@@ -167,7 +166,6 @@ public final class CxxAstScanner {
       .build());
 
     /* Metrics */
-    builder.withSquidAstVisitor(new LinesVisitor<>(CxxMetric.LINES));
     builder.withSquidAstVisitor(new CxxLinesOfCodeVisitor<>(CxxMetric.LINES_OF_CODE));
     builder.withSquidAstVisitor(new CxxPublicApiVisitor<>(CxxMetric.PUBLIC_API,
       CxxMetric.PUBLIC_UNDOCUMENTED_API)

--- a/cxx-squid/src/main/java/org/sonar/cxx/api/CxxMetric.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/api/CxxMetric.java
@@ -25,7 +25,6 @@ import org.sonar.squidbridge.measures.MetricDef;
 public enum CxxMetric implements MetricDef {
 
   FILES,
-  LINES,
   LINES_OF_CODE,
   STATEMENTS,
   FUNCTIONS,

--- a/cxx-squid/src/test/java/org/sonar/cxx/CxxAstScannerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/CxxAstScannerTest.java
@@ -54,12 +54,6 @@ public class CxxAstScannerTest {
   }
 
   @Test
-  public void lines() {
-    SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/metrics/classes.cc"));
-    assertThat(file.getInt(CxxMetric.LINES)).isEqualTo(7);
-  }
-
-  @Test
   public void lines_of_code() {
     SourceFile file = CxxAstScanner.scanSingleFile(new File("src/test/resources/metrics/classes.cc"));
     assertThat(file.getInt(CxxMetric.LINES_OF_CODE)).isEqualTo(5);

--- a/cxx-squid/src/test/java/org/sonar/cxx/api/CxxMetricTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/api/CxxMetricTest.java
@@ -27,7 +27,7 @@ public class CxxMetricTest {
 
   @Test
   public void test() {
-    assertThat(CxxMetric.values()).hasSize(10);
+    assertThat(CxxMetric.values()).hasSize(9);
 
     for (CxxMetric metric : CxxMetric.values()) {
       assertThat(metric.getName()).isEqualTo(metric.name());

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxSquidSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxSquidSensor.java
@@ -199,7 +199,6 @@ public final class CxxSquidSensor implements Sensor {
 
   private void saveMeasures(InputFile inputFile, SourceFile squidFile) {
     context.saveMeasure(inputFile, CoreMetrics.FILES, squidFile.getDouble(CxxMetric.FILES));
-    context.saveMeasure(inputFile, CoreMetrics.LINES, squidFile.getDouble(CxxMetric.LINES));
     context.saveMeasure(inputFile, CoreMetrics.NCLOC, squidFile.getDouble(CxxMetric.LINES_OF_CODE));
     context.saveMeasure(inputFile, CoreMetrics.STATEMENTS, squidFile.getDouble(CxxMetric.STATEMENTS));
     context.saveMeasure(inputFile, CoreMetrics.FUNCTIONS, squidFile.getDouble(CxxMetric.FUNCTIONS));


### PR DESCRIPTION
This is only a test. Unit tests are failing. CoreMetrics.LINES returns wrong value now. Seems that number is number of code lines now (without comment and empty lines)?
