### PR TITLE
JSON Compilation Database support

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxCompilationUnitSettings.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxCompilationUnitSettings.java
@@ -1,0 +1,44 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2017 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx;
+
+import java.util.List;
+import java.util.Map;
+
+public class CxxCompilationUnitSettings {
+  private Map<String, String> defines = null;
+  private List<String> includes = null;
+
+  public Map<String, String> getDefines() {
+    return defines;
+  }
+
+  public void setDefines(Map<String, String> defines) {
+    this.defines = defines;
+  }
+
+  public List<String> getIncludes() {
+    return includes;
+  }
+
+  public void setIncludes(List<String> includes) {
+    this.includes = includes;
+  }
+}

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -48,6 +49,9 @@ public class CxxConfiguration extends SquidConfiguration {
   private boolean errorRecoveryEnabled = true;
   private List<String> cFilesPatterns = new ArrayList<>();
   private boolean missingIncludeWarningsEnabled = true;
+  private String specFile = null;
+  private CxxCompilationUnitSettings globalCompilationUnitSettings = null;
+  private HashMap<String, CxxCompilationUnitSettings> compilationUnitSettings = new HashMap<>();
 
   private final CxxVCppBuildLogParser cxxVCppParser;
 
@@ -214,6 +218,41 @@ public class CxxConfiguration extends SquidConfiguration {
 
   public boolean getMissingIncludeWarningsEnabled() {
     return this.missingIncludeWarningsEnabled;
+  }
+
+  public String getSpecFile() {
+	return specFile;
+  }
+
+  public void setSpecFile(String specFile) {
+    this.specFile = specFile;
+  }
+
+  public CxxCompilationUnitSettings getGlobalCompilationUnitSettings() {
+    return globalCompilationUnitSettings;
+  }
+
+  public void setGlobalCompilationUnitSettings(CxxCompilationUnitSettings globalCompilationUnitSettings) {
+    this.globalCompilationUnitSettings = globalCompilationUnitSettings;
+  }
+
+  public CxxCompilationUnitSettings getCompilationUnitSettings(String filename) {
+    return compilationUnitSettings.get(filename);
+  }
+
+  public void addCompilationUnitSettings(String filename, CxxCompilationUnitSettings settings) {
+    compilationUnitSettings.put(filename, settings);
+  }
+
+  public List<File> getCompilationUnitSourceFiles() {
+    List<File> files = new ArrayList<File>();
+
+    for (Iterator<String> iter = compilationUnitSettings.keySet().iterator(); iter.hasNext(); ) {
+      String item = iter.next();
+      files.add(new File(item));
+    }
+
+    return files;
   }
 
   public void setCompilationPropertiesWithBuildLog(List<File> reports,

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
@@ -50,6 +50,7 @@ public class CxxConfiguration extends SquidConfiguration {
   private List<String> cFilesPatterns = new ArrayList<>();
   private boolean missingIncludeWarningsEnabled = true;
   private String jsonCompilationDatabaseFile = null;
+  private boolean scanOnlySpecifiedSources = false;
   private CxxCompilationUnitSettings globalCompilationUnitSettings = null;
   private HashMap<String, CxxCompilationUnitSettings> compilationUnitSettings = new HashMap<>();
 
@@ -226,6 +227,14 @@ public class CxxConfiguration extends SquidConfiguration {
 
   public void setJsonCompilationDatabaseFile(String jsonCompilationDatabaseFile) {
     this.jsonCompilationDatabaseFile = jsonCompilationDatabaseFile;
+  }
+
+  public boolean isScanOnlySpecifiedSources() {
+    return scanOnlySpecifiedSources;
+  }
+
+  public void setScanOnlySpecifiedSources(boolean scanOnlySpecifiedSources) {
+    this.scanOnlySpecifiedSources = scanOnlySpecifiedSources;
   }
 
   public CxxCompilationUnitSettings getGlobalCompilationUnitSettings() {

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
@@ -49,7 +49,7 @@ public class CxxConfiguration extends SquidConfiguration {
   private boolean errorRecoveryEnabled = true;
   private List<String> cFilesPatterns = new ArrayList<>();
   private boolean missingIncludeWarningsEnabled = true;
-  private String specFile = null;
+  private String jsonCompilationDatabaseFile = null;
   private CxxCompilationUnitSettings globalCompilationUnitSettings = null;
   private HashMap<String, CxxCompilationUnitSettings> compilationUnitSettings = new HashMap<>();
 
@@ -220,12 +220,12 @@ public class CxxConfiguration extends SquidConfiguration {
     return this.missingIncludeWarningsEnabled;
   }
 
-  public String getSpecFile() {
-	return specFile;
+  public String getJsonCompilationDatabaseFile() {
+	return jsonCompilationDatabaseFile;
   }
 
-  public void setSpecFile(String specFile) {
-    this.specFile = specFile;
+  public void setJsonCompilationDatabaseFile(String jsonCompilationDatabaseFile) {
+    this.jsonCompilationDatabaseFile = jsonCompilationDatabaseFile;
   }
 
   public CxxCompilationUnitSettings getGlobalCompilationUnitSettings() {

--- a/cxx-squid/src/test/java/org/sonar/cxx/CxxConfigurationTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/CxxConfigurationTest.java
@@ -280,4 +280,22 @@ public class CxxConfigurationTest {
 
   }
 
+  @Test
+  public void shouldGetSourceFilesList() {
+    CxxConfiguration config = new CxxConfiguration();
+
+    String [] files = new String [] { "testfile", "anotherfile", "thirdfile" };
+
+    for (String filename : files) {
+      config.addCompilationUnitSettings(filename, new CxxCompilationUnitSettings());
+    }
+
+    List <File> sourceFiles = config.getCompilationUnitSourceFiles();
+
+    assertThat(sourceFiles.size()).isEqualTo(files.length);
+
+    for (File file : sourceFiles) {
+      Assertions.assertThat(files).as(file.getName());
+    }
+  }
 }

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
@@ -57,11 +57,11 @@ public class CxxParseErrorLoggerVisitorTest {
   @Test
   public void handleParseErrorTest() throws Exception {
     List<String> log = logTester.logs();
-    assertThat(log.size()).isEqualTo(7);
-    assertThat(log.get(2)).contains("skip declarartion: namespace X {");
-    assertThat(log.get(3)).contains("skip declarartion: void test :: f1 ( ) {");
-    assertThat(log.get(4)).contains("syntax error: i = unsigend int ( i + 1 )");
-    assertThat(log.get(5)).contains("skip declarartion: void test :: f3 ( ) {");
-    assertThat(log.get(6)).contains("syntax error: int i = 0 i ++");
+    assertThat(log.size()).isEqualTo(8);
+    assertThat(log.get(3)).contains("skip declarartion: namespace X {");
+    assertThat(log.get(4)).contains("skip declarartion: void test :: f1 ( ) {");
+    assertThat(log.get(5)).contains("syntax error: i = unsigend int ( i + 1 )");
+    assertThat(log.get(6)).contains("skip declarartion: void test :: f3 ( ) {");
+    assertThat(log.get(7)).contains("syntax error: int i = 0 i ++");
   }
 }

--- a/sonar-cxx-plugin/pom.xml
+++ b/sonar-cxx-plugin/pom.xml
@@ -95,6 +95,16 @@
       <version>2.6</version>
       <type>jar</type>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.8.6</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.8.6</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -71,6 +71,7 @@ public final class CxxPlugin implements Plugin {
   public static final String FORCE_INCLUDE_FILES_KEY = "sonar.cxx.forceIncludes";
   public static final String C_FILES_PATTERNS_KEY = "sonar.cxx.cFilesPatterns";
   public static final String MISSING_INCLUDE_WARN = "sonar.cxx.missingIncludeWarnings";
+  public static final String JSON_COMPILATION_DATABASE_KEY = "sonar.cxx.jsonCompilationDatabase";
   public static final String CPD_IGNORE_LITERALS_KEY = "sonar.cxx.cpd.ignoreLiterals";
   public static final String CPD_IGNORE_IDENTIFIERS_KEY = "sonar.cxx.cpd.ignoreIdentifiers";
       
@@ -142,6 +143,13 @@ public final class CxxPlugin implements Plugin {
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
       .type(PropertyType.BOOLEAN)
       .index(8)
+      .build(),
+      PropertyDefinition.builder(CxxPlugin.JSON_COMPILATION_DATABASE_KEY)
+      .subCategory(subcateg)
+      .name("JSON Compilation Database")
+      .description("JSON Compilation Database file to use as specification for what defines and includes should be used for source files.")
+      .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+      .index(9)
       .build()
     ));
   }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -72,6 +72,7 @@ public final class CxxPlugin implements Plugin {
   public static final String C_FILES_PATTERNS_KEY = "sonar.cxx.cFilesPatterns";
   public static final String MISSING_INCLUDE_WARN = "sonar.cxx.missingIncludeWarnings";
   public static final String JSON_COMPILATION_DATABASE_KEY = "sonar.cxx.jsonCompilationDatabase";
+  public static final String SCAN_ONLY_SPECIFIED_SOURCES_KEY = "sonar.cxx.scanOnlySpecifiedSources";
   public static final String CPD_IGNORE_LITERALS_KEY = "sonar.cxx.cpd.ignoreLiterals";
   public static final String CPD_IGNORE_IDENTIFIERS_KEY = "sonar.cxx.cpd.ignoreIdentifiers";
       
@@ -150,6 +151,15 @@ public final class CxxPlugin implements Plugin {
       .description("JSON Compilation Database file to use as specification for what defines and includes should be used for source files.")
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
       .index(9)
+      .build(),
+      PropertyDefinition.builder(CxxPlugin.SCAN_ONLY_SPECIFIED_SOURCES_KEY)
+      .defaultValue("False")
+      .name("Scan only specified source files")
+      .description("Only scan source files defined in specification file. Eg. by JSON Compilation Database.")
+      .subCategory(subcateg)
+      .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+      .type(PropertyType.BOOLEAN)
+      .index(10)
       .build()
     ));
   }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxSquidSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/squid/CxxSquidSensor.java
@@ -20,6 +20,7 @@
 package org.sonar.plugins.cxx.squid;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Locale;
 
 import javax.annotation.Nullable;
+import javax.xml.stream.XMLStreamException;
 
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
@@ -55,6 +57,9 @@ import org.sonar.squidbridge.api.SourceFunction;
 import org.sonar.squidbridge.api.SourceClass;
 import org.sonar.squidbridge.indexer.QueryByParent;
 import org.sonar.squidbridge.indexer.QueryByType;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.sonar.sslr.api.Grammar;
 import java.util.HashMap;
 import java.util.Map;
@@ -159,6 +164,19 @@ public final class CxxSquidSensor implements Sensor {
     cxxConf.setCFilesPatterns(settings.getStringArray(CxxPlugin.C_FILES_PATTERNS_KEY));
     cxxConf.setHeaderFileSuffixes(settings.getStringArray(CxxPlugin.HEADER_FILE_SUFFIXES_KEY));
     cxxConf.setMissingIncludeWarningsEnabled(settings.getBoolean(CxxPlugin.MISSING_INCLUDE_WARN));
+    cxxConf.setJsonCompilationDatabaseFile(settings.getString(CxxPlugin.JSON_COMPILATION_DATABASE_KEY));
+
+    if (cxxConf.getJsonCompilationDatabaseFile() != null) {
+      try {
+        new org.sonar.plugins.cxx.utils.JsonCompilationDatabase(cxxConf, new File(cxxConf.getJsonCompilationDatabaseFile()));
+      } catch (JsonParseException e) {
+        e.printStackTrace();
+      } catch (JsonMappingException e) {
+        e.printStackTrace();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
 
     String filePaths = settings.getString(CxxCompilerSensor.REPORT_PATH_KEY);
     if (filePaths != null && !"".equals(filePaths)) {

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/JsonCompilationDatabase.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/JsonCompilationDatabase.java
@@ -1,0 +1,185 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2017 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.cxx.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import org.sonar.cxx.CxxCompilationUnitSettings;
+import org.sonar.cxx.CxxConfiguration;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JsonCompilationDatabase {
+  public static final Logger LOG = Loggers.get(JsonCompilationDatabase.class);
+
+  public JsonCompilationDatabase(CxxConfiguration config, File compileCommandsFile)
+      throws IOException, JsonParseException, JsonMappingException {
+    LOG.debug("Parsing 'JSON Compilation Database' format");
+
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    mapper.enable(DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY);
+
+    JsonCompilationDatabaseCommandObject[] commandObjects = mapper.readValue(compileCommandsFile,
+        JsonCompilationDatabaseCommandObject[].class);
+
+    for (JsonCompilationDatabaseCommandObject commandObject : commandObjects) {
+
+      Path cwd = null;
+      Path absPath = null;
+
+      if (commandObject.directory != null) {
+        cwd = Paths.get(commandObject.directory);
+      } else {
+        cwd = Paths.get(".");
+      }
+      absPath = cwd.resolve(commandObject.file);
+
+      if (commandObject.file.equals("__global__")) {
+        CxxCompilationUnitSettings globalSettings = new CxxCompilationUnitSettings();
+
+        parseCommandObject(globalSettings, commandObject);
+
+        config.setGlobalCompilationUnitSettings(globalSettings);
+      } else {
+        CxxCompilationUnitSettings settings = new CxxCompilationUnitSettings();
+
+        parseCommandObject(settings, commandObject);
+
+        config.addCompilationUnitSettings(absPath.toAbsolutePath().normalize().toString(), settings);
+      }
+    }
+  }
+
+  private void parseCommandObject(CxxCompilationUnitSettings settings,
+      JsonCompilationDatabaseCommandObject commandObject) {
+    settings.setDefines(commandObject.defines);
+    settings.setIncludes(commandObject.includes);
+
+    // No need to parse command lines as we have needed information
+    if (commandObject.defines != null || commandObject.includes != null)
+      return;
+
+    String cmdLine = null;
+
+    if (commandObject.arguments != null)
+      cmdLine = commandObject.arguments;
+    else if (commandObject.command != null)
+      cmdLine = commandObject.command;
+    else
+      return;
+
+    String[] args = tokenizeCommandLine(cmdLine);
+    boolean nextInclude = false;
+    boolean nextDefine = false;
+    List<String> includes = new ArrayList<String>();
+    HashMap<String, String> defines = new HashMap<String, String>();
+
+    // Capture defines and includes from command line
+    for (String arg : args) {
+      if (nextInclude == true) {
+        nextInclude = false;
+        includes.add(arg);
+      } else if (nextDefine == true) {
+        nextDefine = false;
+        String[] define = arg.split("=", 2);
+        if (define.length == 1) {
+          defines.put(define[0], "");
+        } else {
+          defines.put(define[0], define[1]);
+        }
+      } else if (arg.equals("-I")) {
+        nextInclude = true;
+      } else if (arg.startsWith("-I")) {
+        includes.add(arg.substring(2));
+      } else if (arg.equals("-D")) {
+        nextDefine = true;
+      } else if (arg.startsWith("-D")) {
+        String[] define = arg.substring(2).split("=", 2);
+        if (define.length == 1) {
+          defines.put(define[0], "");
+        } else {
+          defines.put(define[0], define[1]);
+        }
+      }
+    }
+
+    settings.setDefines(defines);
+    settings.setIncludes(includes);
+  }
+
+  private String[] tokenizeCommandLine(String cmdLine) {
+    List<String> args = new ArrayList<String>();
+    boolean escape = false;
+    char stringOpen = 0;
+    StringBuffer sb = new StringBuffer();
+
+    // Tokenize command line with support for escaping
+    for (char ch : cmdLine.toCharArray()) {
+      if (escape) {
+        escape = false;
+        sb.append(ch);
+      } else {
+        if (stringOpen == 0) {
+          // String not open
+          if (ch == '\\')
+            escape = true;
+          else if (ch == '\'')
+            stringOpen = '\'';
+          else if (ch == '\"')
+            stringOpen = '\"';
+          else if (ch == ' ') {
+            if (sb.length() > 0) {
+              args.add(sb.toString());
+              sb = new StringBuffer();
+            }
+          }
+
+          if (ch != ' ')
+            sb.append(ch);
+        } else {
+          // String open
+          if (ch == '\\')
+            escape = true;
+          else if (ch == stringOpen)
+            stringOpen = 0;
+
+          sb.append(ch);
+        }
+      }
+    }
+
+    if (sb.length() > 0)
+      args.add(sb.toString());
+
+    return args.toArray(new String[0]);
+  }
+}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/JsonCompilationDatabaseCommandObject.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/JsonCompilationDatabaseCommandObject.java
@@ -1,0 +1,62 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2017 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.cxx.utils;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+
+@SuppressWarnings("serial")
+public class JsonCompilationDatabaseCommandObject implements Serializable {
+  /**
+   * The working directory of the compilation. All paths specified in the command or file fields must be either absolute or relative to this directory.
+   */
+  public String directory;
+
+  /**
+   * The main translation unit source processed by this compilation step. This is used by tools as the key into the compilation database. There can be multiple command objects for the same file, for example if the same source file is compiled with different configurations.
+   */
+  public String file;
+
+  /**
+   * The compile command executed. After JSON unescaping, this must be a valid command to rerun the exact compilation step for the translation unit in the environment the build system uses. Parameters use shell quoting and shell escaping of quotes, with ‘"‘ and ‘\‘ being the only special characters. Shell expansion is not supported.
+   */
+  public String command;
+
+  /**
+   * The compile command executed as list of strings. Either arguments or command is required.
+   */
+  public String arguments;
+
+  /**
+   * The name of the output created by this compilation step. This field is optional. It can be used to distinguish different processing modes of the same input file.
+   */
+  public String output;
+
+  /**
+   * Extension to define defines
+   */
+  public HashMap<String,String> defines;
+
+  /**
+   * Extension to define include directories
+   */
+  public List<String> includes;
+}

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -32,6 +32,6 @@ public class CxxPluginTest {
    Plugin.Context context = new Plugin.Context(SonarQubeVersion.V5_6);
    CxxPlugin plugin = new CxxPlugin();
    plugin.define(context);
-   assertThat(context.getExtensions()).hasSize(68);
+   assertThat(context.getExtensions()).hasSize(69);
   }
 }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -32,6 +32,6 @@ public class CxxPluginTest {
    Plugin.Context context = new Plugin.Context(SonarQubeVersion.V5_6);
    CxxPlugin plugin = new CxxPlugin();
    plugin.define(context);
-   assertThat(context.getExtensions()).hasSize(69);
+   assertThat(context.getExtensions()).hasSize(70);
   }
 }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/JsonCompilationDatabaseTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/JsonCompilationDatabaseTest.java
@@ -1,0 +1,195 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2017 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.cxx;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+import org.sonar.api.Plugin;
+import org.sonar.api.SonarQubeVersion;
+import org.sonar.cxx.CxxCompilationUnitSettings;
+import org.sonar.cxx.CxxConfiguration;
+import org.sonar.plugins.cxx.utils.JsonCompilationDatabase;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+
+public class JsonCompilationDatabaseTest {
+
+  @Test
+  public void testGlobalSettings() throws Exception {
+    Plugin.Context context = new Plugin.Context(SonarQubeVersion.V5_6);
+    CxxPlugin plugin = new CxxPlugin();
+    plugin.define(context);
+    CxxConfiguration conf = new CxxConfiguration();
+
+    File file = new File("src/test/resources/org/sonar/plugins/cxx/json-compilation-database-project/compile_commands.json");
+
+    new JsonCompilationDatabase(conf, file);
+
+    CxxCompilationUnitSettings cus = conf.getGlobalCompilationUnitSettings();
+
+    assertThat(cus).isNotNull();
+    assertThat(cus.getDefines().containsKey("UNIT_DEFINE")).isFalse();
+    assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isTrue();
+    assertThat(cus.getIncludes().contains("/usr/local/include")).isFalse();
+    assertThat(cus.getIncludes().contains("/usr/include")).isTrue();
+  }
+
+  @Test
+  public void testExtensionSettings() throws Exception {
+    Plugin.Context context = new Plugin.Context(SonarQubeVersion.V5_6);
+    CxxPlugin plugin = new CxxPlugin();
+    plugin.define(context);
+    CxxConfiguration conf = new CxxConfiguration();
+
+    File file = new File("src/test/resources/org/sonar/plugins/cxx/json-compilation-database-project/compile_commands.json");
+
+    new JsonCompilationDatabase(conf, file);
+
+    Path cwd = Paths.get(".");
+    Path absPath = cwd.resolve("test-extension.cpp");
+    String filename = absPath.toAbsolutePath().normalize().toString();
+
+    CxxCompilationUnitSettings cus = conf.getCompilationUnitSettings(filename);
+
+    assertThat(cus).isNotNull();
+    assertThat(cus.getDefines().containsKey("UNIT_DEFINE")).isTrue();
+    assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
+    assertThat(cus.getIncludes().contains("/usr/local/include")).isTrue();
+    assertThat(cus.getIncludes().contains("/usr/include")).isFalse();
+  }
+
+  @Test
+  public void testCommandSettings() throws Exception {
+    Plugin.Context context = new Plugin.Context(SonarQubeVersion.V5_6);
+    CxxPlugin plugin = new CxxPlugin();
+    plugin.define(context);
+    CxxConfiguration conf = new CxxConfiguration();
+
+    File file = new File("src/test/resources/org/sonar/plugins/cxx/json-compilation-database-project/compile_commands.json");
+
+    new JsonCompilationDatabase(conf, file);
+
+    Path cwd = Paths.get(".");
+    Path absPath = cwd.resolve("test-with-command.cpp");
+    String filename = absPath.toAbsolutePath().normalize().toString();
+
+    CxxCompilationUnitSettings cus = conf.getCompilationUnitSettings(filename);
+
+    assertThat(cus).isNotNull();
+    assertThat(cus.getDefines().containsKey("COMMAND_DEFINE")).isTrue();
+    assertThat(cus.getDefines().containsKey("COMMAND_SPACE_DEFINE")).isTrue();
+    assertThat(cus.getDefines().get("COMMAND_SPACE_DEFINE")).isEqualTo("\" foo 'bar' zoo \"");
+    assertThat(cus.getDefines().containsKey("SIMPLE")).isTrue();
+    assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("");
+    assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
+    assertThat(cus.getIncludes().contains("/usr/local/include")).isTrue();
+    assertThat(cus.getIncludes().contains("/another/include/dir")).isTrue();
+    assertThat(cus.getIncludes().contains("/usr/include")).isFalse();
+  }
+
+  @Test
+  public void testArgumentSettings() throws Exception {
+    Plugin.Context context = new Plugin.Context(SonarQubeVersion.V5_6);
+    CxxPlugin plugin = new CxxPlugin();
+    plugin.define(context);
+    CxxConfiguration conf = new CxxConfiguration();
+
+    File file = new File("src/test/resources/org/sonar/plugins/cxx/json-compilation-database-project/compile_commands.json");
+
+    new JsonCompilationDatabase(conf, file);
+
+    Path cwd = Paths.get(".");
+    Path absPath = cwd.resolve("test-with-arguments.cpp");
+    String filename = absPath.toAbsolutePath().normalize().toString();
+
+    CxxCompilationUnitSettings cus = conf.getCompilationUnitSettings(filename);
+
+    assertThat(cus).isNotNull();
+    assertThat(cus.getDefines().containsKey("ARG_DEFINE")).isTrue();
+    assertThat(cus.getDefines().containsKey("ARG_SPACE_DEFINE")).isTrue();
+    assertThat(cus.getDefines().get("ARG_SPACE_DEFINE")).isEqualTo("\" foo 'bar' zoo \"");
+    assertThat(cus.getDefines().containsKey("SIMPLE")).isTrue();
+    assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("");
+    assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
+    assertThat(cus.getIncludes().contains("/usr/local/include")).isTrue();
+    assertThat(cus.getIncludes().contains("/another/include/dir")).isTrue();
+    assertThat(cus.getIncludes().contains("/usr/include")).isFalse();
+  }
+
+  @Test
+  public void testUnknownUnitSettings() throws Exception {
+    Plugin.Context context = new Plugin.Context(SonarQubeVersion.V5_6);
+    CxxPlugin plugin = new CxxPlugin();
+    plugin.define(context);
+    CxxConfiguration conf = new CxxConfiguration();
+
+    File file = new File("src/test/resources/org/sonar/plugins/cxx/json-compilation-database-project/compile_commands.json");
+
+    new JsonCompilationDatabase(conf, file);
+
+    Path cwd = Paths.get(".");
+    Path absPath = cwd.resolve("unknown.cpp");
+    String filename = absPath.toAbsolutePath().normalize().toString();
+
+    CxxCompilationUnitSettings cus = conf.getCompilationUnitSettings(filename);
+
+    assertThat(cus).isNull();
+  }
+
+  @Test
+  public void testInvalidJson() throws Exception {
+    Plugin.Context context = new Plugin.Context(SonarQubeVersion.V5_6);
+    CxxPlugin plugin = new CxxPlugin();
+    plugin.define(context);
+    CxxConfiguration conf = new CxxConfiguration();
+
+    File file = new File("src/test/resources/org/sonar/plugins/cxx/json-compilation-database-project/invalid.json");
+
+    try {
+      new JsonCompilationDatabase(conf, file);
+      assertThat(true).isFalse();
+    } catch (JsonMappingException e) {
+      // Expect to get exception
+    }
+  }
+
+  @Test
+  public void testFileNotFound() throws Exception {
+    Plugin.Context context = new Plugin.Context(SonarQubeVersion.V5_6);
+    CxxPlugin plugin = new CxxPlugin();
+    plugin.define(context);
+    CxxConfiguration conf = new CxxConfiguration();
+
+    File file = new File("src/test/resources/org/sonar/plugins/cxx/json-compilation-database-project/not-found.json");
+
+    try {
+      new JsonCompilationDatabase(conf, file);
+      assertThat(true).isFalse();
+    } catch (FileNotFoundException e) {
+      // Expect to get exception
+    }
+  }
+}

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/json-compilation-database-project/compile_commands.json
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/json-compilation-database-project/compile_commands.json
@@ -1,0 +1,37 @@
+[
+	{
+		"_comment_" : "example extension to define global defines and includes for headers and for files which are not compiled",
+		"file" : "__global__",
+		"defines" : {
+			"GLOBAL_DEFINE" : "1"
+			},
+		"includes" : [
+			"/usr/include"
+			]
+	},
+	{
+		"_comment_" : "example with command for compilation",
+		"directory" : ".",
+		"file" : "test-with-command.cpp",
+		"command" : "gcc -o test -I/usr/local/include -I /another/include/dir -DSIMPLE -DCOMMAND_DEFINE=1 -D COMMAND_SPACE_DEFINE=\" foo 'bar' zoo \" test.cpp",
+		"output" : "test"
+	},
+	{
+		"_comment_" : "example with using arguments",
+		"directory" : ".",
+		"file" : "test-with-arguments.cpp",
+		"arguments" : "-o test -I/usr/local/include -I /another/include/dir -DSIMPLE -DARG_DEFINE=1 -D ARG_SPACE_DEFINE=\" foo 'bar' zoo \" test.cpp",
+		"output" : "test"
+	},
+	{
+		"_comment_" : "example extension using defines and includes to define usage",
+		"directory" : ".",
+		"file" : "test-extension.cpp",
+		"defines" : {
+			"UNIT_DEFINE" : "1"
+			},
+		"includes" : [
+			"/usr/local/include"
+			]
+	}
+]

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/json-compilation-database-project/invalid.json
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/json-compilation-database-project/invalid.json
@@ -1,0 +1,36 @@
+[
+	{
+		"_comment_" : "example extension to define global defines and includes for headers and for files which are not compiled",
+		"file" : "__global__",
+		"defines" : {
+			"GLOBAL_DEFINE" : "1"
+			},
+		"includes" : [
+			"/usr/include"
+			]
+	},
+	{
+		"_comment_" : "example with command for compilation",
+		"directory" : ".",
+		"file" : "test-with-command.cpp",
+		"command" : "gcc -o test -I/usr/local/include -I /another/include/dir -DSIMPLE -DCOMMAND_DEFINE=1 -D COMMAND_SPACE_DEFINE=\" foo 'bar' zoo \" test.cpp",
+		"output" : "test"
+	},
+	{
+		"_comment_" : "example with using arguments",
+		"directory" : ".",
+		"file" : "test-with-arguments.cpp",
+		"arguments" : "-o test -I/usr/local/include -I /another/include/dir -DSIMPLE -DARG_DEFINE=1 -D ARG_SPACE_DEFINE=\" foo 'bar' zoo \" test.cpp",
+		"output" : "test"
+	},
+	{
+		"_comment_" : "example extension using defines and includes to define usage",
+		"directory" : ".",
+		"file" : "test-extension.cpp",
+		"defines" : {
+			"UNIT_DEFINE" : "1"
+			},
+		"includes" : [
+			"/usr/local/include"
+			]
+	}

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/json-compilation-database-project/sonar-project.properties
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/json-compilation-database-project/sonar-project.properties
@@ -1,0 +1,8 @@
+# required metadata
+sonar.projectKey=TEST_json_compilation_database_project
+sonar.projectName=TEST_json_compilation_database_project
+sonar.projectVersion=0.0.1
+sonar.language=c++
+
+# path to source directories (required)
+sonar.sources=.


### PR DESCRIPTION
This pull request adds support for use compilation unit specification file (xml) to specify defines and includes for compilation units (source files) and for global files which are not compilation units (include files).

Example usage is to use in example Klocwork to statically analyse source code. Use its captured include and defines and from those generate this compilation unit specification file.

With this compiler includes and defines are automatically set correctly for analysis thus giving better analysis results.
