### PR TITLE
improve FileLinesVisitor

### DIFF
--- a/integration-tests/features/importing_coverage.feature
+++ b/integration-tests/features/importing_coverage.feature
@@ -83,14 +83,14 @@ Feature: Importing coverage data
               """
           AND the following metrics have following values:
               | metric                  | value |
-              | coverage                | 5.9   |
-              | line_coverage           | 3.1   |
+              | coverage                | 8.0   |
+              | line_coverage           | 4.3   |
               | branch_coverage         | 50    |
-              | it_coverage             | 14.1  |
-              | it_line_coverage        | 8.2   |
+              | it_coverage             | 18.2  |
+              | it_line_coverage        | 11.1  |
               | it_branch_coverage      | 50    |
-              | overall_coverage        | 20.0  |
-              | overall_line_coverage   | 12.5  |
+              | overall_coverage        | 25.0  |
+              | overall_line_coverage   | 16.7  |
               | overall_branch_coverage | 50    |
 
           
@@ -115,8 +115,8 @@ Feature: Importing coverage data
               """
           AND the following metrics have following values:
               | metric                  | value |
-              | coverage                | 16.9  |
-              | line_coverage           | 10.1  |
+              | coverage                | 22.2  |
+              | line_coverage           | 14.3  |
               | branch_coverage         | 50    |
   
               

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/metrics/FileLinesVisitorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/metrics/FileLinesVisitorTest.java
@@ -59,11 +59,12 @@ public class FileLinesVisitorTest {
 
     assertThat(linesOfCode).hasSize(1);
     assertThat(linesOfCode.get(inputFile)).containsOnly(
-      8, 9, 10, 11,
-      14, 15, 16, 17, 18, 19,
-      21, 22, 23, 24, 25, 26, 27,
-      31, 32, 34, 35, 36, 37,
-      42, 43, 44, 45, 46
+      8, 10,
+      14, 16, 17, 18,
+      21, 22, 23, 26,
+      31, 34, 35,
+      42, 44, 45,
+      57, 60, 61
     );
   }
 

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/ncloc.cc
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/ncloc.cc
@@ -45,4 +45,22 @@ void func5()
    int sum = ADD(a, b);
 }
 
+// declaration
+void func6();
+
+// inline
+class MyClass {
+public:
+   MyClass();
+   int method1();
+   
+   int method2()
+   {
+      // comment
+      for(int iii=0; iii<NUMBER; ++iii) {
+         h1 += iii; // comment
+      }
+   }
+};
+
 /* EOF */


### PR DESCRIPTION
Improve results in case of forceZeroCoverage:
- mark only CxxGrammarImpl.functionDefinition
- ignore { }, ( ),  [ ]
