### PR TITLE
Fixes syntax error: std::nullptr_t in func args

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/lexer/CxxLexer.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/lexer/CxxLexer.java
@@ -84,7 +84,7 @@ public final class CxxLexer {
       .withChannel(regexp(CxxTokenType.NUMBER, "0" + opt(UD_SUFFIX))) // Decimal zero
 
       // C++ Standard, Section 2.14.7 "Pointer literals"
-      .withChannel(regexp(CxxTokenType.NUMBER, CxxKeyword.NULLPTR.getValue()))
+      .withChannel(regexp(CxxTokenType.NUMBER, CxxKeyword.NULLPTR.getValue() + "\\b"))
       // C++ Standard, Section 2.12 "Keywords"
       // C++ Standard, Section 2.11 "Identifiers"
       .withChannel(new IdentifierAndKeywordChannel(and("[a-zA-Z_]", o2n("\\w")), true, CxxKeyword.values()))

--- a/cxx-squid/src/test/resources/parser/own/C++11/nullptr-literal.cc
+++ b/cxx-squid/src/test/resources/parser/own/C++11/nullptr-literal.cc
@@ -17,6 +17,21 @@ void g(int* i)
   std::cout << "Function g called\n";
 }
 
+void n(int* pi)
+{
+  std::cout << "Pointer to integer overload\n";
+}
+
+void n(double* pd)
+{
+  std::cout << "Pointer to double overload\n";
+}
+
+void n(std::nullptr_t nullp)
+{
+  std::cout << "null pointer overload\n";
+}
+
 int main()
 {
   g(NULL);           // Fine
@@ -24,4 +39,10 @@ int main()
 
   Fwd(g, nullptr);   // Fine
                      //  Fwd(g, NULL);  // ERROR: No function g(int)
+
+  int* pi; double* pd;
+  n(pi);             // Fine - integer pointer overload
+  n(pd);             // Fine - double pointer overload
+  n(nullptr);        // Fine - would be ambiguous without void n(nullptr_t)
+                     //  n(NULL);   // ERROR: ambiguous overload
 }


### PR DESCRIPTION
Example:
```
void n(std::nullptr_t nullp)
{
  std::cout << "null pointer overload\n";
}
```
causes syntax error:
```
   29:
  -->  void n(std::nullptr_t nullp)
   31: {
   32:   std::cout << "null pointer overload\n";
   33: }
```


http://en.cppreference.com/w/cpp/types/nullptr_t

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1178)
<!-- Reviewable:end -->
