### PR TITLE
sonar-api-5.6-RC2

### DIFF
--- a/cxx-checks/pom.xml
+++ b/cxx-checks/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.codehaus.sonar-plugins.cxx</groupId>
+    <groupId>org.sonarsource.sonarqube-plugins.cxx</groupId>
     <artifactId>cxx</artifactId>
     <version>0.9.6-SNAPSHOT</version>
   </parent>

--- a/cxx-lint/pom.xml
+++ b/cxx-lint/pom.xml
@@ -1,90 +1,90 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.codehaus.sonar-plugins.cxx</groupId>
-        <artifactId>cxx</artifactId>
-        <version>0.9.6-SNAPSHOT</version>
-    </parent>
-    <artifactId>cxx-lint</artifactId>
-    <name>Cxx :: Lint</name>
-    <packaging>jar</packaging>
-    <dependencies>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>cxx-checks</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>com.google.code.gson</groupId>
-          <artifactId>gson</artifactId>
-          <version>2.4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.sonar</groupId>
-            <artifactId>sonar-check-api</artifactId>
-            <version>4.5.4</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.sonar</groupId>
-            <artifactId>sonar-plugin-api</artifactId>
-            <version>4.5.4</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-            <version>1.3.1</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-    
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonarsource.sonarqube-plugins.cxx</groupId>
+    <artifactId>cxx</artifactId>
+    <version>0.9.6-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cxx-lint</artifactId>
+  <name>Cxx :: Lint</name>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cxx-checks</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.sonarqube</groupId>
+      <artifactId>sonar-check-api</artifactId>
+      <version>5.4</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.sonarqube</groupId>
+      <artifactId>sonar-plugin-api</artifactId>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>1.3.1</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
-<plugin>
-  <artifactId>maven-assembly-plugin</artifactId>
-  <configuration>
-    <archive>
-      <manifest>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
               <addClasspath>true</addClasspath>
-              <mainClass>org.codehaus.sonarplugins.cxx.cxxlint.CxxLint</mainClass>
+              <mainClass>org.sonarsource.sonarqubeplugins.cxx.cxxlint.CxxLint</mainClass>
               <classpathPrefix>lib/</classpathPrefix>
-      </manifest>
-    </archive>
-    <descriptorRefs>
-      <descriptorRef>jar-with-dependencies</descriptorRef>
-      
-    </descriptorRefs>
-    <finalName>cxx-lint-${project.version}</finalName>
-    <appendAssemblyId>false</appendAssemblyId>
-  </configuration>
-  <executions>
-    <execution>
-      <id>make-assembly</id> <!-- this is used for inheritance merges -->
-      <phase>package</phase> <!-- bind to the packaging phase -->
-      <goals>
-        <goal>single</goal>
-      </goals>
-    </execution>
-  </executions>
-</plugin>
-        
-      
-   
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <finalName>cxx-lint-${project.version}</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <!-- this is used for inheritance merges -->
+            <phase>package</phase>
+            <!-- bind to the packaging phase -->
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
-      
+
 </project>

--- a/cxx-squid/pom.xml
+++ b/cxx-squid/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.codehaus.sonar-plugins.cxx</groupId>
+    <groupId>org.sonarsource.sonarqube-plugins.cxx</groupId>
     <artifactId>cxx</artifactId>
     <version>0.9.6-SNAPSHOT</version>
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>32</version>
   </parent>
 
-  <groupId>org.codehaus.sonar-plugins.cxx</groupId>
+  <groupId>org.sonarsource.sonarqube-plugins.cxx</groupId>
   <artifactId>cxx</artifactId>
   <version>0.9.6-SNAPSHOT</version>
   <packaging>pom</packaging>
@@ -104,7 +104,7 @@
       <name>Chris Bagwell</name>
       <email>chris@cnpbagwell.com</email>
     </developer>
-       <developer>
+    <developer>
       <id>mjdetullio</id>
       <name>Matthew DeTullio</name>
       <email></email>
@@ -129,7 +129,7 @@
   <modules>
     <module>cxx-squid</module>
     <module>cxx-checks</module>
-    <module>cxx-lint</module>    
+    <module>cxx-lint</module>
     <module>sonar-cxx-plugin</module>
     <module>sslr-cxx-toolkit</module>
   </modules>
@@ -154,7 +154,7 @@
     <license.owner>SonarOpenCommunity</license.owner>
     <license.mailto>http://github.com/SonarOpenCommunity/sonar-cxx</license.mailto>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-    <sonar.version>5.1</sonar.version>
+    <sonar.version>5.6-RC2</sonar.version>
     <sslr.version>1.21</sslr.version>
     <sonar.pluginClass>org.sonar.plugins.cxx.CxxPlugin</sonar.pluginClass>
     <sonar.artifact.path>target/${project.artifactId}-${project.version}.jar</sonar.artifact.path>
@@ -167,21 +167,21 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.codehaus.sonar</groupId>
+        <groupId>org.sonarsource.sonarqube</groupId>
         <artifactId>sonar-plugin-api</artifactId>
         <version>${sonar.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.sonar</groupId>
+        <groupId>org.sonarsource.sonarqube</groupId>
         <artifactId>sonar-deprecated</artifactId>
         <version>${sonar.version}</version>
-      </dependency>      
+      </dependency>
       <dependency>
-        <groupId>org.codehaus.sonar</groupId>
+        <groupId>org.sonarsource.sonarqube</groupId>
         <artifactId>sonar-testing-harness</artifactId>
         <version>${sonar.version}</version>
       </dependency>
-     
+
       <dependency>
         <groupId>org.sonarsource.sslr</groupId>
         <artifactId>sslr-core</artifactId>
@@ -204,7 +204,7 @@
         </exclusions>
       </dependency>
 
-       <dependency>
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.12</version>
@@ -214,12 +214,12 @@
         <artifactId>fest-assert</artifactId>
         <version>1.4</version>
       </dependency>
-       <dependency>
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
         <version>1.10.16</version>
       </dependency>
-       <dependency>
+      <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>1.0.13</version>
@@ -234,7 +234,7 @@
         <artifactId>slf4j-api</artifactId>
         <version>1.6.2</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
@@ -246,9 +246,9 @@
         <version>1.0</version>
       </dependency>
       <dependency>
-      <groupId>org.codehaus.sonar.dotnet.tests</groupId>
-      <artifactId>sonar-dotnet-tests-library</artifactId>
-      <version>1.2</version>
+        <groupId>org.sonarsource.dotnet</groupId>
+        <artifactId>sonar-dotnet-tests-library</artifactId>
+        <version>1.3.2</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>

--- a/sonar-cxx-plugin/pom.xml
+++ b/sonar-cxx-plugin/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.codehaus.sonar-plugins.cxx</groupId>
+    <groupId>org.sonarsource.sonarqube-plugins.cxx</groupId>
     <artifactId>cxx</artifactId>
     <version>0.9.6-SNAPSHOT</version>
   </parent>
@@ -22,20 +22,21 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.codehaus.sonar</groupId>
+      <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.sonar</groupId>
       <artifactId>sonar-deprecated</artifactId>
+      <version>5.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.sonar.dotnet.tests</groupId>
+      <groupId>org.sonarsource.dotnet</groupId>
       <artifactId>sonar-dotnet-tests-library</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>cxx-squid</artifactId>
@@ -46,13 +47,13 @@
       <artifactId>cxx-checks</artifactId>
       <version>${project.version}</version>
     </dependency>
-    
+
     <dependency>
       <groupId>org.sonarsource.sslr</groupId>
       <artifactId>sslr-testing-harness</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
@@ -60,11 +61,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.sonar</groupId>
+      <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-testing-harness</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
@@ -76,7 +77,6 @@
     <dependency>
       <groupId>org.codehaus.sonar.common-rules</groupId>
       <artifactId>sonar-common-rules</artifactId>
-      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -89,13 +89,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>cxx-lint</artifactId>
-        <version>${project.version}</version>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cxx-lint</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.collections</groupId>
+      <artifactId>google-collections</artifactId>
+      <version>1.0</version>
     </dependency>
   </dependencies>
 
- <build>
+  <build>
     <resources>
       <resource>
         <directory>src/main/resources</directory>
@@ -113,4 +118,5 @@
       </resource>
     </resources>
   </build>
+
 </project>

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxRuleRepository.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxRuleRepository.java
@@ -19,10 +19,10 @@
  */
 package org.sonar.plugins.cxx;
 
+import java.util.List;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.cxx.checks.CheckList;
 import org.sonar.squidbridge.annotations.AnnotationBasedRulesDefinition;
-import org.sonar.squidbridge.rules.SqaleXmlLoader;
 
 public class CxxRuleRepository implements RulesDefinition {
 
@@ -33,12 +33,10 @@ public class CxxRuleRepository implements RulesDefinition {
     NewRepository repository = context.
       createRepository(CheckList.REPOSITORY_KEY, CxxLanguage.KEY).
       setName(REPOSITORY_NAME);
-    AnnotationBasedRulesDefinition.load(repository, CxxLanguage.KEY, CheckList.getChecks());
-    for (NewRule rule : repository.rules()) {
-      //FIXME: set internal key to key to ensure rule templates works properly : should be removed when SONAR-6162 is fixed.
-      rule.setInternalKey(rule.key());
-    }
-
+    List<Class> checks = CheckList.getChecks();
+        
+    AnnotationBasedRulesDefinition.load(repository, CxxLanguage.KEY, checks);
+    
     repository.done();
   }
 }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/dotnet/CxxUnitTestResultsProvider.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/dotnet/CxxUnitTestResultsProvider.java
@@ -28,7 +28,12 @@ public class CxxUnitTestResultsProvider {
 
   public static final String VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY = "sonar.cxx.vstest.reportsPaths";
   public static final String NUNIT_TEST_RESULTS_PROPERTY_KEY = "sonar.cxx.nunit.reportsPaths";
-  private static final UnitTestConfiguration UNIT_TEST_CONF = new UnitTestConfiguration(VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY, NUNIT_TEST_RESULTS_PROPERTY_KEY);
+  public static final String XUNIT_TEST_RESULTS_PROPERTY_KEY = "sonar.cxx.xunit.reportsPaths";
+  
+  private static final UnitTestConfiguration UNIT_TEST_CONF = new UnitTestConfiguration(
+          VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY,
+          NUNIT_TEST_RESULTS_PROPERTY_KEY,
+          XUNIT_TEST_RESULTS_PROPERTY_KEY);
   
   private CxxUnitTestResultsProvider() {
   }

--- a/sslr-cxx-toolkit/pom.xml
+++ b/sslr-cxx-toolkit/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.codehaus.sonar-plugins.cxx</groupId>
+    <groupId>org.sonarsource.sonarqube-plugins.cxx</groupId>
     <artifactId>cxx</artifactId>
     <version>0.9.6-SNAPSHOT</version>
   </parent>
@@ -23,7 +23,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.sonar</groupId>
+      <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -31,7 +31,6 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
     </dependency>
-
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -74,17 +73,17 @@
                 <include>jaxen:jaxen</include>
                 <include>org.sonarsource.sslr:sslr-toolkit</include>
                 <include>org.sonarsource.sslr-squid-bridge:sslr-squid-bridge</include>
-                <include>org.codehaus.sonar:sonar-colorizer</include>
-                <include>org.codehaus.sonar:sonar-squid</include>
-                <include>org.codehaus.sonar:sonar-channel</include>
-                <include>org.codehaus.sonar:sonar-plugin-api</include>
+                <include>org.sonarsource.sonarqube:sonar-colorizer</include>
+                <include>org.sonarsource.sonarqube:sonar-squid</include>
+                <include>org.sonarsource.sonarqube:sonar-channel</include>
+                <include>org.sonarsource.sonarqube:sonar-plugin-api</include>
                 <include>org.slf4j:slf4j-api</include>
                 <include>org.slf4j:jcl-over-slf4j</include>
                 <include>ch.qos.logback:logback-classic</include>
                 <include>ch.qos.logback:logback-core</include>
                 <include>commons-io:commons-io</include>
                 <include>commons-lang:commons-lang</include>
-                <include>com.google.guava:guava</include>                
+                <include>com.google.guava:guava</include>
               </includes>
               <rules>
                 <keep>
@@ -108,8 +107,8 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>4300000</maxsize>
-                  <minsize>3100000</minsize>
+                  <maxsize>8500000</maxsize>
+                  <minsize>7000000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>
                   </files>


### PR DESCRIPTION
- org.codehaus.sonar => org.sonarsource.sonarqube
- use API version 5.6-RC2
- org.sonarsource.dotnet:sonar-dotnet-tests-library:1.3.2
  - support: sonar.cxx.xunit.reportsPaths