### PR TITLE
Catch PC-Lint MISRA C++ messages

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/pclint/CxxPCLintSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/pclint/CxxPCLintSensor.java
@@ -94,8 +94,8 @@ public class CxxPCLintSensor extends CxxReportSensor {
             String msg = errorCursor.getAttrValue("desc");
 
             if (isInputValid(file, line, id, msg)) {
-              //remap MISRA IDs. Only Unique rules for MISRA 2004 and 2008 has been created in the rule repository
-              if (msg.contains("MISRA 2004") || msg.contains("MISRA 2008")) {
+              //remap MISRA IDs. Only Unique rules for MISRA C 2004 and MISRA C/C++ 2008 have been created in the rule repository
+              if (msg.contains("MISRA 2004") || msg.contains("MISRA 2008") || msg.contains("MISRA C++ 2008") || msg.contains("MISRA C++ Rule")) {
                 id = mapMisraRulesToUniqueSonarRules(msg);
               }
               saveUniqueViolation(context, CxxPCLintRuleRepository.KEY,

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/pclint-reports/pclint-result-MISRACPP.xml
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/reports-project/pclint-reports/pclint-result-MISRACPP.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+<issue file =".\test.c" line = "4" number = "1960" desc = "Violates MISRA C++ 2008 Required Rule 5-0-19, More than two pointer indirection levels used for type: 'struct _wireSAFEARRAY ***"/>
+<issue file =".\test.c" line = "10" number = "586" desc = "operator 'new' is deprecated. [MISRA C++ Rule 18-4-1]"/>
+</result>


### PR DESCRIPTION
Added check for default PC-Lint MISRA C++ 2008 message identifier.  Rules already exist.