### PR TITLE
add clangtidy.charset support

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensor.java
@@ -38,9 +38,12 @@ import org.sonar.cxx.sensors.utils.CxxReportSensor;
  * Sensor for clang-tidy
  */
 public class CxxClangTidySensor extends CxxReportSensor {
+
   public static final Logger LOG = Loggers.get(CxxClangTidySensor.class);
   public static final String KEY = "Clang-Tidy";
   public static final String REPORT_PATH_KEY = "clangtidy.reportPath";
+  public static final String REPORT_CHARSET_DEF = "clangtidy.charset";
+  public static final String DEFAULT_CHARSET_DEF = "UTF-8";
 
   /**
    * {@inheritDoc}
@@ -58,21 +61,38 @@ public class CxxClangTidySensor extends CxxReportSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor.onlyOnLanguage(this.language.getKey()).name(language.getName() + " ClangTidySensor");
   }
-  
+
+  /**
+   * Get string property from configuration. If the string is not set or empty,
+   * return the default value.
+   *
+   * @param name Name of the property
+   * @param def Default value
+   * @return Value of the property if set and not empty, else default value.
+   */
+  public String getParserStringProperty(String name, String def) {
+    String s = this.settings.getString(name);
+    if (s == null || s.isEmpty()) {
+      return def;
+    }
+    return s;
+  }
+
   @Override
   protected void processReport(final SensorContext context, File report) {
-    LOG.debug("Parsing clang-tidy report");
+    final String reportCharset = getParserStringProperty(this.language.getPluginProperty(REPORT_CHARSET_DEF), "UTF-8");
+    LOG.debug("Parsing 'clang-tidy' report, CharSet= '{}'", reportCharset);
 
-    try (Scanner scanner = new Scanner(report, StandardCharsets.UTF_8.name())) {
+    try (Scanner scanner = new Scanner(report, reportCharset)) {
       // E:\Development\SonarQube\cxx\sonar-cxx\sonar-cxx-plugin\src\test\resources\org\sonar\plugins\cxx\reports-project\clang-tidy-reports\..\..\cpd.cc:76:20: warning: ISO C++11 does not allow conversion from string literal to 'char *' [clang-diagnostic-writable-strings]
       // <path>:<line>:<column>: <level>: <message> [<checkname>]
       // relative paths
       final String regex = "(.+|[a-zA-Z]:\\\\.+):([0-9]+):([0-9]+): ([^:]+): ([^]]+) \\[([^]]+)\\]";
       final Pattern pattern = Pattern.compile(regex);
-      
+
       while (scanner.hasNextLine()) {
         String line = scanner.nextLine();
-        final Matcher matcher = pattern.matcher(line);     
+        final Matcher matcher = pattern.matcher(line);
         if (matcher.matches()) {
           MatchResult m = matcher.toMatchResult();
           String path = m.group(1);
@@ -80,23 +100,23 @@ public class CxxClangTidySensor extends CxxReportSensor {
           String message = m.group(5);
           String check = m.group(6);
           saveUniqueViolation(context,
-                  CxxClangTidyRuleRepository.KEY,
-                  path,
-                  lineId,
-                  check,
-                  message);
+            CxxClangTidyRuleRepository.KEY,
+            path,
+            lineId,
+            check,
+            message);
         }
       }
     } catch (final java.io.FileNotFoundException
-                  |java.lang.IllegalArgumentException
-                  |java.lang.IllegalStateException
-                  |java.util.InputMismatchException e) {
+      | java.lang.IllegalArgumentException
+      | java.lang.IllegalStateException
+      | java.util.InputMismatchException e) {
       LOG.error("Failed to parse clang-tidy report: {}", e);
     }
-  } 
-  
+  }
+
   @Override
   protected String getSensorKey() {
     return KEY;
-  } 
+  }
 }

--- a/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
+++ b/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
@@ -282,12 +282,20 @@ public final class CPlugin implements Plugin {
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
       .index(13)
       .build(),
+      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidySensor.REPORT_CHARSET_DEF)
+      .defaultValue(CxxClangTidySensor.DEFAULT_CHARSET_DEF)
+      .name("Encoding")
+      .description("The encoding to use when reading the clang-tidy report. Leave empty to use parser's default UTF-8.")
+      .subCategory(subcateg)
+      .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+      .index(14)
+      .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidyRuleRepository.CUSTOM_RULES_KEY)
       .name("Clang-Tidy custom rules")
       .description("XML definitions of custom Clang-Tidy rules, which aren't builtin into the plugin." + EXTENDING_THE_CODE_ANALYSIS)
       .type(PropertyType.TEXT)
       .subCategory(subcateg)
-      .index(14)
+      .index(15)
       .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangSASensor.REPORT_PATH_KEY)
       .name("Clang Static analyzer analyzer report(s)")
@@ -295,14 +303,14 @@ public final class CPlugin implements Plugin {
         + " If neccessary, <a href='https://ant.apache.org/manual/dirtasks.html'>Ant-style wildcards</a> are at your service.")
       .subCategory(subcateg)
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-      .index(15)
+      .index(16)
       .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangSARuleRepository.CUSTOM_RULES_KEY)
       .name("Clang-SA custom rules")
       .description("NO DESC")
       .type(PropertyType.TEXT)
       .subCategory(subcateg)
-      .index(16)
+      .index(17)
       .build()
     ));
   }
@@ -330,7 +338,7 @@ public final class CPlugin implements Plugin {
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerSensor.REPORT_CHARSET_DEF)
       .defaultValue(CxxCompilerSensor.DEFAULT_CHARSET_DEF)
       .name("Encoding")
-      .description("The encoding to use when reading the compiler report. Leave empty to use parser's default.")
+      .description("The encoding to use when reading the compiler report. Leave empty to use parser's default UTF-8.")
       .subCategory(subcateg)
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
       .index(3)

--- a/sonar-c-plugin/src/test/java/org/sonar/plugins/c/CPluginTest.java
+++ b/sonar-c-plugin/src/test/java/org/sonar/plugins/c/CPluginTest.java
@@ -32,6 +32,6 @@ public class CPluginTest {
    Plugin.Context context = new Plugin.Context(SonarQubeVersion.V5_6);
    CPlugin plugin = new CPlugin();
    plugin.define(context);
-   assertThat(context.getExtensions()).hasSize(74);
+   assertThat(context.getExtensions()).hasSize(75);
   }
 }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -305,13 +305,21 @@ public final class CxxPlugin implements Plugin {
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
       .index(13)
       .build(),
+      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidySensor.REPORT_CHARSET_DEF)
+      .defaultValue(CxxClangTidySensor.DEFAULT_CHARSET_DEF)
+      .name("Encoding")
+      .description("The encoding to use when reading the clang-tidy report. Leave empty to use parser's default UTF-8.")
+      .subCategory(subcateg)
+      .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+      .index(14)
+      .build(),      
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidyRuleRepository.CUSTOM_RULES_KEY)
       .name("Clang-Tidy custom rules")
       .description("XML definitions of custom Clang-Tidy rules, which aren't builtin into the plugin."
         + EXTENDING_THE_CODE_ANALYSIS)
       .type(PropertyType.TEXT)
       .subCategory(subcateg)
-      .index(14)
+      .index(15)
       .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangSASensor.REPORT_PATH_KEY)
       .name("Clang Static analyzer analyzer report(s)")
@@ -319,14 +327,14 @@ public final class CxxPlugin implements Plugin {
         + "<a href='https://ant.apache.org/manual/dirtasks.html'>Ant-style wildcards</a> are at your service.")
       .subCategory(subcateg)
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-      .index(15)
+      .index(16)
       .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangSARuleRepository.CUSTOM_RULES_KEY)
       .name("Clang-SA custom rules")
       .description("NO DESC")
       .type(PropertyType.TEXT)
       .subCategory(subcateg)
-      .index(16)
+      .index(17)
       .build()
     ));
   }
@@ -356,7 +364,7 @@ public final class CxxPlugin implements Plugin {
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerSensor.REPORT_CHARSET_DEF)
       .defaultValue(CxxCompilerSensor.DEFAULT_CHARSET_DEF)
       .name("Encoding")
-      .description("The encoding to use when reading the compiler report. Leave empty to use parser's default.")
+      .description("The encoding to use when reading the compiler report. Leave empty to use parser's default UTF-8.")
       .subCategory(subcateg)
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
       .index(3)

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -32,6 +32,6 @@ public class CxxPluginTest {
    Plugin.Context context = new Plugin.Context(SonarQubeVersion.V5_6);
    CxxPlugin plugin = new CxxPlugin();
    plugin.define(context);
-   assertThat(context.getExtensions()).hasSize(74);
+   assertThat(context.getExtensions()).hasSize(75);
   }
 }


### PR DESCRIPTION
- new setting sonar.cxx.clangtidy.charset
- default is UTF-8
- close #1213

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1240)
<!-- Reviewable:end -->
