### PR TITLE
Alias declaration in function is not public API

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
@@ -2,17 +2,17 @@
  * Sonar C++ Plugin (Community)
  * Copyright (C) 2011-2016 SonarOpenCommunity
  * http://github.com/SonarOpenCommunity/sonar-cxx
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -502,6 +502,15 @@ public abstract class AbstractCxxPublicApiVisitor<GRAMMAR extends Grammar>
   }
 
   private void visitAliasDeclaration(AstNode aliasDeclNode) {
+    AstNode parent = aliasDeclNode.getFirstAncestor(
+      CxxGrammarImpl.functionDefinition,
+      CxxGrammarImpl.classSpecifier);
+
+    // An alias declaration inside a function is not part of the public API
+    if (parent != null && parent.getType() == CxxGrammarImpl.functionDefinition){
+        return;
+    }
+
     if (isPublicApiMember(aliasDeclNode)) {
       logDebug("AliasDeclaration");
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/CxxPublicApiVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/CxxPublicApiVisitorTest.java
@@ -138,6 +138,11 @@ public class CxxPublicApiVisitorTest {
   }
 
   @Test
+  public void alias_function_template() throws IOException {
+    testFile("src/test/resources/metrics/alias_in_template_func.h", 4, 3, false);
+  }
+
+  @Test
   public void unnamed_class() throws IOException {
     testFile("src/test/resources/metrics/unnamed_class.h", 3, 1, false);
   }

--- a/cxx-squid/src/test/resources/metrics/alias_in_template_func.h
+++ b/cxx-squid/src/test/resources/metrics/alias_in_template_func.h
@@ -1,0 +1,25 @@
+template<typename Second>
+struct A {
+    template<typename Third>
+    void foo(){
+        using type = void;
+    }
+};
+
+template<typename Fourth>
+void bar(){
+    using type = void;
+}
+
+/*!
+ * \brief Commented
+ */
+template<typename Fourth>
+void foobar(){
+    /*!
+     * \brief Commented (Not a doxygen comment)
+     */
+    using type = void;
+
+    using second_type = double;
+}


### PR DESCRIPTION
This commit prevents alias declaration declared at block-scope to be
identified as public API. It also adds a test to ensure that it
works.