### PR TITLE
C++17: Structured Bindings

### DIFF
--- a/cxx-squid/dox/grammar-diff.txt
+++ b/cxx-squid/dox/grammar-diff.txt
@@ -92,11 +92,7 @@ iteration-statement:
    do statement while ( expression ) ;
    for ( init-statement conditionopt ; expressionopt ) statement
    for ( for-range-declaration : for-range-initializer ) statement
-   
-for-range-declaration:
-   attribute-specifier-seqopt decl-specifier-seq declarator
-   attribute-specifier-seqopt decl-specifier-seq ref-qualifieropt [ identifier-list ]
-
+ 
 for-range-initializer:
    expr-or-braced-init-list
 
@@ -124,11 +120,6 @@ nodeclspec-function-declaration:
 
 alias-declaration:
    using identifier attribute-specifier-seqopt = defining-type-id ;
-
-simple-declaration:
-   decl-specifier-seq init-declarator-listopt ;
-   attribute-specifier-seq decl-specifier-seq init-declarator-list ;
-   attribute-specifier-seqopt decl-specifier-seq ref-qualifieropt [ identifier-list ] initializer ;
 
 decl-specifier:
    storage-class-specifier

--- a/cxx-squid/src/main/java/org/sonar/cxx/api/CxxGrammar.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/api/CxxGrammar.java
@@ -106,7 +106,7 @@ public class CxxGrammar extends Grammar {
   public Rule forRangeDeclSpecifierSeq;
   public Rule parameterDeclSpecifierSeq;
   public Rule functionDeclSpecifierSeq;
-  public Rule simpleDeclSpecifierSeq;
+  public Rule declSpecifierSeq;
   public Rule memberDeclSpecifierSeq;
 
   public Rule storageClassSpecifier;

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
@@ -265,14 +265,14 @@ public abstract class AbstractCxxPublicApiVisitor<GRAMMAR extends Grammar>
       return false;
     }
 
-    AstNode simpleDeclSpecifierSeq = simpleDeclNode
-      .getFirstChild(CxxGrammarImpl.simpleDeclSpecifierSeq);
+    AstNode declSpecifierSeq = simpleDeclNode
+      .getFirstChild(CxxGrammarImpl.declSpecifierSeq);
 
-    if (simpleDeclSpecifierSeq == null) {
+    if (declSpecifierSeq == null) {
       return false;
     }
 
-    List<AstNode> declSpecifiers = simpleDeclSpecifierSeq
+    List<AstNode> declSpecifiers = declSpecifierSeq
       .getChildren(CxxGrammarImpl.declSpecifier);
 
     for (AstNode declSpecifier : declSpecifiers) {
@@ -464,14 +464,14 @@ public abstract class AbstractCxxPublicApiVisitor<GRAMMAR extends Grammar>
       return false;
     }
 
-    AstNode simpleDeclSpecifierSeq = simpleDeclNode
-      .getFirstChild(CxxGrammarImpl.simpleDeclSpecifierSeq);
+    AstNode declSpecifierSeq = simpleDeclNode
+      .getFirstChild(CxxGrammarImpl.declSpecifierSeq);
 
-    if (simpleDeclSpecifierSeq == null) {
+    if (declSpecifierSeq == null) {
       return false;
     }
 
-    List<AstNode> declSpecifiers = simpleDeclSpecifierSeq
+    List<AstNode> declSpecifiers = declSpecifierSeq
       .getChildren(CxxGrammarImpl.declSpecifier);
 
     for (AstNode declSpecifier : declSpecifiers) {

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/DeclarationsTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/DeclarationsTest.java
@@ -22,9 +22,6 @@ package org.sonar.cxx.parser;
 import static org.sonar.sslr.tests.Assertions.assertThat;
 
 import org.junit.Test;
-import static org.sonar.cxx.parser.CxxGrammarImpl.namedNamespaceDefinition;
-import static org.sonar.cxx.parser.CxxGrammarImpl.nestedNamespaceDefinition;
-import static org.sonar.cxx.parser.CxxGrammarImpl.unnamedNamespaceDefinition;
 
 public class DeclarationsTest extends ParserBaseTest {
 
@@ -109,16 +106,24 @@ public class DeclarationsTest extends ParserBaseTest {
     p.setRootRule(g.rule(CxxGrammarImpl.simpleDeclaration));
 
     mockRule(CxxGrammarImpl.attributeSpecifierSeq);
-    mockRule(CxxGrammarImpl.simpleDeclSpecifierSeq);
+    mockRule(CxxGrammarImpl.declSpecifierSeq);
     mockRule(CxxGrammarImpl.initDeclaratorList);
+    mockRule(CxxGrammarImpl.refQualifier);
+    mockRule(CxxGrammarImpl.identifierList);
+    mockRule(CxxGrammarImpl.initializer);
 
     assertThat(p).matches(";");
     assertThat(p).matches("initDeclaratorList ;");
-    assertThat(p).matches("simpleDeclSpecifierSeq ;");
-    assertThat(p).matches("simpleDeclSpecifierSeq initDeclaratorList ;");
+    assertThat(p).matches("declSpecifierSeq ;");
+    assertThat(p).matches("declSpecifierSeq initDeclaratorList ;");
 
     assertThat(p).matches("attributeSpecifierSeq initDeclaratorList ;");
-    assertThat(p).matches("attributeSpecifierSeq simpleDeclSpecifierSeq initDeclaratorList ;");
+    assertThat(p).matches("attributeSpecifierSeq declSpecifierSeq initDeclaratorList ;");
+    
+    assertThat(p).matches("declSpecifierSeq [ identifierList ] initializer ;");
+    assertThat(p).matches("attributeSpecifierSeq declSpecifierSeq [ identifierList ] initializer ;");
+    assertThat(p).matches("declSpecifierSeq refQualifier [ identifierList ] initializer ;");
+    assertThat(p).matches("attributeSpecifierSeq declSpecifierSeq refQualifier [ identifierList ] initializer ;");
   }
 
   @Test
@@ -169,6 +174,7 @@ public class DeclarationsTest extends ParserBaseTest {
     assertThat(p).matches("auto f() -> int(*)[4];");
     assertThat(p).matches("auto fpif(int) -> int(*)(int);");
 
+    assertThat(p).matches("auto[a, b] = f();");
   }
 
   @Test

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/StatementTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/StatementTest.java
@@ -224,6 +224,9 @@ public class StatementTest extends ParserBaseTest {
 
     // CLI extension
     assertThat(p).matches("for each(String^% s in arr) { s = i++.ToString(); }");
+    
+    // C++17 structered bindings
+    assertThat(p).matches("for (const auto&[key, val] : mymap) { std::cout << key << \": \" << val << std::endl; }");
   }
 
   @Test
@@ -239,9 +242,18 @@ public class StatementTest extends ParserBaseTest {
     mockRule(CxxGrammarImpl.forRangeDeclSpecifierSeq);
     mockRule(CxxGrammarImpl.declarator);
     mockRule(CxxGrammarImpl.attributeSpecifierSeq);
+    mockRule(CxxGrammarImpl.declSpecifierSeq);
+    mockRule(CxxGrammarImpl.identifierList);
+    mockRule(CxxGrammarImpl.refQualifier);
 
     assertThat(p).matches("forRangeDeclSpecifierSeq declarator");
     assertThat(p).matches("attributeSpecifierSeq forRangeDeclSpecifierSeq declarator");
+    
+    assertThat(p).matches("declSpecifierSeq [ identifierList ]");
+    assertThat(p).matches("attributeSpecifierSeq declSpecifierSeq [ identifierList ]");
+    assertThat(p).matches("attributeSpecifierSeq declSpecifierSeq [ identifierList ]");
+    assertThat(p).matches("declSpecifierSeq refQualifier [ identifierList ]");
+    assertThat(p).matches("attributeSpecifierSeq declSpecifierSeq refQualifier [ identifierList ]");
   }
 
   @Test

--- a/cxx-squid/src/test/resources/parser/own/C++17/structured-bindings.cc
+++ b/cxx-squid/src/test/resources/parser/own/C++17/structured-bindings.cc
@@ -1,0 +1,22 @@
+//todo int[2] f();
+auto[x, y] = f();
+
+tuple<T1, T2, T3> g();
+auto[a, b, c] = g();
+
+struct MyStruct {
+    int x;
+    double y;
+};
+
+MyStruct h();
+auto[u, v] = h();
+
+void inForRange()
+{
+    std::map<string, double> mymap;
+    for (const auto&[key, val] : mymap) {
+        std::cout << key << ": " << val << std::endl;
+    }
+}
+


### PR DESCRIPTION
- support structured bindings
- rename simpleDeclSpecifierSeq => declSpecifierSeq
- changes on cliAttributes support necessary (@Bertk)
- close #1082

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1137)
<!-- Reviewable:end -->
