### PR TITLE
Trailing comma is not removed in complex empty variadic macro

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -935,17 +935,20 @@ public class CxxPreprocessor extends Preprocessor {
           while (j > 0 && body.get(j - 1).getType().equals(WS)) {
             j--;
           }
-          if (j == 0 || !"##".equals(body.get(--j).getValue())) {
-            continue;
-          }
-          int k = j;
-          while (j > 0 && body.get(j - 1).getType().equals(WS)) {
-            j--;
-          }
-          if (j > 0 && ",".equals(body.get(j - 1).getValue())) {
-            newTokens.remove(newTokens.size() - 1 + j - i); // remove the comma
-            newTokens.remove(newTokens.size() - 1 + k - i); // remove the paste
-                                                            // operator
+          if (j != 0 && "##".equals(body.get(--j).getValue())) {
+            int k = j;
+            while (j > 0 && body.get(j - 1).getType().equals(WS)) {
+              j--;
+            }
+            if (j > 0 && ",".equals(body.get(j - 1).getValue())) {
+              newTokens.remove(newTokens.size() - 1 + j - i); // remove the comma
+              newTokens.remove(newTokens.size() - 1 + k - i); // remove the paste
+              // operator
+            }
+          } else {
+            // Got empty variadic args, remove comma
+            if (j > 0 && ",".equals(body.get(j).getValue()))
+              newTokens.remove(newTokens.size() + j - i);
           }
         } else if (index < arguments.size()) {
           // token pasting operator?

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/PreprocessorDirectivesTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/PreprocessorDirectivesTest.java
@@ -209,6 +209,11 @@ public class PreprocessorDirectivesTest extends ParserBaseTest {
         + "MACRO(\"error\");"))
         .equals("printf ( \"error\" ) ; EOF"));
 
+    assert (serialize(p.parse(
+        "#define MACRO(s, ...) do { printf(s, __VA_ARGS__); } while (false)\n"
+        + "int main() { MACRO(\"error\"); }"))
+        .equals("int main ( ) { do { printf ( \"error\" ) ; } while ( false ) ; } EOF"));
+
     // without whitespace after the parameter list
     assert (serialize(p.parse(
       "#define foo(a...);\n"


### PR DESCRIPTION
Example:
```
#define MACRO(s, ...) do { printf(s, __VA_ARGS__); } while (false)
int main() { MACRO(\"error\"); }
```
Parser doesn't remove comma on empty \_\_VA_ARGS__

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1166)
<!-- Reviewable:end -->
