### PR TITLE
Ignore empty statement after generated code in TooManyStatementsPerLine

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/TooManyStatementsPerLineCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/TooManyStatementsPerLineCheck.java
@@ -32,6 +32,9 @@ import org.sonar.squidbridge.annotations.ActivatedByDefault;
 import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
 import org.sonar.cxx.tag.Tag;
 
+/**
+ * TooManyStatementsPerLineCheck - Statements should be on separate lines
+ */
 @Rule(
   key = "TooManyStatementsPerLine",
   name = "Statements should be on separate lines",
@@ -43,6 +46,10 @@ public class TooManyStatementsPerLineCheck extends AbstractOneStatementPerLineCh
 
   private static final boolean DEFAULT_EXCLUDE_CASE_BREAK = false;
 
+  /**
+   * excludeCaseBreak - Exclude 'break' statement if it is on the same line
+   * as the switch label (case: or default:)
+   */
   @RuleProperty(
     key = "excludeCaseBreak",
     description = "Exclude 'break' statement if it is on the same line as the switch label (case: or default:)",
@@ -109,6 +116,8 @@ public class TooManyStatementsPerLineCheck extends AbstractOneStatementPerLineCh
       if (statement != null ) {
         return astNode.getTokenLine() == statement.getTokenLine();
       }
+
+      return isGeneratedNodeExcluded(astNode);
     }
     return false;
   }

--- a/cxx-checks/src/test/resources/checks/TooManyStatementsPerLine.cc
+++ b/cxx-checks/src/test/resources/checks/TooManyStatementsPerLine.cc
@@ -8,7 +8,7 @@ bool condition = true;
 #define TEST(a,b) if (a) {    \
                   } if (b) {  \
                   }
-
+#define TEST2() doSomething();
 // without alias
 
 class TooManyStatementsPerLine {
@@ -88,6 +88,7 @@ int main()
 			//    fpoly_only(c); // error, enable_if prohibits this
 	S s;
 	fpoly_only(s); // okay, enable_if allows this
+	TEST2(); // OK - empty statement after generated code
 }
 
 template <typename RBM, typename Trainer>


### PR DESCRIPTION
Example triggers TooManyStatementsPerLine rule.
```
#define TEST2() doSomething();

TEST2();
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1164)
<!-- Reviewable:end -->
