### PR TITLE
consume empty VS coverage report

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
@@ -247,7 +247,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
             }
           }
           measuresTotal.putAll(cacheCov.get(report.getAbsolutePath()));
-        } catch (EmptyReportException e) {
+        } catch (EmptyReportException | NullPointerException e) {
           LOG.debug("Report is empty {}", e);
         }
       } else {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
@@ -234,21 +234,22 @@ public class CxxCoverageSensor extends CxxReportSensor {
 
     for (File report : reports) {
       if (!cacheCov.containsKey(report.getAbsolutePath())) {
-        try {
-          for (CoverageParser parser : parsers) {
-            if (parseCoverageReport(parser, context, report, measuresTotal)) {
-              if (LOG.isDebugEnabled()) {
-                LOG.debug("cached measures for '{}' : current cache content data = '{}'", 
-                      report.getAbsolutePath(), cacheCov.size());
-              }
-              cacheCov.put(report.getAbsolutePath(), measuresTotal);
-              // Only use first coverage parser which handles the data correctly
-              break;
+        for (CoverageParser parser : parsers) {
+          try {
+            parseCoverageReport(parser, context, report, measuresTotal);
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("cached measures for '{}' : current cache content data = '{}'", report.getAbsolutePath(),
+                  cacheCov.size());
             }
+            cacheCov.put(report.getAbsolutePath(), measuresTotal);
+            // Only use first coverage parser which handles the data correctly
+            break;
+          } catch (EmptyReportException e) {
+            LOG.debug("Report is empty {}", e);
           }
+        }
+        if (cacheCov.get(report.getAbsolutePath()) != null) {
           measuresTotal.putAll(cacheCov.get(report.getAbsolutePath()));
-        } catch (EmptyReportException | NullPointerException e) {
-          LOG.debug("Report is empty {}", e);
         }
       } else {
         measuresTotal = cacheCov.get(report.getAbsolutePath());
@@ -267,7 +268,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
    * @param measuresTotal
    * @return true if report was parsed and results are available otherwise false
    */
-  private boolean parseCoverageReport(CoverageParser parser, final SensorContext context, File report,
+  private void parseCoverageReport(CoverageParser parser, final SensorContext context, File report,
                                       Map<String, CoverageMeasures> measuresTotal) {
     Map<String, CoverageMeasures> measuresForReport = new HashMap<>();
     try {
@@ -277,13 +278,11 @@ public class CxxCoverageSensor extends CxxReportSensor {
     }
 
     if (measuresForReport.isEmpty()) {
-      LOG.warn("Coverage report {} result is empty (parsed by {})", report, parser);
-      return false;
+      throw new EmptyReportException("Coverage report " + report + " result is empty (parsed by " + parser +")");
     }
 
     measuresTotal.putAll(measuresForReport);
     LOG.info("Added coverage report '{}' (parsed by: {})", report, parser);
-    return true;
   }
 
   private void saveMeasures(SensorContext context,

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensorTest.java
@@ -162,7 +162,7 @@ public class CxxCoverageSensorTest {
   }
 
   @Test
-  public void shouldReportNoCoverageWhenInvalidFilesInvalid() {
+  public void shouldReportNoCoverageWhenFilesInvalid() {
     SensorContextTester context = SensorContextTester.create(fs.baseDir());
 
     settings.setProperty(language.getPluginProperty(CxxCoverageSensor.REPORT_PATH_KEY), "coverage-reports/cobertura/specific-cases/coverage-result-invalid.xml");

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxMSCoverageSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxMSCoverageSensorTest.java
@@ -114,7 +114,25 @@ public class CxxMSCoverageSensorTest {
    for (int oneHitline : oneHitlinesB) {
      assertThat(context.lineHits("ProjectKey:source/motorcontroller/motorcontroller.cpp", CoverageType.UNIT, oneHitline)).isEqualTo(1);
    }
+ }
+ 
+ //@Test(expected=NullPointerException.class)
+ @Test
+ public void shouldConsumeEmptyReport() {
+   context = SensorContextTester.create(fs.baseDir());
+   context.setSonarQubeVersion(SQ_6_2);
 
+   Settings settings = new Settings();
+   settings.setProperty(language.getPluginProperty(CxxCoverageSensor.REPORT_PATH_KEY), "coverage-reports/MSCoverage/empty-report.xml");
+   context.setSettings(settings);
+  
+   context.setSettings(settings);
+  
+   context.fileSystem().add(new DefaultInputFile("ProjectKey", "source/motorcontroller/motorcontroller.cpp").setLanguage("cpp").initMetadata("asd\nasdas\nasda\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"));
+   sensor = new CxxCoverageSensor(new CxxCoverageCache(), language, context);
+   sensor.execute(context, linesOfCodeByFile);
+   assertThat(context.lineHits("ProjectKey:source/motorcontroller/motorcontroller.cpp", CoverageType.UNIT, 1)).isNull();
+ 
  }
 }
 

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/coverage-reports/MSCoverage/empty-report.xml
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/coverage-reports/MSCoverage/empty-report.xml
@@ -1,0 +1,6 @@
+<coverage branch-rate="0.0" branches-covered="0" branches-valid="0" complexity="0" line-rate="0.0" lines-covered="0" lines-valid="0" timestamp="1505224719" version="2.0.3">
+  <sources>
+    <source>/random/path</source>
+  </sources>
+  <packages/>
+</coverage>


### PR DESCRIPTION
close #1231 
- empty VS coverage reports create NullPointerException and not EmptyReportException

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1232)
<!-- Reviewable:end -->
