### PR TITLE
unify error handling

### DIFF
--- a/integration-tests/features/test_execution_statistics.feature
+++ b/integration-tests/features/test_execution_statistics.feature
@@ -132,7 +132,7 @@ Feature: Providing test execution numbers
    @SqApi56 @SqApi62
    Scenario: googletest report is invalid
        GIVEN the project "googletest_project"
-       WHEN I run "sonar-scanner -Dsonar.cxx.xunit.reportPath=invalid_report.xml"
+       WHEN I run "sonar-scanner -Dsonar.cxx.errorRecoveryEnabled=false -Dsonar.cxx.xunit.reportPath=invalid_report.xml"
        THEN the analysis breaks
            AND the analysis log contains a line matching:
                """

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/coverage/CxxCoverageSensor.java
@@ -153,7 +153,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
           newCoverage.lineHits(line, 0);
         } catch (Exception ex) {
           LOG.error("Cannot save Line Hits for Line '{}' '{}' : '{}', ignoring measure", inputFile.relativePath(), line, ex.getMessage());
-          CxxUtils.ValidateRecovery(ex, settings);
+          CxxUtils.validateRecovery(ex, settings);
         }
       }
 
@@ -161,7 +161,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
         newCoverage.save();
       } catch (Exception ex) {
         LOG.error("Cannot save measure '{}' : '{}', ignoring measure", inputFile.relativePath(), ex.getMessage());
-        CxxUtils.ValidateRecovery(ex, settings);
+        CxxUtils.validateRecovery(ex, settings);
       }
     }
   }
@@ -225,7 +225,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
               newCoverage.lineHits(measure.getLine(), measure.getHits());
             } catch(Exception ex) {
               LOG.error("Cannot save Line Hits for Line '{}' '{}' : '{}', ignoring measure", filePath, measure.getLine(), ex.getMessage());
-              CxxUtils.ValidateRecovery(ex, settings);
+              CxxUtils.validateRecovery(ex, settings);
             }            
           }
           
@@ -235,7 +235,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
               newCoverage.conditions(measure.getLine(), measure.getConditions(), measure.getCoveredConditions());
             } catch(Exception ex) {
               LOG.error("Cannot save Conditions Hits for Line '{}' '{}' : '{}', ignoring measure", filePath, measure.getLine(), ex.getMessage());
-              CxxUtils.ValidateRecovery(ex, settings);
+              CxxUtils.validateRecovery(ex, settings);
             }                         
           }                             
         }
@@ -245,7 +245,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
           newCoverage.save();
         } catch(Exception ex) {
           LOG.error("Cannot save measure '{}' : '{}', ignoring measure", filePath, ex.getMessage());
-          CxxUtils.ValidateRecovery(ex, settings);
+          CxxUtils.validateRecovery(ex, settings);
         }        
       } else {
         LOG.debug("Cannot find the file '{}', ignoring coverage measures", filePath);

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/drmemory/CxxDrMemorySensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/drmemory/CxxDrMemorySensor.java
@@ -92,7 +92,8 @@ public class CxxDrMemorySensor extends CxxReportSensor {
         .append(e)
         .append("'")
         .toString();
-      throw new IllegalStateException(msg, e);
+      LOG.error(msg);
+      CxxUtils.validateRecovery(e, settings);
     }
   }
 

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/xunit/CxxXunitSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/tests/xunit/CxxXunitSensor.java
@@ -23,9 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
 import javax.xml.stream.XMLStreamException;
 
@@ -48,9 +46,6 @@ import org.sonar.plugins.cxx.utils.EmptyReportException;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
-import org.sonar.plugins.cxx.CxxLanguage;
-import org.sonar.plugins.cxx.CxxPlugin;
-import static org.sonar.plugins.cxx.coverage.CxxCoverageSensor.LOG;
 import org.sonar.plugins.cxx.utils.CxxUtils;
 import org.sonar.plugins.cxx.utils.StaxParser;
 
@@ -126,7 +121,7 @@ public class CxxXunitSensor extends CxxReportSensor {
         .append("'")
         .toString();
       LOG.error(msg);
-      throw new IllegalStateException(msg, e);
+      CxxUtils.validateRecovery(e, settings);
     }
   }
 
@@ -166,7 +161,7 @@ public class CxxXunitSensor extends CxxReportSensor {
            .save();
       } catch(Exception ex) {
         LOG.error("Cannot save measure TESTS : '{}', ignoring measure", ex.getMessage());
-        CxxUtils.ValidateRecovery(ex, settings);
+        CxxUtils.validateRecovery(ex, settings);
       }       
 
       try
@@ -178,7 +173,7 @@ public class CxxXunitSensor extends CxxReportSensor {
          .save();
       } catch(Exception ex) {
         LOG.error("Cannot save measure TEST_ERRORS : '{}', ignoring measure", ex.getMessage());
-        CxxUtils.ValidateRecovery(ex, settings);
+        CxxUtils.validateRecovery(ex, settings);
       } 
       
       try
@@ -190,7 +185,7 @@ public class CxxXunitSensor extends CxxReportSensor {
          .save();
       } catch(Exception ex) {
         LOG.error("Cannot save measure TEST_FAILURES : '{}', ignoring measure", ex.getMessage());
-        CxxUtils.ValidateRecovery(ex, settings);
+        CxxUtils.validateRecovery(ex, settings);
       } 
       
       try
@@ -202,7 +197,7 @@ public class CxxXunitSensor extends CxxReportSensor {
          .save();
       } catch(Exception ex) {
         LOG.error("Cannot save measure SKIPPED_TESTS : '{}', ignoring measure", ex.getMessage());
-        CxxUtils.ValidateRecovery(ex, settings);
+        CxxUtils.validateRecovery(ex, settings);
       } 
 
       try
@@ -214,7 +209,7 @@ public class CxxXunitSensor extends CxxReportSensor {
          .save();
       } catch(Exception ex) {
         LOG.error("Cannot save measure TEST_SUCCESS_DENSITY : '{}', ignoring measure", ex.getMessage());
-        CxxUtils.ValidateRecovery(ex, settings);
+        CxxUtils.validateRecovery(ex, settings);
       }       
 
       try
@@ -226,7 +221,7 @@ public class CxxXunitSensor extends CxxReportSensor {
          .save();
       } catch(Exception ex) {
         LOG.error("Cannot save measure TEST_EXECUTION_TIME : '{}', ignoring measure", ex.getMessage());
-        CxxUtils.ValidateRecovery(ex, settings);
+        CxxUtils.validateRecovery(ex, settings);
       }       
     } else {
       LOG.debug("The reports contain no testcases");

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/CxxReportSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/CxxReportSensor.java
@@ -85,7 +85,7 @@ public abstract class CxxReportSensor implements Sensor {
              violationsCount - prevViolationsCount);
         } catch (EmptyReportException e) {
           LOG.warn("The report '{}' seems to be empty, ignoring.", report);
-          CxxUtils.ValidateRecovery(e, settings);
+          CxxUtils.validateRecovery(e, settings);
         }
       }
 
@@ -105,7 +105,8 @@ public abstract class CxxReportSensor implements Sensor {
         .append(e)
         .append("'")
         .toString();
-      throw new IllegalStateException(msg, e);
+      LOG.error(msg);
+      CxxUtils.validateRecovery(e, settings);
     }
   }
 
@@ -221,7 +222,7 @@ public abstract class CxxReportSensor implements Sensor {
             violationsCount++;
           } catch (Exception ex) {
             LOG.error("Could not add the issue '{}', skipping issue", ex.getMessage());
-            CxxUtils.ValidateRecovery(ex, settings);
+            CxxUtils.validateRecovery(ex, settings);
           }
         } else {
           LOG.warn("Cannot find the file '{}', skipping violations", normalPath);
@@ -240,7 +241,7 @@ public abstract class CxxReportSensor implements Sensor {
         violationsCount++;
       } catch (Exception ex) {
         LOG.error("Could not add the issue '{}', skipping issue", ex.getMessage());
-        CxxUtils.ValidateRecovery(ex, settings);
+        CxxUtils.validateRecovery(ex, settings);
       }
     }
   }
@@ -257,7 +258,7 @@ public abstract class CxxReportSensor implements Sensor {
         }
       } catch (java.lang.NumberFormatException nfe) {
         LOG.warn("Skipping invalid line number: {}", line);
-        CxxUtils.ValidateRecovery(nfe, settings);
+        CxxUtils.validateRecovery(nfe, settings);
         lineNr = -1;
       }
     }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/CxxUtils.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/utils/CxxUtils.java
@@ -85,7 +85,7 @@ public final class CxxUtils {
     return sw.getBuffer().toString();
   }
   
-  public static void ValidateRecovery(Exception ex, Settings settings) throws IllegalStateException {
+  public static void validateRecovery(Exception ex, Settings settings) throws IllegalStateException {
     if (!settings.getBoolean(CxxPlugin.ERROR_RECOVERY_KEY)) {
       LOG.info("Recovery is disabled, failing analysis : '{}'", ex.toString());
       throw new IllegalStateException(ex.getMessage(), ex.getCause());


### PR DESCRIPTION
- all sensors should continue if 'sonar.cxx.errorRecoveryEnabled = true'
- 'validateRecovery' method should start with lower case
- close #1050