### PR TITLE
Fixes 'hardcoded ip' rule false positive on macros

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/HardcodedIpCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/HardcodedIpCheck.java
@@ -79,7 +79,7 @@ public class HardcodedIpCheck extends SquidCheck<Grammar> {
 
   @Override
   public void visitNode(AstNode node) {
-    if (node.is(CxxGrammarImpl.LITERAL)) {
+    if (node.is(CxxGrammarImpl.LITERAL) && !node.isCopyBookOrGeneratedNode()) {
       IP.reset(node.getTokenOriginalValue());
       if (IP.find()) {
         String ip = IP.group(0).replaceAll("\"", "");

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/HardcodedIpCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/HardcodedIpCheckTest.java
@@ -20,7 +20,6 @@
 package org.sonar.cxx.checks;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 
 //import org.sonar.squid.api.CheckMessage;
 import org.junit.Rule;
@@ -39,13 +38,14 @@ public class HardcodedIpCheckTest {
   private final HardcodedIpCheck check = new HardcodedIpCheck();
 
   @Test
-  public void detected() throws UnsupportedEncodingException, IOException {
+  public void detected() throws IOException {
     CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/checks/HardcodedIpCheck.cc", ".");
     SourceFile file = CxxAstScanner.scanSingleFile(tester.cxxFile, tester.sensorContext, CxxFileTesterHelper.mockCxxLanguage(), check);   
     
     CheckMessagesVerifier.verify(file.getCheckMessages())
-      .next().atLine(5).withMessage("Make this IP \"0.0.0.0\" address configurable.")
-      .next().atLine(6).withMessage("Make this IP \"http://192.168.0.1/admin.html\" address configurable.");
+      .next().atLine(7).withMessage("Make this IP \"0.0.0.0\" address configurable.")
+      .next().atLine(8).withMessage("Make this IP \"http://192.168.0.1/admin.html\" address configurable.")
+      .noMore();
   }
 
 }

--- a/cxx-checks/src/test/resources/checks/HardcodedIpCheck.cc
+++ b/cxx-checks/src/test/resources/checks/HardcodedIpCheck.cc
@@ -1,5 +1,7 @@
 #include <string>
 
+#define VERSION_STR "1.2.3.4"
+
 using namespace std;
 class A {
     const string ip = "0.0.0.0"; // Non-compliant
@@ -12,5 +14,6 @@ class A {
     const string  notAnIp4 = ".0.0.0.0"; // Compliant
     char chBuffer[5120 * 4]; // Compliant
     const std::string  printerUID { "1.2.840.10008.5.1.1.16"}; // Compliant
+    const string version = VERSION_STR; // Compliant (generated code)
     };
 


### PR DESCRIPTION
Hi, we got 'Hardcode IP' rule triggered on macros.

```
#include <string>

#define VERSION_STR "1.2.3.4"

using namespace std;

class A {
    const string version = VERSION_STR; // Compliant (generated code)
};

int main() {
    return 0;
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1236)
<!-- Reviewable:end -->
