### PR TITLE
Fixes syntax error in list initialization with template

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -415,7 +415,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
     b.rule(unqualifiedId).is(
       b.firstOf(
         // Mitigate ambiguity between relational operators < > and angular brackets by looking ahead
-        b.sequence(templateId, b.next(b.firstOf("(", ")", "[", "]", "?", ":", binaryOperator, ",", ";", EOF))), // todo?
+        b.sequence(templateId, b.next(b.firstOf("(", ")", "[", "]", "?", ":", binaryOperator, ",", ";", "}", EOF))), // todo?
         IDENTIFIER, // C++
         operatorFunctionId, // C++
         conversionFunctionId, // C++

--- a/cxx-squid/src/test/resources/parser/own/C++11/list-initialization.cc
+++ b/cxx-squid/src/test/resources/parser/own/C++11/list-initialization.cc
@@ -13,7 +13,7 @@ Object anArray[] = {{13.4f, 3}, {43.28f, 29}, {5.934f, 17}}; // An array of thre
 
 class SequenceClass {
 public:
-    SequenceClass(std::initializer_list<int> list);
+    SequenceClass(std::initializer_list<int> list){};
 };
 SequenceClass some_var = {1, 4, 5, 6};
 
@@ -31,6 +31,12 @@ std::vector<std::string> v3{ "xyzzy", "plugh", "abracadabra" }; // see "Uniform 
 std::pair<std::string, std::string> f(std::pair<std::string, std::string> p)
 {
   return{ p.second, p.first }; // list-initialization in return statement
+}
+
+template <typename T>
+std::string* string_creator()
+{
+    return new T();
 }
 
 int main()
@@ -71,4 +77,17 @@ int main()
     std::cout << n << ' ';
   for (auto n : f.mem2)
     std::cout << n << ' ';
+
+  static const struct
+  {
+    std::string* (*create)();
+  }
+  strings[] =
+  {
+    &string_creator<std::string>
+  };
+
+  for(auto const& s: strings)
+    std::cout << s.create();
+
 }


### PR DESCRIPTION
Fixing syntax error on having template inside list initializer
Test example:
```c++
#include <string>


template <typename T>
std::string* string_creator()
{
    return new T();
}

int main()
{
  static const struct
  {
    std::string* (*create)();
  }
  strings[] =
  {
    &string_creator<std::string>
  };
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1182)
<!-- Reviewable:end -->
