### PR TITLE
fix CPD sensor

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -400,9 +400,9 @@ public final class CxxPlugin implements Plugin {
       .index(1)
       .build(),
       PropertyDefinition.builder(CxxPlugin.CPD_IGNORE_IDENTIFIERS_KEY)
-      .defaultValue("True")
+      .defaultValue("False")
       .name("Ignores identifier value differences when evaluating a duplicate block")
-      .description("Ignores identifier value differences when evaluating a duplicate block e.g. variable names, methods names, and so forth. Default is 'True'.")
+      .description("Ignores identifier value differences when evaluating a duplicate block e.g. variable names, methods names, and so forth. Default is 'False'.")
       .subCategory(subcateg)
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
       .type(PropertyType.BOOLEAN)

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/cpd/CxxCpdVisitorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/cpd/CxxCpdVisitorTest.java
@@ -58,29 +58,29 @@ public class CxxCpdVisitorTest {
     List<TokensLine> cpdTokenLines = context.cpdTokens("moduleKey:" + inputFile.file().getName());
     assertThat(cpdTokenLines).hasSize(75);
 
-    // bits unixtime1(bits ld, bits ex)
-    TokensLine firstTokensLine = cpdTokenLines.get(0);
-    assertThat(firstTokensLine.getValue()).isEqualTo("_I_I(_I_I,_I_I)");
-    assertThat(firstTokensLine.getStartLine()).isEqualTo(2);
-    assertThat(firstTokensLine.getStartUnit()).isEqualTo(1);
-    assertThat(firstTokensLine.getEndLine()).isEqualTo(2);
-    assertThat(firstTokensLine.getEndUnit()).isEqualTo(9);
-
     // ld &= 0xFF;
-    TokensLine secondTokensLine = cpdTokenLines.get(2);
-    assertThat(secondTokensLine.getValue()).isEqualTo("_I&=_N;");
-    assertThat(secondTokensLine.getStartLine()).isEqualTo(4);
-    assertThat(secondTokensLine.getStartUnit()).isEqualTo(11);
-    assertThat(secondTokensLine.getEndLine()).isEqualTo(4);
-    assertThat(secondTokensLine.getEndUnit()).isEqualTo(14);
+    TokensLine firstTokensLine = cpdTokenLines.get(2);
+    assertThat(firstTokensLine.getValue()).isEqualTo("_I&=_N;");
+    assertThat(firstTokensLine.getStartLine()).isEqualTo(4);
+    assertThat(firstTokensLine.getStartUnit()).isEqualTo(10);
+    assertThat(firstTokensLine.getEndLine()).isEqualTo(4);
+    assertThat(firstTokensLine.getEndUnit()).isEqualTo(13);
+
+    // if (xosfile_read_stamped_no_path(fn, &ob, 1, 1, 1, 1, 1)) return 1;
+    TokensLine secondTokensLine = cpdTokenLines.get(48);
+    assertThat(secondTokensLine.getValue()).isEqualTo("if(_I(_I,&_I,_N,_N,_N,_N,_N))return_N;");
+    assertThat(secondTokensLine.getStartLine()).isEqualTo(60);
+    assertThat(secondTokensLine.getStartUnit()).isEqualTo(283);
+    assertThat(secondTokensLine.getEndLine()).isEqualTo(60);
+    assertThat(secondTokensLine.getEndUnit()).isEqualTo(305);
 
     // case 3: return "three";
     TokensLine thirdTokensLine = cpdTokenLines.get(71);
     assertThat(thirdTokensLine.getValue()).isEqualTo("case_N:return_S;");
     assertThat(thirdTokensLine.getStartLine()).isEqualTo(86);
-    assertThat(thirdTokensLine.getStartUnit()).isEqualTo(388);
+    assertThat(thirdTokensLine.getStartUnit()).isEqualTo(381);
     assertThat(thirdTokensLine.getEndLine()).isEqualTo(86);
-    assertThat(thirdTokensLine.getEndUnit()).isEqualTo(393);
+    assertThat(thirdTokensLine.getEndUnit()).isEqualTo(386);
   }
 
 }

--- a/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/cpd.cc
+++ b/sonar-cxx-plugin/src/test/resources/org/sonar/plugins/cxx/cpd.cc
@@ -87,3 +87,18 @@ char* tostring2(int value)
     }
     return "undefined";
 }
+
+// CPD should ignore declarations
+class A {
+public:
+   virtual void a();
+   virtual void b();
+   virtual void c();
+};
+
+class B : public A {
+public:
+   virtual void a();
+   virtual void b();
+   virtual void c();
+};


### PR DESCRIPTION
- feedback from developer is that default should be sonar.cxx.cpd.ignoreLiterals=False & sonar.cxx.cpd.ignoreIdentifiers=False (not True)
- CPD sensor is looking now only in functionDefinition for duplicates. Gave false positives e.g. with interfaces before