### PR TITLE
Fixes "Generated strings in macros results in DuplicatedLiterals false alarms

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/StringLiteralDuplicatedCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/StringLiteralDuplicatedCheck.java
@@ -67,7 +67,7 @@ public class StringLiteralDuplicatedCheck extends SquidCheck<Grammar> {
 
   @Override
   public void visitNode(AstNode node) {
-    if (node.is(CxxGrammarImpl.LITERAL)) {
+    if (!node.getToken().isGeneratedCode()) {
       visitOccurence(node.getTokenOriginalValue(), node.getTokenLine());
     }
   }

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/StringLiteralDuplicatedCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/StringLiteralDuplicatedCheckTest.java
@@ -38,8 +38,8 @@ public class StringLiteralDuplicatedCheckTest {
     SourceFile file = CxxAstScanner.scanSingleFile(tester.cxxFile, tester.sensorContext, CxxFileTesterHelper.mockCxxLanguage(), new StringLiteralDuplicatedCheck()); 
         
     checkMessagesVerifier.verify(file.getCheckMessages())
-      .next().atLine(12).withMessage("Define a constant instead of duplicating this literal \"bbbbb\" 2 times.")
-      .next().atLine(14).withMessage("Define a constant instead of duplicating this literal \"ccccc\" 3 times.");
+      .next().atLine(13).withMessage("Define a constant instead of duplicating this literal \"bbbbb\" 2 times.")
+      .next().atLine(15).withMessage("Define a constant instead of duplicating this literal \"ccccc\" 3 times.");
   }
 
 }

--- a/cxx-checks/src/test/resources/checks/StringLiteralDuplicatedCheck.cc
+++ b/cxx-checks/src/test/resources/checks/StringLiteralDuplicatedCheck.cc
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <tchar.h>
 #include <string>
+#define MACRO(ex) printf(#ex)
 class A {
     //    @SupressWarnings("allall") // Compliant
     //    @SupressWarnings("allall")
@@ -16,6 +17,8 @@ public:
         printf("ccccc");
         printf("dddd"); // Compliant - too short
         printf("dddd");
+        MACRO(printf()); // Compliant
+        MACRO(printf());
     }
 
     const std::string ACTION_1 = "action1";  // Compliant


### PR DESCRIPTION
https://github.com/SonarOpenCommunity/sonar-cxx/issues/1147

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1150)
<!-- Reviewable:end -->
