### PR TITLE
create missing rules for cppcheck 1.82 (and probably older versions too)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
         - oraclejdk8
 
 env:
-        - SONARHOME=/tmp/sonarqube-6.7.1   SONARAPI=SqApi67
+        - SONARHOME=/tmp/sonarqube-6.7.2   SONARAPI=SqApi67
         - SONARHOME=/tmp/sonarqube-7.0     SONARAPI=SqApi67
 
 matrix:
@@ -39,8 +39,8 @@ before_install:
 
 install:
         - cd /tmp
-        - travis_retry wget -q https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-6.7.1.zip
-        - unzip -qq sonarqube-6.7.1.zip
+        - travis_retry wget -q https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-6.7.2.zip
+        - unzip -qq sonarqube-6.7.2.zip
         - travis_retry wget -q https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-7.0.zip
         - unzip -qq sonarqube-7.0.zip
         - travis_retry wget -q https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.0.3.778.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,10 @@ install:
       }
       if (!(Test-Path -Path "C:\sonarqube" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-6.7.1.zip',
-          'C:\sonarqube-6.7.1.zip'
+          'https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-6.7.2.zip',
+          'C:\sonarqube-6.7.2.zip'
         )
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonarqube-6.7.1.zip", "C:\sonarqube")
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonarqube-6.7.2.zip", "C:\sonarqube")
       }
   - ps: |
       If ($env:Platform -Match "x86") {
@@ -49,7 +49,7 @@ install:
   - cmd: SET PATH=C:\maven\apache-maven-3.2.5\bin;%JAVA_HOME%\bin;C:\sonar-scanner\sonar-scanner-3.0.3.778\bin;%PATH%
   - cmd: SET M2_HOME=C:\maven\apache-maven-3.2.5
   - cmd: SET MAVEN_HOME=C:\maven\apache-maven-3.2.5
-  - cmd: SET SONARHOME=C:\sonarqube\sonarqube-6.7.1
+  - cmd: SET SONARHOME=C:\sonarqube\sonarqube-6.7.2
   - cmd: SET TestDataFolder=C:\projects\sonar-cxx\integration-tests\testdata
   - cmd: SET
 
@@ -81,4 +81,4 @@ on_failure:
   - ps: Get-ChildItem cxx-checks\target\surefire-reports\*.txt | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   - ps: Get-ChildItem sonar-cxx-plugin\target\surefire-reports\*.txt | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   - ps: Get-ChildItem *.log | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-  - ps: Get-ChildItem C:\sonarqube\sonarqube-6.7.1\logs\* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+  - ps: Get-ChildItem C:\sonarqube\sonarqube-6.7.2\logs\* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/cxx-lint/src/main/java/org/sonar/cxx/cxxlint/CxxLint.java
+++ b/cxx-lint/src/main/java/org/sonar/cxx/cxxlint/CxxLint.java
@@ -140,6 +140,7 @@ public class CxxLint {
       LOG.error("Parsing Command line Failed.  Reason: " + exp);
       HelpFormatter formatter = new HelpFormatter();
       formatter.printHelp("java -jar CxxLint-<sersion>.jar -f filetoanalyse", options);
+      return;
     }
 
     SensorContextTester sensorContext = SensorContextTester.create(targetFile.getParentFile().toPath());

--- a/cxx-sensors/src/main/resources/cppcheck.xml
+++ b/cxx-sensors/src/main/resources/cppcheck.xml
@@ -6345,7 +6345,1017 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
   </rule>
-  <!-- ########### add missing rules which seems not to be part of cppcheck errorlist ########### -->
+  <!-- ########### keys matching the schema <some-function-id>Called are not listed by the simple cppcheck -errorlist          ########### -->
+  <!-- ########### they become visible only if corresponding library was loaded, e.g. cppcheck -errorlist -library=posix.cfg   ########### -->
+  <!-- ########### see generate_cppcheck_resources.sh for more details                                                         ########### -->
+  <rule>
+    <key>pthread_attr_getstackaddrCalled</key>
+    <name>Obsolescent function 'pthread_attr_getstackaddr' called. It is recommended to use 'pthread_attr_getstack' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'pthread_attr_getstackaddr' called. It is recommended to use 'pthread_attr_getstack' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>pthread_attr_getstackaddrCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>mktempCalled</key>
+    <name>Obsolete function 'mktemp' called. It is recommended to use 'mkstemp' or 'mkdtemp' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolete function 'mktemp' called. It is recommended to use 'mkstemp' or 'mkdtemp' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>mktempCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getspnamCalled</key>
+    <name>Non reentrant function 'getspnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getspnam_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getspnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getspnam_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getspnamCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>swapcontextCalled</key>
+    <name>Obsolescent function 'swapcontext' called. Applications are recommended to be rewritten to use POSIX threads.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'swapcontext' called. Applications are recommended to be rewritten to use POSIX threads.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>swapcontextCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>ctime_rCalled</key>
+    <name>Obsolescent function 'ctime_r' called. It is recommended to use 'strftime' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'ctime_r' called. It is recommended to use 'strftime' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>ctime_rCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>usleepCalled</key>
+    <name>Obsolescent function 'usleep' called. It is recommended to use 'nanosleep' or 'setitimer' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'usleep' called. It is recommended to use 'nanosleep' or 'setitimer' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>usleepCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>pthread_attr_setstackaddrCalled</key>
+    <name>Obsolescent function 'pthread_attr_setstackaddr' called. It is recommended to use 'pthread_attr_setstack' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'pthread_attr_setstackaddr' called. It is recommended to use 'pthread_attr_setstack' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>pthread_attr_setstackaddrCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getrpcbynameCalled</key>
+    <name>Non reentrant function 'getrpcbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcbyname_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getrpcbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcbyname_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getrpcbynameCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getserventCalled</key>
+    <name>Non reentrant function 'getservent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservent_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getservent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservent_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getserventCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>ecvtCalled</key>
+    <name>Obsolescent function 'ecvt' called. It is recommended to use 'sprintf' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'ecvt' called. It is recommended to use 'sprintf' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>ecvtCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getrpcbynumberCalled</key>
+    <name>Non reentrant function 'getrpcbynumber' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcbynumber_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getrpcbynumber' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcbynumber_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getrpcbynumberCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>asctime_rCalled</key>
+    <name>Obsolescent function 'asctime_r' called. It is recommended to use 'strftime' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'asctime_r' called. It is recommended to use 'strftime' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>asctime_rCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>gethostbyname2Called</key>
+    <name>Non reentrant function 'gethostbyname2' called. For threadsafe applications it is recommended to use the reentrant replacement function 'gethostbyname2_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'gethostbyname2' called. For threadsafe applications it is recommended to use the reentrant replacement function 'gethostbyname2_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>gethostbyname2Called</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>utimeCalled</key>
+    <name>Obsolescent function 'utime' called. It is recommended to use 'utimensat' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'utime' called. It is recommended to use 'utimensat' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>utimeCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getprotoentCalled</key>
+    <name>Non reentrant function 'getprotoent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getprotoent_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getprotoent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getprotoent_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getprotoentCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>cryptCalled</key>
+    <name>Non reentrant function 'crypt' called. For threadsafe applications it is recommended to use the reentrant replacement function 'crypt_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'crypt' called. For threadsafe applications it is recommended to use the reentrant replacement function 'crypt_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>cryptCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getservbynameCalled</key>
+    <name>Non reentrant function 'getservbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservbyname_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getservbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservbyname_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getservbynameCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>ttynameCalled</key>
+    <name>Non reentrant function 'ttyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'ttyname_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'ttyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'ttyname_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>ttynameCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>tempnamCalled</key>
+    <name>Non reentrant function 'tempnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'tempnam_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'tempnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'tempnam_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>tempnamCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getspentCalled</key>
+    <name>Non reentrant function 'getspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getspent_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getspent_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getspentCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getnetbyaddrCalled</key>
+    <name>Non reentrant function 'getnetbyaddr' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetbyaddr_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getnetbyaddr' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetbyaddr_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getnetbyaddrCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getnetgrentCalled</key>
+    <name>Non reentrant function 'getnetgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetgrent_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getnetgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetgrent_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getnetgrentCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getrpcentCalled</key>
+    <name>Non reentrant function 'getrpcent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcent_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getrpcent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcent_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getrpcentCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>std::strtokCalled</key>
+    <name>Non reentrant function 'strtok' called. For threadsafe applications it is recommended to use the reentrant replacement function 'strtok_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'strtok' called. For threadsafe applications it is recommended to use the reentrant replacement function 'strtok_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>std::strtokCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>scalbCalled</key>
+    <name>Obsolescent function 'scalb' called. It is recommended to use 'scalbln', 'scalblnf', 'scalbln', 'scalbn', 'scalbnf' or 'scalbnl' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'scalb' called. It is recommended to use 'scalbln', 'scalblnf', 'scalbln', 'scalbn', 'scalbnf' or 'scalbnl' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>scalbCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getsCalled</key>
+    <name>Obsolete function 'gets' called. It is recommended to use 'fgets' or 'gets_s' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolete function 'gets' called. It is recommended to use 'fgets' or 'gets_s' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getsCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>tmpnam_rCalled</key>
+    <name>Obsolescent function 'tmpnam_r' called. It is recommended to use 'tmpfile', 'mkstemp' or 'mkdtemp' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'tmpnam_r' called. It is recommended to use 'tmpfile', 'mkstemp' or 'mkdtemp' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>tmpnam_rCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>gethostbyaddrCalled</key>
+    <name>Obsolescent function 'gethostbyaddr' called. It is recommended to use 'getnameinfo' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'gethostbyaddr' called. It is recommended to use 'getnameinfo' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>gethostbyaddrCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>bsd_signalCalled</key>
+    <name>Obsolescent function 'bsd_signal' called. It is recommended to use 'sigaction' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'bsd_signal' called. It is recommended to use 'sigaction' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>bsd_signalCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getgrnamCalled</key>
+    <name>Non reentrant function 'getgrnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrnam_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getgrnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrnam_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getgrnamCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>rindexCalled</key>
+    <name>Obsolescent function 'rindex' called. It is recommended to use 'strrchr' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'rindex' called. It is recommended to use 'strrchr' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>rindexCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getloginCalled</key>
+    <name>Non reentrant function 'getlogin' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getlogin_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getlogin' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getlogin_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getloginCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getgrgidCalled</key>
+    <name>Non reentrant function 'getgrgid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrgid_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getgrgid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrgid_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getgrgidCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>lstrcatCalled</key>
+    <name>Due to security concerns it is not recommended to use this function, see MSDN for details.</name>
+    <description><![CDATA[
+        <p>
+  Due to security concerns it is not recommended to use this function, see MSDN for details.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>lstrcatCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>gcvtCalled</key>
+    <name>Obsolescent function 'gcvt' called. It is recommended to use 'sprintf' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'gcvt' called. It is recommended to use 'sprintf' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>gcvtCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>fgetgrentCalled</key>
+    <name>Non reentrant function 'fgetgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetgrent_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'fgetgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetgrent_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>fgetgrentCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getnetentCalled</key>
+    <name>Non reentrant function 'getnetent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetent_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getnetent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetent_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getnetentCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>std::asctimeCalled</key>
+    <name>Obsolete function 'std::asctime' called. It is recommended to use 'strftime' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolete function 'std::asctime' called. It is recommended to use 'strftime' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>std::asctimeCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>rand_rCalled</key>
+    <name>Obsolescent function 'rand_r' called. It is recommended to use 'rand' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'rand_r' called. It is recommended to use 'rand' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>rand_rCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>sgetspentCalled</key>
+    <name>Non reentrant function 'sgetspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'sgetspent_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'sgetspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'sgetspent_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>sgetspentCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>fgetpwentCalled</key>
+    <name>Non reentrant function 'fgetpwent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetpwent_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'fgetpwent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetpwent_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>fgetpwentCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getpwentCalled</key>
+    <name>Non reentrant function 'getpwent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwent_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getpwent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwent_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getpwentCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>ctermidCalled</key>
+    <name>Non reentrant function 'ctermid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'ctermid_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'ctermid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'ctermid_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>ctermidCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>vforkCalled</key>
+    <name>Obsolescent function 'vfork' called. It is recommended to use 'fork' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'vfork' called. It is recommended to use 'fork' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>vforkCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getwdCalled</key>
+    <name>Obsolescent function 'getwd' called. It is recommended to use 'getcwd' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'getwd' called. It is recommended to use 'getcwd' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getwdCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>indexCalled</key>
+    <name>Obsolescent function 'index' called. It is recommended to use 'strchr' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'index' called. It is recommended to use 'strchr' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>indexCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getnetbynameCalled</key>
+    <name>Non reentrant function 'getnetbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetbyname_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getnetbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetbyname_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getnetbynameCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>makecontextCalled</key>
+    <name>Obsolescent function 'makecontext' called. Applications are recommended to be rewritten to use POSIX threads.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'makecontext' called. Applications are recommended to be rewritten to use POSIX threads.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>makecontextCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>bzeroCalled</key>
+    <name>Obsolescent function 'bzero' called. It is recommended to use 'memset' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'bzero' called. It is recommended to use 'memset' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>bzeroCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getcontextCalled</key>
+    <name>Obsolescent function 'getcontext' called. Applications are recommended to be rewritten to use POSIX threads.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'getcontext' called. Applications are recommended to be rewritten to use POSIX threads.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getcontextCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>ualarmCalled</key>
+    <name>Obsolescent function 'ualarm' called. It is recommended to use 'timer_create', 'timer_delete', 'timer_getoverrun', 'timer_gettime' or 'timer_settime' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'ualarm' called. It is recommended to use 'timer_create', 'timer_delete', 'timer_getoverrun', 'timer_gettime' or 'timer_settime' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>ualarmCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>fcvtCalled</key>
+    <name>Obsolescent function 'fcvt' called. It is recommended to use 'sprintf' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'fcvt' called. It is recommended to use 'sprintf' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>fcvtCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getprotobynameCalled</key>
+    <name>Non reentrant function 'getprotobyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getprotobyname_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getprotobyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getprotobyname_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getprotobynameCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getpwnamCalled</key>
+    <name>Non reentrant function 'getpwnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwnam_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getpwnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwnam_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getpwnamCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getpwuidCalled</key>
+    <name>Non reentrant function 'getpwuid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwuid_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getpwuid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwuid_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getpwuidCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>readdirCalled</key>
+    <name>Non reentrant function 'readdir' called. For threadsafe applications it is recommended to use the reentrant replacement function 'readdir_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'readdir' called. For threadsafe applications it is recommended to use the reentrant replacement function 'readdir_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>readdirCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>bcopyCalled</key>
+    <name>Obsolescent function 'bcopy' called. It is recommended to use 'memcpy' or 'memmove' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'bcopy' called. It is recommended to use 'memcpy' or 'memmove' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>bcopyCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>bcmpCalled</key>
+    <name>Obsolescent function 'bcmp' called. It is recommended to use 'memcmp' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'bcmp' called. It is recommended to use 'memcmp' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>bcmpCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>wcswcsCalled</key>
+    <name>Obsolescent function 'wcswcs' called. It is recommended to use 'wcsstr' instead.</name>
+    <description><![CDATA[
+        <p>
+  Obsolescent function 'wcswcs' called. It is recommended to use 'wcsstr' instead.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>wcswcsCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>fgetspentCalled</key>
+    <name>Non reentrant function 'fgetspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetspent_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'fgetspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetspent_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>fgetspentCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getservbyportCalled</key>
+    <name>Non reentrant function 'getservbyport' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservbyport_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getservbyport' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservbyport_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getservbyportCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>gethostentCalled</key>
+    <name>Non reentrant function 'gethostent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'gethostent_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'gethostent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'gethostent_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>gethostentCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
+  <rule>
+    <key>getgrentCalled</key>
+    <name>Non reentrant function 'getgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrent_r'.</name>
+    <description><![CDATA[
+        <p>
+  Non reentrant function 'getgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrent_r'.
+  </p><h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
+      ]]></description>
+    <tag>cwe</tag>
+    <internalKey>getgrentCalled</internalKey>
+    <severity>MINOR</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+  </rule>
   <rule>
     <key>asctimeCalled</key>
     <name>Obsolete function 'asctime' called</name>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
@@ -41,6 +41,6 @@ public class CxxCppCheckRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxCppCheckRuleRepository.KEY);
-    assertEquals(379, repo.rules().size());
+    assertEquals(442, repo.rules().size());
   }
 }

--- a/cxx-sensors/src/tools/cppcheck_createrules.py
+++ b/cxx-sensors/src/tools/cppcheck_createrules.py
@@ -26,10 +26,14 @@
 import sys
 import xml.etree.ElementTree as et
 
-severity_2_priority = {
-    "error": "MAJOR",
-    "style": "MINOR"
-    }
+severity_2_sonarqube = {
+    "error": {"type": "BUG", "priority": "MAJOR"},
+    "warning": {"type": "BUG", "priority": "MINOR"},
+    "portability": {"type": "BUG", "priority": "MINOR"},
+    "performance": {"type": "BUG", "priority": "MINOR"},
+    "style": {"type": "CODE_SMELL", "priority": "MINOR"},
+    "information": {"type": "CODE_SMELL", "priority": "MINOR"},
+}
 
 # xml prettifyer
 #
@@ -48,54 +52,65 @@ def indent(elem, level=0):
         if level and (not elem.tail or not elem.tail.strip()):
             elem.tail = i
 
-# monkey pathing element tree to support CDATA as by 
-# Eli Golovinsky, 2008, www.gooli.org
-#            
+# see https://stackoverflow.com/questions/174890/how-to-output-cdata-using-elementtree
 def CDATA(text=None):
-    """
-    A CDATA element factory function that uses the function itself as the tag
-    (based on the Comment factory function in the ElementTree implementation).
-    """
-    element = et.Element(CDATA)
+    element = et.Element('![CDATA[')
     element.text = text
     return element
 
-old_ElementTree = et.ElementTree
-class ElementTree_CDATA(old_ElementTree):
-    def _write(self, file, node, encoding, namespaces):
-        if node.tag is CDATA:
-            if node.text:
-                text = node.text.encode(encoding)
-                file.write("<![CDATA[%s]]>" % text)
-        else:
-            old_ElementTree._write(self, file, node, encoding, namespaces)
-et.ElementTree = ElementTree_CDATA
-       
+et._original_serialize_xml = et._serialize_xml
+
+def _serialize_xml(write, elem, encoding, qnames, namespaces):
+    if elem.tag == '![CDATA[':
+        write("<%s%s]]>%s" % (elem.tag, elem.text, "" if elem.tail is None else elem.tail))
+    else:
+        et._original_serialize_xml(write, elem, encoding, qnames, namespaces)
+
+et._serialize_xml = et._serialize['xml'] = _serialize_xml
+
+
 def header():
-    return '<?xml version="1.0" encoding="ASCII"?>\n'
+    return '<?xml version="1.0" encoding="us-ascii"?>\n'
+
 
 def error_to_rule(error):
     rule = et.Element('rule')
-    
+
     errId = error.attrib["id"]
     errMsg = error.attrib["msg"]
+    errSeverity = error.attrib["severity"]
+    isCWE = "cwe" in error.attrib
+
     et.SubElement(rule, 'key').text = errId
-    et.SubElement(rule, 'configkey').text = errId
     et.SubElement(rule, 'name').text = errMsg
-    et.SubElement(rule, 'description').text = "\n%s\n" % errMsg
-    
+
+    # encode description tag always as CDATA
+    cdata = CDATA(errMsg)
+    et.SubElement(rule, 'description').append(cdata)
+
+    if isCWE:
+        et.SubElement(rule, 'tag').text = "cwe"
+
+    et.SubElement(rule, 'internalKey').text = errId
+    et.SubElement(rule, 'severity').text = severity_2_sonarqube[errSeverity]["priority"]
+    et.SubElement(rule, 'type').text = severity_2_sonarqube[errSeverity]["type"]
+    et.SubElement(rule, 'remediationFunction').text = "LINEAR"
+    et.SubElement(rule, 'remediationFunctionGapMultiplier').text = "5min"
+
     return rule
+
 
 def error_to_rule_in_profile(error):
     rule = et.Element('rule')
-    
+
     errId = error.attrib["id"]
     errSeverity = error.attrib["severity"]
     et.SubElement(rule, 'repositoryKey').text = "cppcheck"
     et.SubElement(rule, 'key').text = errId
-    et.SubElement(rule, 'priority').text = severity_2_priority[errSeverity]
-    
+    et.SubElement(rule, 'priority').text = severity_2_sonarqube[errSeverity]["priority"]
+
     return rule
+
 
 def createRules(errors, converter):
     rules = et.Element('rules')
@@ -103,33 +118,111 @@ def createRules(errors, converter):
         rules.append(converter(error))
     return rules
 
-def usage():
-    return 'Usage: %s <"rules"|"profile"> < cppcheck --errorlist' % sys.argv[0]
 
-if len(sys.argv) != 2:
+def parseRules(path):
+    tree = et.parse(path)
+    root = tree.getroot()
+    entries = 0
+    keys = set()
+    keys_to_ruleelement = {}
+
+    for rules_tag in root.iter('rules'):
+        for rule_tag in rules_tag.iter('rule'):
+            for key_tag in rule_tag.iter('key'):
+                entries = entries + 1
+                keys.add(key_tag.text)
+                keys_to_ruleelement[key_tag.text] = rule_tag
+    return entries, keys, keys_to_ruleelement
+
+
+def compareRules(old_path, new_path):
+    old_entries, old_keys, old_keys_mapping = parseRules(old_path)
+    new_entries, new_keys, new_keys_mapping = parseRules(new_path)
+    print "# OLD RULE SET vs NEW RULE SET\n"
+
+    print "## OLD RULE SET\n"
+    print "nr of xml entries: ", old_entries, "\n"
+    print "nr of unique rules: ", len(old_keys), "\n"
+    print "rules which are only in the old rule set:"
+    only_in_old = old_keys.difference(new_keys)
+    for key in sorted(only_in_old):
+        print "*", key
+    print ""
+
+    print "## NEW RULE SET\n"
+    print "nr of xml entries: ", new_entries, "\n"
+    print "nr of unique rules: ", len(new_keys), "\n"
+    print "rules which are only in the new rule set:"
+    only_in_new = new_keys.difference(old_keys)
+    for key in sorted(only_in_new):
+        print "*", key
+    print ""
+
+    print "## COMMON RULES\n"
+    common_keys = old_keys.intersection(new_keys)
+    print "nr of rules: ", len(common_keys), "\n"
+    for key in sorted(common_keys):
+        print "*", key
+    print ""
+
+    print "### NEW RULES WHICH MUST BE ADDED\n"
+    print "```XML"
+    for key in only_in_new:
+        rule_tag = new_keys_mapping[key]
+        indent(rule_tag)
+        # after parsing we lost the CDATA information
+        # restore it for <description> tag, assume it always encoded as CDATA
+        for description_tag in rule_tag.iter('description'):
+            desc = description_tag.text
+            description_tag.text = ""
+            description_tag.append(CDATA(desc))
+        et.ElementTree(rule_tag).write(sys.stdout)
+    print "```\n"
+
+    # we might have more analysis here: e.g. check if severity didn't change
+    # after cppcheck updated its rules
+
+
+def usage():
+    return """Usage: %s <"rules"|"profile"> < cppcheck --errorlist
+       %s comparerules old_cppcheck.xml new_cppcheck.xml
+           """ % (sys.argv[0], sys.argv[0])
+
+
+def parseCppcheckErrorlist(f):
+    tree = et.parse(f)
+    root = tree.getroot()
+    errors = []
+    for errors_tag in root.iter('errors'):
+        for error_tag in errors_tag.iter('error'):
+            errors.append(error_tag)
+    return errors
+
+
+def writeXML(root, f):
+    indent(root)
+    f.write(header())
+    et.ElementTree(root).write(f)
+
+if len(sys.argv) < 2:
     print usage()
     exit()
 
-# transform the std input into an elementtree
-tree = et.parse(sys.stdin)
-results = tree.getroot()
-errors = results.findall("error")
-
 # transform to an other elementtree
-root = None
 if sys.argv[1] == "rules":
+    errors = parseCppcheckErrorlist(sys.stdin)
     root = createRules(errors, error_to_rule)
+    writeXML(root, sys.stdout)
 elif sys.argv[1] == "profile":
+    errors = parseCppcheckErrorlist(sys.stdin)
     rules = createRules(errors, error_to_rule_in_profile)
     root = et.Element('profile')
     et.SubElement(root, 'name').text = "Default C++ Profile"
     et.SubElement(root, 'language').text = "c++"
     root.append(rules)
+    writeXML(root, sys.stdout)
+elif sys.argv[1] == "comparerules" and len(sys.argv) == 4:
+    compareRules(sys.argv[2], sys.argv[3])
 else:
     print usage()
     exit()
-
-# write the resulting elementtree to the out stream
-indent(root)
-sys.stdout.write(header())
-et.ElementTree(root).write(sys.stdout)

--- a/cxx-sensors/src/tools/generate_cppcheck_resources.sh
+++ b/cxx-sensors/src/tools/generate_cppcheck_resources.sh
@@ -1,3 +1,19 @@
 #!/bin/sh
-cppcheck --errorlist | python cppcheck_createrules.py rules > cppcheck.xml
-cppcheck --errorlist | python cppcheck_createrules.py profile > cppcheck-profile.xml
+
+# directory where cppcheck stores description (configuration) files for libraries
+# these configurations contain additional rules about undesired (obsolete, not thread-safe etc) functions
+#
+# typical location:
+# * Red Hat based linux: /usr/share/cppcheck/
+# * cppcheck sources:    cppcheck/cfg/
+CFG_DIR=/usr/share/cppcheck/
+
+CPPCHECK_LIBRARY_ARGS=""
+for CFG in ${CFG_DIR}*.cfg; do
+   [ -e "${CFG}" ] && CPPCHECK_LIBRARY_ARGS="${CPPCHECK_LIBRARY_ARGS} --library=${CFG}" || echo "no *.cfg files exist in ${CFG_DIR}; no library specific rules will be generated!"
+done
+
+cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist > cppcheck-errorlist.xml
+cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist | python cppcheck_createrules.py rules > cppcheck.xml
+cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist | python cppcheck_createrules.py profile > cppcheck-profile.xml
+python cppcheck_createrules.py comparerules sonar-cxx/cxx-sensors/src/main/resources/cppcheck.xml cppcheck.xml > cppcheck-comparison.md

--- a/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CLanguage.java
+++ b/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CLanguage.java
@@ -84,7 +84,7 @@ public class CLanguage extends CxxLanguage {
   /**
    * c name
    */
-  public static final String NAME = "c";
+  public static final String NAME = "C (Community)";
 
   /**
    * Default c source files suffixes

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CppLanguage.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CppLanguage.java
@@ -85,7 +85,7 @@ public class CppLanguage extends CxxLanguage {
   /**
    * cxx name
    */
-  public static final String NAME = "c++";
+  public static final String NAME = "C++ (Community)";
 
   /**
    * Default cxx source files suffixes


### PR DESCRIPTION
It looks like rules from the cppcheck's libraries' configurations (included into standard cppcheck installation) were never registered purposeful. Some single rules were added on demand (e.g. if missing rule were reported as defect). My change 

* adds all missing rules from the libraries' configuration (cppcheck 1.82)
* fixes import scripts in order to
** generate the SonarQube rules from cppcheck's ones
** find out, which rules are missing in the current version of sonar-cxx

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1444)
<!-- Reviewable:end -->
