### PR TITLE
improve syntax error warnings in LOG file

### DIFF
--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2016 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.visitors;
+
+import java.io.File;
+import java.util.List;
+import org.apache.commons.io.Charsets;
+import static org.fest.assertions.Assertions.assertThat;
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.api.batch.fs.internal.DefaultInputFile;
+import org.sonar.api.batch.fs.internal.FileMetadata;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.utils.log.LogTester;
+import org.sonar.cxx.CxxAstScanner;
+
+public class CxxParseErrorLoggerVisitorTest {
+  
+  @org.junit.Rule
+  public LogTester logTester = new LogTester();
+  
+  private SensorContextTester context;
+  private File file;
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void scanFile() {    
+    String dir = "src/test/resources/visitors";
+
+    file = new File(dir, "/syntaxerror.cc");
+    DefaultInputFile inputFile = new DefaultInputFile("moduleKey", file.getName())
+      .initMetadata(new FileMetadata().readMetadata(file, Charsets.UTF_8));
+
+    context = SensorContextTester.create(new File(dir));
+    context.fileSystem().add(inputFile);
+
+    CxxAstScanner.scanSingleFile(inputFile, context);
+  }
+
+  @Test
+  public void handleParseErrorTest() throws Exception {
+    List<String> log = logTester.logs();
+    assertThat(log.size()).isEqualTo(7);
+    assertThat(log.get(2)).contains("skip declarartion: namespace X {");
+    assertThat(log.get(3)).contains("skip declarartion: void test :: f1 ( ) {");
+    assertThat(log.get(4)).contains("syntax error: i = unsigend int ( i + 1 )");
+    assertThat(log.get(5)).contains("skip declarartion: void test :: f3 ( ) {");
+    assertThat(log.get(6)).contains("syntax error: int i = 0 i ++");
+  }
+}

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
@@ -17,7 +17,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.cxx;
+package org.sonar.cxx.visitors;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -25,21 +25,24 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 
 import org.fest.assertions.Fail;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.sonar.cxx.api.CxxMetric;
-import org.sonar.cxx.visitors.CxxPublicApiVisitor;
 import org.sonar.cxx.visitors.CxxPublicApiVisitor.PublicApiHandler;
 import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.cxx.CxxFileTester;
+import org.sonar.cxx.CxxFileTesterHelper;
+import org.sonar.cxx.CxxAstScanner;
 
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
 import com.sonar.sslr.api.Token;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 
 public class CxxPublicApiVisitorTest {
 

--- a/cxx-squid/src/test/resources/visitors/syntaxerror.cc
+++ b/cxx-squid/src/test/resources/visitors/syntaxerror.cc
@@ -1,0 +1,17 @@
+namespace X {
+   void test::f1() {
+      int i = 0;
+      if( i ) {
+         throw i;
+      }
+      i = unsigend int(i + 1);
+   }
+}
+
+voif f2() {
+}
+
+void test::f3() {
+ int i = 0
+ i++;
+}


### PR DESCRIPTION
improve 'syntax error, skip ...' warnings in LOG file