### PR TITLE
Adds handling of const template typename specifier

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -1685,7 +1685,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
       b.firstOf(
         b.sequence(CxxKeyword.TYPENAME, nestedNameSpecifier, b.optional(CxxKeyword.TEMPLATE), simpleTemplateId), // C++
         b.sequence(CxxKeyword.TYPENAME, nestedNameSpecifier, IDENTIFIER), // C++
-        b.sequence(CxxKeyword.TYPENAME, IDENTIFIER), // todo
+        b.sequence(CxxKeyword.TYPENAME, b.optional(CxxKeyword.CONST), IDENTIFIER), // todo
         IDENTIFIER // todo
       )
     );

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/TemplatesTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/TemplatesTest.java
@@ -146,6 +146,7 @@ public class TemplatesTest extends ParserBaseTest {
     assertThat(p).matches("typename nestedNameSpecifier simpleTemplateId");
     assertThat(p).matches("typename nestedNameSpecifier template simpleTemplateId");
     assertThat(p).matches("typename IDENTIFIER");
+    assertThat(p).matches("typename const IDENTIFIER");
     assertThat(p).matches("IDENTIFIER");
   }
 }


### PR DESCRIPTION
Hi again)

Adding optional `const` keyword to template typename specifier

```
template <typename... T>
struct TypeList
{
    template <std::size_t I> using type = typename std::tuple_element<I, std::tuple<T...>>::type; // **OK**

    template <std::size_t I>
    using type_ref = typename std::tuple_element<I, std::tuple<T...>>::type&; // **OK**

    template <std::size_t I>
    using const_type_ref = typename const std::tuple_element<I, std::tuple<T...>>::type&; // **syntax error**
};
```

> syntax error: template < std :: size_t I > using const_type_ref = typename const std :: tuple_element < I , std :: tuple < T ... >> :: type &

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1170)
<!-- Reviewable:end -->
