### PR TITLE
Ignore generated nodes in nested statement check

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/NestedStatementsCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/NestedStatementsCheck.java
@@ -78,7 +78,7 @@ public class NestedStatementsCheck extends SquidCheck<Grammar> {
 
   @Override
   public void visitNode(AstNode node) {
-    if (checkedNodes.contains(node)) {
+    if (node.isCopyBookOrGeneratedNode() || checkedNodes.contains(node)) {
       return;
     }
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/NestedStatementsCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/NestedStatementsCheckTest.java
@@ -40,8 +40,8 @@ public class NestedStatementsCheckTest {
     SourceFile file = CxxAstScanner.scanSingleFile(tester.cxxFile, tester.sensorContext, CxxFileTesterHelper.mockCxxLanguage(), check); 
     
     checkMessagesVerifier.verify(file.getCheckMessages())
-      .next().atLine(62)
-      .next().atLine(67)
+      .next().atLine(64)
+      .next().atLine(69)
       .noMore();
   }
 

--- a/cxx-checks/src/test/resources/checks/NestedStatementsCheck.cc
+++ b/cxx-checks/src/test/resources/checks/NestedStatementsCheck.cc
@@ -1,3 +1,5 @@
+#define MACRO(x) if (true) { printf(x); }
+
 class Abc {
   public:
 
@@ -69,6 +71,7 @@ class Abc {
                   } catch (Exception e) {
                     // pass
                   }
+                  MACRO("Macro contain sixth level if, but shouldn't trigger; compiant");
                   break;
               }
             }


### PR DESCRIPTION
We have a lot of false positives triggered on macroses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1171)
<!-- Reviewable:end -->
