### PR TITLE
Fixes bullseye conditions to be shown in SQ UI

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/BullseyeParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/BullseyeParser.java
@@ -211,9 +211,11 @@ public class BullseyeParser extends CxxCoverageParser {
         setTotalCoveredConditions(event);
         break;
       case "function":
+        int lineHits = 0;
         if ("full".equalsIgnoreCase(event)) {
-          fileMeasuresBuilderIn.setHits(Integer.parseInt(line), 1);
+          lineHits = 1;
         }
+        fileMeasuresBuilderIn.setHits(Integer.parseInt(line), lineHits);
         break;
       case "constant":
         break;

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CoverageMeasure.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CoverageMeasure.java
@@ -25,21 +25,12 @@ package org.sonar.cxx.sensors.coverage;
  */
 class CoverageMeasure {
 
-  private int hits;
-
-  public enum CoverageType
-  {
-    LINE,
-    CONDITION
-  }
-  
-  private final CoverageType type;
   private final int line;
+  private int hits;
   private int conditions;  
   private int coveredConditions;
 
-  CoverageMeasure(CoverageType coverageType, int line) {
-    this.type = coverageType;
+  CoverageMeasure(int line) {
     this.line = line;
   }
 
@@ -55,17 +46,13 @@ class CoverageMeasure {
     return this.coveredConditions;
   }
 
-  void setHits(int lineId, int i) {
-    this.hits += i;
+  void setHits(int hits) {
+    this.hits += hits;
   }
 
   void setConditions(int totalConditions, int coveredConditions) {
     this.coveredConditions = coveredConditions;
     this.conditions = totalConditions;
-  }
-  
-  CoverageType getType() {
-    return this.type;
   }
   
   int getLine() {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CoverageMeasures.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CoverageMeasures.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.Map.Entry;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -33,8 +32,7 @@ import com.google.common.collect.Sets;
  * @author jocs
  */
 class CoverageMeasures {
-  private final Map<Integer, CoverageMeasure> measuresLines = new HashMap<>();
-  private final Map<Integer, CoverageMeasure> measuresConditions = new HashMap<>();
+  private final Map<Integer, CoverageMeasure> lineMeasures = new HashMap<>();
   
   private CoverageMeasures() {
     // empty
@@ -44,54 +42,41 @@ class CoverageMeasures {
     return new CoverageMeasures();
   }
 
-  void setHits(int lineId, int i) {
-    if (measuresLines.containsKey(lineId)) {
-      CoverageMeasure existentData = measuresLines.get(lineId);
-      existentData.setHits(lineId, i);      
-    } else {
-      CoverageMeasure newLineHit = new CoverageMeasure(CoverageMeasure.CoverageType.LINE, lineId);
-      newLineHit.setHits(lineId, i);
-      measuresLines.put(lineId, newLineHit);
-    }
+  void setHits(int lineId, int hits) {
+    lineMeasures.computeIfAbsent(lineId, v -> new CoverageMeasure(lineId));
+    CoverageMeasure coverageMeasure = lineMeasures.get(lineId);
+    coverageMeasure.setHits(hits);
   }
 
   void setConditions(int lineId, int totalConditions, int coveredConditions) {
-    if (measuresConditions.containsKey(lineId)) {
-      CoverageMeasure existentData = measuresConditions.get(lineId);
-      existentData.setConditions(totalConditions, coveredConditions);
-    } else {
-      CoverageMeasure newLineHit = new CoverageMeasure(CoverageMeasure.CoverageType.CONDITION, lineId);
-      newLineHit.setConditions(totalConditions, coveredConditions);
-      measuresConditions.put(lineId, newLineHit);
-    }
+    lineMeasures.computeIfAbsent(lineId, v -> new CoverageMeasure(lineId));
+    CoverageMeasure coverageMeasure = lineMeasures.get(lineId);
+    coverageMeasure.setConditions(totalConditions, coveredConditions);
   }
 
   Collection<CoverageMeasure> getCoverageMeasures() {
     Map<Integer, CoverageMeasure> measures = new HashMap<>();
-    measures.putAll(measuresLines);
-    measures.putAll(measuresConditions);
+    measures.putAll(lineMeasures);
     return measures.values();
   }  
   
-  public Set<Integer> getCoveredLines() {
+  Set<Integer> getCoveredLines() {
     Set<Integer> coveredLines = Sets.newHashSet();
-    measuresLines.entrySet().forEach(
-             (Entry<Integer, CoverageMeasure> line) -> {
-              if (line.getValue().getHits()!=0) {
-                coveredLines.add(line.getValue().getLine());
-             }
-            });
+    lineMeasures.forEach((key, value) -> {
+      if (value.getHits() != 0) {
+        coveredLines.add(value.getLine());
+      }
+    });
     return ImmutableSet.copyOf(coveredLines);
   }
   
-  public  Set<Integer> getCoveredConditions() {
+  Set<Integer> getCoveredConditions() {
     Set<Integer> coveredConditionLines = Sets.newHashSet();
-    measuresConditions.entrySet().forEach(
-            (Entry<Integer, CoverageMeasure> line) -> {
-             if (line.getValue().getCoveredConditions()!=0) {
-               coveredConditionLines.add(line.getValue().getLine());
-            }
-           });
+    lineMeasures.forEach((key, value) -> {
+      if (value.getCoveredConditions() != 0) {
+        coveredConditionLines.add(value.getLine());
+      }
+    });
     return ImmutableSet.copyOf(coveredConditionLines);
   }
 }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
@@ -307,7 +307,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
             LOG.debug("Saving '{}' coverage measures for file '{}'", measures.size(), filePath);
           }
           
-          measures.forEach((CoverageMeasure measure) -> checkCoverage(newCoverage, measure, measure.getType()));
+          measures.forEach((CoverageMeasure measure) -> checkCoverage(newCoverage, measure));
 
           try {
             newCoverage.save();
@@ -334,22 +334,17 @@ public class CxxCoverageSensor extends CxxReportSensor {
   /**
    * @param newCoverage
    * @param measure
-   * @param type
    */
-  private void checkCoverage(NewCoverage newCoverage, CoverageMeasure measure, CoverageMeasure.CoverageType type) {
+  private void checkCoverage(NewCoverage newCoverage, CoverageMeasure measure) {
     try {
-      if(type == CoverageMeasure.CoverageType.CONDITION) {
-        newCoverage.conditions(measure.getLine(), measure.getConditions(), measure.getCoveredConditions());
-      } else {
-        newCoverage.lineHits(measure.getLine(), measure.getHits()); 
-      }
+      newCoverage.lineHits(measure.getLine(), measure.getHits());
+      newCoverage.conditions(measure.getLine(), measure.getConditions(), measure.getCoveredConditions());
     } catch(RuntimeException ex) {
       LOG.error("Cannot save Conditions Hits for Line '{}' , ignoring measure. ", 
                  measure.getLine(), ex);
       CxxUtils.validateRecovery(ex, this.language);
     }
   }
-
 
   private void warnUsageOfDeprecatedProperty(Settings settings, String reportPathProperty) {
     if (isSQ_6_2_or_newer && !settings.hasKey(getReportPathKey())) {

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxBullseyeCoverageSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxBullseyeCoverageSensorTest.java
@@ -95,6 +95,12 @@ public class CxxBullseyeCoverageSensorTest {
       sensor.execute(context, linesOfCodeByFile);
   
       assertThat(context.lineHits("ProjectKey:main.cpp", CoverageType.UNIT, 7)).isEqualTo(1);
+
+      int[] zeroHitLines = new int[] { 5, 10, 15, 17, 28, 32, 35, 40, 41, 44};
+      for (int line : zeroHitLines) {
+        LOG.debug("Check zero line coverage: {}", line);
+        assertThat(context.lineHits("ProjectKey:source_1.cpp", CoverageType.UNIT, line)).isEqualTo(0);
+      }
   
       int[] oneHitlinesA = new int[] { 7, 12, 17, 30};
       for (int line : oneHitlinesA) {
@@ -102,25 +108,38 @@ public class CxxBullseyeCoverageSensorTest {
         assertThat(context.lineHits("ProjectKey:testclass.cpp", CoverageType.UNIT, line)).isEqualTo(1);
         assertThat(context.lineHits("ProjectKey:src/testclass.cpp", CoverageType.UNIT, line)).isEqualTo(1);
       }
-      int[] coveredCondition = new int [] { 34, 42, 43, 46};
-      // full covered condition
-      for (int line : coveredCondition) {
-        LOG.debug("Check conditions line: {}", line);
+      int[] fullCoveredTwoCondition = new int [] { 34, 43, 46};
+      for (int line : fullCoveredTwoCondition) {
+        LOG.debug("Check full covered two conditions - line: {}", line);
         assertThat(context.conditions("ProjectKey:testclass.cpp", CoverageType.UNIT, line)).isEqualTo(2);
         assertThat(context.conditions("ProjectKey:src/testclass.cpp", CoverageType.UNIT, line)).isEqualTo(2);
         assertThat(context.coveredConditions("ProjectKey:testclass.cpp", CoverageType.UNIT, line)).isEqualTo(2);
         assertThat(context.coveredConditions("ProjectKey:src/testclass.cpp", CoverageType.UNIT, line)).isEqualTo(2);
+        assertThat(context.lineHits("ProjectKey:testclass.cpp", CoverageType.UNIT, line)).isEqualTo(1);
+        assertThat(context.lineHits("ProjectKey:src/testclass.cpp", CoverageType.UNIT, line)).isEqualTo(1);
       }
-      LOG.debug("partial covered condition - line: 19"); 
+
+      LOG.debug("Check full covered four conditions - line: 42");
+      assertThat(context.conditions("ProjectKey:testclass.cpp", CoverageType.UNIT, 42)).isEqualTo(4);
+      assertThat(context.conditions("ProjectKey:src/testclass.cpp", CoverageType.UNIT, 42)).isEqualTo(4);
+      assertThat(context.coveredConditions("ProjectKey:testclass.cpp", CoverageType.UNIT, 42)).isEqualTo(4);
+      assertThat(context.coveredConditions("ProjectKey:src/testclass.cpp", CoverageType.UNIT, 42)).isEqualTo(4);
+      assertThat(context.lineHits("ProjectKey:testclass.cpp", CoverageType.UNIT, 42)).isEqualTo(1);
+      assertThat(context.lineHits("ProjectKey:src/testclass.cpp", CoverageType.UNIT, 42)).isEqualTo(1);
+
+      LOG.debug("Check partial covered two condition - line: 19");
       assertThat(context.conditions("ProjectKey:testclass.cpp", CoverageType.UNIT, 19)).isEqualTo(2);
       assertThat(context.coveredConditions("ProjectKey:testclass.cpp", CoverageType.UNIT, 19)).isEqualTo(1);
-      LOG.debug("multiple covered condition - line: 37"); 
-      // multiple covered condition
-      assertThat(context.conditions("ProjectKey:testclass.cpp", CoverageType.UNIT, 37)).isEqualTo(4);
-      assertThat(context.conditions("ProjectKey:src/testclass.cpp", CoverageType.UNIT, 37)).isEqualTo(4);
-      assertThat(context.coveredConditions("ProjectKey:testclass.cpp", CoverageType.UNIT, 37)).isEqualTo(4);
-      assertThat(context.coveredConditions("ProjectKey:src/testclass.cpp", CoverageType.UNIT, 37)).isEqualTo(4);
-      // ToDo check total number of hits for each file
+      assertThat(context.lineHits("ProjectKey:testclass.cpp", CoverageType.UNIT, 19)).isEqualTo(1);
+      assertThat(context.lineHits("ProjectKey:src/testclass.cpp", CoverageType.UNIT, 19)).isEqualTo(1);
+
+      LOG.debug("Check full covered six conditions - line: 37");
+      assertThat(context.conditions("ProjectKey:testclass.cpp", CoverageType.UNIT, 37)).isEqualTo(6);
+      assertThat(context.conditions("ProjectKey:src/testclass.cpp", CoverageType.UNIT, 37)).isEqualTo(6);
+      assertThat(context.coveredConditions("ProjectKey:testclass.cpp", CoverageType.UNIT, 37)).isEqualTo(6);
+      assertThat(context.coveredConditions("ProjectKey:src/testclass.cpp", CoverageType.UNIT, 37)).isEqualTo(6);
+      assertThat(context.lineHits("ProjectKey:testclass.cpp", CoverageType.UNIT, 37)).isEqualTo(1);
+      assertThat(context.lineHits("ProjectKey:src/testclass.cpp", CoverageType.UNIT, 37)).isEqualTo(1);
     }
   }
 
@@ -170,7 +189,8 @@ public class CxxBullseyeCoverageSensorTest {
           "covfile/import/cereal/external/rapidjson/prettywriter.h",
           "covfile/import/cereal/external/rapidjson/document.h",
           "covfile/src/main/main/main.cpp",
-          "covfile/import/cereal/details/static_object.hpp"
+          "covfile/import/cereal/details/static_object.hpp",
+          "covfile/src/main/vr_core/src/VR.cpp"
       };
       
       StringBuilder sourceContent = new StringBuilder();
@@ -185,18 +205,19 @@ public class CxxBullseyeCoverageSensorTest {
       sensor = new CxxCoverageSensor(new CxxCoverageCache(), language, context);
       sensor.execute(context, linesOfCodeByFile);
 
-      int[] coveredCondition = new int [] { 496, 475, 524};
+      int[] coveredCondition = new int [] { 496, 524};
 
       for (int line : coveredCondition) {
         LOG.debug("Check conditions line: {}", line);
         assertThat(context.conditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, line)).isEqualTo(2);
         assertThat(context.coveredConditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, line)).isEqualTo(2);
       }
-      assertThat(context.conditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 530)).isEqualTo(4);
-      assertThat(context.coveredConditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 530)).isEqualTo(3);
 
-      assertThat(context.conditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 483)).isEqualTo(4);
-      assertThat(context.coveredConditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 483)).isEqualTo(2);
+      assertThat(context.conditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 530)).isEqualTo(6);
+      assertThat(context.coveredConditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 530)).isEqualTo(5);
+
+      assertThat(context.conditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 483)).isEqualTo(6);
+      assertThat(context.coveredConditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 483)).isEqualTo(3);
 
       assertThat(context.conditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 552)).isEqualTo(2);
       assertThat(context.coveredConditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 552)).isEqualTo(1);
@@ -204,6 +225,18 @@ public class CxxBullseyeCoverageSensorTest {
       assertThat(context.conditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 495)).isEqualTo(2);
       assertThat(context.coveredConditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 495)).isEqualTo(1);
 
+      LOG.debug("Switch-label probe");
+      assertThat(context.lineHits("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 474)).isEqualTo(0);
+      assertThat(context.conditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 474)).isEqualTo(1);
+      assertThat(context.coveredConditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 474)).isEqualTo(0);
+      assertThat(context.lineHits("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 475)).isEqualTo(1);
+      assertThat(context.conditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 475)).isEqualTo(1);
+      assertThat(context.coveredConditions("ProjectKey:covfile/import/cereal/archives/json.hpp", CoverageType.UNIT, 475)).isEqualTo(1);
+
+      LOG.debug("Try and catch probe on one line");
+      assertThat(context.lineHits("ProjectKey:covfile/src/main/vr_core/src/VR.cpp", CoverageType.UNIT, 39)).isEqualTo(1);
+      assertThat(context.conditions("ProjectKey:covfile/src/main/vr_core/src/VR.cpp", CoverageType.UNIT, 39)).isEqualTo(2);
+      assertThat(context.coveredConditions("ProjectKey:covfile/src/main/vr_core/src/VR.cpp", CoverageType.UNIT, 39)).isEqualTo(1);
     }
   }
 

--- a/integration-tests/features/importing_coverage.feature
+++ b/integration-tests/features/importing_coverage.feature
@@ -22,14 +22,14 @@ Feature: Importing coverage data
       """
     And the following metrics have following values:
       | metric                  | value |
-      | coverage                | 20.0  |
-      | line_coverage           | 12.5  |
+      | coverage                | 23.8  |
+      | line_coverage           | 17.6  |
       | branch_coverage         | 50    |
-      | it_coverage             | 34.5  |
-      | it_line_coverage        | 26.3  |
+      | it_coverage             | 40.6  |
+      | it_line_coverage        | 36.4  |
       | it_branch_coverage      | 50    |
-      | overall_coverage        | 28.6  |
-      | overall_line_coverage   | 20.0  |
+      | overall_coverage        | 34.0  |
+      | overall_line_coverage   | 28.2  |
       | overall_branch_coverage | 50.0  |
 
   @SqApi62
@@ -73,14 +73,14 @@ Feature: Importing coverage data
       """
     And the following metrics have following values:
       | metric                  | value |
-      | coverage                | 9.1   |
-      | line_coverage           | 5.0   |
+      | coverage                | 11.1  |
+      | line_coverage           | 7.3   |
       | branch_coverage         | 50    |
-      | it_coverage             | 20.4  |
-      | it_line_coverage        | 12.8  |
+      | it_coverage             | 25.0  |
+      | it_line_coverage        | 19.0  |
       | it_branch_coverage      | 50    |
-      | overall_coverage        | 21.5  |
-      | overall_line_coverage   | 13.7  |
+      | overall_coverage        | 26.1  |
+      | overall_line_coverage   | 20.0  |
       | overall_branch_coverage | 50    |
 
   @SqApi56

--- a/integration-tests/features/importing_coverage.feature
+++ b/integration-tests/features/importing_coverage.feature
@@ -50,8 +50,8 @@ Feature: Importing coverage data
       """
     And the following metrics have following values:
       | metric                  | value |
-      | coverage                | 25.9  |
-      | line_coverage           | 17.5  |
+      | coverage                | 31.0  |
+      | line_coverage           | 25.0  |
       | branch_coverage         | 50    |
 
   @SqApi56

--- a/integration-tests/features/smoketest.feature
+++ b/integration-tests/features/smoketest.feature
@@ -87,8 +87,8 @@ Feature: Smoketest
       | file_complexity          | 0.9   |
       | class_complexity         | 6     |
       | violations               | 12    |
-      | coverage                 | 50    |
-      | line_coverage            | 50    |
+      | coverage                 | 53.8  |
+      | line_coverage            | 54.8  |
       | branch_coverage          | 50    |
       | test_failures            | 2     |
       | test_errors              | 0     |

--- a/integration-tests/features/smoketest.feature
+++ b/integration-tests/features/smoketest.feature
@@ -38,13 +38,13 @@ Feature: Smoketest
       | file_complexity          | 0.9   |
       | class_complexity         | 6     |
       | violations               | 12    |
-      | coverage                 | 81.8  |
+      | coverage                 | 84.0  |
       | line_coverage            | 100.0 |
       | branch_coverage          | 50    |
-      | it_coverage              | 81.8  |
+      | it_coverage              | 84.0  |
       | it_line_coverage         | 100.0 |
       | it_branch_coverage       | 50    |
-      | overall_coverage         | 81.8  |
+      | overall_coverage         | 84.0  |
       | overall_line_coverage    | 100.0 |
       | overall_branch_coverage  | 50    |
       | test_failures            | 2     |


### PR DESCRIPTION
Hi. Fixing bug, when bullseye conditions are not shown in SonarQube UI. 
Tested with 6.3

Removing unneeded CoverageType from CoverageMeasure. It successfully contains line hits and conditions simultaneously.

Here comes my paint madskillz: 
![bullseye_before](https://user-images.githubusercontent.com/7347796/30744383-8602a4b8-9faa-11e7-988a-76b2f80ca59d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1237)
<!-- Reviewable:end -->
