### PR TITLE
Analysis does not continue after error (sonar.cxx.errorRecoveryEnabled=true)

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
@@ -130,7 +130,7 @@ public class CxxSquidSensor implements Sensor {
 
     List<SquidAstVisitor<Grammar>> visitors = new ArrayList<>((Collection) checks.all());
     visitors.add(new CxxHighlighterVisitor(context));
-    visitors.add(new CxxFileLinesVisitor(fileLinesContextFactory, context, linesOfCodeByFile));
+    visitors.add(new CxxFileLinesVisitor(language, fileLinesContextFactory, context, linesOfCodeByFile));
 
     visitors.add(
       new CxxCpdVisitor(

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxFileLinesVisitorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxFileLinesVisitorTest.java
@@ -75,7 +75,7 @@ public class CxxFileLinesVisitorTest {
     when(fileLinesContextFactory.createFor(inputFile)).thenReturn(fileLinesContext);
 
     HashMap<InputFile, Set<Integer>> linesOfCode = new HashMap<>();
-    CxxFileLinesVisitor visitor = new CxxFileLinesVisitor(fileLinesContextFactory, sensorContext, linesOfCode);
+    CxxFileLinesVisitor visitor = new CxxFileLinesVisitor(language, fileLinesContextFactory, sensorContext, linesOfCode);
 
     CxxAstScanner.scanSingleFile(inputFile, sensorContext, TestUtils.mockCxxLanguage(), visitor);
 
@@ -109,7 +109,7 @@ public class CxxFileLinesVisitorTest {
     when(fileLinesContextFactory.createFor(inputFile)).thenReturn(fileLinesContext);
 
     HashMap<InputFile, Set<Integer>> linesOfCode = new HashMap<>();
-    CxxFileLinesVisitor visitor = new CxxFileLinesVisitor(fileLinesContextFactory, sensorContext, linesOfCode);
+    CxxFileLinesVisitor visitor = new CxxFileLinesVisitor(language, fileLinesContextFactory, sensorContext, linesOfCode);
 
     CxxAstScanner.scanSingleFile(inputFile, sensorContext, TestUtils.mockCxxLanguage(), visitor);
 


### PR DESCRIPTION
- continue in case there is an error in CxxFileLinesVisitor (sonar.cxx.errorRecoveryEnabled=true)
- close #1386

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1387)
<!-- Reviewable:end -->
