### PR TITLE
close #989

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -1674,6 +1674,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
       b.firstOf(
         b.sequence(CxxKeyword.TYPENAME, nestedNameSpecifier, b.optional(CxxKeyword.TEMPLATE), simpleTemplateId), // C++
         b.sequence(CxxKeyword.TYPENAME, nestedNameSpecifier, IDENTIFIER), // C++
+        b.sequence(CxxKeyword.TYPENAME, IDENTIFIER), // todo
         IDENTIFIER // todo
       )
     );

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/TemplatesTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/TemplatesTest.java
@@ -142,9 +142,10 @@ public class TemplatesTest extends ParserBaseTest {
     mockRule(CxxGrammarImpl.nestedNameSpecifier);
     mockRule(CxxGrammarImpl.simpleTemplateId);
 
-    assertThat(p).matches("typename nestedNameSpecifier foo");
-
+    assertThat(p).matches("typename nestedNameSpecifier IDENTIFIER");
     assertThat(p).matches("typename nestedNameSpecifier simpleTemplateId");
     assertThat(p).matches("typename nestedNameSpecifier template simpleTemplateId");
+    assertThat(p).matches("typename IDENTIFIER");
+    assertThat(p).matches("IDENTIFIER");
   }
 }

--- a/cxx-squid/src/test/resources/parser/own/C++11/typename.cc
+++ b/cxx-squid/src/test/resources/parser/own/C++11/typename.cc
@@ -1,0 +1,78 @@
+template<typename T> class my_array {};
+
+// two type template parameters and one template template parameter:
+template<typename K, typename V, template<typename> typename C = my_array>
+class Map
+{
+    C<K> key;
+    C<V> value;
+};
+
+// class template with a template template parameter V
+template<template<typename> class V> class C
+{
+    V<int> y; // uses the primary template
+    V<int*> z; // uses the partial specialization
+};
+
+template<typename T1 = int, typename T2 = int> class A;
+
+// template template parameter T has a parameter list, which 
+// consists of one type template parameter with a default
+template<template<typename = float> typename T> struct A
+{
+    void f();
+    void g();
+};
+
+template<typename T>
+struct X : B<T> // "B<T>" is dependent on T
+{
+    typename T::A* pa; // "T::A" is dependent on T
+                       // (see below for the meaning of this use of "typename")
+    void f(B<T>* pb) {
+        static int i = B<T>::i; // "B<T>::i" is dependent on T
+        pb->j++; // "pb->j" is dependent on T
+    }
+};
+
+template <class BiIter>
+bool operator<=(const sub_match<BiIter>& lhs,
+    const typename iterator_traits<BiIter>::value_type& rhs);
+
+template<typename ...Args>
+bool f(Args ...args) {
+    return (true && ... && args); // OK
+}
+
+// issue #1000
+namespace Publishing {
+    namespace Simulators {
+        template<typename T> class ManagedMemoryVector
+        {
+        public:
+            class iterator : public std::iterator<std::bidirectional_iterator_tag, T>
+            {
+            private:
+                typename std::vector<TypedMemoryBlock<T> *>::iterator stditerator;
+                typename std::vector<T>::size_type index;
+
+            private:
+                iterator(const typename std::vector<TypedMemoryBlock<T> *>::iterator &stditerator,
+                    typename std::vector<T>::size_type index) : stditerator(stditerator), index(index)
+                {
+                }
+            };
+        };
+    }
+}
+
+// issue #1000
+class HydraulicSimulatorOutputEntry {
+    HydraulicSimulatorOutputEntry(const typename PresetLocation presetLocation);
+};
+
+// issue #1000
+class HydraulicSimulatorOutput {
+    std::map<typename OutputEntryNames, std::string> m_outputEntryNameDictionary;
+};


### PR DESCRIPTION
fix typename usage. Add `typename identifier` which is not really in the standard but compilers seems to support it: close #989

```C++
typename-specifier:
   typename nested-name-specifier identifier
   typename nested-name-specifier templateopt simple-template-id
   typename identifier
```

Sample:
```C++
class HydraulicSimulatorOutputEntry {
    HydraulicSimulatorOutputEntry(const typename PresetLocation presetLocation);
};
```