### PR TITLE
handling clangsa report errors

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensor.java
@@ -77,6 +77,8 @@ public class CxxClangSASensor extends CxxReportSensor {
 
       NSDictionary rootDict = (NSDictionary) PropertyListParser.parse(f);
 
+      final String clangVersion = ((NSString) rootDict.get("clang_version")).getContent();
+
       // Array of file paths where an issue was detected.
       NSObject[] sourceFiles = ((NSArray) rootDict.objectForKey("files")).getArray();
 
@@ -88,7 +90,12 @@ public class CxxClangSASensor extends CxxReportSensor {
         NSString desc = (NSString) diag.get("description");
         String description = desc.getContent();
 
-        String checkerName = ((NSString) diag.get("check_name")).getContent();
+        final NSObject checkNameValue = diag.get("check_name");
+        if(checkNameValue == null) {
+            LOG.error("clang version > 3.7.0 is required. Your version is: " + clangVersion);
+            return;
+        }
+        String checkerName = ((NSString) checkNameValue).getContent();
 
         NSDictionary location = (NSDictionary) diag.get("location");
 

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxReportSensor.java
@@ -124,7 +124,7 @@ public abstract class CxxReportSensor implements Sensor {
         .append(e)
         .append("'")
         .toString();
-      LOG.error(msg);
+      LOG.error(msg, e);
       CxxUtils.validateRecovery(e, this.language);
     }
   }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensorTest.java
@@ -92,6 +92,21 @@ public class CxxClangSASensorTest {
   }
 
   @Test
+  public void clangVersionIsTooOld() {
+    SensorContextTester context = SensorContextTester.create(fs.baseDir());
+
+    settings.setProperty(language.getPluginProperty(CxxClangSASensor.REPORT_PATH_KEY), "clangsa-reports/clangsa-wrong-version.plist");
+    context.setSettings(settings);
+
+    context.fileSystem().add(TestInputFileBuilder.create("ProjectKey", "src/cxx-library-sample/foo.cpp")
+      .setLanguage("cpp").initMetadata(new String("asd\nasdas\nasda\n")).build());
+
+    CxxClangSASensor sensor = new CxxClangSASensor(language);
+    sensor.execute(context);
+    assertThat(context.allIssues()).hasSize(0);
+  }
+
+  @Test
   public void sensorDescriptor() {
     DefaultSensorDescriptor descriptor = new DefaultSensorDescriptor();
     CxxClangSASensor sensor = new CxxClangSASensor(language);

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clangsa-reports/clangsa-wrong-version.plist
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clangsa-reports/clangsa-wrong-version.plist
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+ <key>clang_version</key>
+<string>clang version 3.5.1 (tags/RELEASE_351/final)</string>
+ <key>files</key>
+ <array>
+  <string>src/cxx-library-sample/foo.cpp</string>
+ </array>
+ <key>diagnostics</key>
+ <array>
+  <dict>
+   <key>path</key>
+   <array>
+    <dict>
+     <key>kind</key><string>event</string>
+     <key>location</key>
+     <dict>
+      <key>line</key><integer>17</integer>
+      <key>col</key><integer>11</integer>
+      <key>file</key><integer>0</integer>
+     </dict>
+     <key>ranges</key>
+     <array>
+       <array>
+        <dict>
+         <key>line</key><integer>17</integer>
+         <key>col</key><integer>11</integer>
+         <key>file</key><integer>0</integer>
+        </dict>
+        <dict>
+         <key>line</key><integer>17</integer>
+         <key>col</key><integer>11</integer>
+         <key>file</key><integer>0</integer>
+        </dict>
+       </array>
+       <array>
+        <dict>
+         <key>line</key><integer>17</integer>
+         <key>col</key><integer>15</integer>
+         <key>file</key><integer>0</integer>
+        </dict>
+        <dict>
+         <key>line</key><integer>17</integer>
+         <key>col</key><integer>28</integer>
+         <key>file</key><integer>0</integer>
+        </dict>
+       </array>
+     </array>
+     <key>depth</key><integer>0</integer>
+     <key>extended_message</key>
+     <string>Value stored to &apos;x&apos; during its initialization is never read</string>
+     <key>message</key>
+     <string>Value stored to &apos;x&apos; during its initialization is never read</string>
+    </dict>
+   </array>
+   <key>description</key><string>Value stored to &apos;x&apos; during its initialization is never read</string>
+   <key>category</key><string>Dead store</string>
+   <key>type</key><string>Dead initialization</string>
+  <key>issue_hash</key><string>1</string>
+  <key>location</key>
+  <dict>
+   <key>line</key><integer>17</integer>
+   <key>col</key><integer>11</integer>
+   <key>file</key><integer>0</integer>
+  </dict>
+  </dict>
+ </array>
+</dict>
+</plist>


### PR DESCRIPTION
Exception stack trace is not printed on this line.

Increasing verbosity and adding other debug options won't help producing a stack trace because this catch block by itself is not expected to produce stack trace.

Next `CxxUtils.validateRecovery()` could print the stack trace,  however on [this line](https://github.com/SonarOpenCommunity/sonar-cxx/blob/master/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxUtils.java#L122) 
```
throw new IllegalStateException(ex.getMessage(), ex.getCause());
```
`ex.getCase()` tries to get cause of NPE instead of NPE itself, which of course is missing since NPE in this case if the original exception. Therefore even with `sonar.cxx.errorRecoveryEnabled=false` NPE stack trace is not printed

Error message before:
```
14:16:53.983 ERROR - Cannot feed the data into sonar, details: 'java.lang.NullPointerException'
```

Error message after this change applied:
```
14:18:11.336 ERROR - Cannot feed the data into sonar, details: 'java.lang.NullPointerException'
java.lang.NullPointerException: null
        at org.sonar.cxx.sensors.clangsa.CxxClangSASensor.processReport(CxxClangSASensor.java:91)
        at org.sonar.cxx.sensors.utils.CxxReportSensor.executeReport(CxxReportSensor.java:140)
        at org.sonar.cxx.sensors.utils.CxxReportSensor.execute(CxxReportSensor.java:99)
        at org.sonar.scanner.sensor.SensorWrapper.analyse(SensorWrapper.java:53)
        at org.sonar.scanner.phases.SensorsExecutor.executeSensor(SensorsExecutor.java:88)
        at org.sonar.scanner.phases.SensorsExecutor.execute(SensorsExecutor.java:82)
        at org.sonar.scanner.phases.SensorsExecutor.execute(SensorsExecutor.java:68)
        at org.sonar.scanner.phases.AbstractPhaseExecutor.execute(AbstractPhaseExecutor.java:88)
        at org.sonar.scanner.scan.ModuleScanContainer.doAfterStart(ModuleScanContainer.java:180)
        at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:135)
        at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:121)
        at org.sonar.scanner.scan.ProjectScanContainer.scan(ProjectScanContainer.java:288)
        at org.sonar.scanner.scan.ProjectScanContainer.scanRecursively(ProjectScanContainer.java:283)
        at org.sonar.scanner.scan.ProjectScanContainer.doAfterStart(ProjectScanContainer.java:261)
        at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:135)
        at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:121)
        at org.sonar.scanner.task.ScanTask.execute(ScanTask.java:48)
        at org.sonar.scanner.task.TaskContainer.doAfterStart(TaskContainer.java:84)
        at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:135)
        at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:121)
        at org.sonar.scanner.bootstrap.GlobalContainer.executeTask(GlobalContainer.java:121)
        at org.sonar.batch.bootstrapper.Batch.doExecuteTask(Batch.java:116)
        at org.sonar.batch.bootstrapper.Batch.execute(Batch.java:71)
        at org.sonar.runner.batch.IsolatedLauncher.execute(IsolatedLauncher.java:48)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.sonar.runner.impl.BatchLauncher$1.delegateExecution(BatchLauncher.java:87)
        at org.sonar.runner.impl.BatchLauncher$1.run(BatchLauncher.java:75)
        at java.security.AccessController.doPrivileged(Native Method)
        at org.sonar.runner.impl.BatchLauncher.doExecute(BatchLauncher.java:69)
        at org.sonar.runner.impl.BatchLauncher.execute(BatchLauncher.java:50)
        at org.sonar.runner.api.EmbeddedRunner.doExecute(EmbeddedRunner.java:102)
        at org.sonar.runner.api.Runner.execute(Runner.java:100)
        at org.sonar.runner.Main.executeTask(Main.java:70)
        at org.sonar.runner.Main.execute(Main.java:59)
        at org.sonar.runner.Main.main(Main.java:53)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1449)
<!-- Reviewable:end -->
