### PR TITLE
fix custom rules

### DIFF
--- a/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
+++ b/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
@@ -22,10 +22,10 @@ package org.sonar.plugins.c;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Arrays;
+import javax.annotation.Nullable;
 import org.sonar.api.Plugin;
 
 import org.sonar.api.PropertyType;
-import org.sonar.api.batch.bootstrap.ProjectDefinition;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.config.Configuration;
@@ -34,6 +34,7 @@ import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.resources.Qualifiers;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.sensors.clangtidy.CxxClangTidyRuleRepository;
 import org.sonar.cxx.sensors.clangtidy.CxxClangTidySensor;
 import org.sonar.cxx.sensors.clangsa.CxxClangSARuleRepository;
@@ -55,6 +56,7 @@ import org.sonar.cxx.sensors.pclint.CxxPCLintRuleRepository;
 import org.sonar.cxx.sensors.pclint.CxxPCLintSensor;
 import org.sonar.cxx.sensors.rats.CxxRatsRuleRepository;
 import org.sonar.cxx.sensors.rats.CxxRatsSensor;
+import org.sonar.cxx.sensors.squid.CustomCxxRulesDefinition;
 import org.sonar.cxx.sensors.squid.CxxSquidSensor;
 import org.sonar.cxx.sensors.tests.xunit.CxxXunitSensor;
 import org.sonar.cxx.sensors.utils.CxxMetrics;
@@ -606,11 +608,19 @@ public final class CPlugin implements Plugin {
   }
 
   public static class CxxSquidSensorImpl extends CxxSquidSensor {
+
     public CxxSquidSensorImpl(Configuration settings,
-            FileLinesContextFactory fileLinesContextFactory,
-            CheckFactory checkFactory,
-            CxxCoverageAggregator coverageCache) {
+      FileLinesContextFactory fileLinesContextFactory,
+      CheckFactory checkFactory,
+      CxxCoverageAggregator coverageCache) {
       super(new CLanguage(settings), fileLinesContextFactory, checkFactory);
+    }
+
+    public CxxSquidSensorImpl(CxxLanguage language,
+      FileLinesContextFactory fileLinesContextFactory,
+      CheckFactory checkFactory,
+      @Nullable CustomCxxRulesDefinition[] customRulesDefinition) {
+      super(language, fileLinesContextFactory, checkFactory, customRulesDefinition);
     }
   }
 

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -67,6 +67,9 @@ import org.sonar.cxx.sensors.veraxx.CxxVeraxxRuleRepository;
 import org.sonar.cxx.sensors.veraxx.CxxVeraxxSensor;
 
 import com.google.common.collect.ImmutableList;
+import javax.annotation.Nullable;
+import org.sonar.cxx.CxxLanguage;
+import org.sonar.cxx.sensors.squid.CustomCxxRulesDefinition;
 
 /**
  * {@inheritDoc}
@@ -634,11 +637,19 @@ public final class CxxPlugin implements Plugin {
   }
 
   public static class CxxSquidSensorImpl extends CxxSquidSensor {
+
     public CxxSquidSensorImpl(Configuration settings,
-            FileLinesContextFactory fileLinesContextFactory,
-          CheckFactory checkFactory,
-          CxxCoverageAggregator coverageCache) {
+      FileLinesContextFactory fileLinesContextFactory,
+      CheckFactory checkFactory,
+      CxxCoverageAggregator coverageCache) {
       super(new CppLanguage(settings), fileLinesContextFactory, checkFactory);
+    }
+
+    public CxxSquidSensorImpl(CxxLanguage language,
+      FileLinesContextFactory fileLinesContextFactory,
+      CheckFactory checkFactory,
+      @Nullable CustomCxxRulesDefinition[] customRulesDefinition) {
+      super(language, fileLinesContextFactory, checkFactory, customRulesDefinition);
     }
   }
 


### PR DESCRIPTION
After splitting the plugin into c and cxx plugin there was only one ctor exported. Just a guess: but exporting both again custom rules should work again.
- close #1308

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1343)
<!-- Reviewable:end -->
