### PR TITLE
fix coverage caching

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
@@ -288,9 +288,9 @@ public class CxxCoverageSensor extends CxxReportSensor {
     Map<String, CoverageMeasures> coverageMeasures,
     CoverageType ctype) {
     for (Map.Entry<String, CoverageMeasures> entry : coverageMeasures.entrySet()) {
-      String filePath = CxxUtils.normalizePathFull(PathUtils.sanitize(entry.getKey()),  
-                                                  context.fileSystem().baseDir().getAbsolutePath());
+      String filePath = PathUtils.sanitize(entry.getKey());
       if (filePath!= null) {
+        filePath = CxxUtils.normalizePathFull(filePath, context.fileSystem().baseDir().getAbsolutePath());
         InputFile cxxFile = context.fileSystem().inputFile(context.fileSystem().predicates().hasPath(filePath));
         if (LOG.isDebugEnabled()) {
           LOG.debug("save coverage measure for file: '{}' cxxFile = '{}'", filePath, cxxFile);

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
@@ -288,7 +288,8 @@ public class CxxCoverageSensor extends CxxReportSensor {
     Map<String, CoverageMeasures> coverageMeasures,
     CoverageType ctype) {
     for (Map.Entry<String, CoverageMeasures> entry : coverageMeasures.entrySet()) {
-      String filePath = PathUtils.sanitize(entry.getKey());
+      String filePath = CxxUtils.normalizePathFull(PathUtils.sanitize(entry.getKey()),  
+                                                  context.fileSystem().baseDir().getAbsolutePath());
       if (filePath!= null) {
         InputFile cxxFile = context.fileSystem().inputFile(context.fileSystem().predicates().hasPath(filePath));
         if (LOG.isDebugEnabled()) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 import javax.xml.stream.XMLStreamException;
+
 import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.FileSystem;
 
@@ -239,7 +240,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
                       report.getAbsolutePath(), cacheCov.size());
               }
               cacheCov.put(report.getAbsolutePath(), measuresTotal);
-              // Only use first coverage parser with handles the data correctly
+              // Only use first coverage parser which handles the data correctly
               break;
             }
           }
@@ -248,6 +249,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
           LOG.debug("Report is empty {}", e);
         }
       } else {
+        measuresTotal = cacheCov.get(report.getAbsolutePath());
         if (LOG.isDebugEnabled()) {
           LOG.debug("Processing report '{}' skipped - already in cache", report);
         }
@@ -289,12 +291,15 @@ public class CxxCoverageSensor extends CxxReportSensor {
       String filePath = PathUtils.sanitize(entry.getKey());
       if (filePath!= null) {
         InputFile cxxFile = context.fileSystem().inputFile(context.fileSystem().predicates().hasPath(filePath));
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("save coverage measure for file: '{}' cxxFile = '{}'", filePath, cxxFile);
+        }
         if (cxxFile != null) {
-          
+
           NewCoverage newCoverage = context.newCoverage()
                     .onFile(cxxFile)        
                     .ofType(ctype);
-        
+
           Collection<CoverageMeasure> measures = entry.getValue().getCoverageMeasures();
           if (LOG.isDebugEnabled()) {
             LOG.debug("Saving '{}' coverage measures for file '{}'", measures.size(), filePath);
@@ -310,9 +315,12 @@ public class CxxCoverageSensor extends CxxReportSensor {
             LOG.error("Cannot save measure for file '{}' , ignoring measure. ", filePath, ex);
             CxxUtils.validateRecovery(ex, this.language);
           }
+          LOG.info("Saved '{}' coverage measures for file '{}'", measures.size(), filePath);
         } else {
           if (LOG.isDebugEnabled()) {
             LOG.debug("Cannot find the file '{}', ignoring coverage measures", filePath);
+          } else if (filePath.startsWith(context.fileSystem().baseDir().getAbsolutePath())) {
+            LOG.warn("Cannot find the file '{}', ignoring coverage measures", filePath);
           }
         }
       } else {
@@ -388,3 +396,4 @@ public class CxxCoverageSensor extends CxxReportSensor {
    }
 
 }
+

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
@@ -177,6 +177,11 @@ public class CxxSquidSensor implements Sensor {
         files.add(file.file());
       }
     }
+
+    if (LOG.isDebugEnabled() && !files.isEmpty()) {
+      LOG.debug("All source files (Type.MAIN): {}" , files);
+    }
+
     scanner.scanFiles(files);
 
     (new CxxCoverageSensor(this.cache, this.language, context)).execute(context, linesOfCodeByFile);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxBullseyeCoverageSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxBullseyeCoverageSensorTest.java
@@ -72,7 +72,7 @@ public class CxxBullseyeCoverageSensorTest {
     when(language.hasKey(CxxCoverageSensor.OVERALL_REPORT_PATH_KEY)).thenReturn(true);
   }
 
-  @Test
+//  @Test
   public void shouldReportCorrectCoverage() {
     String coverageReport = "coverage-reports/bullseye/coverage-result-bullseye.xml";
     SensorContextTester context = SensorContextTester.create(fs.baseDir());

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxBullseyeCoverageSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxBullseyeCoverageSensorTest.java
@@ -30,6 +30,8 @@ import org.sonar.api.config.Settings;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.junit.Before;
+import org.junit.Test;
+
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
@@ -59,9 +61,9 @@ public class CxxBullseyeCoverageSensorTest {
     .thenReturn("sonar.cxx." + CxxCoverageSensor.REPORT_PATH_KEY);
     when(language.getPluginProperty(CxxCoverageSensor.IT_REPORT_PATH_KEY))
     .thenReturn("sonar.cxx." + CxxCoverageSensor.IT_REPORT_PATH_KEY);
-    when(language.getPluginProperty(CxxCoverageSensor.IT_REPORT_PATH_KEY))
-    .thenReturn("sonar.cxx." + CxxCoverageSensor.OVERALL_REPORT_PATH_KEY);
     when(language.getPluginProperty(CxxCoverageSensor.OVERALL_REPORT_PATH_KEY))
+    .thenReturn("sonar.cxx." + CxxCoverageSensor.OVERALL_REPORT_PATH_KEY);
+    when(language.getPluginProperty(CxxCoverageSensor.FORCE_ZERO_COVERAGE_KEY))
     .thenReturn("sonar.cxx." + CxxCoverageSensor.FORCE_ZERO_COVERAGE_KEY);
 
     //    when(language.hasKey(CxxCoverageSensor.REPORT_PATHS_KEY)).thenReturn(true);
@@ -70,7 +72,7 @@ public class CxxBullseyeCoverageSensorTest {
     when(language.hasKey(CxxCoverageSensor.OVERALL_REPORT_PATH_KEY)).thenReturn(true);
   }
 
-//  @Test
+  @Test
   public void shouldReportCorrectCoverage() {
     String coverageReport = "coverage-reports/bullseye/coverage-result-bullseye.xml";
     SensorContextTester context = SensorContextTester.create(fs.baseDir());
@@ -81,7 +83,6 @@ public class CxxBullseyeCoverageSensorTest {
 //    settings.setProperty(language.getPluginProperty(CxxCoverageSensor.OVERALL_REPORT_PATH_KEY), coverageReport);
 //    settings.setProperty(language.getPluginProperty(CxxCoverageSensor.REPORT_PATHS_KEY), coverageReport);
 
-    
     context.setSettings(settings);
     context.fileSystem().add(new DefaultInputFile("ProjectKey", "main.cpp").setLanguage("cpp").initMetadata("asd\nasdas\nasda\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"));
     context.fileSystem().add(new DefaultInputFile("ProjectKey", "source_1.cpp").setLanguage("cpp").initMetadata("asd\nasdas\nasda\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"));
@@ -184,3 +185,4 @@ public class CxxBullseyeCoverageSensorTest {
 //    verify(context, times(28)).newCoverage();
   }
 }
+


### PR DESCRIPTION
a) add missing statement "measuresTotal = cacheCov.get(report.getAbsolutePath());" to enable coverage for multi-module projects again
b) the lookup for ```InputFile cxxFile``` fails because the path from coverage file is lowercase but the InputFile cxxFile uses case sensitive names ```
InputFile cxxFile =
context.fileSystem().inputFile(context.fileSystem().predicates().hasPath(filePath));```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1198)
<!-- Reviewable:end -->
