### PR TITLE
Fix issue #928

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
@@ -511,11 +511,19 @@ public abstract class AbstractCxxPublicApiVisitor<GRAMMAR extends Grammar>
       if (aliasDeclIdNode == null) {
         LOG.error("No identifier found at {}", aliasDeclNode.getTokenLine());
       } else {
-        // check if this is a template specification to adjust
+        // Check if this is a template specification to adjust
         // documentation node
-        AstNode template = aliasDeclNode
-            .getFirstAncestor(CxxGrammarImpl.templateDeclaration);
-        AstNode docNode = (template != null) ? template : aliasDeclNode;
+        AstNode container = aliasDeclNode.getFirstAncestor(
+          CxxGrammarImpl.templateDeclaration,
+          CxxGrammarImpl.classSpecifier);
+
+        AstNode docNode;
+        if (container == null
+          || container.getType() == CxxGrammarImpl.classSpecifier) {
+          docNode = aliasDeclNode;
+        } else {
+          docNode = container;
+        }
 
         // look for block documentation
         List<Token> comments = getBlockDocumentation(docNode);

--- a/cxx-squid/src/test/java/org/sonar/cxx/CxxPublicApiVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/CxxPublicApiVisitorTest.java
@@ -2,17 +2,17 @@
  * Sonar C++ Plugin (Community)
  * Copyright (C) 2011-2016 SonarOpenCommunity
  * http://github.com/SonarOpenCommunity/sonar-cxx
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -89,7 +89,7 @@ public class CxxPublicApiVisitorTest {
 
     visitor.withHeaderFileSuffixes(Arrays
       .asList(getFileExtension(fileName)));
-    
+
     CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester(fileName, ".");
     SourceFile file = CxxAstScanner.scanSingleFile(tester.cxxFile, tester.sensorContext,
       visitor);
@@ -134,7 +134,7 @@ public class CxxPublicApiVisitorTest {
 
   @Test
   public void template() throws IOException {
-    testFile("src/test/resources/metrics/template.h", 5, 2, true);
+    testFile("src/test/resources/metrics/template.h", 9, 4, true);
   }
 
   @Test
@@ -170,7 +170,7 @@ public class CxxPublicApiVisitorTest {
 
     visitor.withHeaderFileSuffixes(Arrays.asList(".h"));
 
-    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/metrics/public_api.h", ".");    
+    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/metrics/public_api.h", ".");
     SourceFile file = CxxAstScanner.scanSingleFile(tester.cxxFile, tester.sensorContext, visitor); //
 
     if (LOG.isDebugEnabled()) {
@@ -264,5 +264,5 @@ public class CxxPublicApiVisitorTest {
       expectedIdCommentMap.keySet().size());
     assertThat(file.getInt(CxxMetric.PUBLIC_UNDOCUMENTED_API)).isEqualTo(0);
   }
-  
+
 }

--- a/cxx-squid/src/test/resources/metrics/template.h
+++ b/cxx-squid/src/test/resources/metrics/template.h
@@ -1,13 +1,29 @@
 /**
  testClass
 */
-template<T>
+template<typename T>
 class testClass
 {
 public:
 	void publicMethod();
-	
+
 	int publicAttr;
+
+    // Issue #928 (should be marked undocumented)
+    using type = void;
+};
+
+template<typename Second>
+struct second_struct {
+    /*!
+     * \brief Issue #928 (should be marked documented)
+     */
+    using alpha = float;
+
+    /*!
+     * \brief Issue #928 (should be marked documented)
+     */
+    using beta = double;
 };
 
 /*!


### PR DESCRIPTION
This PR fixes #928 

The fix was simpler than I thought, it was already done for member declarations. I just used the same for alias declarations. This avoid that the wrong template declaration is used. 