### PR TITLE
Fixes syntax error if template argument is casting pack expansion

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -1664,8 +1664,8 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
         // FIXME: workaround to parse stuff like "carray<int, 10>"
         // actually, it should be covered by the next rule (constantExpression)
         // but it doesnt work because of ambiguity template syntax <--> relationalExpression
-        b.sequence(shiftExpression, b.next(b.firstOf(">", ","))),
-        b.sequence(constantExpression, b.next(b.firstOf(">", ","))) // C++
+        b.sequence(shiftExpression, b.next(b.firstOf(">", ",", "..."))),
+        b.sequence(constantExpression, b.next(b.firstOf(">", ",", "..."))) // C++
       //        idExpression
       )
     );

--- a/cxx-squid/src/test/resources/parser/own/C++11/variadic-template.cc
+++ b/cxx-squid/src/test/resources/parser/own/C++11/variadic-template.cc
@@ -17,3 +17,11 @@ void g(Args ... args) {
    f(const_cast<const Args*>(&args)...);
    f(h(args ...) + args ...);
 }
+
+template<typename T, T... Ns>
+struct integer_sequence {
+    template< class U >
+    struct rebind {
+        typedef integer_sequence<U, static_cast<U>(Ns)...> type;
+    };
+};


### PR DESCRIPTION
Fix syntax error if template argument is casting pack expansion.
http://en.cppreference.com/w/cpp/language/parameter_pack
Example:
```
template<typename T, T... Ns>
struct integer_sequence {
    template< class U >
    struct rebind {
        typedef integer_sequence<U, static_cast<U>(Ns)...> type;
    };
};
```
```
   21: typename T, T... Ns>
   22: struct integer_sequence {
   23:     template< class U >
   24:     struct rebind {
  -->          typedef integer_sequence<U, static_cast<U>(Ns)...> type;
   26:     };
   27: };
   28: EOF
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1176)
<!-- Reviewable:end -->
