### PR TITLE
undo-1342: set plugin name back to 'c++'

### DIFF
--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/CxxFileTesterHelper.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/CxxFileTesterHelper.java
@@ -61,7 +61,7 @@ public class CxxFileTesterHelper {
   public static CxxLanguage mockCxxLanguage() {
     CxxLanguage language = Mockito.mock(CxxLanguage.class);
     when(language.getKey()).thenReturn("c++");
-    when(language.getName()).thenReturn("C++");
+    when(language.getName()).thenReturn("c++");
     when(language.getPropertiesKey()).thenReturn("cxx");
     when(language.IsRecoveryEnabled()).thenReturn(Optional.of(Boolean.TRUE));
     when(language.getFileSuffixes())

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxMetricsTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxMetricsTest.java
@@ -38,7 +38,7 @@ public class CxxMetricsTest {
   public class CxxLanguageImpl extends CxxLanguage {
 
     public CxxLanguageImpl(Configuration settings) {
-      super("c++", "C++", settings);
+      super("c++", "c++", settings);
     }
 
     @Override

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/TestUtils.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/TestUtils.java
@@ -93,7 +93,7 @@ public class TestUtils {
   public static CxxLanguage mockCxxLanguage() {
     CxxLanguage language = Mockito.mock(CxxLanguage.class);
     when(language.getKey()).thenReturn("c++");
-    when(language.getName()).thenReturn("C++");
+    when(language.getName()).thenReturn("c++");
     when(language.getRepositorySuffix()).thenReturn("");
     when(language.getRepositoryKey()).thenReturn("cxx");
     when(language.getPropertiesKey()).thenReturn("cxx");

--- a/cxx-squid/src/test/java/org/sonar/cxx/CxxFileTesterHelper.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/CxxFileTesterHelper.java
@@ -53,7 +53,7 @@ public class CxxFileTesterHelper {
   public static CxxLanguage mockCxxLanguage() {
     CxxLanguage language = Mockito.mock(CxxLanguage.class);
     when(language.getKey()).thenReturn("c++");
-    when(language.getName()).thenReturn("C++");
+    when(language.getName()).thenReturn("c++");
     when(language.getPropertiesKey()).thenReturn("cxx");
     when(language.IsRecoveryEnabled()).thenReturn(Optional.of(Boolean.TRUE));
     when(language.getFileSuffixes())

--- a/cxx-squid/src/test/java/org/sonar/cxx/CxxLanguageTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/CxxLanguageTest.java
@@ -33,7 +33,7 @@ public class CxxLanguageTest {
   private MapSettings settings;
 
   private static final String KEY = "c++";
-  private static final String NAME = "C++";
+  private static final String NAME = "c++";
   private static final String PLUGIN_ID = "cxx";
   private static final String SOURCE_SUFFIXES = ".cxx,.cpp,.cc,.c";
   private static final String HEADER_SUFFIXES = ".hxx,.hpp,.hh,.h";

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CppLanguage.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CppLanguage.java
@@ -85,7 +85,7 @@ public class CppLanguage extends CxxLanguage {
   /**
    * cxx name
    */
-  public static final String NAME = "C++";
+  public static final String NAME = "c++";
 
   /**
    * Default cxx source files suffixes


### PR DESCRIPTION
- set plugin name back to 'c++'
- issue #1328 still open
- undo #1342

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1374)
<!-- Reviewable:end -->

  