### PR TITLE
revert java.nio.file.Files.readAllLines usage

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/FileHeaderCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/FileHeaderCheck.java
@@ -20,10 +20,11 @@
 package org.sonar.cxx.checks;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.charset.Charset;
 import java.util.Iterator;
 import java.util.List;
+
+import com.google.common.io.Files;
 
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
@@ -98,7 +99,7 @@ public class FileHeaderCheck extends SquidCheck<Grammar> implements CxxCharsetAw
     if (isRegularExpression) {
       String fileContent;
       try {
-        fileContent = new String(Files.readAllBytes(getContext().getFile().toPath()), charset);
+        fileContent = Files.toString(getContext().getFile(), charset);
       } catch (IOException e) {
         throw new AnalysisException(e);
       }
@@ -106,7 +107,7 @@ public class FileHeaderCheck extends SquidCheck<Grammar> implements CxxCharsetAw
     } else {
       List<String> lines;
       try {
-        lines = Files.readAllLines(getContext().getFile().toPath(), charset);
+        lines = Files.readLines(getContext().getFile(), charset);
       } catch (IOException e) {
         throw new IllegalStateException(e);
       }

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/IndentationCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/IndentationCheck.java
@@ -20,10 +20,11 @@
 package org.sonar.cxx.checks;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Stack;
+
+import com.google.common.io.Files;
 
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
@@ -148,7 +149,7 @@ public class IndentationCheck extends SquidCheck<Grammar> implements CxxCharsetA
   private int getTabColumn(Token token) {
     if (fileLines == null) {
       try {
-        fileLines = Files.readAllLines(getContext().getFile().toPath(), charset);
+        fileLines = Files.readLines(getContext().getFile(), charset);
       } catch (IOException e) {
         throw new IllegalStateException(e);
       }

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/LineRegularExpressionCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/LineRegularExpressionCheck.java
@@ -20,12 +20,13 @@
 package org.sonar.cxx.checks;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
+import com.google.common.io.Files;
 
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
@@ -107,7 +108,7 @@ public class LineRegularExpressionCheck extends SquidCheck<Grammar> implements C
       if (compare(invertFilePattern, matchFile())) {
         List<String> lines;
         try {
-          lines = Files.readAllLines(getContext().getFile().toPath(), charset);
+          lines = Files.readLines(getContext().getFile(), charset);
         } catch (IOException e) {
           throw new IllegalStateException(e);
         }

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/ReservedNamesCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/ReservedNamesCheck.java
@@ -20,9 +20,10 @@
 package org.sonar.cxx.checks;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.charset.Charset;
 import java.util.List;
+
+import com.google.common.io.Files;
 
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
@@ -61,7 +62,7 @@ public class ReservedNamesCheck extends SquidCheck<Grammar> implements CxxCharse
   public void visitFile(AstNode astNode) {
     List<String> lines;
     try {
-      lines = Files.readAllLines(getContext().getFile().toPath(), charset);
+      lines = Files.readLines(getContext().getFile(), charset);
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/TabCharacterCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/TabCharacterCheck.java
@@ -20,9 +20,10 @@
 package org.sonar.cxx.checks;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.charset.Charset;
 import java.util.List;
+
+import com.google.common.io.Files;
 
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
@@ -68,7 +69,7 @@ public class TabCharacterCheck extends SquidCheck<Grammar> implements CxxCharset
   public void visitFile(AstNode astNode) {
     List<String> lines;
     try {
-      lines = Files.readAllLines(getContext().getFile().toPath(), charset);
+      lines = Files.readLines(getContext().getFile(), charset);
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/TooLongLineCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/TooLongLineCheck.java
@@ -20,9 +20,10 @@
 package org.sonar.cxx.checks;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.charset.Charset;
 import java.util.List;
+
+import com.google.common.io.Files;
 
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
@@ -75,7 +76,7 @@ public class TooLongLineCheck extends SquidCheck<Grammar> implements CxxCharsetA
   public void visitFile(AstNode astNode) {
     List<String> lines;
     try {
-      lines = Files.readAllLines(getContext().getFile().toPath(), charset);
+      lines = Files.readLines(getContext().getFile(), charset);
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectIncludeCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectIncludeCheck.java
@@ -20,10 +20,11 @@
 package org.sonar.cxx.checks;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import com.google.common.io.Files;
 
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
@@ -70,7 +71,7 @@ public class UseCorrectIncludeCheck extends SquidCheck<Grammar> implements CxxCh
   public void visitFile(AstNode astNode) {
     List<String> lines;
     try {
-      lines = Files.readAllLines(getContext().getFile().toPath(), charset);
+      lines = Files.readLines(getContext().getFile(), charset);
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }


### PR DESCRIPTION
`java.nio.file.Files.readAllLines` behaves different as `com.google.common.io.Files.readLines`, sample:
* read `/* ü */` with US-ASCII
* `com.google.common.io.Files.readLines` returns `/* ? */`, no exception
* `java.nio.file.Files.readAllLines`: exception & list = null

Behavior: replacing invalid character and will allow to continue the check.