### PR TITLE
fix custom rules - second try

### DIFF
--- a/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
+++ b/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
@@ -34,7 +34,6 @@ import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.resources.Qualifiers;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
-import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.sensors.clangtidy.CxxClangTidyRuleRepository;
 import org.sonar.cxx.sensors.clangtidy.CxxClangTidySensor;
 import org.sonar.cxx.sensors.clangsa.CxxClangSARuleRepository;
@@ -616,11 +615,11 @@ public final class CPlugin implements Plugin {
       super(new CLanguage(settings), fileLinesContextFactory, checkFactory);
     }
 
-    public CxxSquidSensorImpl(CxxLanguage language,
+    public CxxSquidSensorImpl(Configuration settings,
       FileLinesContextFactory fileLinesContextFactory,
       CheckFactory checkFactory,
       @Nullable CustomCxxRulesDefinition[] customRulesDefinition) {
-      super(language, fileLinesContextFactory, checkFactory, customRulesDefinition);
+      super(new CLanguage(settings), fileLinesContextFactory, checkFactory, customRulesDefinition);
     }
   }
 

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -68,7 +68,6 @@ import org.sonar.cxx.sensors.veraxx.CxxVeraxxSensor;
 
 import com.google.common.collect.ImmutableList;
 import javax.annotation.Nullable;
-import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.sensors.squid.CustomCxxRulesDefinition;
 
 /**
@@ -645,11 +644,11 @@ public final class CxxPlugin implements Plugin {
       super(new CppLanguage(settings), fileLinesContextFactory, checkFactory);
     }
 
-    public CxxSquidSensorImpl(CxxLanguage language,
+    public CxxSquidSensorImpl(Configuration settings,
       FileLinesContextFactory fileLinesContextFactory,
       CheckFactory checkFactory,
       @Nullable CustomCxxRulesDefinition[] customRulesDefinition) {
-      super(language, fileLinesContextFactory, checkFactory, customRulesDefinition);
+      super(new CppLanguage(settings), fileLinesContextFactory, checkFactory, customRulesDefinition);
     }
   }
 


### PR DESCRIPTION
After splitting the plugin into c and cxx plugin there was only one ctor exported. Just a guess: but exporting both again custom rules should work again.

- close #1308

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1346)
<!-- Reviewable:end -->
