### PR TITLE
Preserve generated status in concatenated strings

### DIFF
--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/StringLiteralDuplicatedCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/StringLiteralDuplicatedCheckTest.java
@@ -38,8 +38,9 @@ public class StringLiteralDuplicatedCheckTest {
     SourceFile file = CxxAstScanner.scanSingleFile(tester.cxxFile, tester.sensorContext, CxxFileTesterHelper.mockCxxLanguage(), new StringLiteralDuplicatedCheck()); 
         
     checkMessagesVerifier.verify(file.getCheckMessages())
-      .next().atLine(13).withMessage("Define a constant instead of duplicating this literal \"bbbbb\" 2 times.")
-      .next().atLine(15).withMessage("Define a constant instead of duplicating this literal \"ccccc\" 3 times.");
+      .next().atLine(14).withMessage("Define a constant instead of duplicating this literal \"bbbbb\" 2 times.")
+      .next().atLine(16).withMessage("Define a constant instead of duplicating this literal \"ccccc\" 3 times.")
+      .next().atLine(25).withMessage("Define a constant instead of duplicating this literal \"eeeee\" 2 times.");
   }
 
 }

--- a/cxx-checks/src/test/resources/checks/StringLiteralDuplicatedCheck.cc
+++ b/cxx-checks/src/test/resources/checks/StringLiteralDuplicatedCheck.cc
@@ -2,6 +2,7 @@
 #include <tchar.h>
 #include <string>
 #define MACRO(ex) printf(#ex)
+#define CONCAT_MACRO(ex) printf("eee" #ex "eee")
 class A {
     //    @SupressWarnings("allall") // Compliant
     //    @SupressWarnings("allall")
@@ -19,6 +20,10 @@ public:
         printf("dddd");
         MACRO(printf()); // Compliant
         MACRO(printf());
+        CONCAT_MACRO(printf()); // Compliant
+        CONCAT_MACRO(printf());
+        printf("ee" "eee"); // Non-Compliant
+        printf("ee" "eee");
     }
 
     const std::string ACTION_1 = "action1";  // Compliant

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/JoinStringsPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/JoinStringsPreprocessor.java
@@ -40,6 +40,7 @@ public class JoinStringsPreprocessor extends Preprocessor { //@todo deprecated P
       // Joining string literals (C++ Standard, "2.2 Phases of translation, Phase 6")
       StringBuilder newStr = null;
       int numberOfStrings = 1;
+      boolean isGenerated = token.isGeneratedCode();
 
       for (;;) {
         Token nextToken = tokens.get(numberOfStrings);
@@ -55,6 +56,8 @@ public class JoinStringsPreprocessor extends Preprocessor { //@todo deprecated P
           newStr.append(stripQuotes(token.getValue()));
         }
         newStr.append(stripQuotes(nextToken.getValue()));
+        if (nextToken.isGeneratedCode())
+          isGenerated = true;
         numberOfStrings++;
       }
 
@@ -67,6 +70,7 @@ public class JoinStringsPreprocessor extends Preprocessor { //@todo deprecated P
             .setURI(token.getURI())
             .setType(CxxTokenType.STRING)
             .setValueAndOriginalValue(newStr.toString())
+            .setGeneratedCode(isGenerated)
             .build()
         );
         return new PreprocessorAction(numberOfStrings, Collections.EMPTY_LIST, tokensToInject); //@todo deprecated PreprocessorAction


### PR DESCRIPTION
Concatenated strings doesn't preserve generated status, thus macro concatenations are considered as StringLiteralDuplicates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1163)
<!-- Reviewable:end -->
