### PR TITLE
Align Cppcheck messages with the latest version 1.83

### DIFF
--- a/cxx-sensors/src/main/resources/cppcheck.xml
+++ b/cxx-sensors/src/main/resources/cppcheck.xml
@@ -328,7 +328,7 @@ Buffer overrun possible for long command line arguments.
 Undefined behaviour, pointer arithmetic '' is out of bounds. From
 chapter 6.5.6 in the C specification:
 <cite>"When an expression that has
-integer type is added to or subtracted from a pointer, .."</cote> and then
+integer type is added to or subtracted from a pointer, .."</cite> and then
 <cite>"If both the pointer operand and the result point to elements of the
 same array object, or one past the last element of the array object,
 the evaluation shall not produce an overflow; otherwise, the behavior

--- a/cxx-sensors/src/main/resources/cppcheck.xml
+++ b/cxx-sensors/src/main/resources/cppcheck.xml
@@ -23,18 +23,20 @@ Follow these steps to make your custom Custom rules available in SonarQube:
   </rule>    
   <rule>
     <key>AssignmentAddressToInteger</key>
-    <name>Assigning an address value to an integer (int/long/etc.) type is not portable</name>
+    <name>Assigning a pointer to an integer is not portable</name>
     <description>
       <![CDATA[
-<p>
-Assigning a pointer to an integer (int/long/etc) is not portable across different platforms and
-compilers. For example in 32-bit Windows and linux they are same width, but in 64-bit Windows and linux
-they are of different width. In worst case you end up assigning 64-bit address to 32-bit integer. The safe
-way is to store addresses only in pointer types (or typedefs like uintptr_t).
+      <p>
+Assigning a pointer to an integer (int/long/etc) is not portable
+across different platforms and compilers. For example in 32-bit
+Windows and linux they are same width, but in 64-bit Windows and linux
+they are of different width. In worst case you end up assigning 64-bit
+address to 32-bit integer. The safe way is to store addresses only in
+pointer types (or typedefs like uintptr_t).
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/758.html" target="_blank">CWE-758: Reliance on Undefined, Unspecified, or Implementation-Defined Behavior</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>AssignmentAddressToInteger</internalKey>
@@ -46,17 +48,20 @@ way is to store addresses only in pointer types (or typedefs like uintptr_t).
   </rule>
   <rule>
     <key>AssignmentIntegerToAddress</key>
-    <name>Assigning an integer (int/long/etc) to a pointer is not portable</name>
-    <description><![CDATA[
-<p>
-Assigning an integer (int/long/etc) to a pointer is not portable across different platforms and
-compilers. For example in 32-bit Windows and linux they are same width, but in 64-bit Windows and linux
-they are of different width. In worst case you end up assigning 64-bit integer to 32-bit pointer. The safe
-way is to store addresses only in pointer types (or typedefs like uintptr_t).
+    <name>Assigning an integer to a pointer is not portable</name>
+    <description>
+      <![CDATA[
+      <p>
+Assigning an integer (int/long/etc) to a pointer is not portable
+across different platforms and compilers. For example in 32-bit
+Windows and linux they are same width, but in 64-bit Windows and linux
+they are of different width. In worst case you end up assigning 64-bit
+integer to 32-bit pointer. The safe way is to store addresses only in
+pointer types (or typedefs like uintptr_t).
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/758.html" target="_blank">CWE-758: Reliance on Undefined, Unspecified, or Implementation-Defined Behavior</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>AssignmentIntegerToAddress</internalKey>
@@ -70,22 +75,16 @@ way is to store addresses only in pointer types (or typedefs like uintptr_t).
     <key>autoVariables</key>
     <name>Assigning address of local auto-variable to a function parameter</name>
     <description>
-<![CDATA[
-<p>
-
-    Dangerous assignment - the function parameter is assigned the address of a local
-    auto-variable. Local auto-variables are reserved from the stack which
-    is freed when the function ends. So the pointer to a local variable is invalid after the function ends
-</p>
-<p>
-    <li>Function parameter is assigned the address of a local auto-variable.</li>
-    <li>Local auto-variables are reserved from the stack which is freed when</li>
-    <li>the function ends. The address is invalid after the function ends and it</li>
-    <li>might 'leak' from the function through the parameter</li>
+      <![CDATA[
+      <p>
+Dangerous assignment - the function parameter is assigned the address
+of a local auto-variable. Local auto-variables are reserved from the
+stack which is freed when the function ends. So the pointer to a local
+variable is invalid after the function ends.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/562.html" target="_blank">CWE-562: Return of Stack Variable Address</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <tag>bug</tag>
@@ -98,7 +97,7 @@ way is to store addresses only in pointer types (or typedefs like uintptr_t).
   </rule>
   <rule>
     <key>returnAddressOfAutoVariable</key>
-    <name>Return of the address of an auto-variable</name>
+    <name>Address of an auto-variable returned</name>
     <description>
       <![CDATA[
 <p>
@@ -119,7 +118,7 @@ Address of an auto-variable returned.
   </rule>
   <rule>
     <key>returnLocalVariable</key>
-    <name>Returning pointer to local array variable</name>
+    <name>Pointer to local array variable returned</name>
     <description>
 <![CDATA[
 <p>
@@ -139,7 +138,7 @@ Pointer to local array variable returned.
   </rule>
   <rule>
     <key>returnReference</key>
-    <name>Returning reference to auto variable</name>
+    <name>Reference to auto variable returned.</name>
     <description>
 <![CDATA[
 <p>
@@ -159,7 +158,7 @@ Reference to auto variable returned.
   </rule>
   <rule>
     <key>returnTempReference</key>
-    <name>Returning reference to temporary</name>
+    <name>Reference to temporary returned.</name>
     <description>
 <![CDATA[
 <p>
@@ -179,11 +178,12 @@ Reference to temporary returned.
   </rule>
   <rule>
     <key>autovarInvalidDeallocation</key>
-    <name>Deallocating auto-variable is invalid</name>
+    <name>Deallocation of an auto-variable results in undefined behaviour</name>
     <description>
-<![CDATA[
-<p>
-Address of an auto-variable returned.
+      <![CDATA[
+      <p>
+The deallocation of an auto-variable results in undefined behaviour.
+You should only free memory that has been allocated dynamically.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/590.html" target="_blank">CWE-590: Free of Memory not on the Heap</a></p>
@@ -220,11 +220,11 @@ Array index out of bounds.
   </rule>
   <rule>
     <key>bufferAccessOutOfBounds</key>
-    <name>Buffer access out-of-bounds</name>
+    <name>Buffer is accessed out of bounds</name>
     <description>
-<![CDATA[
-<p>
-Buffer is accessed out-of-bounds.
+      <![CDATA[
+      <p>
+Buffer is accessed out of bounds
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/788.html" target="_blank">CWE-788: Access of Memory Location After End of Buffer</a></p>
@@ -260,17 +260,17 @@ Index is out of bounds: Supplied size is larger than actual size.
   </rule>
   <rule>
     <key>terminateStrncpy</key>
-    <name>The buffer may not be zero-terminated after the call to strncpy()</name>
+    <name>The buffer may not be null-terminated after the call to strncpy()</name>
     <description>
-<![CDATA[
-<p>
-The buffer 'varname' may not be null-terminated after the call to strncpy().
-If the source string's size fits or exceeds the given size, strncpy() does not add a 
-zero at the end of the buffer. This causes bugs later in the code if the code 
-assumes buffer is null-terminated.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+If the source string's size fits or exceeds the given size, strncpy()
+does not add a zero at the end of the buffer. This causes bugs later
+in the code if the code assumes buffer is null-terminated.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/170.html" target="_blank">CWE-170: Improper Null Termination</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>terminateStrncpy</internalKey>
@@ -301,7 +301,7 @@ Negative array index is always out of bounds.
   </rule>
   <rule>
     <key>insecureCmdLineArgs</key>
-    <name>Buffer overrun possible for long cmd-line args</name>
+    <name>Buffer overrun possible for long command line arguments</name>
     <description>
 <![CDATA[
 <p>
@@ -321,17 +321,18 @@ Buffer overrun possible for long command line arguments.
   </rule>
   <rule>
     <key>pointerOutOfBounds</key>
-    <name>Undefined behavior, pointer arithmetic 'expr' or index is out of bounds</name>
+    <name>Undefined behaviour, pointer arithmetic 'expr' or index is out of bounds</name>
     <description>
-<![CDATA[
-<p>
-Undefined behaviour, pointer arithmetic 'expr' or index is out of bounds.
-From chapter 6.5.6 in the C specification:
-<i>"When an expression that has integer type is added to or subtracted from a pointer, .."</i>
- and then 
-<i>"If both the pointer operand and the result point to elements of the same array object,
- or one past the last element of the array object,
- the evaluation shall not produce an overflow; otherwise, the behavior is undefined."</i>
+      <![CDATA[
+      <p>
+Undefined behaviour, pointer arithmetic '' is out of bounds. From
+chapter 6.5.6 in the C specification:
+<cite>"When an expression that has
+integer type is added to or subtracted from a pointer, .."</cote> and then
+<cite>"If both the pointer operand and the result point to elements of the
+same array object, or one past the last element of the array object,
+the evaluation shall not produce an overflow; otherwise, the behavior
+is undefined."</cite>
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
@@ -349,9 +350,15 @@ From chapter 6.5.6 in the C specification:
     <key>arrayIndexThenCheck</key>
     <name>Array index is used before limits check</name>
     <description>
-<![CDATA[<p>
-Array index is used before limits check.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Defensive programming: The variable 'index' is used as an array index
+before it is checked that is within limits. This can mean that the
+array might be accessed out of bounds. Reorder conditions such as
+<code>'(a[i] && i < 10)'</code> to <code>'(i < 10 && a[i])'</code>. That way the array will not
+be accessed if the index is out of limits.
+</p>
+<h2>References</h2>
 <p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=47677453" target="_blank">ARR30-C. Do not form or use out-of-bounds pointers or array subscripts</a></p>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
 ]]>
@@ -369,11 +376,12 @@ Array index is used before limits check.
     <key>noConstructor</key>
     <name>Class does not have a constructor</name>
     <description>
-<![CDATA[
-<p>
-The <code>struct</code> or <code>class</code> 'classname' does not have a constructor although it has private member variables.
-Member variables of builtin types are left uninitialized when the class is instantiated.
-That may cause bugs or undefined behavior.
+      <![CDATA[
+      <p>
+The <code>struct</code> or <code>class</code> 'classname' does not have a constructor although it has
+private member variables. Member variables of builtin types are left
+uninitialized when the class is instantiated. That may cause bugs or
+undefined behavior.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
@@ -450,10 +458,12 @@ Unused private function.
     <key>memsetClass</key>
     <name>Invalid usage of memset|memmove|memcpy on classes</name>
     <description>
-<![CDATA[
-<p>
-Usage of the functions from the memset-family on classes should be avoided because it leads to undefined behavior in a number of
-cases (e.g. when the class contains a virtual method). Use constructors or init-routines to initialize your members instead
+      <![CDATA[
+      <p>
+Using memset-family on class that contains a classname is unsafe, because
+constructor, destructor and copy operator calls are omitted. These are
+necessary for this non-POD type to ensure that a valid object is
+created.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/762.html" target="_blank">CWE-762: Mismatched Memory Management Routines</a></p>
@@ -470,18 +480,15 @@ cases (e.g. when the class contains a virtual method). Use constructors or init-
     <key>operatorEq</key>
     <name>'class::operator=' should return 'class &amp;'</name>
     <description>
-<![CDATA[
-<p>
-The 'className::operator=' does not conform to standard C/C++ behaviour. To conform to standard C/C++ behaviour, return a reference to self (such as: 
-<code>
-className &className::operator=(..) 
-{ 
-  .. 
-  return *this; 
-}
-</code>
-For safety reasons it might be better to not fix this message. If you think that safety is always more important than conformance then please ignore/suppress this message. 
-For more details about this topic, see the book "Effective C++" by Scott Meyers.
+      <![CDATA[
+      <p>
+The class::operator= does not conform to standard C/C++ behaviour. To
+conform to standard C/C++ behaviour, return a reference to self (such
+as: <code>'class &class::operator=(..) { .. return *this; }'</code>. For safety
+reasons it might be better to not fix this message. If you think that
+safety is always more important than conformance then please
+ignore/suppress this message. For more details about this topic, see
+the book "Effective C++" by Scott Meyers.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
@@ -515,15 +522,14 @@ Suspicious pointer subtraction. Did you intend to write '->'?
   </rule>
   <rule>
     <key>operatorEqRetRefThis</key>
-    <name>'operator=' should return reference to self</name>
+    <name>'operator=' should return reference to 'this' instance</name>
     <description>
-<![CDATA[
-<p>
-'operator=' should return reference to self.
-</p>
-<h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+'operator=' should return reference to 'this' instance.
+</p><h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>operatorEqRetRefThis</internalKey>
@@ -536,10 +542,11 @@ Suspicious pointer subtraction. Did you intend to write '->'?
     <key>operatorEqToSelf</key>
     <name>'operator=' should check for assignment to self</name>
     <description>
-<![CDATA[
-<p>
-'operator=' should check for assignment to self to ensure that each block of dynamically
-allocated memory is owned and managed by only one instance of the class.
+      <![CDATA[
+      <p>
+'operator=' should check for assignment to self to ensure that each
+block of dynamically allocated memory is owned and managed by only one
+instance of the class.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
@@ -556,8 +563,17 @@ allocated memory is owned and managed by only one instance of the class.
     <key>exceptThrowInDestructor</key>
     <name>Throwing exception in destructor</name>
     <description>
-      Throwing exception in destructor.
+      <![CDATA[
+      <p>
+The class Class is not safe because its destructor throws an
+exception. If Class is used and an exception is thrown that is caught
+in an outer scope the program will terminate.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>exceptThrowInDestructor</internalKey>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -568,8 +584,14 @@ allocated memory is owned and managed by only one instance of the class.
     <key>exceptDeallocThrow</key>
     <name>Throwing exception in invalid state</name>
     <description>
-      Throwing exception in invalid state: a pointer points at deallocated memory.
+      <![CDATA[
+      <p>
+Exception thrown in invalid state, pointer points at deallocated memory.
+</p><h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>exceptDeallocThrow</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -578,11 +600,19 @@ allocated memory is owned and managed by only one instance of the class.
   </rule>
   <rule>
     <key>exceptRethrowCopy</key>
-    <name>Throwing a copy of the caught exception instead of re-throwing the original exception</name>
+    <name>Throwing a copy of the caught exception instead of rethrowing the original exception</name>
     <description>
-      Throwing a copy of the caught exception instead of re-throwing
-      the original exception.
+      <![CDATA[
+      <p>
+Rethrowing an exception with 'throw varname;' creates an unnecessary
+copy of 'varname'. To rethrow the caught exception without unnecessary
+copying or slicing, use a bare 'throw;'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>exceptRethrowCopy</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -593,8 +623,16 @@ allocated memory is owned and managed by only one instance of the class.
     <key>catchExceptionByValue</key>
     <name>Exception should be caught by reference</name>
     <description>
-      Exception should be caught by reference.
+      <![CDATA[
+      <p>
+The exception is caught by value. It could be caught as a (const)
+reference which is usually recommended in C++.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>catchExceptionByValue</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -605,13 +643,12 @@ allocated memory is owned and managed by only one instance of the class.
     <key>assignIfError</key>
     <name>Mismatching assignment and comparison, comparison is always true or false</name>
     <description>
-<![CDATA[
-<p>
- Mismatching assignment and comparison, comparison is always true or false.
-</p>
-<h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+Mismatching assignment and comparison, comparison is always false.
+</p><h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>assignIfError</internalKey>
@@ -624,11 +661,12 @@ allocated memory is owned and managed by only one instance of the class.
     <key>comparisonError</key>
     <name>Expression is always true or false</name>
     <description>
-<![CDATA[
-<p>
-Expression is always true or false.
-Check carefully constants and operators used, these errors might be hard to spot sometimes.
-In case of complex expression it might help to split it to separate expressions.
+      <![CDATA[
+      <p>
+The expression is always true/false. Check carefully
+constants and operators used, these errors might be hard to spot
+sometimes. In case of complex expression it might help to split it to
+separate expressions.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
@@ -645,9 +683,10 @@ In case of complex expression it might help to split it to separate expressions.
     <key>multiCondition</key>
     <name>'else if' condition matches previous condition</name>
     <description>
-<![CDATA[
-<p>
-Expression is always false because 'else if' condition matches previous condition.
+      <![CDATA[
+      <p>
+Expression is always false because 'else if' condition matches
+previous condition.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
@@ -666,7 +705,7 @@ Expression is always false because 'else if' condition matches previous conditio
     <description>
 <![CDATA[
 <p>
-Memory leak.
+Memory leak
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/401.html" target="_blank">CWE-401: Improper Release of Memory Before Removing Last Reference ('Memory Leak')</a></p>
@@ -686,7 +725,7 @@ Memory leak.
     <description>
 <![CDATA[
 <p>
-Resource leak.
+Resource leak
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/775.html" target="_blank">CWE-775: Missing Release of File Descriptor or Handle after Effective Lifetime</a></p>
@@ -1252,10 +1291,16 @@ Common realloc mistake: variable nulled but not freed upon failure.
     <key>gmtimeCalled</key>
     <name>Non reentrant function 'gmtime' called</name>
     <description>
-      Non reentrant function 'gmtime' called. For threadsafe
-      applications it is recommended to use the reentrant replacement
-      function 'gmtime_r'.
+      <![CDATA[
+      <p>
+Non reentrant function 'gmtime' called. For threadsafe applications it
+is recommended to use the reentrant replacement function 'gmtime_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>gmtimeCalled</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -1444,11 +1489,18 @@ Possible null pointer dereference.
   </rule>        
   <rule>
     <key>ftimeCalled</key>
-    <name>Obsolescent function 'ftime' called</name>
-    <description>      
-      Obsolescent function 'ftime' called. It is recommended to use 'time',
-      'gettimeofday' or 'clock_gettime' instead.
+    <name>Obsolescent function 'ftime' called. It is recommended to use 'time', 'gettimeofday' or 'clock_gettime' instead.</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'ftime' called. It is recommended to use 'time',
+'gettimeofday' or 'clock_gettime' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>ftimeCalled</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -1684,7 +1736,7 @@ Possible null pointer dereference.
   </rule>
   <rule>
     <key>assignBoolToPointer</key>
-    <name>Assigning bool value to pointer (converting bool value to address)</name>
+    <name>Boolean value assigned to pointer</name>
     <description>
 <![CDATA[
 <p>
@@ -1706,11 +1758,17 @@ Boolean value assigned to pointer.
     <key>sprintfOverlappingData</key>
     <name>Undefined behavior: variable is used as parameter and destination in s[n]printf()</name>
     <description>
-<![CDATA[
-<p>
-Undefined behavior: variable is used as parameter and destination in s[n]printf(). From Single UNIX Specification: "If
-copying takes place between objects that overlap as a result of a call to sprintf() or snprintf(), the results are undefined".
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+The variable 'varname' is used both as a parameter and as destination
+in s[n]printf(). The origin and destination buffers overlap. Quote
+from glibc (C-library) documentation
+(http://www.gnu.org/software/libc/manual/html_mono/libc.html
+#Formatted-Output-Functions): <cite>"If copying takes place between objects
+that overlap as a result of a call to sprintf() or snprintf(), the
+results are undefined."</cite>
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/628.html" target="_blank">CWE-628: Function Call with Incorrectly Specified Arguments</a></p>
 ]]>
     </description>
@@ -1726,11 +1784,12 @@ copying takes place between objects that overlap as a result of a call to sprint
     <key>staticStringCompare</key>
     <name>Unnecessary comparison of static strings</name>
     <description>
-      Unnecessary comparison of static strings.
-<![CDATA[
-<p>
-Unnecessary comparison of static strings.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+The compared strings are always equal/unequal. Therefore
+the comparison is unnecessary and looks suspicious.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/570.html" target="_blank">CWE-570: Expression is Always False</a></p>
 <p><a href="https://cwe.mitre.org/data/definitions/571.html" target="_blank">CWE-571: Expression is Always True</a></p>
 ]]>      
@@ -1794,10 +1853,18 @@ Passing value "#" to #() leads to implementation-defined result.
   </rule>
   <rule>
     <key>fflushOnInputStream</key>
-    <name>fflush() called on input stream &apos;stdin&apos; may result in undefined behavior</name>
+    <name>fflush() called on input stream &apos;stdin&apos; may result in undefined behaviour</name>
     <description>
-      fflush() called on input stream &apos;stdin&apos; may result in undefined behavior on non-linux systems.
+      <![CDATA[
+      <p>
+fflush() called on input stream 'stdin' may result in undefined
+behaviour on non-linux systems.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>fflushOnInputStream</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -1808,8 +1875,20 @@ Passing value "#" to #() leads to implementation-defined result.
     <key>functionConst</key>
     <name>Member function can be const</name>
     <description>
-      Technically the member function can be const.
+      <![CDATA[
+      <p>
+The member function 'class::function' can be made a const function.
+Making this function 'const' should not cause compiler errors. Even
+though the function can be made const function technically it may not
+make sense conceptually. Think about your design and the task of the
+function first - is it a function that must not change object internal
+state?
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>functionConst</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -1820,13 +1899,12 @@ Passing value "#" to #() leads to implementation-defined result.
     <key>unusedScopedObject</key>
     <name>Instance destroyed immediately</name>
     <description>
-<![CDATA[
-<p>
-Instance destroyed immediately.
-</p>
-<h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/563.html" target="_blank">CWE-563: Assignment to Variable without Use ('Unused Variable')</a></p>
-]]>
+      <![CDATA[
+      <p>
+Instance of 'varname' object is destroyed immediately.
+</p><h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/563.html" target="_blank">CWE-563: Assignment to Variable without Use</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>unusedScopedObject</internalKey>
@@ -1837,15 +1915,25 @@ Instance destroyed immediately.
   </rule>
   <rule>
     <key>sizeofwithsilentarraypointer</key>
-    <name>Using sizeof on array given as function argument returns the size of pointer</name>
+    <name>Using 'sizeof' on array given as function argument returns size of a pointer</name>
     <description>
-<![CDATA[
-<p>
-Using 'sizeof' for array given as function argument returns the size of pointer.
+      <![CDATA[
+      <p>
+Using 'sizeof' for array given as function argument returns the size
+of a pointer. It does not return the size of the whole array in bytes
+as might be expected. For example, this code:
+<pre>
+int f(char a[100]) {
+  return sizeof(a);
+}
+</pre>
+returns 4 (in
+32-bit systems) or 8 (in 64-bit systems) instead of 100 (the size of
+the array in bytes).
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/467.html" target="_blank">CWE-467: Use of sizeof() on a Pointer Type</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>sizeofwithsilentarraypointer</internalKey>
@@ -1856,16 +1944,18 @@ Using 'sizeof' for array given as function argument returns the size of pointer.
   </rule>
   <rule>
     <key>sizeofwithnumericparameter</key>
-    <name>Using sizeof with a numeric constant as function argument might not be what you intended</name>
+    <name>Suspicious usage of 'sizeof' with a numeric constant as parameter</name>
     <description>
-      Using sizeof with a numeric constant as function argument might not be what you intended.
-<![CDATA[
-<p>
-Using sizeof with a numeric constant as function argument might not be what you intended.
+      <![CDATA[
+      <p>
+It is unusual to use a constant value with sizeof. For example,
+'sizeof(10)' returns 4 (in 32-bit systems) or 8 (in 64-bit systems)
+instead of 10. 'sizeof('A')' and 'sizeof(char)' can return different
+results.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/682.html" target="_blank">CWE-682: Incorrect Calculation</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>sizeofwithnumericparameter</internalKey>
@@ -1878,8 +1968,21 @@ Using sizeof with a numeric constant as function argument might not be what you 
     <key>cstyleCast</key>
     <name>C-style pointer casting</name>
     <description>
-      C-style pointer casting.
+      <![CDATA[
+      <p>
+C-style pointer casting detected. C++ offers four different kinds of
+casts as replacements: static_cast, const_cast, dynamic_cast and
+reinterpret_cast. A C-style cast could evaluate to any of those
+automatically, thus it is considered safer if the programmer
+explicitly states which kind of cast is expected. See also: https://ww
+w.securecoding.cert.org/confluence/display/cplusplus/EXP05-CPP.+Do+not
++use+C-style+casts.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>cstyleCast</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -1901,10 +2004,13 @@ Using sizeof with a numeric constant as function argument might not be what you 
   <rule>
     <key>passedByValue</key>
     <name>Function parameter should be passed by reference</name>
-    <description>    
-<![CDATA[<p>
-Function parameter should be passed by reference.
-</p><h2>References</h2>
+    <description>
+      <![CDATA[
+      <p>
+Parameter 'parametername' is passed by value. It could be passed as a
+(const) reference which is usually faster and recommended in C++.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
 ]]>
     </description>
@@ -1919,8 +2025,14 @@ Function parameter should be passed by reference.
     <key>constStatement</key>
     <name>Redundant code: Found a statement that begins with type constant</name>
     <description>
-      Redundant code: Found a statement that begins with type constant.
+      <![CDATA[
+      <p>
+Redundant code: Found a statement that begins with type constant.
+</p><h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>constStatement</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -1941,11 +2053,26 @@ Function parameter should be passed by reference.
   </rule>
   <rule>
     <key>charBitOp</key>
-    <name>When using char variables in bit operations, sign extension can generate unexpected results</name>
+    <name>When using 'char' variables in bit operations, sign extension can generate unexpected results</name>
     <description>
-      When using char variables in bit operations, sign extension can
-      generate unexpected results.
+      <![CDATA[
+      <p>
+When using 'char' variables in bit operations, sign extension can
+generate unexpected results. For example:
+<pre>
+char c = 0x80;
+int i = 0 | c;
+if (i & 0x8000)
+  printf("not expected");
+</pre>
+The "not expected" will be printed on the screen.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>charBitOp</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -1956,8 +2083,33 @@ Function parameter should be passed by reference.
     <key>variableScope</key>
     <name>The scope of the variable can be reduced</name>
     <description>
-      The scope of the variable can be reduced.
+      <![CDATA[
+      <p>
+The scope of the variable 'varname' can be reduced. Warning: Be
+careful when fixing this message, especially when there are inner
+loops. Here is an example where cppcheck will write that the scope for
+'i' can be reduced:
+<pre>
+void f(int x)
+{
+  int i = 0;
+  if (x) {
+    // it's safe to move 'int i = 0;' here
+    for (int n = 0; n < 10; ++n) {
+       // it is possible but not safe to move 'int i = 0;' here
+       do_something(&i);
+    }
+   }
+}
+</pre>
+When you see this message it is always safe to
+reduce the variable scope 1 level.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>variableScope</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -1968,13 +2120,14 @@ Function parameter should be passed by reference.
     <key>strPlusChar</key>
     <name>Unusual pointer arithmetic</name>
     <description>
-<![CDATA[
-<p>
-Unusual pointer arithmetic.
+      <![CDATA[
+      <p>
+Unusual pointer arithmetic. A value of type 'char' is added to a
+string literal.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/665.html" target="_blank">CWE-665: Improper Initialization</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>strPlusChar</internalKey>
@@ -1985,15 +2138,18 @@ Unusual pointer arithmetic.
   </rule>
   <rule>
     <key>sizeofsizeof</key>
-    <name>Calling sizeof for 'sizeof'</name>
+    <name>Calling 'sizeof' on 'sizeof'</name>
     <description>
-<![CDATA[<p>
-Calling sizeof for 'sizeof looks like a suspicious code and most likely there should be just one 'sizeof'.
-The current code is equivalent to 'sizeof(size_t)'
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Calling sizeof for 'sizeof looks like a suspicious code and most
+likely there should be just one 'sizeof'. The current code is
+equivalent to 'sizeof(T)'
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/682.html" target="_blank">CWE-682: Incorrect Calculation</a></p>
-]]>
-      </description>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>sizeofsizeof</internalKey>
     <severity>MINOR</severity>
@@ -2012,6 +2168,7 @@ Found calculation inside sizeof().
 ]]>      
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>sizeofCalculation</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2022,8 +2179,17 @@ Found calculation inside sizeof().
     <key>redundantAssignInSwitch</key>
     <name>Redundant assignment in switch</name>
     <description>
-      Redundant assignment in switch.
+      <![CDATA[
+      <p>
+Variable is reassigned a value before the old one has been used.
+'break;' missing?
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/563.html" target="_blank">CWE-563: Assignment to Variable without Use</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>redundantAssignInSwitch</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2050,9 +2216,10 @@ Found calculation inside sizeof().
 Redundant assignment to itself.
 </p><h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>      
+]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>selfAssignment</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2064,11 +2231,11 @@ Redundant assignment to itself.
     <name>Assert statement modifies variable</name>
     <description>
       <![CDATA[
-<p>
-Variable 'varname' is modified insert assert statement.
-Assert statements are removed from release builds so the code inside
-assert statement is not executed. If the code is needed also in release
-builds, this is a bug.
+      <p>
+Variable 'var' is modified insert assert statement. Assert statements
+are removed from release builds so the code inside assert statement is
+not executed. If the code is needed also in release builds, this is a
+bug.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
@@ -2086,8 +2253,41 @@ builds, this is a bug.
     <key>invalidscanf</key>
     <name>scanf() without field width limits can crash with huge input data</name>
     <description>
-      scanf() without field width limits can crash with huge input data.
+      <![CDATA[
+      <p>
+scanf() without field width limits can crash with huge input data. Add
+a field width specifier to fix this problem.
+</p>
+<p>
+Sample program
+that can crash:
+</p>
+<pre>
+#include <stdio.h>
+int main()
+{
+  char c[5];
+  scanf("%s", c);
+  return 0;
+}
+</pre>
+<p>
+Typing
+in 5 or more characters may make the program crash. The correct usage
+here is 'scanf("%4s", c);', as the maximum field width does not
+include the terminating null byte.
+</p>
+<p>
+Source: http://linux.die.net/man/3/scanf
+</p>
+<p>
+Source: http://www.opensource.apple.com/source/xnu/xnu-1456.1.26/libkern/stdio/scanf.c
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/119.html" target="_blank">CWE-119: Improper Restriction of Operations within the Bounds of a Memory Buffer</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>invalidscanf</internalKey>
     <severity>MINOR</severity>
     <type>VULNERABILITY</type>
@@ -2098,9 +2298,11 @@ builds, this is a bug.
     <key>incorrectLogicOperator</key>
     <name>Suspicious use of the '&amp;&amp;' or '||' logic operator</name>
     <description>
-<![CDATA[
-<p>
-Logical disjunction always evaluates to true or false . Did you intend to use '&&' or '||' instead?
+      <![CDATA[
+      <p>
+Logical disjunction always evaluates to true/false. Are
+these conditions necessary? Did you intend to use && instead? Are the
+numbers correct? Are you comparing the correct variables?
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/570.html" target="_blank">CWE-570: Expression is Always False</a></p>
@@ -2108,6 +2310,7 @@ Logical disjunction always evaluates to true or false . Did you intend to use '&
 ]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>incorrectLogicOperator</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2118,11 +2321,14 @@ Logical disjunction always evaluates to true or false . Did you intend to use '&
     <key>memsetZeroBytes</key>
     <name>Effectless memset() call</name>
     <description>
-<![CDATA[<p>
-memset() called to fill 0 bytes.
-The second and third arguments might be inverted.
-The function memset ( void * ptr, int value, size_t num ) sets the first num bytes of the block of memory pointed by ptr to the specified value.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+memset() called to fill 0 bytes. The second and third arguments might
+be inverted. The function memset ( void * ptr, int value, size_t num )
+sets the first num bytes of the block of memory pointed by ptr to the
+specified value.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/687.html" target="_blank">CWE-687: Function Call With Incorrectly Specified Argument Value</a></p>
 ]]>
     </description>
@@ -2135,14 +2341,17 @@ The function memset ( void * ptr, int value, size_t num ) sets the first num byt
   </rule>
   <rule>
     <key>clarifyCalculation</key>
-    <name>Clarify calculation precedence for + and ?</name>
+    <name>Clarify calculation precedence for '+' and '?'.</name>
     <description>
-<![CDATA[<p>
-Clarify calculation precedence for + and ?
+      <![CDATA[
+      <p>
 Suspicious calculation. Please use parentheses to clarify the code.
-</p><h2>References</h2>
+The code <code>a+b?c:d</code> should be written as either <code>(a+b)?c:d</code> or
+<code>a+(b?c:d)</code>.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/783.html" target="_blank">CWE-783: Operator Precedence Logic Error</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>clarifyCalculation</internalKey>
@@ -2153,18 +2362,18 @@ Suspicious calculation. Please use parentheses to clarify the code.
   </rule>
   <rule>
     <key>clarifyCondition</key>
-    <name>Suspicious condition (assignment+comparison)</name>
+    <name>Suspicious condition (assignment + comparison)</name>
     <description>
 <![CDATA[
 <p>
 <ul>
-<li>Suspicious condition (assignment+comparison), it can be clarified with parentheses.</li
+<li>Suspicious condition (assignment + comparison), it can be clarified with parentheses.</li>
 <li>Suspicious expression. Boolean result is used in bitwise operation. The operator '!'
 and the comparison operators have higher precedence than bitwise operators.
-It is recommended that the expression is clarified with parentheses.</li
+It is recommended that the expression is clarified with parentheses.</li>
 <li>Suspicious condition (bitwise operator + comparison).
 Comparison operators have higher precedence than bitwise operators.
-Please clarify the condition with parentheses.</li
+Please clarify the condition with parentheses.</li>
 </ul>
 </p>
 <h2>References</h2>
@@ -2197,16 +2406,17 @@ String literal doesn't match length argument for substr().
   </rule>
   <rule>
     <key>incrementboolean</key>
-    <name>Suspicious use of the postfix '++' operator on a boolean</name>
+    <name>Incrementing a variable of type 'bool' with postfix operator++ is deprecated by the C++ Standard. You should assign it the value 'true' instead.</name>
     <description>
-<![CDATA[
-<p>
-The operand of a postfix increment operator may be of type bool but it is deprecated by C++ Standard (Annex D-1) 
-and the operand is always set to true. You should assign it the value 'true' instead.
+      <![CDATA[
+      <p>
+The operand of a postfix increment operator may be of type bool but it
+is deprecated by C++ Standard (Annex D-1) and the operand is always
+set to true. You should assign it the value 'true' instead.
 </p>
 <h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>incrementboolean</internalKey>
@@ -2241,13 +2451,15 @@ and the operand is always set to true. You should assign it the value 'true' ins
   </rule>
   <rule>
     <key>duplicateBranch</key>
-    <name>Redundant 'if' and 'else' branches</name>
+    <name>Found duplicate branches for 'if' and 'else'</name>
     <description>
-<![CDATA[<p>
-Found duplicate branches for if and else.
-Finding the same code in an 'if' and related 'else' branch is suspicious and might indicate a cut and paste or logic error.
-Please examine this code carefully to determine if it is correct.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Finding the same code in an 'if' and related 'else' branch is
+suspicious and might indicate a cut and paste or logic error. Please
+examine this code carefully to determine if it is correct.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
 ]]>
     </description>
@@ -2262,12 +2474,13 @@ Please examine this code carefully to determine if it is correct.
     <key>duplicateExpression</key>
     <name>Same expression on both sides of '&amp;&amp;'</name>
     <description>
-      Same expression on both sides of '&amp;&amp;'.
-<![CDATA[<p>
-Same expression on both sides of '&&' or '||'.
-Finding the same expression on both sides of an operator is suspicious and might 
-indicate a cut and paste or logic error. Please examine this code carefully to determine if it is correct.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Finding the same expression on both sides of an operator is suspicious
+and might indicate a cut and paste or logic error. Please examine this
+code carefully to determine if it is correct.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
 ]]>
     </description>
@@ -2282,10 +2495,13 @@ indicate a cut and paste or logic error. Please examine this code carefully to d
     <key>duplicateBreak</key>
     <name>Consecutive return, break, continue, goto or throw statements are unnecessary</name>
     <description>
-<![CDATA[<p>
-Consecutive return, break, continue, goto or throw statements are unnecessary.
-The second statement can never be executed, and so should be removed.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Consecutive return, break, continue, goto or throw statements are
+unnecessary. The second statement can never be executed, and so should
+be removed.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/561.html" target="_blank">CWE-561: Dead Code</a></p>
 ]]>
     </description>
@@ -2300,10 +2516,12 @@ The second statement can never be executed, and so should be removed.
     <key>unsignedLessThanZero</key>
     <name>Checking if unsigned variable is less than zero</name>
     <description>
-<![CDATA[<p>
-Checking if unsigned variable is less than zero.
-The unsigned variable 'varname' will never be negative so it is either pointless or an error to check if it is
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+The unsigned variable 'varname' will never be negative so it is either
+pointless or an error to check if it is.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/570.html" target="_blank">CWE-570: Expression is Always False</a></p>
 ]]>
     </description>
@@ -2318,9 +2536,12 @@ The unsigned variable 'varname' will never be negative so it is either pointless
     <key>unsignedPositive</key>
     <name>An unsigned variable can't be negative so it is unnecessary to test it</name>
     <description>
-<![CDATA[<p>
-An unsigned variable can't be negative so it is unnecessary to test it.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Unsigned variable 'varname' can't be negative so it is unnecessary to
+test it.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/570.html" target="_blank">CWE-570: Expression is Always False</a></p>
 ]]>
     </description>
@@ -2373,15 +2594,14 @@ Same iterator is used with two different containers.
   </rule>
   <rule>
     <key>mismatchingContainers</key>
-    <name>Mismatching containers</name>
+    <name>Iterators of different containers are used together</name>
     <description>
-<![CDATA[
-<p>
-Iterators of different containers are used together
-</p>
-<h2>References</h2>
+      <![CDATA[
+      <p>
+Iterators of different containers are used together.
+</p><h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/664.html" target="_blank">CWE-664: Improper Control of a Resource Through its Lifetime</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <tag>bug</tag>
@@ -2395,10 +2615,10 @@ Iterators of different containers are used together
     <key>eraseDereference</key>
     <name>Dereferenced iterator an already erased iterator</name>
     <description>
-<![CDATA[
-<p>
-Dereferenced iterator an already erased iterator.
-Dereferencing or comparing it with another iterator is invalid operation.
+      <![CDATA[
+      <p>
+The iterator 'iter' is invalid before being assigned. Dereferencing or
+comparing it with another iterator is invalid operation.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/664.html" target="_blank">CWE-664: Improper Control of a Resource Through its Lifetime</a></p>
@@ -2418,7 +2638,7 @@ Dereferencing or comparing it with another iterator is invalid operation.
     <description>
 <![CDATA[
 <p>
-When <code>i==foo.size()</code> foo[i] or foo.at(i) is out of bounds.
+When <code>i==foo.size()</code>, foo[i] or foo.at(i) is out of bounds.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/788.html" target="_blank">CWE-788: Access of Memory Location After End of Buffer</a></p>
@@ -2434,15 +2654,16 @@ When <code>i==foo.size()</code> foo[i] or foo.at(i) is out of bounds.
   </rule>
   <rule>
     <key>invalidIterator2</key>
-    <name>Iterators may get invalid after push_back|push_front|insert</name>
+    <name>After push_back|push_front|insert(), the iterator 'iterator' may be invalid</name>
     <description>
-<![CDATA[
-<p>
-Iterators may get invalid after push_back|push_front|insert.
+      <![CDATA[
+      <p>
+After push_back|push_front|insert(), the iterator 'iterator' may be
+invalid.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/664.html" target="_blank">CWE-664: Improper Control of a Resource Through its Lifetime</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <tag>bug</tag>
@@ -2458,13 +2679,14 @@ Iterators may get invalid after push_back|push_front|insert.
     <description>
 <![CDATA[
 <p>
-Invalid pointer after push_back / push_front.
+Invalid pointer after push_back() / push_front().
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/664.html" target="_blank">CWE-664: Improper Control of a Resource Through its Lifetime</a></p>
 ]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>invalidPointer</internalKey>
     <severity>MAJOR</severity>
     <type>BUG</type>
@@ -2486,11 +2708,14 @@ Invalid pointer after push_back / push_front.
   </rule>
   <rule>
     <key>stlIfFind</key>
-    <name>Suspicious condition. The result of find is an iterator, but it is not properly checked</name>
+    <name>Suspicious condition. The result of find() is an iterator, but it is not properly checked</name>
     <description>
-<![CDATA[<p>
-Suspicious condition. The result of find is an iterator, but it is not properly checked.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Suspicious condition. The result of find() is an iterator, but it is
+not properly checked.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
 ]]>
     </description>
@@ -2503,13 +2728,17 @@ Suspicious condition. The result of find is an iterator, but it is not properly 
   </rule>
   <rule>
     <key>stlIfStrFind</key>
-    <name>Suspicious checking of string::find() return value</name>
+    <name>Inefficient usage of string::find() in condition; string::compare() would be faster</name>
     <description>
-<![CDATA[<p>
-Inefficient usage of string::find() in condition; string::compare() would be faster.
-Either inefficient or wrong usage of string::find(). string::compare() will be faster if string::find's result is compared with 0, because it will not scan the whole 
-string. If your intention is to check that there are no findings in the string, you should compare with std::string::npos
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Either inefficient or wrong usage of string::find(). string::compare()
+will be faster if string::find's result is compared with 0, because it
+will not scan the whole string. If your intention is to check that
+there are no findings in the string, you should compare with
+std::string::npos.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/597.html" target="_blank">CWE-597: Use of Wrong Operator in String Comparison</a></p>
 ]]>
     </description>
@@ -2522,11 +2751,12 @@ string. If your intention is to check that there are no findings in the string, 
   </rule>
   <rule>
     <key>stlcstr</key>
-    <name>Dangerous usage of c_str(). The returned value by c_str() is invalid after this call</name>
+    <name>Dangerous usage of c_str(). The value returned by c_str() is invalid after this call</name>
     <description>
-<![CDATA[
-<p>
-Dangerous usage of c_str(). The returned value by c_str() is invalid after this call.
+      <![CDATA[
+      <p>
+Dangerous usage of c_str(). The c_str() return value is only valid
+until its string is deleted.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/664.html" target="_blank">CWE-664: Improper Control of a Resource Through its Lifetime</a></p>
@@ -2541,12 +2771,15 @@ Dangerous usage of c_str(). The returned value by c_str() is invalid after this 
   </rule>
   <rule>
     <key>stlSize</key>
-    <name>Prefer .empty() to .size() == 0 for emptiness checking</name>
+    <name>Possible inefficient checking for 'list' emptiness</name>
     <description>
-
-<![CDATA[<p>
-Possible inefficient checking for emptiness. Using .empty() instead of .size() can be faster.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Checking for 'list' emptiness might be inefficient. Using list.empty()
+instead of list.size() can be faster. list.size() can take linear time
+but list.empty() is guaranteed to take constant time.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
 ]]>
     </description>
@@ -2561,13 +2794,14 @@ Possible inefficient checking for emptiness. Using .empty() instead of .size() c
     <key>redundantIfRemove</key>
     <name>Redundant checking of STL container element</name>
     <description>
-.
-<![CDATA[<p>
-Redundant checking of STL container element.
-It is safe to call the remove method on a non-existing element.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+Redundant checking of STL container element existence before removing
+it. It is safe to call the remove method on a non-existing element.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>redundantIfRemove</internalKey>
@@ -2580,12 +2814,15 @@ It is safe to call the remove method on a non-existing element.
     <key>useAutoPointerCopy</key>
     <name>Be careful when using 'auto_ptr' copy</name>
     <description>
-<![CDATA[<p>
-Copying 'auto_ptr' pointer to another does not create two equal objects since one has lost its ownership of the pointer.
-'std::auto_ptr' has semantics of strict ownership, meaning that the 'auto_ptr' instance is the sole entity responsible for the object's lifetime. If an 'auto_ptr' is copied, the source looses the reference.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+'std::auto_ptr' has semantics of strict ownership, meaning that the
+'auto_ptr' instance is the sole entity responsible for the object's
+lifetime. If an 'auto_ptr' is copied, the source looses the reference.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>useAutoPointerCopy</internalKey>
@@ -2598,11 +2835,12 @@ Copying 'auto_ptr' pointer to another does not create two equal objects since on
     <key>useAutoPointerContainer</key>
     <name>Don't store 'auto-ptr' in a STL container</name>
     <description>
-<![CDATA[
-<p>
-You can randomly lose access to pointers if you store 'auto_ptr' pointers in a container because the copy-semantics of 'auto_ptr' are not compatible with containers.
-An element of container must be able to be copied but 'auto_ptr' does not fulfill this requirement. You should consider to use 'shared_ptr' or 'unique_ptr'.
-It is suitable for use in containers, because they no longer copy their values, they move them.
+      <![CDATA[
+      <p>
+An element of container must be able to be copied but 'auto_ptr' does
+not fulfill this requirement. You should consider to use 'shared_ptr'
+or 'unique_ptr'. It is suitable for use in containers, because they no
+longer copy their values, they move them.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/664.html" target="_blank">CWE-664: Improper Control of a Resource Through its Lifetime</a></p>
@@ -2619,10 +2857,12 @@ It is suitable for use in containers, because they no longer copy their values, 
     <key>useAutoPointerArray</key>
     <name>Usage of 'auto_ptr' for pointers obtained with operator 'new[]'</name>
     <description>
-<![CDATA[
-<p>
-Object pointed by an 'auto_ptr' is destroyed using operator 'delete'. This means that you should only use 'auto_ptr' for pointers obtained with operator 'new'.
-This excludes arrays, which are allocated by operator 'new[]' and must be deallocated by operator 'delete[]'.
+      <![CDATA[
+      <p>
+Object pointed by an 'auto_ptr' is destroyed using operator 'delete'.
+This means that you should only use 'auto_ptr' for pointers obtained
+with operator 'new'. This excludes arrays, which are allocated by
+operator 'new[]' and must be deallocated by operator 'delete[]'.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/664.html" target="_blank">CWE-664: Improper Control of a Resource Through its Lifetime</a></p>
@@ -2640,9 +2880,12 @@ This excludes arrays, which are allocated by operator 'new[]' and must be deallo
     <key>uninitstring</key>
     <name>Dangerous usage of variable (strncpy doesn't always 0-terminate it)</name>
     <description>
-<![CDATA[<p>
-Dangerous usage of variable (strncpy doesn't always 0-terminate it).
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Dangerous usage of variable (strncpy doesn't always null-terminate
+it).
+</p>
+<h2>References</h2>
 <p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=482" target="_blank">EXP33-C. Do not read uninitialized memory</a></p>
 <p><a href="https://cwe.mitre.org/data/definitions/676.html" target="_blank">CWE-676: Use of Potentially Dangerous Function</a></p>
 ]]>
@@ -2658,10 +2901,11 @@ Dangerous usage of variable (strncpy doesn't always 0-terminate it).
   </rule>
   <rule>
     <key>uninitdata</key>
-    <name>Data is allocated but not initialized</name>
+    <name>Memory is allocated but not initialized: varname</name>
     <description>
-<![CDATA[<p>
-Data is allocated but not initialized.
+      <![CDATA[
+      <p>
+Memory is allocated but not initialized
 </p><h2>References</h2>
 <p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=482" target="_blank">EXP33-C. Do not read uninitialized memory</a></p>
 <p><a href="https://cwe.mitre.org/data/definitions/908.html" target="_blank">CWE-908: Use of Uninitialized Resource</a></p>
@@ -2697,11 +2941,13 @@ The function is never used.
     <key>unusedVariable</key>
     <name>Unused variable</name>
     <description>
-<![CDATA[<p>
-      Unused variable.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/563.html" target="_blank">CWE-563: Assignment to Variable without Use ('Unused Variable')</a></p>
-]]>
+      <![CDATA[
+      <p>
+Unused variable
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/563.html" target="_blank">CWE-563: Assignment to Variable without Use</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>unusedVariable</internalKey>
@@ -2717,8 +2963,8 @@ The function is never used.
 <![CDATA[<p>
 Variable is allocated memory that is never used.
 </p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/563.html" target="_blank">CWE-563: Assignment to Variable without Use ('Unused Variable')</a></p>
-]]>
+<p><a href="https://cwe.mitre.org/data/definitions/563.html" target="_blank">CWE-563: Assignment to Variable without Use</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>unusedAllocatedMemory</internalKey>
@@ -2734,8 +2980,8 @@ Variable is allocated memory that is never used.
 <![CDATA[<p>
 Variable is assigned a value that is never used.
 </p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/563.html" target="_blank">CWE-563: Assignment to Variable without Use ('Unused Variable')</a></p>
-]]>
+<p><a href="https://cwe.mitre.org/data/definitions/563.html" target="_blank">CWE-563: Assignment to Variable without Use</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>unreadVariable</internalKey>
@@ -2768,8 +3014,8 @@ Variable is not assigned a value.
 <![CDATA[<p>
 Struct or union member is never used.
 </p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/563.html" target="_blank">CWE-563: Assignment to Variable without Use ('Unused Variable')</a></p>
-]]>
+<p><a href="https://cwe.mitre.org/data/definitions/563.html" target="_blank">CWE-563: Assignment to Variable without Use</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>unusedStructMember</internalKey>
@@ -2782,12 +3028,16 @@ Struct or union member is never used.
     <key>postfixOperator</key>
     <name>Prefer prefix ++/-- operators for non-primitive types</name>
     <description>
-<![CDATA[<p>
-Pre-increment/decrement can be more efficient than post-increment/decrement. Post-increment/decrement usually involves
-keeping a copy of the previous value around and adds a little extra code.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+Prefix ++/-- operators should be preferred for non-primitive types.
+Pre-increment/decrement can be more efficient than post-
+increment/decrement. Post-increment/decrement usually involves keeping
+a copy of the previous value around and adds a little extra code.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>postfixOperator</internalKey>
@@ -2887,7 +3137,7 @@ keeping a copy of the previous value around and adds a little extra code.
     <key>preprocessorErrorDirective</key>
     <name>Preprocessor directive error</name>
     <description>
-      Preprocessor directive error.
+      Preprocessor directive <code>#error message</code>.
     </description>
     <internalKey>preprocessorErrorDirective</internalKey>
     <severity>MAJOR</severity>
@@ -2899,8 +3149,16 @@ keeping a copy of the previous value around and adds a little extra code.
     <key>publicAllocationError</key>
     <name>Possible leak in public function</name>
     <description>
-      Possible leak in public function. The pointer is not deallocated before it is allocated.
+      <![CDATA[
+      <p>
+Possible leak in public function. The pointer 'varname' is not
+deallocated before it is allocated.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>publicAllocationError</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -2924,15 +3182,17 @@ The size argument is given as a char constant.
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
-  <!-- ########### New in cppcheck 1.51 ########### -->
   <rule>
     <key>bufferNotZeroTerminated</key>
     <name>Buffer is not zero-terminated</name>
     <description>
-<![CDATA[<p>
-A buffer is not zero-terminated after a call to a function.
-This will cause bugs later in the code if the code assumes the buffer is null-terminated.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+The buffer is not null-terminated after the call to
+strncpy(). This will cause bugs later in the code if the code assumes
+the buffer is null-terminated.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/170.html" target="_blank">CWE-170: Improper Null Termination</a></p>
 ]]>
     </description>
@@ -2945,16 +3205,19 @@ This will cause bugs later in the code if the code assumes the buffer is null-te
   </rule>
   <rule>
     <key>initializerList</key>
-    <name>Member variable is in wrong order in the initializer list</name>
+    <name>Member variable is in the wrong place in the initializer list</name>
     <description>
-<![CDATA[<p>
-Member variable is in wrong order in the initializer list.
-Member variable 'classname::varname' is in the wrong place in the initializer list.
-Members are initialized in the order they are declared, not in the order they are in the initializer list.
-Keeping the initializer list in the same order that the members were declared prevents order dependent initialization errors.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+Member variable 'class::variable' is in the wrong place in the
+initializer list. Members are initialized in the order they are
+declared, not in the order they are in the initializer list.  Keeping
+the initializer list in the same order that the members were declared
+prevents order dependent initialization errors.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>initializerList</internalKey>
@@ -2967,13 +3230,16 @@ Keeping the initializer list in the same order that the members were declared pr
     <key>possibleBufferAccessOutOfBounds</key>
     <name>Possible buffer overflow if strlen(source) is larger than or equal to sizeof(destination)</name>
     <description>
-<![CDATA[<p>
-Possible buffer overflow if strlen(source) is larger than or equal to sizeof(destination).
-The source buffer is larger than or equal the destination buffer so there is the potential for overflowing the destination buffer.
-</p><h2>References</h2>
-<p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=47677453" target="_blank">ARR30-C. Do not form or use out-of-bounds pointers or array subscripts</a></p>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+Possible buffer overflow if strlen(source) is larger than or equal to
+sizeof(destination). The source buffer is larger than the destination
+buffer so there is the potential for overflowing the destination
+buffer.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>bug</tag>
     <tag>cert</tag>
@@ -2986,12 +3252,14 @@ The source buffer is larger than or equal the destination buffer so there is the
   </rule>
   <rule>
     <key>returnAddressOfFunctionParameter</key>
-    <name>Return the address of a function parameter</name>
+    <name>Address of function parameter returned.</name>
     <description>
-<![CDATA[
-<p>
-Address of the function parameter 'varname' becomes invalid after the function exits because
-function parameters are stored on the stack which is freed when the function exits. Thus the returned value is invalid.
+      <![CDATA[
+      <p>
+Address of the function parameter 'parameter' becomes invalid after
+the function exits because function parameters are stored on the stack
+which is freed when the function exits. Thus the returned value is
+invalid.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/562.html" target="_blank">CWE-562: Return of Stack Variable Address</a></p>
@@ -3047,13 +3315,14 @@ function parameters are stored on the stack which is freed when the function exi
     <key>boostForeachError</key>
     <name>Invalid usage of BOOST_FOREACH</name>
     <description>
-<![CDATA[
-<p>
-BOOST_FOREACH caches the end() iterator. It's undefined behavior if you modify the container inside.
+      <![CDATA[
+      <p>
+BOOST_FOREACH caches the end() iterator. It's undefined behavior if
+ you modify the container inside.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/664.html" target="_blank">CWE-664: Improper Control of a Resource Through its Lifetime</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <tag>bug</tag>
@@ -3101,10 +3370,11 @@ Invalid usage of output stream: '<< std::cout'.
   </rule>
   <rule>
     <key>incorrectStringBooleanError</key>
-    <name>Suspicious comparison of boolean with a string literal</name>
+    <name>Conversion of string literal to bool always evaluates to true</name>
     <description>
-<![CDATA[<p>
-A boolean comparison with the string literal is always true.
+      <![CDATA[
+      <p>
+Conversion of string literal to bool always evaluates to true.
 </p><h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/571.html" target="_blank">CWE-571: Expression is Always True</a></p>
 ]]>
@@ -3121,11 +3391,13 @@ A boolean comparison with the string literal is always true.
     <key>stringCompare</key>
     <name>Comparison of identical string variables</name>
     <description>
-<![CDATA[<p>
-Comparison of identical string variables.
+      <![CDATA[
+      <p>
+Comparison of identical string variables. This
+could be a logic bug.
 </p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/570.html" target="_blank">CWE-571: Expression is Always True</a></p>
-]]>
+<p><a href="https://cwe.mitre.org/data/definitions/571.html" target="_blank">CWE-571: Expression is Always True</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>stringCompare</internalKey>
@@ -3167,9 +3439,14 @@ Statements following return, break, continue, goto or throw will never be execut
     <key>uselessCallsCompare</key>
     <name>It is inefficient to call 'str.find(str)' as it always returns 0</name>
     <description>
-<![CDATA[<p>
-It is inefficient to call 'str.find(str)' as it always returns 0.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+'std::string::find()' returns zero when given itself as parameter
+(str.find(str)). As it is currently the code is inefficient. It is
+possible either the string searched ('str') or searched for ('str') is
+wrong.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/628.html" target="_blank">CWE-628: Function Call with Incorrectly Specified Arguments</a></p>
 ]]>
     </description>
@@ -3184,11 +3461,13 @@ It is inefficient to call 'str.find(str)' as it always returns 0.
     <key>uselessCallsSwap</key>
     <name>It is inefficient to swap a object with itself by calling 'str.swap(str)'</name>
     <description>
-<![CDATA[<p>
-It is inefficient to swap a object with itself by calling 'str.swap(str)'.
-The 'swap()' function has no logical effect when given itself as parameter ('varname.swap('varname')).
-As it is currently the code is inefficient. Is the object or the parameter wrong here?"
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+The 'swap()' function has no logical effect when given itself as
+parameter (varname.swap(varname)). As it is currently the code is inefficient.
+Is the object or the parameter wrong here?
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/628.html" target="_blank">CWE-628: Function Call with Incorrectly Specified Arguments</a></p>
 ]]>
     </description>
@@ -3203,11 +3482,14 @@ As it is currently the code is inefficient. Is the object or the parameter wrong
     <key>uselessCallsSubstr</key>
     <name>Function 'substr' useless call. Function create copy of the 'str' object</name>
     <description>
-<![CDATA[<p>
-Useless call of function 'substr' because it returns a copy of the object. Use operator= instead.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+Ineffective call of function 'substr' because it returns a copy of the
+object. Use operator= instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>uselessCallsSubstr</internalKey>
@@ -3268,14 +3550,16 @@ Memory or resource handle is freed twice.
     <key>invalidPrintfArgType_s</key>
     <name>Invalid printf argument type (character pointer required)</name>
     <description>
-      Invalid printf argument type (character pointer required).
-<![CDATA[<p>
-Invalid printf argument type (character pointer required).
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+%s in format string requires 'char *'
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/686.html" target="_blank">CWE-686: Function Call With Incorrect Argument Type</a></p>
 ]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>invalidPrintfArgType_s</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3286,13 +3570,16 @@ Invalid printf argument type (character pointer required).
     <key>invalidPrintfArgType_n</key>
     <name>Invalid printf argument type (integer pointer required)</name>
     <description>
-<![CDATA[<p>
-Invalid printf argument type (integer pointer required).
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+%n in format string requires 'int *'
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/686.html" target="_blank">CWE-686: Function Call With Incorrect Argument Type</a></p>
 ]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>invalidPrintfArgType_n</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3303,13 +3590,16 @@ Invalid printf argument type (integer pointer required).
     <key>invalidPrintfArgType_p</key>
     <name>Invalid printf argument type (integer or pointer required)</name>
     <description>
-<![CDATA[<p>
-Invalid printf argument type (integer or pointer required).
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+%p in format string requires an address
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/686.html" target="_blank">CWE-686: Function Call With Incorrect Argument Type</a></p>
 ]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>invalidPrintfArgType_p</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3337,13 +3627,16 @@ Invalid printf argument type (integer required).
     <key>invalidPrintfArgType_sint</key>
     <name>Invalid printf argument type (signed integer required)</name>
     <description>
-<![CDATA[<p>
-Invalid printf argument type (signed integer required).
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+%i in format string requires 'int'
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/686.html" target="_blank">CWE-686: Function Call With Incorrect Argument Type</a></p>
 ]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>invalidPrintfArgType_sint</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3354,13 +3647,16 @@ Invalid printf argument type (signed integer required).
     <key>invalidPrintfArgType_float</key>
     <name>Invalid printf argument type (floating point number required)</name>
     <description>
-<![CDATA[<p>
-Invalid printf argument type (floating point number required).
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+%f in format string requires 'double'
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/686.html" target="_blank">CWE-686: Function Call With Incorrect Argument Type</a></p>
 ]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>invalidPrintfArgType_float</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3478,8 +3774,6 @@ Wrong number of parameters given to printf().
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
-
-  <!-- ########### New in cppcheck 1.54 ########### -->
   <rule>
     <key>uninitMemberVar</key>
     <name>Member variable is not initialized in the constructor</name>
@@ -3524,8 +3818,14 @@ Redundant condition: If <code>x > 11</code> the condition <code>x > 10</code> is
     <key>invalidPointerCast</key>
     <name>Invalid pointer casting</name>
     <description>
-      This casting is not portable due to different binary data representations on different platforms.
+      <![CDATA[
+      <p>
+      This casting is not portable due to different binary data representation.
+</p><h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/704.html" target="_blank">CWE-704: Incorrect Type Conversion or Cast</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>invalidPointerCast</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -3536,13 +3836,18 @@ Redundant condition: If <code>x > 11</code> the condition <code>x > 10</code> is
     <key>virtualDestructor</key>
     <name>Base classes should have virtual destructors</name>
     <description>
-<![CDATA[
-<p>
-Class Base which is inherited by class Derived does not have a virtual destructor.
+      <![CDATA[
+      <p>
+Class 'Base' which is inherited by class 'Derived' does not have a
+virtual destructor. If you destroy instances of the derived class by
+deleting a pointer that points to the base class, only the destructor
+of the base class is executed. Thus, dynamic memory that is managed by
+the derived class could leak. This can be avoided by adding a virtual
+destructor to the base class.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/404.html" target="_blank">CWE-404: Improper Resource Shutdown or Release</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>virtualDestructor</internalKey>
@@ -3575,10 +3880,13 @@ Memory allocated inside the called function is not freed by the caller function.
     <key>stlcstrReturn</key>
     <name>Redundant c_str()-conversion in functions return</name>
     <description>
-<![CDATA[<p>
-Returning the result of c_str() in a function that returns std::string is slow and redundant.
-The conversion from const char* as returned by c_str() to std::string creates an unnecessary string copy. Solve that by directly returning the string.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+The conversion from const char* as returned by c_str() to std::string
+creates an unnecessary string copy. Solve that by directly returning
+the string.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/704.html" target="_blank">CWE-704: Incorrect Type Conversion or Cast</a></p>
 ]]>
     </description>
@@ -3593,10 +3901,13 @@ The conversion from const char* as returned by c_str() to std::string creates an
     <key>stlcstrParam</key>
     <name>Redundant c_str()-conversion in parameter passing</name>
     <description>
-<![CDATA[<p>
-Passing the result of c_str() to a function that takes std::string as argument 0 is slow and redundant.
-The conversion from const char* as returned by c_str() to std::string creates an unnecessary string copy. Solve that by directly returning the string.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+The conversion from const char* as returned by c_str() to std::string
+creates an unnecessary string copy. Solve that by directly passing the
+string.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/704.html" target="_blank">CWE-704: Incorrect Type Conversion or Cast</a></p>
 ]]>    </description>
     <tag>cwe</tag>
@@ -3606,16 +3917,18 @@ The conversion from const char* as returned by c_str() to std::string creates an
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
-
-  <!-- ########### New in cppcheck 1.54 ########### -->
   <rule>
     <key>StlMissingComparison</key>
     <name>Missing bounds check for extra iterator increment in loop</name>
     <description>
-<![CDATA[<p>
-Missing bounds check for extra iterator increment in loop. The iterator incrementing is suspicious - it is incremented at line 'line-number-1' and then at line 'line-number-2'
-The loop might unintentionally skip an element in the container. There is no comparison between these increments to prevent that the iterator is incremented beyond the end.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+The iterator incrementing is suspicious - it is incremented at line
+and then at line . The loop might unintentionally skip an element in
+the container. There is no comparison between these increments to
+prevent that the iterator is incremented beyond the end.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/834.html" target="_blank">CWE-834: Excessive Iteration</a></p>
 ]]>
     </description>
@@ -3630,9 +3943,25 @@ The loop might unintentionally skip an element in the container. There is no com
     <key>strncatUsage</key>
     <name>Dangerous usage of strncat</name>
     <description>
-      Dangerous usage of strncat - 3rd parameter is the maximum number of characters to append.
-      strncat appends at max its 3rd parameter's amount of characters. The safe way to use strncat is to calculate remaining space in the buffer and use it as 3rd parameter.
+      <![CDATA[
+      <p>
+At most, strncat appends the 3rd parameter's amount of characters and
+adds a terminating null byte.
+The safe way to use strncat is to
+subtract one from the remaining space in the buffer and use it as 3rd
+parameter.
+</p>
+<p>
+Source:
+http://www.cplusplus.com/reference/cstring/strncat/
+<p>
+Source: http://www.opensource.apple.com/source/Libc/Libc-167/gen.subproj/i386.subproj/strncat.c
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/119.html" target="_blank">CWE-119: Improper Restriction of Operations within the Bounds of a Memory Buffer</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>strncatUsage</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3646,11 +3975,13 @@ The loop might unintentionally skip an element in the container. There is no com
     <name>Returning an integer in a function with pointer return type is not portable</name>
     <description>
       <![CDATA[
-<p>
-Returning an integer (int/long/etc) in a function with pointer return type is not portable across different
-platforms and compilers. For example in 32-bit Windows and Linux they are same width, but in 64-bit Windows
-and Linux they are of different width. In worst case you end up casting 64-bit integer down to 32-bit pointer.
-The safe way is to always return a pointer.
+      <p>
+Returning an integer (int/long/etc) in a function with pointer return
+type is not portable across different platforms and compilers. For
+example in 32-bit Windows and Linux they are same width, but in 64-bit
+Windows and Linux they are of different width. In worst case you end
+up casting 64-bit integer down to 32-bit pointer. The safe way is to
+always return a pointer.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/758.html" target="_blank">CWE-758: Reliance on Undefined, Unspecified, or Implementation-Defined Behavior</a></p>
@@ -3667,9 +3998,11 @@ The safe way is to always return a pointer.
     <key>IOWithoutPositioning</key>
     <name>Read and write operations without a call to a positioning function</name>
     <description>
-<![CDATA[
-<p>
-Read and write operations without a call to a positioning function (fseek, fsetpos or rewind) or fflush in between result in undefined behavior.
+      <![CDATA[
+      <p>
+Read and write operations without a call to a positioning function
+(fseek, fsetpos or rewind) or fflush in between result in undefined
+behaviour.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/664.html" target="_blank">CWE-664: Improper Control of a Resource Through its Lifetime</a></p>
@@ -3705,14 +4038,12 @@ Boolean variable 'varname' is used in bitwise operation. Did you mean '&&' or '|
     <key>deallocret</key>
     <name>Returning/dereferencing variable after it is deallocated / released</name>
     <description>
-      Returning/dereferencing variable after it is deallocated / released.
-<![CDATA[
-<p>
-Assignment of function parameter has no effect outside the function.
-</p>
-<h2>References</h2>
+      <![CDATA[
+      <p>
+Returning/dereferencing 'p' after it is deallocated / released
+</p><h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/672.html" target="_blank">CWE-672: Operation on a Resource after Expiration or Release</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <tag>bug</tag>
@@ -3724,11 +4055,11 @@ Assignment of function parameter has no effect outside the function.
   </rule>
   <rule>
     <key>invalidScanfFormatWidth</key>
-    <name>wrong width for scanf parameter</name>
+    <name>Wrong width for scanf parameter</name>
     <description>
 <![CDATA[
 <p>
-Width 'parameter' given in format string (no. 'symbol' ) doesn't match destination buffer.
+Width 'parameter' given in format string (no. 'symbol' ) doesn't match destination buffer, use %-1s to prevent overflowing it.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/687.html" target="_blank">CWE-687: Function Call With Incorrectly Specified Argument Value</a></p>
@@ -3756,15 +4087,16 @@ Width 'parameter' given in format string (no. 'symbol' ) doesn't match destinati
   </rule>
   <rule>
     <key>moduloAlwaysTrueFalse</key>
-    <name>Comparison of modulo result is predetermined</name>
+    <name>Comparison of modulo result is predetermined, because it is always less than 'number'.</name>
     <description>
-<![CDATA[
-<p>
-Comparison of modulo result is predetermined.
+      <![CDATA[
+      <p>
+Comparison of modulo result is predetermined, because it is always
+less than 'number'.
 </p>
 <h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>moduloAlwaysTrueFalse</internalKey>
@@ -3777,10 +4109,13 @@ Comparison of modulo result is predetermined.
     <key>pointerSize</key>
     <name>Using size of pointer variable instead of size of its data</name>
     <description>
-<![CDATA[<p>
-Using size of pointer variable instead of size of its data.
-This is likely to lead to a buffer overflow. You probably intend to write 'sizeof(*varname)'.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Size of pointer 'varname' used instead of size of its data. This is
+likely to lead to a buffer overflow. You probably intend to write
+'sizeof(*varname)'.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/467.html" target="_blank">CWE-467: Use of sizeof() on a Pointer Type</a></p>
 ]]>
     </description>
@@ -3873,13 +4208,15 @@ Used file that is not opened.
   </rule>
   <rule>
     <key>useInitializationList</key>
-    <name>member variable shall be initialized using constructor</name>
+    <name>Member variable shall be initialized using initialization list</name>
     <description>
-<![CDATA[
-<p>
-When an object of a class is created, the constructors of all member variables are called consecutively
-in the order the variables are declared, even if you don't explicitly write them to the initialization list.
-You could avoid assigning 'symbol' a value by passing the value to the constructor in the initialization list.
+      <![CDATA[
+      <p>
+When an object of a class is created, the constructors of all member
+variables are called consecutively in the order the variables are
+declared, even if you don't explicitly write them to the
+initialization list. You could avoid assigning 'variable' a value by
+passing the value to the constructor in the initialization list.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
@@ -3917,9 +4254,13 @@ Write operation on a file that was opened only for reading.
     <key>clarifyStatement</key>
     <name>Check statement and clarify behavior</name>
     <description>
-<![CDATA[<p>
-A statement like '*A++;' might not do what you intended. 'operator*' is executed before postfix 'operator++'. Thus, the dereference is meaningless. Did you intend to write '(*A)++;'?
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+A statement like '*A++;' might not do what you intended. Postfix
+'operator++' is executed before 'operator*'. Thus, the dereference is
+meaningless. Did you intend to write '(*A)++;'?
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/783.html" target="_blank">CWE-783: Operator Precedence Logic Error</a></p>
 ]]>
     </description>
@@ -3946,8 +4287,21 @@ A statement like '*A++;' might not do what you intended. 'operator*' is executed
     <key>functionStatic</key>
     <name>The member function 'funcname' can be static</name>
     <description>
-      The member function 'funcname' can be static.
+      <![CDATA[
+      <p>
+The member function 'class::function' can be made a static function.
+Making a function static can bring a performance benefit since no
+'this' instance is passed to the function. This change should not
+cause compiler errors but it does not necessarily make sense
+conceptually. Think about your design and the task of the function
+first - is it a function that must not access members of class
+instances?
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>functionStatic</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -3958,10 +4312,14 @@ A statement like '*A++;' might not do what you intended. 'operator*' is executed
     <key>incompleteArrayFill</key>
     <name>Array 'buffer' is filled incompletely</name>
     <description>
-<![CDATA[<p>
-Array 'buffer' is filled incompletely. Did you forget to multiply the size given to 'function()' with 'sizeof(*buffer)'?
-The array 'buffer' is filled incompletely. The function 'function()' needs the size given in bytes, but an element of the given array is larger than one byte.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+The array 'buffer' is filled incompletely. The function 'function()'
+needs the size given in bytes, but an element of the given array is
+larger than one byte. Did you forget to multiply the size with
+'sizeof(*buffer)'?
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/131.html" target="_blank">CWE-131: Incorrect Calculation of Buffer Size</a></p>
 ]]>
     </description>
@@ -3977,12 +4335,13 @@ The array 'buffer' is filled incompletely. The function 'function()' needs the s
     <name>Invalid printf argument type (unsigned integer required)</name>
     <description>
 <![CDATA[<p>
-Invalid printf argument type (unsigned integer required)
+%u in format string (no. 1) requires 'unsigned int'
 </p><h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/686.html" target="_blank">CWE-686: Function Call With Incorrect Argument Type</a></p>
 ]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>invalidPrintfArgType_uint</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3993,14 +4352,17 @@ Invalid printf argument type (unsigned integer required)
     <key>literalWithCharPtrCompare</key>
     <name>String literal compared with a variable</name>
     <description>
-<![CDATA[<p>
-String literal compared with a variable.
-Char literal compared with pointer 'var'. Did you intend to dereference it?
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+String literal compared with variable 'foo'. Did you intend to use
+strcmp() instead?
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/595.html" target="_blank">CWE-595: Comparison of Object References Instead of Object Contents</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>literalWithCharPtrCompare</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -4011,13 +4373,17 @@ Char literal compared with pointer 'var'. Did you intend to dereference it?
     <key>pointerLessThanZero</key>
     <name>A pointer can not be negative so it is either pointless or an error to check if it is</name>
     <description>
-<![CDATA[<p>
-A pointer can not be negative so it is either pointless or an error to check if it is.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+A pointer can not be negative so it is either pointless or an error to
+check if it is.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/570.html" target="_blank">CWE-570: Expression is Always False</a></p>
 ]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>pointerLessThanZero</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -4028,9 +4394,12 @@ A pointer can not be negative so it is either pointless or an error to check if 
     <key>pointerPositive</key>
     <name>A pointer can not be negative so it is either pointless or an error to check if it is not</name>
     <description>
-<![CDATA[<p>
-A pointer can not be negative so it is either pointless or an error to check if it is not..
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+A pointer can not be negative so it is either pointless or an error to
+check if it is not.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/570.html" target="_blank">CWE-570: Expression is Always False</a></p>
 ]]>
     </description>
@@ -4045,8 +4414,17 @@ A pointer can not be negative so it is either pointless or an error to check if 
     <key>redundantCopyLocalConst</key>
     <name>Use const reference for 'varname' to avoid unnecessary data copying</name>
     <description>
-      Use const reference for 'varname' to avoid unnecessary data copying.
+      <![CDATA[
+      <p>
+The const variable 'varname' is assigned a copy of the data. You can
+avoid the unnecessary data copying by converting 'varname' to const
+reference.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>redundantCopyLocalConst</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -4057,12 +4435,13 @@ A pointer can not be negative so it is either pointless or an error to check if 
     <key>shiftNegative</key>
     <name>Shifting by a negative value</name>
     <description>
-<![CDATA[<p>
-Shifting a negative value is undefined behaviour.
+      <![CDATA[
+      <p>
+Shifting by a negative value is undefined behaviour
 </p><h2>References</h2>
 <p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=4385" target="_blank">INT34-C. Do not shift an expression by a negative number of bits or by greater than or equal to the number of bits that exist in the operand</a></p>
 <p><a href="https://cwe.mitre.org/data/definitions/758.html" target="_blank">CWE-758: Reliance on Undefined, Unspecified, or Implementation-Defined Behavior</a></p>
-]]>
+    ]]>
     </description>
     <tag>bug</tag>
     <tag>cert</tag>
@@ -4087,10 +4466,11 @@ Shifting a negative value is undefined behaviour.
   </rule>
   <rule>
     <key>uselessCallsEmpty</key>
-    <name>Useless call of function 'empty()'</name>
+    <name>Ineffective call of function 'empty()'. Did you intend to call 'clear()' instead?</name>
     <description>
-<![CDATA[<p>
-Useless call of function 'empty()'. Did you intend to call 'clear()' instead?
+      <![CDATA[
+      <p>
+Ineffective call of function 'empty()'. Did you intend to call 'clear()' instead?
 </p><h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
 ]]>
@@ -4104,13 +4484,16 @@ Useless call of function 'empty()'. Did you intend to call 'clear()' instead?
   </rule>
   <rule>
     <key>uselessCallsRemove</key>
-    <name>Return value of std::remove() ignored</name>
+    <name>Return value of std::remove() ignored. Elements remain in container</name>
     <description>
-<![CDATA[<p>
-Return value of std::remove() ignored.
-This function returns an iterator to the end of the range containing those elements that should be kept. 
-Elements past new end remain valid but with unspecified values. Use the erase method of the container to delete them.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+The return value of std::remove() is ignored. This function returns an
+iterator to the end of the range containing those elements that should
+be kept. Elements past new end remain valid but with unspecified
+values. Use the erase method of the container to delete them.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/762.html" target="_blank">CWE-762: Mismatched Memory Management Routines</a></p>
 ]]>
     </description>
@@ -4127,7 +4510,9 @@ Elements past new end remain valid but with unspecified values. Use the erase me
       Skipping configuration 'X' since the value of 'X' is unknown
     </name>
     <description>
+      <![CDATA[
       Skipping configuration 'X' since the value of 'X' is unknown. Use -D if you want to check it. You can use -U to skip it explicitly.
+    ]]>
     </description>
     <internalKey>ConfigurationNotChecked</internalKey>
     <severity>MAJOR</severity>
@@ -4137,13 +4522,15 @@ Elements past new end remain valid but with unspecified values. Use the erase me
   </rule>
   <rule>
     <key>toomanyconfigs</key>
-    <name>
-      Too many #ifdef configurations - cppcheck only checks 12 configurations
-    </name>
+    <name>Too many #ifdef configurations - cppcheck only checks 12 configurations</name>
     <description>
-<![CDATA[
-<p>
-Too many #ifdef configurations - cppcheck only checks 12 configurations. Use --force to check all configurations. For more details, use --enable=information.
+      <![CDATA[
+      <p>
+The checking of the file will be interrupted because there are too
+many #ifdef configurations. Checking of all #ifdef configurations can
+be forced by --force command line option or from GUI preferences.
+However that may increase the checking time. For more details, use
+--enable=information.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
@@ -4163,11 +4550,13 @@ Too many #ifdef configurations - cppcheck only checks 12 configurations. Use --f
     <name>Returning an address value in a function with integer return type is not portable</name>
     <description>
       <![CDATA[
-<p>
-Returning an address value in a function with integer (int/long/etc) return type is not portable across
-different platforms and compilers. For example in 32-bit Windows and Linux they are same width, but in
-64-bit Windows and Linux they are of different width. In worst case you end up casting 64-bit address down
-to 32-bit integer. The safe way is to always return an integer.
+      <p>
+Returning an address value in a function with integer (int/long/etc)
+return type is not portable across different platforms and compilers.
+For example in 32-bit Windows and Linux they are same width, but in
+64-bit Windows and Linux they are of different width. In worst case
+you end up casting 64-bit address down to 32-bit integer. The safe way
+is to always return an integer.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/758.html" target="_blank">CWE-758: Reliance on Undefined, Unspecified, or Implementation-Defined Behavior</a></p>
@@ -4184,13 +4573,15 @@ to 32-bit integer. The safe way is to always return an integer.
     <key>comparisonOfBoolWithBoolError</key>
     <name>Comparison of a variable having boolean value using relational (&lt;, &gt;, &lt;= or &gt;=) operator</name>
     <description>
-<![CDATA[
-<p>
-The variable 'expression' is of type 'bool' and comparing 'bool' value using relational (<, >, <= or >=) operator could cause unexpected results.
+      <![CDATA[
+      <p>
+The variable is of type 'bool' and comparing 'bool' value
+using relational (<, >, <= or >=) operator could cause unexpected
+results.
 </p>
 <h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-     ]]>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <tag>bug</tag>
@@ -4204,14 +4595,15 @@ The variable 'expression' is of type 'bool' and comparing 'bool' value using rel
     <key>comparisonOfFuncReturningBoolError</key>
     <name>Comparison of a function returning boolean value using relational (&lt;, &gt;, &lt;= or &gt;=) operator</name>
     <description>
-<![CDATA[
-<p>
-The return type of function 'expression1' and function 'expression2' is 'bool' and result is of type 'bool'. 
-Comparing 'bool' value using relational (<, >, <= or >=) operator could cause unexpected results.
+      <![CDATA[
+      <p>
+The return type of function is 'bool' and result is of
+type 'bool'. Comparing 'bool' value using relational (<, >, <= or >=)
+operator could cause unexpected results.
 </p>
 <h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <tag>bug</tag>
@@ -4225,14 +4617,15 @@ Comparing 'bool' value using relational (<, >, <= or >=) operator could cause un
     <key>comparisonOfTwoFuncsReturningBoolError</key>
     <name>Comparison of two functions returning boolean value using relational (&lt;, &gt;, &lt;= or &gt;=) operator</name>
     <description>
-<![CDATA[
-<p>
-The return type of function 'expression1' and function 'expression2' is 'bool' and result is of type 'bool'.
-Comparing 'bool' value using relational (<, >, <= or >=) operator could cause unexpected results.
+      <![CDATA[
+      <p>
+The return type of both functions is
+'bool' and result is of type 'bool'. Comparing 'bool' value using
+relational (<, >, <= or >=) operator could cause unexpected results.
 </p>
 <h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <tag>bug</tag>
@@ -4244,15 +4637,16 @@ Comparing 'bool' value using relational (<, >, <= or >=) operator could cause un
   </rule>
   <rule>
     <key>copyCtorPointerCopying</key>
-    <name>Value of pointer 'varname', which points to allocated memory, is copied in copy constructor instead of allocating new memory</name>
+    <name>Value of pointer 'var', which points to allocated memory, is copied in copy constructor instead of allocating new memory</name>
     <description>
-<![CDATA[
-<p>
-Value of pointer 'varname', which points to allocated memory, is copied in copy constructor instead of allocating new memory.
+      <![CDATA[
+      <p>
+Value of pointer 'var', which points to allocated memory, is copied in
+copy constructor instead of allocating new memory.
 </p>
 <h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>copyCtorPointerCopying</internalKey>
@@ -4292,11 +4686,12 @@ Value of pointer 'varname', which points to allocated memory, is copied in copy 
   </rule>
   <rule>
     <key>noCopyConstructor</key>
-    <name>class 'name' does not have a copy constructor which is recommended since the class contains a pointer to allocated memory</name>
+    <name>class 'class' does not have a copy constructor which is recommended since the class contains a pointer to allocated memory</name>
     <description>
-<![CDATA[
-<p>
-class 'name' does not have a copy constructor which is recommended since the class contains a pointer to allocated memory.
+      <![CDATA[
+      <p>
+class 'class' does not have a copy constructor which is recommended
+since the class contains a pointer to allocated memory.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
@@ -4311,15 +4706,14 @@ class 'name' does not have a copy constructor which is recommended since the cla
   </rule>
   <rule>
     <key>identicalConditionAfterEarlyExit</key>
-    <name>Identical condition &apos;x&apos;, second condition is always false</name>
+    <name>Identical condition 'x', second condition is always false</name>
     <description>
-<![CDATA[
-<p>
-Identical condition &apos;x&apos;, second condition is always false.
-</p>
-<h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+Identical condition 'x', second condition is always false
+</p><h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <tag>bug</tag>
@@ -4331,15 +4725,16 @@ Identical condition &apos;x&apos;, second condition is always false.
   </rule>
     <rule>
     <key>oppositeInnerCondition</key>
-    <name>Opposite conditions in nested 'if' blocks lead to a dead code block</name>
+    <name>Opposite inner 'if' condition leads to a dead code block</name>
     <description>
-<![CDATA[
-<p>
-Opposite conditions in nested 'if' blocks lead to a dead code block.
+      <![CDATA[
+      <p>
+Opposite inner 'if' condition leads to a dead code block (outer
+condition is 'x' and inner condition is '!x').
 </p>
 <h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <tag>bug</tag>
@@ -4353,8 +4748,14 @@ Opposite conditions in nested 'if' blocks lead to a dead code block.
     <key>redundantAssignment</key>
     <name>Variable 'var' is reassigned a value before the old one has been used</name>
     <description>
-      Variable 'var' is reassigned a value before the old one has been used.
+      <![CDATA[
+      <p>
+Variable 'var' is reassigned a value before the old one has been used.
+</p><h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/563.html" target="_blank">CWE-563: Assignment to Variable without Use</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>redundantAssignment</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -4365,8 +4766,16 @@ Opposite conditions in nested 'if' blocks lead to a dead code block.
     <key>redundantCopyInSwitch</key>
     <name>Buffer 'var' is being written before its old content has been used</name>
     <description>
-      Buffer 'var' is being written before its old content has been used. 'break;' missing?
+      <![CDATA[
+      <p>
+Buffer 'var' is being written before its old content has been used.
+'break;' missing?
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/563.html" target="_blank">CWE-563: Assignment to Variable without Use</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>redundantCopyInSwitch</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -4387,10 +4796,19 @@ Opposite conditions in nested 'if' blocks lead to a dead code block.
   </rule>
   <rule>
     <key>unsafeClassCanLeak</key>
-    <name>Class 'classname' is unsafe, 'varname' can leak by wrong usage</name>
+    <name>Class 'class' is unsafe, 'class::varname' can leak by wrong usage</name>
     <description>
-      Class 'classname' is unsafe, 'varname' can leak by wrong usage.
+      <![CDATA[
+      <p>
+The class 'class' is unsafe, wrong usage can cause memory/resource
+leaks for 'class::varname'. This can for instance be fixed by adding
+proper cleanup in the destructor.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>unsafeClassCanLeak</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -4401,25 +4819,31 @@ Opposite conditions in nested 'if' blocks lead to a dead code block.
     <key>redundantCopy</key>
     <name>Buffer 'var' is being written before its old content has been used</name>
     <description>
-      Buffer 'var' is being written before its old content has been used.
+      <![CDATA[
+      <p>
+Buffer 'var' is being written before its old content has been used.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/563.html" target="_blank">CWE-563: Assignment to Variable without Use</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>redundantCopy</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
-
-  <!-- ########### New in cppcheck 1.58 ########### -->
   <rule>
     <key>argumentSize</key>
     <name>
       Passing too small array as argument.
     </name>
     <description>
-<![CDATA[
-<p>
-The array 'varname' is too small, the function 'functionName' expects a bigger one.
+      <![CDATA[
+      <p>
+The array 'array' is too small, the function 'function' expects a
+bigger one.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
@@ -4437,29 +4861,37 @@ The array 'varname' is too small, the function 'functionName' expects a bigger o
   <!-- ########### New in cppcheck 1.59 ########### -->
   <rule>
     <key>checkCastIntToCharAndBack</key>
-    <name>
-      Storing func_name() return value in char variable and then comparing with EOF.
-    </name>
+    <name>Storing func_name() return value in char variable and then comparing with EOF</name>
     <description>
-      Storing func_name() return value in char variable and then comparing with EOF.
+      <![CDATA[
+      <p>
+When saving func_name() return value in char variable there is loss of
+precision.  When func_name() returns EOF this value is truncated.
+Comparing the char variable with EOF can have unexpected results. For
+instance a loop "while (EOF != (c = func_name());" loops forever on
+some compilers/platforms and on other compilers/platforms it will stop
+when the file contains a matching character.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/197.html" target="_blank">CWE-197: Numeric Truncation Error</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>checkCastIntToCharAndBack</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
-
   <rule>
     <key>mallocOnClassError</key>
-    <name>
-       Memory for class instance allocated with malloc(), but class provides constructors.
-    </name>
+    <name>Memory for class instance allocated with malloc(), but class provides constructors</name>
     <description>
-<![CDATA[
-<p>
+      <![CDATA[
+      <p>
 Memory for class instance allocated with malloc(), but class provides constructors.
-This is unsafe, since no constructor is called and class members remain uninitialized. Consider using 'new' instead.
+This is unsafe, since no constructor is called and class
+members remain uninitialized. Consider using 'new' instead.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/665.html" target="_blank">CWE-665: Improper Initialization</a></p>
@@ -4473,17 +4905,15 @@ This is unsafe, since no constructor is called and class members remain uninitia
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
-
   <rule>
     <key>mallocOnClassWarning</key>
-    <name>
-      Memory for class instance allocated with malloc(), but class provides constructors.
-    </name>
+    <name>Memory for class instance allocated with malloc(), but class provides constructors</name>
     <description>
-<![CDATA[
-<p>
-Memory for class instance allocated with malloc(), but class provides constructors.
-This is unsafe, since no constructor is called and class members remain uninitialized. Consider using 'new' instead.
+      <![CDATA[
+      <p>
+Memory for class instance allocated with malloc(), but class provides
+constructors. This is unsafe, since no constructor is called and class
+members remain uninitialized. Consider using 'new' instead.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/762.html" target="_blank">CWE-762: Mismatched Memory Management Routines</a></p>
@@ -4496,20 +4926,17 @@ This is unsafe, since no constructor is called and class members remain uninitia
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
-
   <rule>
     <key>mismatchingBitAnd</key>
-    <name>
-      Mismatching bitmasks.
-    </name>
+    <name>Mismatching bitmasks</name>
     <description>
 <![CDATA[
 <p>
 Mismatching bitmasks. Result is always 0
-<code>
+<pre>
 X = Y & 0xf0; 
 Z = X & 0x1;
-</code>
+</pre>
 results => Z=0
 </p>
 <h2>References</h2>
@@ -4523,14 +4950,13 @@ results => Z=0
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
-
   <rule>
     <key>missingIncludeSystem</key>
-    <name>
-      Included files not found.
-    </name>
+    <name>Include file not found</name>
     <description>
-      Include files not found. Please note: Cppcheck does not need standard library headers to get proper results.
+      <![CDATA[
+      Include file not found. Please note: Cppcheck does not need standard library headers to get proper results.
+    ]]>
     </description>
     <tag>tool-error</tag>
     <internalKey>missingIncludeSystem</internalKey>
@@ -4539,18 +4965,15 @@ results => Z=0
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
-
   <rule>
     <key>stlBoundaries</key>
-    <name>
-      Dangerous iterator comparison using operator &lt;.
-    </name>
+    <name>Dangerous comparison using operator&lt; on iterator</name>
     <description>
-<![CDATA[
-<p>
-Dangerous iterator comparison using 'operator<' on iterator.
-This is dangerous since the order of items in the container is not guaranteed. 
-One should use 'operator!=' instead to compare iterators.
+      <![CDATA[
+      <p>
+Iterator compared with <code>operator<</code>. This is dangerous since the order of
+items in the container is not guaranteed. One should use <code>operator!=</code>
+instead to compare iterators.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/664.html" target="_blank">CWE-664: Improper Control of a Resource Through its Lifetime</a></p>
@@ -4563,27 +4986,19 @@ One should use 'operator!=' instead to compare iterators.
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
-
   <rule>
     <key>tooBigSleepTime</key>
-    <name>
-      Invalid argument for usleep
-    </name>
-    <description>
-      The argument of usleep must be less than 1000000.
-    </description>
+    <name>Invalid argument for usleep</name>
+    <description>The argument of usleep must be less than 1000000.</description>
     <internalKey>tooBigSleepTime</internalKey>
     <severity>MAJOR</severity>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
-
   <rule>
     <key>uninitStructMember</key>
-    <name>
-      Uninitialized struct member
-    </name>
+    <name>Uninitialized struct member</name>
     <description>
 <![CDATA[<p>
 Missing initialization for a struct member.
@@ -4601,20 +5016,18 @@ Missing initialization for a struct member.
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
-
   <rule>
     <key>uselessAssignmentPtrArg</key>
-    <name>
-      Effectless function parameter assignment.
-    </name>
+    <name>Effectless function parameter assignment</name>
     <description>
-<![CDATA[
-<p>
-Assignment of function parameter has no effect outside the function. Did you forget dereferencing it?
+      <![CDATA[
+      <p>
+Assignment of function parameter has no effect outside the function.
+Did you forget dereferencing it?
 </p>
 <h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <tag>bug</tag>
@@ -4624,54 +5037,69 @@ Assignment of function parameter has no effect outside the function. Did you for
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
-
   <rule>
     <key>varFuncNullUB</key>
-    <name>
-      Passing NULL after the last typed argument to a variadic function leads to undefined behavior.
-    </name>
+    <name>Passing NULL after the last typed argument to a variadic function leads to undefined behaviour</name>
     <description>
-<![CDATA[<p>
-Passing NULL after the last typed argument to a variadic function leads to undefined behavior.
-The C99 standard, in section 7.15.1.1, states that if the type used by va_arg() is not compatible with the type of the actual next argument (as promoted according to the default argument promotions), the behavior is undefined.
-The value of the NULL macro is an implementation-defined null pointer constant (7.17), which can be any integer constant expression with the value 0, or such an expression casted to (void*) (6.3.2.3). This includes values like 0, 0L, or even 0LL.
-To reproduce you might be able to use this little code example on 64bit platforms. If the output includes "ERROR", the sentinel had only 4 out of 8 bytes initialized to zero and was not detected as the final argument to stop argument processing via va_arg().
-Changing the 0 to (void*)0 or 0L will make the "ERROR" output go away.
-
+      <![CDATA[
+      <p>
+Passing NULL after the last typed argument to a variadic function
+leads to undefined behaviour.
+The C99 standard, in section
+7.15.1.1, states that if the type used by va_arg() is not compatible
+with the type of the actual next argument (as promoted according to
+the default argument promotions), the behavior is undefined.
+The
+value of the NULL macro is an implementation-defined null pointer
+constant (7.17), which can be any integer constant expression with the
+value 0, or such an expression casted to (void*) (6.3.2.3). This
+includes values like 0, 0L, or even 0LL.
+In practice on common
+architectures, this will cause real crashes if sizeof(int) !=
+sizeof(void*), and NULL is defined to 0 or any other null pointer
+constant that promotes to int.
+To reproduce you might be able to
+use this little code example on 64bit platforms. If the output
+includes "ERROR", the sentinel had only 4 out of 8 bytes initialized
+to zero and was not detected as the final argument to stop argument
+processing via va_arg(). Changing the 0 to (void*)0 or 0L will make
+the "ERROR" output go away.
+<pre>
 #include <stdarg.h>
 #include <stdio.h>
 
 void f(char *s, ...) {
-va_list ap;
-    va_start(ap,s);
-    for (;;) {
-        char *p = va_arg(ap,char*);
-        printf(\"%018p, %s\\n\", p, (long)p & 255 ? p : \"\");
-        if(!p) break;
-    }
-    va_end(ap);
+  va_list ap;
+  va_start(ap,s);
+  for (;;) {
+    char *p = va_arg(ap,char*);
+    printf("%018p, %s\n", p, (long)p & 255 ? p : "");
+    if(!p) break;
+  }
+  va_end(ap);
 }
 
 void g() {
-    char *s2 = \"x\";
-    char *s3 = \"ERROR\";
+  char *s2 = "x";
+  char *s3 = "ERROR";
 
-    // changing 0 to 0L for the 7th argument (which is intended to act as sentinel) makes the error go away on x86_64
-    f(\"first\", s2, s2, s2, s2, s2, 0, s3, (char*)0);
+  // changing 0 to 0L for the 7th argument (which is intended to act as sentinel) makes the error go away on x86_64
+  f("first", s2, s2, s2, s2, s2, 0, s3, (char*)0);
 }
 
 void h() {
-    int i;
-    volatile unsigned char a[1000];
-    for (i = 0; i<sizeof(a); i++)
-        a[i] = -1;
+  int i;
+  volatile unsigned char a[1000];
+  for (i = 0; i<sizeof(a); i++)
+    a[i] = -1;
 }
 
 int main() {
-    h();
-    g();
-    return 0;
-}"
+  h();
+  g();
+  return 0;
+}
+</pre>
 </p><h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/475.html" target="_blank">CWE-475: Undefined Behavior for Input to API</a></p>
 ]]>
@@ -4687,12 +5115,8 @@ int main() {
 
   <rule>
     <key>writeOutsideBufferSize</key>
-    <name>
-      Writing '1' bytes outside buffer size.
-    </name>
-    <description>
-      Writing '1' bytes outside buffer size.
-    </description>
+    <name>Writing '1' bytes outside buffer size.</name>
+    <description>Writing '1' bytes outside buffer size.</description>
     <tag>bug</tag>
     <internalKey>writeOutsideBufferSize</internalKey>
     <severity>MAJOR</severity>
@@ -4703,19 +5127,21 @@ int main() {
 
   <rule>
     <key>wrongPipeParameterSize</key>
-    <name>
-      A buffer must have size of 2 integers if used as parameter of pipe().
-    </name>
+    <name>Buffer must have size of 2 integers if used as parameter of pipe()</name>
     <description>
-<![CDATA[
-<p>
-A buffer must have size of 2 integers if used as parameter of pipe().
+      <![CDATA[
+      <p>
+The pipe()/pipe2() system command takes an argument, which is an array
+of exactly two integers.
+The variable 'varname' is an array of size
+dimension, which does not match.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/686.html" target="_blank">CWE-686: Function Call With Incorrect Argument Type</a></p>
 ]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>wrongPipeParameterSize</internalKey>
     <severity>MAJOR</severity>
     <type>BUG</type>
@@ -4726,9 +5152,7 @@ A buffer must have size of 2 integers if used as parameter of pipe().
   <rule>
     <key>class_X_Y</key>
     <name>Unhandled code</name>
-    <description>
-      This code is not handled. You can use -I or --include to add handling of this code.
-    </description>
+    <description>This code is not handled. You can use -I or --include to add handling of this code.</description>
     <internalKey>class_X_Y</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -4739,14 +5163,14 @@ A buffer must have size of 2 integers if used as parameter of pipe().
   <!-- ########### New in cppcheck 1.60 ########### -->
   <rule>
     <key>derefInvalidIterator</key>
-    <name>
-      Possible dereference of an invalid iterator
-    </name>
+    <name>Possible dereference of an invalid iterator</name>
     <description>
-<![CDATA[<p>
-Possible dereference of an invalid iterator
-Make sure to check that the iterator is valid before dereferencing it - not after.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Make sure to check that the iterator is valid before dereferencing it
+- not after.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/825.html" target="_blank">CWE-825: Expired Pointer Dereference</a></p>
 ]]>
     </description>
@@ -4761,14 +5185,16 @@ Make sure to check that the iterator is valid before dereferencing it - not afte
   <!-- ########### New in cppcheck 1.61 ########### -->
   <rule>
     <key>arithOperationsOnVoidPointer</key>
-    <name>
-      Undefined pointer calculation behavior
-    </name>
+    <name>Undefined pointer calculation behaviour</name>
     <description>
-<![CDATA[<p>
-When using void pointers in calculations, the behavior is undefined.
-Arithmetic operations on 'void *' is a GNU C extension, which defines the 'sizeof(void)' to be 1.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+When using void pointers in
+calculations, the behaviour is undefined. Arithmetic operations on
+'void *' is a GNU C extension, which defines the 'sizeof(void)' to be
+1.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/467.html" target="_blank">CWE-467: Use of sizeof() on a Pointer Type</a></p>
 ]]>
     </description>
@@ -4782,22 +5208,26 @@ Arithmetic operations on 'void *' is a GNU C extension, which defines the 'sizeo
   </rule>
   <rule>
     <key>commaSeparatedReturn</key>
-    <name>
-      Usage of comma in return statements
-    </name>
+    <name>Usage of comma in return statements</name>
     <description>
-
-<![CDATA[<p>
-Do not use the comma in return statements: it can be easily be misread as a ';'.
-Comma is used in return statement. When comma is used in a return statement it can easily be misread as a semicolon.
-For example in the code below the value of 'b' is returned if the condition is true, but it is easy to think that 'a+1' is returned:
-   if (x)
+      <![CDATA[
+      <p>
+Comma is used in return statement. When comma is used in a return
+statement it can easily be misread as a semicolon. For example in the
+code below the value of 'b' is returned if the condition is true, but
+it is easy to think that 'a+1' is returned:
+<pre>
+  if (x)
     return a + 1,
-    b++;
-However it can be useful to use comma in macros. Cppcheck does not warn when such a macro is then used in a return statement, it is less likely such code is misunderstood.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+  b++;
+</pre>
+However it can be useful to use comma in
+macros. Cppcheck does not warn when such a macro is then used in a
+return statement, it is less likely such code is misunderstood.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>commaSeparatedReturn</internalKey>
@@ -4808,13 +5238,14 @@ However it can be useful to use comma in macros. Cppcheck does not warn when suc
   </rule>
   <rule>
     <key>nanInArithmeticExpression</key>
-    <name>
-      Using NaN/Inf in a computation.
-    </name>
+    <name>Using NaN/Inf in a computation</name>
     <description>
-<![CDATA[<p>
-Using NaN/Inf in a computation.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Using NaN/Inf in a computation. Although nothing bad really happens,
+it is suspicious.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/369.html" target="_blank">CWE-369: Divide By Zero</a></p>
 ]]>
     </description>
@@ -4828,13 +5259,16 @@ Using NaN/Inf in a computation.
   </rule>
   <rule>
     <key>sizeofDereferencedVoidPointer</key>
-    <name>
-      Usage of 'sizeof' on dereferenced void pointer.
-    </name>
+    <name>Usage of 'sizeof' on dereferenced void pointer</name>
     <description>
-<![CDATA[<p>
-The behavior of 'sizeof(void)' is not covered by the ISO C standard.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+'*varname' is of type 'void', the behaviour of 'sizeof(void)' is not
+covered by the ISO C standard. A value for 'sizeof(void)' is defined
+only as part of a GNU C extension, which defines 'sizeof(void)' to be
+1.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/682.html" target="_blank">CWE-682: Incorrect Calculation</a></p>
 ]]>
     </description>
@@ -4848,14 +5282,15 @@ The behavior of 'sizeof(void)' is not covered by the ISO C standard.
   </rule>
   <rule>
     <key>sizeofVoid</key>
-    <name>
-      Behavior of 'sizeof(void)' is undefined
-    </name>
+    <name>Behaviour of 'sizeof(void)' is not covered by the ISO C standard</name>
     <description>
-<![CDATA[<p>
-Behavior of 'sizeof(void)' is not covered by the ISO C standard.
-A value for 'sizeof(void)' is defined only as part of a GNU C extension, which defines 'sizeof(void)' to be 1.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Behaviour of 'sizeof(void)' is not covered by the ISO C standard. A
+value for 'sizeof(void)' is defined only as part of a GNU C extension,
+which defines 'sizeof(void)' to be 1.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/682.html" target="_blank">CWE-682: Incorrect Calculation</a></p>
 ]]>
     </description>
@@ -4869,12 +5304,10 @@ A value for 'sizeof(void)' is defined only as part of a GNU C extension, which d
   </rule>
   <rule>
     <key>wrongPrintfScanfParameterPositionError</key>
-    <name>
-      printf: referencing parameter 2 while 1 arguments given.
-    </name>
+    <name>printf: referencing wrong parameter index</name>
     <description>
 <![CDATA[<p>
-printf: referencing parameter 2 while 1 arguments given.
+printf: referencing parameter 'x' while 'y' arguments given.
 </p><h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/685.html" target="_blank">CWE-685: Function Call With Incorrect Number of Arguments</a></p>
 ]]>
@@ -4889,12 +5322,8 @@ printf: referencing parameter 2 while 1 arguments given.
   </rule>
   <rule>
     <key>obsoleteFunctionsctime_r</key>
-    <name>
-      Obsolete function 'ctime_r' called
-    </name>
-    <description>
-      Obsolete function 'ctime_r' called. It is recommended to use the function 'strftime' instead.
-    </description>
+    <name>Obsolete function 'ctime_r' called</name>
+    <description>Obsolete function 'ctime_r' called. It is recommended to use the function 'strftime' instead</description>
     <internalKey>obsoleteFunctionsctime_r</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -4905,13 +5334,12 @@ printf: referencing parameter 2 while 1 arguments given.
   <!-- ########### New in cppcheck 1.62 ########### -->
   <rule>
     <key>duplInheritedMember</key>
-    <name>
-      Redefinition of a member variable in a subclass.
-    </name>
+    <name>Redefinition of a member variable in a subclass</name>
     <description>
-<![CDATA[
-<p>
- A subclass defines a member variable which is already defined in its parent class.
+      <![CDATA[
+      <p>
+The class 'derived' defines member variable with name 'variable' also
+defined in its parent class 'base'.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
@@ -4926,11 +5354,13 @@ printf: referencing parameter 2 while 1 arguments given.
   </rule>
   <rule>
     <key>invalidScanfArgType_int</key>
-    <name>Mismatch in string format: 'unsigned int *' vs 'DWORD *'</name>
+    <name>Invalid scanf argument type (int pointer required)</name>
     <description>
-<![CDATA[<p>
-The format string requires 'unsigned int *' but the argument type is 'DWORD * {aka unsigned long *}'
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+%d in format string requires 'int *'
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/686.html" target="_blank">CWE-686: Function Call With Incorrect Argument Type</a></p>
 ]]>
     </description>
@@ -4944,11 +5374,13 @@ The format string requires 'unsigned int *' but the argument type is 'DWORD * {a
   </rule>
   <rule>
     <key>invalidScanfArgType_float</key>
-    <name>Mismatch in string format: 'float *' vs Unknown</name>
+    <name>Invalid scanf argument type (float pointer required)</name>
     <description>
-<![CDATA[<p>
-%f in format string requires 'float *' but the argument type is Unknown.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+%f in format string requires 'float *'
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/686.html" target="_blank">CWE-686: Function Call With Incorrect Argument Type</a></p>
 ]]>
     </description>
@@ -4962,11 +5394,13 @@ The format string requires 'unsigned int *' but the argument type is 'DWORD * {a
   </rule>
   <rule>
     <key>invalidScanfArgType_s</key>
-    <name>Mismatch in string format: 'char *' vs Unknown</name>
+    <name>Invalid scanf argument type (char pointer required)</name>
     <description>
-<![CDATA[<p>
-%s in format string requires a 'char *' but the argument type is Unknown.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+%s in format string requires a 'char *'
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/686.html" target="_blank">CWE-686: Function Call With Incorrect Argument Type</a></p>
 ]]>
     </description>
@@ -4982,8 +5416,17 @@ The format string requires 'unsigned int *' but the argument type is 'DWORD * {a
     <key>comparisonFunctionIsAlwaysTrueOrFalse</key>
     <name>Suspicious variable comparison with isless()</name>
     <description>
-      Comparison of two identical variables with isless(varName,varName) evaluates always to false.
+      <![CDATA[
+      <p>
+The function isless is designed to compare two variables. Calling this
+function with one variable (varName) for both parameters leads to a
+statement which is always false.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/570.html" target="_blank">CWE-570: Expression is Always False</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <tag>bug</tag>
     <internalKey>comparisonFunctionIsAlwaysTrueOrFalse</internalKey>
     <severity>MINOR</severity>
@@ -4995,12 +5438,15 @@ The format string requires 'unsigned int *' but the argument type is 'DWORD * {a
     <key>zerodivcond</key>
     <name>Either the condition is redundant or there is division by zero</name>
     <description>
-<![CDATA[<p>
+      <![CDATA[
+      <p>
 Either the condition is redundant or there is division by zero.
-</p><h2>References</h2>
-<p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=624" target="_blank">INT33-C. Ensure that division and remainder operations do not result in divide-by-zero errors</a></p>
-]]>
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/369.html" target="_blank">CWE-369: Divide By Zero</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <tag>bug</tag>
     <tag>cert</tag>
     <internalKey>zerodivcond</internalKey>
@@ -5016,11 +5462,11 @@ Either the condition is redundant or there is division by zero.
     <name>Assert with side effect</name>
     <description>
       <![CDATA[
-<p>
-Non-pure function: 'functionName' is called inside assert statement.
+      <p>
+Non-pure function: 'function' is called inside assert statement.
 Assert statements are removed from release builds so the code inside
-assert statement is not executed. If the code is needed also in release
-builds, this is a bug.
+assert statement is not executed. If the code is needed also in
+release builds, this is a bug.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
@@ -5038,14 +5484,15 @@ builds, this is a bug.
     <key>pointerArithBool</key>
     <name>Pointer arithmetic conversion</name>
     <description>
-<![CDATA[
-<p>
-Converting pointer arithmetic result to bool. The boolean result is always true unless there is pointer arithmetic overflow, 
-and overflow is undefined behaviour. Probably a dereference is forgotten.
+      <![CDATA[
+      <p>
+Converting pointer arithmetic result to bool. The boolean result is
+always true unless there is pointer arithmetic overflow, and overflow
+is undefined behaviour. Probably a dereference is forgotten.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/571.html" target="_blank">CWE-571: Expression is Always True</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <tag>bug</tag>
@@ -5057,10 +5504,10 @@ and overflow is undefined behaviour. Probably a dereference is forgotten.
   </rule>
   <rule>
     <key>leakReturnValNotUsed</key>
-    <name>Leak return value</name>
+    <name>Leak of return value</name>
     <description>
 <![CDATA[<p>
-Return value of allocation function is not used.
+Return value of allocation function is not stored.
 </p><h2>References</h2>
 <p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=445" target="_blank">MEM31-C. Free dynamically allocated memory when no longer needed</a></p>
 <p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=17924853" target="_blank">EXP12-C. Do not ignore values returned by functions</a></p>
@@ -5077,11 +5524,11 @@ Return value of allocation function is not used.
   </rule>
   <rule>
     <key>invalidFunctionArg</key>
-    <name>Invalid func_name() argument nr 1. The value is 0 or 1 (boolean) but the valid values are '1:4'</name>
+    <name>Invalid value range of function argument</name>
     <description>
-<![CDATA[
-<p>
-Invalid func_name() argument nr 1. The value is 0 or 1 (boolean) but the valid values are '1:4'.
+      <![CDATA[
+      <p>
+Invalid value range of function argument
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/628.html" target="_blank">CWE-628: Function Call with Incorrectly Specified Arguments</a></p>
@@ -5107,6 +5554,7 @@ A function gets passed an invalid argument. A non-boolean value is required.
 ]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>invalidFunctionArgBool</internalKey>
     <severity>MAJOR</severity>
     <type>BUG</type>
@@ -5117,12 +5565,12 @@ A function gets passed an invalid argument. A non-boolean value is required.
   <!-- ########### New in cppcheck 1.64 ########### -->
   <rule>
     <key>negativeMemoryAllocationSize</key>
-    <name>Memory allocation is negative</name>
+    <name>Memory allocation size is negative</name>
     <description>
-<![CDATA[
-<p>
-Memory allocation size have to be greater or equal to 0.
-Negative allocation size has no specified behaviour.
+      <![CDATA[
+      <p>
+Memory allocation size is negative.Negative allocation size has no
+specified behaviour.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/131.html" target="_blank">CWE-131: Incorrect Calculation of Buffer Size</a></p>
@@ -5140,8 +5588,18 @@ Negative allocation size has no specified behaviour.
     <key>memsetFloat</key>
     <name>Memset Float</name>
     <description>
-      The 2nd memset() argument is a float, its representation is implementation defined.
+      <![CDATA[
+      <p>
+The 2nd memset() argument 'varname' is a float, its representation is
+implementation defined. memset() is used to set each byte of a block
+of memory to a specific value and the actual representation of a
+floating-point value is implementation defined.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/688.html" target="_blank">CWE-688: Function Call With Incorrect Variable or Reference as Argument</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
     <internalKey>memsetFloat</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -5152,13 +5610,18 @@ Negative allocation size has no specified behaviour.
     <key>memsetValueOutOfRange</key>
     <name>Memset value out of range</name>
     <description>
-<![CDATA[<p>
-The 2nd memset() argument doesn't fit into an 'unsigned char'.
-</p><h2>References</h2>
-<p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=325" target="_blank">INT31-C. Ensure that integer conversions do not result in lost or misinterpreted data</a></p>
+      <![CDATA[
+      <p>
+The 2nd memset() argument 'varname' doesn't fit into an 'unsigned
+char'. The 2nd parameter is passed as an 'int', but the function fills
+the block of memory using the 'unsigned char' conversion of this
+value.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/686.html" target="_blank">CWE-686: Function Call With Incorrect Argument Type</a></p>
 ]]>
     </description>
+    <tag>cwe</tag>
     <tag>bug</tag>
     <tag>cert</tag>
     <tag>cwe</tag>
@@ -5222,8 +5685,17 @@ The 2nd memset() argument doesn't fit into an 'unsigned char'.
     <key>seekOnAppendedFile</key>
     <name>Repositioning operation in append mode</name>
     <description>
-      Repositioning operation performed on a file opened in append mode has no effect.
+      <![CDATA[
+      <p>
+Repositioning operation performed on a file opened in append mode has
+no effect.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>seekOnAppendedFile</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -5235,10 +5707,12 @@ The 2nd memset() argument doesn't fit into an 'unsigned char'.
     <key>arrayIndexOutOfBoundsCond</key>
     <name>Array index out of bounds</name>
     <description>
-<![CDATA[<p>
-The array access using this index may be out of bounds.
-</p><h2>References</h2>
-<p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=47677453" target="_blank">ARR30-C. Do not form or use out-of-bounds pointers or array subscripts</a></p>
+      <![CDATA[
+      <p>
+Array 'x[SZ]' accessed at larger index I, which is out of bounds. Otherwise
+condition '==I' is redundant.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/119.html" target="_blank">CWE-119: Improper Restriction of Operations within the Bounds of a Memory Buffer</a></p>
 ]]>
 </description>
@@ -5255,13 +5729,17 @@ The array access using this index may be out of bounds.
     <key>charLiteralWithCharPtrCompare</key>
     <name>Char literal compared with pointer</name>
     <description>
-<![CDATA[<p>
-Char literal compared with a pointer. Did you intend to dereference it?
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Char literal compared with a pointer. Did you intend to
+dereference it?
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/595.html" target="_blank">CWE-595: Comparison of Object References Instead of Object Contents</a></p>
 ]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>charLiteralWithCharPtrCompare</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -5286,9 +5764,10 @@ Char literal compared with a pointer. Did you intend to dereference it?
     <key>deadpointer</key>
     <name>Dead pointer usage</name>
     <description>
-<![CDATA[
-<p>
-Pointer &apos;pointer&apos; is dead if it has been assigned &apos;&amp;x&apos; at line 0.
+      <![CDATA[
+      <p>
+Dead pointer usage. Pointer 'pointer' is dead if it has been assigned
+'&x'.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/825.html" target="_blank">CWE-825: Expired Pointer Dereference</a></p>
@@ -5303,12 +5782,13 @@ Pointer &apos;pointer&apos; is dead if it has been assigned &apos;&amp;x&apos; a
   </rule>
   <rule>
     <key>ignoredReturnValue</key>
-    <name>Return value of  malloc() not used</name>
+    <name>Return value not used</name>
     <description>
-<![CDATA[<p>
-Return value of function malloc() is not used.
-</p><h2>References</h2>
-<p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=17924853" target="_blank">EXP12-C. Do not ignore values returned by functions</a></p>
+      <![CDATA[
+      <p>
+Return value of function f() is not used.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/252.html" target="_blank">CWE-252: Unchecked Return Value</a></p>
 ]]>
 </description>
@@ -5324,8 +5804,16 @@ Return value of function malloc() is not used.
     <key>integerOverflow</key>
     <name>Signed integer overflow for expression</name>
     <description>
-      Signed integer overflow for expression.
+      <![CDATA[
+      <p>
+Signed integer overflow for expression.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/190.html" target="_blank">CWE-190: Integer Overflow or Wraparound</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>integerOverflow</internalKey>
     <severity>MAJOR</severity>
     <type>BUG</type>
@@ -5346,18 +5834,20 @@ Return value of function malloc() is not used.
   </rule>
   <rule>
     <key>memsetClassFloat</key>
-    <name>memset is used on class which contains a floating point number</name>
+    <name>Using memset() on class which contains a floating point number</name>
     <description>
-<![CDATA[
-<p>
-Using memset() on class which contains a floating point number.
-This is not portable because memset() sets each byte of a block of memory to a specific value and
-the actual representation of a floating-point value is implementation defined.
-<i>Note: In case of an IEEE754-1985 compatible implementation setting all bits to zero results in the value 0.0.</i>
+      <![CDATA[
+      <p>
+Using memset() on class which contains a floating point number. This
+is not portable because memset() sets each byte of a block of memory
+to a specific value and the actual representation of a floating-point
+value is implementation defined. Note: In case of an IEEE754-1985
+compatible implementation setting all bits to zero results in the
+value 0.0.
 </p>
 <h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/590.html" target="_blank">CWE-590: Free of Memory not on the Heap</a></p>
-]]>
+<p><a href="https://cwe.mitre.org/data/definitions/758.html" target="_blank">CWE-758: Reliance on Undefined, Unspecified, or Implementation-Defined Behavior</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>memsetClassFloat</internalKey>
@@ -5368,15 +5858,15 @@ the actual representation of a floating-point value is implementation defined.
   </rule>
   <rule>
     <key>memsetClassReference</key>
-    <name>Using memory function on class that contains references</name>
+    <name>Using memory function on class that contains a reference</name>
     <description>
-<![CDATA[
-<p>
-Using "memfunc" on class that contains a reference.
+      <![CDATA[
+      <p>
+Using 'memfunc' on class that contains a reference.
 </p>
 <h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/590.html" target="_blank">CWE-590: Free of Memory not on the Heap</a></p>
-]]>
+<p><a href="https://cwe.mitre.org/data/definitions/665.html" target="_blank">CWE-665: Improper Initialization</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>memsetClassReference</internalKey>
@@ -5389,13 +5879,13 @@ Using "memfunc" on class that contains a reference.
     <key>selfInitialization</key>
     <name>Member variable is initialized by itself</name>
     <description>
-<![CDATA[
-<p>
+      <![CDATA[
+      <p>
 Member variable 'var' is initialized by itself.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/665.html" target="_blank">CWE-665: Improper Initialization</a></p>
-]]>
+    ]]>
     </description>
     <tag>cwe</tag>
     <tag>bug</tag>
@@ -5449,9 +5939,12 @@ Shifting signed 32-bit value by 31 bits is undefined behaviour.
     <key>signConversion</key>
     <name>Suspicious sign conversion of var in calculation</name>
     <description>
-<![CDATA[<p>
-Suspicious code: sign conversion of var in calculation, even though var can have a negative value.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Suspicious code: sign conversion of var in calculation, even though
+var can have a negative value
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/195.html" target="_blank">CWE-195: Signed to Unsigned Conversion Error</a></p>
 ]]>
     </description>
@@ -5466,9 +5959,12 @@ Suspicious code: sign conversion of var in calculation, even though var can have
     <key>sizeofDivisionMemfunc</key>
     <name>Suspicious calculation of memset() bytes size</name>
     <description>
-<![CDATA[<p>
-Division by result of sizeof(). memset() expects a size in bytes, did you intend to multiply instead?
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Division by result of sizeof(). memset() expects a size in bytes, did
+you intend to multiply instead?
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/682.html" target="_blank">CWE-682: Incorrect Calculation</a></p>
 ]]>
     </description>
@@ -5483,9 +5979,12 @@ Division by result of sizeof(). memset() expects a size in bytes, did you intend
     <key>unpreciseMathCall</key>
     <name>Avoid loss of precision for expression</name>
     <description>
-<![CDATA[<p>
-Expression '1 - erf(x)' can be replaced by 'erfc(x)' to avoid loss of precision.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Expression '1 - erf(x)' can be replaced by 'erfc(x)' to avoid loss of
+precision.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/758.html" target="_blank">CWE-758: Reliance on Undefined, Unspecified, or Implementation-Defined Behavior</a></p>
 ]]>
     </description>
@@ -5538,7 +6037,7 @@ va_list 'vl' was opened but not closed by va_end().
   </rule>
   <rule>
     <key>va_list_usedBeforeStarted</key>
-    <name>va_list used before va_start() call</name>
+    <name>va_list 'vl' used before va_start() was called</name>
     <description>
 <![CDATA[
 <p>
@@ -5559,9 +6058,10 @@ va_list 'vl' used before va_start() was called.
     <key>va_start_referencePassed</key>
     <name>Using reference as parameter for va_start() is undefined behaviour</name>
     <description>
-<![CDATA[
-<p>
-Using reference &apos;arg1&apos; as parameter for va_start() results in undefined behaviour.
+      <![CDATA[
+      <p>
+Using reference 'arg1' as parameter for va_start() results in
+undefined behaviour.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/758.html" target="_blank">CWE-758: Reliance on Undefined, Unspecified, or Implementation-Defined Behavior</a></p>
@@ -5579,9 +6079,10 @@ Using reference &apos;arg1&apos; as parameter for va_start() results in undefine
     <key>va_start_subsequentCalls</key>
     <name>va_start() or va_copy() called without va_end() inbetween</name>
     <description>
-<![CDATA[
-<p>
-va_start() or va_copy() called subsequently on 'vl' without va_end() inbetween.
+      <![CDATA[
+      <p>
+va_start() or va_copy() called subsequently on 'vl' without va_end()
+in between.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/664.html" target="_blank">CWE-664: Improper Control of a Resource Through its Lifetime</a></p>
@@ -5599,9 +6100,12 @@ va_start() or va_copy() called subsequently on 'vl' without va_end() inbetween.
     <key>va_start_wrongParameter</key>
     <name>Given argument to va_start() is not last one</name>
     <description>
-<![CDATA[<p>
-'arg1' given to va_start() is not last named argument of the function. Did you intend to pass 'arg2'?.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+'arg1' given to va_start() is not last named argument of the function.
+Did you intend to pass 'arg2'?
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/688.html" target="_blank">CWE-688: Function Call With Incorrect Variable or Reference as Argument</a></p>
 ]]>
     </description>
@@ -5629,12 +6133,14 @@ va_start() or va_copy() called subsequently on 'vl' without va_end() inbetween.
     <key>duplicateExpressionTernary</key>
     <name>Same expression in both branches of ternary operator</name>
     <description>
-<![CDATA[<p>
-Same expression in both branches of ternary operator.
-Finding the same expression in both branches of ternary operator is suspicious as the same code is executed regardless of the condition.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+Finding the same expression in both branches of ternary operator is
+suspicious as the same code is executed regardless of the condition.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>bug</tag>
     <tag>cwe</tag>
@@ -5648,11 +6154,16 @@ Finding the same expression in both branches of ternary operator is suspicious a
     <key>noExplicitConstructor</key>
     <name>Class has a constructor with 1 argument that is not explicit</name>
     <description>
-<![CDATA[<p>
-Class 'classname' has a constructor with 1 argument that is not explicit.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+Class 'classname' has a constructor with 1 argument that is not
+explicit. Such constructors should in general be explicit for type
+safety reasons. Using the explicit keyword in the constructor means
+some mistakes when using the class can be avoided.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>noExplicitConstructor</internalKey>
@@ -5675,10 +6186,10 @@ Class 'classname' has a constructor with 1 argument that is not explicit.
   </rule>
   <rule>
     <key>operatorEqMissingReturnStatement</key>
-    <name>Missing &apos;return&apos; statement in non-void function causes undefined behavior</name>
+    <name>No 'return' statement in non-void function causes undefined behavior</name>
     <description>
-<![CDATA[
-<p>
+      <![CDATA[
+      <p>
 No <code>return</code> statement in non-void function causes undefined behavior.
 </p>
 <h2>References</h2>
@@ -5695,11 +6206,12 @@ No <code>return</code> statement in non-void function causes undefined behavior.
   </rule>
   <rule>
     <key>operatorEqShouldBeLeftUnimplemented</key>
-    <name>&apos;operator=&apos; should either return reference to &apos;this&apos;</name>
+    <name>'operator=' should either return reference to 'this'</name>
     <description>
-<![CDATA[
-<p>
-'operator=' should either return reference to 'this'instance or be declared private and left unimplemented.
+      <![CDATA[
+      <p>
+'operator=' should either return reference to 'this' instance or be
+declared private and left unimplemented.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
@@ -5716,11 +6228,13 @@ No <code>return</code> statement in non-void function causes undefined behavior.
     <key>redundantPointerOp</key>
     <name>Redundant pointer operation on varname</name>
     <description>
-<![CDATA[<p>
-Redundant pointer operation on varname - it's already a pointer.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+Redundant pointer operation on 'varname' - it's already a pointer.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>redundantPointerOp</internalKey>
@@ -5733,8 +6247,16 @@ Redundant pointer operation on varname - it's already a pointer.
     <key>throwInNoexceptFunction</key>
     <name>Exception thrown in function declared not to throw exceptions</name>
     <description>
-      Exception thrown in function declared not to throw exceptions.
+      <![CDATA[
+      <p>
+Exception thrown in function declared not to throw exceptions.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
+    <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>throwInNoexceptFunction</internalKey>
     <severity>MAJOR</severity>
     <type>BUG</type>
@@ -5743,11 +6265,18 @@ Redundant pointer operation on varname - it's already a pointer.
   </rule>
   <rule>
     <key>useAutoPointerMalloc</key>
-    <name>Object pointed by an &apos;auto_ptr&apos; is destroyed using operator &apos;delete&apos;</name>
+    <name>Object pointed by an 'auto_ptr' is destroyed using operator 'delete'</name>
     <description>
-<![CDATA[<p>
-Object pointed by an 'auto_ptr' is destroyed using operator 'delete'. You should not use 'auto_ptr' for pointers obtained with function 'malloc'.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Object pointed by an 'auto_ptr' is destroyed using operator 'delete'.
+You should not use 'auto_ptr' for pointers obtained with function
+'malloc'. This means that you should only use 'auto_ptr' for pointers
+obtained with operator 'new'. This excludes use C library allocation
+functions (for example 'malloc'), which must be deallocated by the
+appropriate C library function.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/762.html" target="_blank">CWE-762: Mismatched Memory Management Routines</a></p>
 ]]>
     </description>
@@ -5761,10 +6290,10 @@ Object pointed by an 'auto_ptr' is destroyed using operator 'delete'. You should
   <!-- ########### New in cppcheck 1.70 release ########### -->
   <rule>
     <key>negativeArraySize</key>
-    <name>Declaration of array &apos;identifier&apos; with negative size is undefined behaviour</name>
+    <name>Declaration of array with negative size is undefined behaviour</name>
     <description>
 <![CDATA[<p>
-Declaration of array &apos;identifier&apos; with negative size is undefined behaviour.
+Declaration of array with negative size is undefined behaviour
 </p><h2>References</h2>
 <p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=2681" target="_blank">ARR32-C. Ensure size arguments for variable length arrays are in a valid range</a></p>
 <p><a href="https://cwe.mitre.org/data/definitions/758.html" target="_blank">CWE-758: Reliance on Undefined, Unspecified, or Implementation-Defined Behavior</a></p>
@@ -5781,11 +6310,14 @@ Declaration of array &apos;identifier&apos; with negative size is undefined beha
   </rule>
   <rule>
     <key>badBitmaskCheck</key>
-    <name>Result of operator &apos;|&apos; is always true if one operand is non-zero</name>
+    <name>Result of operator '|' is always true if one operand is non-zero</name>
     <description>
-<![CDATA[<p>
-Result of operator '|' is always true if one operand is non-zero. Did you intend to use '&'?
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Result of operator '|' is always true if one operand is non-zero. Did
+you intend to use '&'?
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/571.html" target="_blank">CWE-571: Expression is Always True</a></p>
 ]]>
     </description>
@@ -5799,10 +6331,10 @@ Result of operator '|' is always true if one operand is non-zero. Did you intend
   </rule>
   <rule>
     <key>knownConditionTrueFalse</key>
-    <name>Condition &apos;x&apos; is always true or false</name>
+    <name>Condition is always true/false</name>
     <description>
 <![CDATA[<p>
-Condition 'x' is always true or false.
+Condition 'x' is always true/false.
 </p><h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/570.html" target="_blank">CWE-570: Expression is Always False</a></p>
 <p><a href="https://cwe.mitre.org/data/definitions/571.html" target="_blank">CWE-571: Expression is Always True</a></p>
@@ -5820,10 +6352,12 @@ Condition 'x' is always true or false.
     <key>nullPointerDefaultArg</key>
     <name>Possible null pointer dereference if the default parameter value is used: pointer</name>
     <description>
-<![CDATA[<p>
-Possible null pointer dereference if the default parameter value is used: pointer.
-</p><h2>References</h2>
-<p><a href="https://www.securecoding.cert.org/confluence/display/c/EXP34-C.+Do+not+dereference+null+pointers" target="_blank">EXP34-C. Do not dereference null pointers</a></p>
+      <![CDATA[
+      <p>
+Possible null pointer dereference if the default parameter value is
+used
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/476.html" target="_blank">CWE-476: NULL Pointer Dereference</a></p>
 ]]>
     </description>
@@ -5840,10 +6374,12 @@ Possible null pointer dereference if the default parameter value is used: pointe
     <key>nullPointerRedundantCheck</key>
     <name>Either the condition is redundant or there is possible null pointer dereference: pointer</name>
     <description>
-<![CDATA[<p>
-Either the condition is redundant or there is possible null pointer dereference: pointer.
-</p><h2>References</h2>
-<p><a href="https://www.securecoding.cert.org/confluence/display/c/EXP34-C.+Do+not+dereference+null+pointers" target="_blank">EXP34-C. Do not dereference null pointers</a></p>
+      <![CDATA[
+      <p>
+Either the condition is redundant or there is possible null pointer
+dereference
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/476.html" target="_blank">CWE-476: NULL Pointer Dereference</a></p>
 ]]>
     </description>
@@ -5873,7 +6409,14 @@ Either the condition is redundant or there is possible null pointer dereference:
     <key>raceAfterInterlockedDecrement</key>
     <name>Race condition: non-interlocked access after InterlockedDecrement()</name>
     <description>
-      Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.
+      <![CDATA[
+      <p>
+Race condition: non-interlocked access after InterlockedDecrement().
+Use InterlockedDecrement() return value instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/362.html" target="_blank">CWE-362: Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>raceAfterInterlockedDecrement</internalKey>
@@ -5884,13 +6427,15 @@ Either the condition is redundant or there is possible null pointer dereference:
   </rule>
   <rule>
     <key>unusedLabel</key>
-    <name>Label &apos;identifier&apos; is not used</name>
+    <name>Label is not used</name>
     <description>
-<![CDATA[<p>
-Label 'identifier' is not used.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+Label is not used.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>unusedLabel</internalKey>
@@ -5903,9 +6448,12 @@ Label 'identifier' is not used.
     <key>stringLiteralWrite</key>
     <name>Modifying string literal directly or indirectly is undefined behaviour</name>
     <description>
-<![CDATA[<p>
-Modifying string literal directly or indirectly is undefined behaviour.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Modifying string literal directly or indirectly is undefined
+behaviour.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/758.html" target="_blank">CWE-758: Reliance on Undefined, Unspecified, or Implementation-Defined Behavior</a></p>
 ]]>
     </description>
@@ -5921,10 +6469,14 @@ Modifying string literal directly or indirectly is undefined behaviour.
     <key>truncLongCastAssignment</key>
     <name>int result is assigned to long variable (potential truncation)</name>
     <description>
-<![CDATA[<p>
-int result is assigned to long variable. If the variable is long to avoid loss of information, then you have loss of information.
-To avoid loss of information you must cast a calculation operand to long, for example 'l = a * b;' => 'l = (long)a * b;'.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+int result is assigned to long variable. If the variable is long to
+avoid loss of information, then there is loss of information. To avoid
+loss of information you must cast a calculation operand to long, for
+example 'l = a * b;' => 'l = (long)a * b;'.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/197.html" target="_blank">CWE-197: Numeric Truncation Error</a></p>
 ]]>
     </description>
@@ -5939,10 +6491,14 @@ To avoid loss of information you must cast a calculation operand to long, for ex
     <key>truncLongCastReturn</key>
     <name>int result is returned as long value (potential truncation)</name>
     <description>
-<![CDATA[<p>
-int result is returned as long value. If the return value is long to avoid loss of information, then you have loss of information.
-To avoid loss of information you must cast a calculation operand to long, for example 'return a*b;' => 'return (long)a*b'.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+int result is returned as long value. If the return value is long to
+avoid loss of information, then there is loss of information. To avoid
+loss of information you must cast a calculation operand to long, for
+example 'return a*b;' => 'return (long)a*b'.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/197.html" target="_blank">CWE-197: Numeric Truncation Error</a></p>
 ]]>
     </description>
@@ -5975,9 +6531,12 @@ Boolean value assigned to floating point variable.
     <key>invalidTestForOverflow</key>
     <name>Invalid test for overflow (undefined behavior)</name>
     <description>
-<![CDATA[<p>
-Invalid test for overflow 'x + u < x'. Condition is always false unless there is overflow, and overflow is undefined behaviour.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Invalid test for overflow 'x + u < x'. Condition is always false
+unless there is overflow, and overflow is undefined behaviour.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/570.html" target="_blank">CWE-570: Expression is Always False</a></p>
 ]]>
     </description>
@@ -5992,9 +6551,11 @@ Invalid test for overflow 'x + u < x'. Condition is always false unless there is
     <key>unknownEvaluationOrder</key>
     <name>Expression depends on order of evaluation (side effects)</name>
     <description>
-<![CDATA[<p>
-Expression &apos;x = x++;&apos; depends on order of evaluation of side effects.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Expression 'x = x++;' depends on order of evaluation of side effects
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/768.html" target="_blank">CWE-768: Incorrect Short Circuit Evaluation</a></p>
 ]]>
     </description>
@@ -6010,9 +6571,12 @@ Expression &apos;x = x++;&apos; depends on order of evaluation of side effects.
     <key>signedCharArrayIndex</key>
     <name>Signed 'char' type used as array index</name>
     <description>
-<![CDATA[<p>
-Signed 'char' type used as array index. If the value can be greater than 127 there will be a buffer underflow because of sign extension.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Signed 'char' type used as array index. If the value can be greater
+than 127 there will be a buffer underflow because of sign extension.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/128.html" target="_blank">CWE-128: Wrap-around Error</a></p>
 ]]>
     </description>
@@ -6027,9 +6591,13 @@ Signed 'char' type used as array index. If the value can be greater than 127 the
     <key>unknownSignCharArrayIndex</key>
     <name>'char' type used as array index</name>
     <description>
-<![CDATA[<p>
-      'char' type used as array index. Values greater that 127 will be treated depending on whether 'char' is signed or unsigned on target platform.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+'char' type used as array index. Values greater that 127 will be
+treated depending on whether 'char' is signed or unsigned on target
+platform.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/758.html" target="_blank">CWE-758: Reliance on Undefined, Unspecified, or Implementation-Defined Behavior</a></p>
 ]]>
     </description>
@@ -6044,11 +6612,14 @@ Signed 'char' type used as array index. If the value can be greater than 127 the
     <key>unusedLabelSwitch</key>
     <name>Label is not used. </name>
     <description>
-<![CDATA[<p>
-Label is not used.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+Label is not used. Should this be a 'case' of the enclosing
+switch()?
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>unusedLabelSwitch</internalKey>
@@ -6063,11 +6634,14 @@ Label is not used.
     <key>leakUnsafeArgAlloc</key>
     <name>Unsafe allocation. If 'funcName()' throws, memory could be leaked</name>
     <description>
-<![CDATA[<p>
-Unsafe allocation. If 'funcName()' throws, memory could be leaked. Use 'factoryFunc<objType>()' instead.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+Unsafe allocation. If funcName() throws, memory could be leaked. Use
+make_shared<T>() / make_unique<T>() instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/401.html" target="_blank">CWE-401: Improper Release of Memory Before Removing Last Reference ('Memory Leak')</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>leakUnsafeArgAlloc</internalKey>
@@ -6080,12 +6654,15 @@ Unsafe allocation. If 'funcName()' throws, memory could be leaked. Use 'factoryF
     <key>suspiciousCase</key>
     <name>Found suspicious case label in switch()</name>
     <description>
-<![CDATA[<p>
-Found suspicious case label in switch(). Operator 'operatorString' probably doesn't work as intended.
-Using an operator like 'operatorString' in a case label is suspicious. Did you intend to use a bitwise operator, multiple case labels or if/else instead?
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
-]]>
+      <![CDATA[
+      <p>
+Using an operator like '||' in a case label is suspicious. Did you
+intend to use a bitwise operator, multiple case labels or if/else
+instead?
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>suspiciousCase</internalKey>
@@ -6096,12 +6673,14 @@ Using an operator like 'operatorString' in a case label is suspicious. Did you i
   </rule>
   <rule>
     <key>suspiciousEqualityComparison</key>
-    <name>Found suspicious case label in switch()</name>
+    <name>Found suspicious equality comparison</name>
     <description>
-<![CDATA[<p>
-Found suspicious case label in switch(). Operator 'operatorString' probably doesn't work as intended.
-Using an operator like 'operatorString' in a case label is suspicious. Did you intend to use a bitwise operator, multiple case labels or if/else instead?
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Found suspicious equality comparison. Did you intend to assign a value
+instead?
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/482.html" target="_blank">CWE-482: Comparing instead of Assigning</a></p>
 ]]>
     </description>
@@ -6133,9 +6712,12 @@ Multiplying sizeof() with sizeof() indicates a logic error.
     <key>divideSizeof</key>
     <name>Division of result of sizeof() on pointer type</name>
     <description>
-<![CDATA[<p>
-Division of result of sizeof() on pointer type. sizeof() returns the size of the pointer not the size of the memory area it points to.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Division of result of sizeof() on pointer type. sizeof() returns the
+size of the pointer, not the size of the memory area it points to.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/682.html" target="_blank">CWE-682: Incorrect Calculation</a></p>
 ]]>
     </description>
@@ -6183,11 +6765,13 @@ Overflow in pointer arithmetic, NULL pointer is subtracted.
   </rule>
   <rule>
     <key>shiftNegativeLHS</key>
-    <name>Shifting a negative value is technically undefined behavior</name>
+    <name>Shifting a negative value is technically undefined behaviour</name>
     <description>
-<![CDATA[<p>
-Shifting a negative value is technically undefined behavior.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Shifting a negative value is technically undefined behaviour
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/758.html" target="_blank">CWE-758: Reliance on Undefined, Unspecified, or Implementation-Defined Behavior</a></p>
 ]]>
     </description>
@@ -6200,11 +6784,13 @@ Shifting a negative value is technically undefined behavior.
   </rule>
   <rule>
     <key>accessMoved</key>
-    <name>Access of moved variable &apos;name&apos;</name>
+    <name>Access of moved variable 'name'</name>
     <description>
-<![CDATA[<p>
+      <![CDATA[
+      <p>
 Access of moved variable 'name'.
-</p><h2>References</h2>
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/672.html" target="_blank">CWE-672: Operation on a Resource after Expiration or Release</a></p>
 ]]>
     </description>
@@ -6217,7 +6803,7 @@ Access of moved variable 'name'.
   </rule>
   <rule>
     <key>accessForwarded</key>
-    <name>Access of forwarded variable &apos;name&apos;</name>
+    <name>Access of forwarded variable 'name'</name>
     <description>
 <![CDATA[<p>
 Access of forwarded variable 'name'.
@@ -6252,11 +6838,13 @@ Undefined behaviour: float (1e+100) to integer conversion overflow.
   <!-- ########### New in cppcheck 1.78 ########### -->
   <rule>
     <key>funcArgNamesDifferent</key>
-    <name>Function 'function' argument 2 names different: declaration 'A' definition 'B'</name>
+    <name>Different argument name in function declaration and definition</name>
     <description>
-<![CDATA[<p>
-Function 'function' argument 2 names different: declaration 'A' definition 'B'.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Different argument name in function declaration and function definition.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/628.html" target="_blank">CWE-628: Function Call with Incorrectly Specified Arguments</a></p>
 ]]>
     </description>
@@ -6269,15 +6857,18 @@ Function 'function' argument 2 names different: declaration 'A' definition 'B'.
   </rule>
   <rule>
     <key>funcArgOrderDifferent</key>
-    <name>Function 'function' argument order different: declaration '' definition ''</name>
+    <name>Different argument order in function declaration and definition</name>
     <description>
-<![CDATA[<p>
-Function 'function' argument order different: declaration '' definition ''.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Different argument order in function declaration and definition
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/683.html" target="_blank">CWE-683: Function Call With Incorrect Order of Arguments</a></p>
 ]]>
     </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>funcArgOrderDifferent</internalKey>
     <severity>MAJOR</severity>
     <type>BUG</type>
@@ -6288,10 +6879,9 @@ Function 'function' argument order different: declaration '' definition ''.
     <key>copyCtorAndEqOperator</key>
     <name>The class 'class' has 'operator=' but lack of 'copy constructor'</name>
     <description>
-<![CDATA[<p>
-The class 'class' has 'operator=' but lack of 'copy constructor'.
-</p>
-]]>
+      <![CDATA[
+      The class 'class' has 'operator=' but lack of 'copy constructor'.
+    ]]>
     </description>
     <internalKey>copyCtorAndEqOperator</internalKey>
     <severity>MINOR</severity>
@@ -6304,10 +6894,9 @@ The class 'class' has 'operator=' but lack of 'copy constructor'.
     <key>unsafeClassDivZero</key>
     <name>Public interface of Class is not safe</name>
     <description>
-<![CDATA[<p>
-Public interface of Class is not safe. When calling Class::dostuff(), if parameter 'x' is 0 that leads to division by zero.
-</p>
-]]>
+      <![CDATA[
+      Public interface of Class is not safe. When calling Class::dostuff(), if parameter x is 0 that leads to division by zero.
+    ]]>
     </description>
     <internalKey>unsafeClassDivZero</internalKey>
     <severity>MINOR</severity>
@@ -6317,12 +6906,11 @@ Public interface of Class is not safe. When calling Class::dostuff(), if paramet
   </rule>
   <rule>
     <key>pointerAdditionResultNotNull</key>
-    <name>Comparison is wrong. Result of &apos;ptr+1&apos; can&apos;t be 0</name>
+    <name>Comparison is wrong. Result of can be 0</name>
     <description>
-<![CDATA[<p>
-Comparison is wrong. Result of 'ptr+1' can't be 0 unless there is pointer overflow, and pointer overflow is undefined behaviour.
-</p>
-]]>
+      <![CDATA[
+      Comparison is wrong. Result of 'ptr+1' can't be 0 unless there is pointer overflow, and pointer overflow is undefined behaviour.
+    ]]>
     </description>
     <internalKey>pointerAdditionResultNotNull</internalKey>
     <severity>MAJOR</severity>
@@ -6350,13 +6938,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   <!-- ########### see generate_cppcheck_resources.sh for more details                                                         ########### -->
   <rule>
     <key>LocalAllocCalled</key>
-    <name>Obsolete function 'LocalAlloc' called. It is recommended to use 'HeapAlloc' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolete function 'LocalAlloc' called. It is recommended to use 'HeapAlloc' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolete function 'LocalAlloc' called. It is recommended to use 'HeapAlloc' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolete function 'LocalAlloc' called. It is recommended to use
+'HeapAlloc' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>LocalAllocCalled</internalKey>
     <severity>MINOR</severity>
@@ -6366,13 +6958,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>RtlFillBytesCalled</key>
-    <name>Obsolete function 'RtlFillBytes' called. It is recommended to use 'RtlFillMemory' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolete function 'RtlFillBytes' called. It is recommended to use 'RtlFillMemory' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolete function 'RtlFillBytes' called. It is recommended to use 'RtlFillMemory' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolete function 'RtlFillBytes' called. It is recommended to use
+'RtlFillMemory' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>RtlFillBytesCalled</internalKey>
     <severity>MINOR</severity>
@@ -6382,13 +6978,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>RtlZeroBytesCalled</key>
-    <name>Obsolete function 'RtlZeroBytes' called. It is recommended to use 'RtlZeroMemory' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolete function 'RtlZeroBytes' called. It is recommended to use 'RtlZeroMemory' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolete function 'RtlZeroBytes' called. It is recommended to use 'RtlZeroMemory' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolete function 'RtlZeroBytes' called. It is recommended to use
+'RtlZeroMemory' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>RtlZeroBytesCalled</internalKey>
     <severity>MINOR</severity>
@@ -6398,13 +6998,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>asctime_rCalled</key>
-    <name>Obsolescent function 'asctime_r' called. It is recommended to use 'strftime' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'asctime_r' called. It is recommended to use 'strftime' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'asctime_r' called. It is recommended to use 'strftime' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'asctime_r' called. It is recommended to use
+'strftime' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>asctime_rCalled</internalKey>
     <severity>MINOR</severity>
@@ -6414,14 +7018,19 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>autoVariablesAssignGlobalPointer</key>
-    <name>Address of local array array is assigned to global pointer pointer and not reassigned before array goes out of scope.</name>
-    <description><![CDATA[
-        <p>
-  Address of local array array is assigned to global pointer pointer and not reassigned before array goes out of scope.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/562.html" target="_blank">CWE-562</a></p>
-      ]]></description>
+    <name>Address of local array array is assigned to global pointer pointer and not reassigned before array goes out of scope</name>
+    <description>
+      <![CDATA[
+      <p>
+Address of local array array is assigned to global pointer pointer and
+not reassigned before array goes out of scope.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/562.html" target="_blank">CWE-562: Return of Stack Variable Address</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>autoVariablesAssignGlobalPointer</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -6430,13 +7039,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>bcmpCalled</key>
-    <name>Obsolescent function 'bcmp' called. It is recommended to use 'memcmp' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'bcmp' called. It is recommended to use 'memcmp' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'bcmp' called. It is recommended to use 'memcmp' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'bcmp' called. It is recommended to use 'memcmp'
+instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>bcmpCalled</internalKey>
     <severity>MINOR</severity>
@@ -6446,13 +7059,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>bcopyCalled</key>
-    <name>Obsolescent function 'bcopy' called. It is recommended to use 'memcpy' or 'memmove' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'bcopy' called. It is recommended to use 'memcpy' or 'memmove' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'bcopy' called. It is recommended to use 'memcpy' or 'memmove' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'bcopy' called. It is recommended to use 'memcpy'
+or 'memmove' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>bcopyCalled</internalKey>
     <severity>MINOR</severity>
@@ -6462,13 +7079,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>bsd_signalCalled</key>
-    <name>Obsolescent function 'bsd_signal' called. It is recommended to use 'sigaction' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'bsd_signal' called. It is recommended to use 'sigaction' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'bsd_signal' called. It is recommended to use 'sigaction' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'bsd_signal' called. It is recommended to use
+'sigaction' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>bsd_signalCalled</internalKey>
     <severity>MINOR</severity>
@@ -6478,13 +7099,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>bzeroCalled</key>
-    <name>Obsolescent function 'bzero' called. It is recommended to use 'memset' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'bzero' called. It is recommended to use 'memset' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'bzero' called. It is recommended to use 'memset' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'bzero' called. It is recommended to use 'memset'
+instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>bzeroCalled</internalKey>
     <severity>MINOR</severity>
@@ -6494,13 +7119,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>cryptCalled</key>
-    <name>Non reentrant function 'crypt' called. For threadsafe applications it is recommended to use the reentrant replacement function 'crypt_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'crypt' called. For threadsafe applications it is recommended to use the reentrant replacement function 'crypt_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'crypt' called. For threadsafe applications it is recommended to use the reentrant replacement function 'crypt_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'crypt' called. For threadsafe applications it
+is recommended to use the reentrant replacement function 'crypt_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>cryptCalled</internalKey>
     <severity>MINOR</severity>
@@ -6510,13 +7139,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>ctermidCalled</key>
-    <name>Non reentrant function 'ctermid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'ctermid_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'ctermid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'ctermid_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'ctermid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'ctermid_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'ctermid' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'ctermid_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>ctermidCalled</internalKey>
     <severity>MINOR</severity>
@@ -6526,13 +7160,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>ctime_rCalled</key>
-    <name>Obsolescent function 'ctime_r' called. It is recommended to use 'strftime' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'ctime_r' called. It is recommended to use 'strftime' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'ctime_r' called. It is recommended to use 'strftime' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'ctime_r' called. It is recommended to use
+'strftime' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>ctime_rCalled</internalKey>
     <severity>MINOR</severity>
@@ -6542,13 +7180,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>ecvtCalled</key>
-    <name>Obsolescent function 'ecvt' called. It is recommended to use 'sprintf' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'ecvt' called. It is recommended to use 'sprintf' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'ecvt' called. It is recommended to use 'sprintf' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'ecvt' called. It is recommended to use 'sprintf'
+instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>ecvtCalled</internalKey>
     <severity>MINOR</severity>
@@ -6558,13 +7200,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>fcvtCalled</key>
-    <name>Obsolescent function 'fcvt' called. It is recommended to use 'sprintf' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'fcvt' called. It is recommended to use 'sprintf' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'fcvt' called. It is recommended to use 'sprintf' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'fcvt' called. It is recommended to use 'sprintf'
+instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>fcvtCalled</internalKey>
     <severity>MINOR</severity>
@@ -6574,13 +7220,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>fgetgrentCalled</key>
-    <name>Non reentrant function 'fgetgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetgrent_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'fgetgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetgrent_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'fgetgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetgrent_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'fgetgrent' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'fgetgrent_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>fgetgrentCalled</internalKey>
     <severity>MINOR</severity>
@@ -6590,13 +7241,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>fgetpwentCalled</key>
-    <name>Non reentrant function 'fgetpwent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetpwent_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'fgetpwent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetpwent_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'fgetpwent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetpwent_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'fgetpwent' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'fgetpwent_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>fgetpwentCalled</internalKey>
     <severity>MINOR</severity>
@@ -6606,13 +7262,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>fgetspentCalled</key>
-    <name>Non reentrant function 'fgetspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetspent_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'fgetspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetspent_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'fgetspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'fgetspent_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'fgetspent' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'fgetspent_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>fgetspentCalled</internalKey>
     <severity>MINOR</severity>
@@ -6622,13 +7283,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>gcvtCalled</key>
-    <name>Obsolescent function 'gcvt' called. It is recommended to use 'sprintf' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'gcvt' called. It is recommended to use 'sprintf' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'gcvt' called. It is recommended to use 'sprintf' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'gcvt' called. It is recommended to use 'sprintf'
+instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>gcvtCalled</internalKey>
     <severity>MINOR</severity>
@@ -6638,13 +7303,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getcontextCalled</key>
-    <name>Obsolescent function 'getcontext' called. Applications are recommended to be rewritten to use POSIX threads.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'getcontext' called. Applications are recommended to be rewritten to use POSIX threads.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'getcontext' called. Applications are recommended to be rewritten to use POSIX threads</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'getcontext' called. Applications are recommended
+to be rewritten to use POSIX threads.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getcontextCalled</internalKey>
     <severity>MINOR</severity>
@@ -6654,13 +7323,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getgrentCalled</key>
-    <name>Non reentrant function 'getgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrent_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrent_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrent_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getgrent' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'getgrent_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getgrentCalled</internalKey>
     <severity>MINOR</severity>
@@ -6670,13 +7344,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getgrgidCalled</key>
-    <name>Non reentrant function 'getgrgid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrgid_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getgrgid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrgid_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getgrgid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrgid_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getgrgid' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'getgrgid_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getgrgidCalled</internalKey>
     <severity>MINOR</severity>
@@ -6686,13 +7365,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getgrnamCalled</key>
-    <name>Non reentrant function 'getgrnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrnam_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getgrnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrnam_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getgrnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getgrnam_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getgrnam' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'getgrnam_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getgrnamCalled</internalKey>
     <severity>MINOR</severity>
@@ -6702,13 +7386,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>gethostbyaddrCalled</key>
-    <name>Obsolescent function 'gethostbyaddr' called. It is recommended to use 'getnameinfo' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'gethostbyaddr' called. It is recommended to use 'getnameinfo' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'gethostbyaddr' called. It is recommended to use 'getnameinfo' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'gethostbyaddr' called. It is recommended to use
+'getnameinfo' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>gethostbyaddrCalled</internalKey>
     <severity>MINOR</severity>
@@ -6718,13 +7406,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>gethostbyname2Called</key>
-    <name>Non reentrant function 'gethostbyname2' called. For threadsafe applications it is recommended to use the reentrant replacement function 'gethostbyname2_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'gethostbyname2' called. For threadsafe applications it is recommended to use the reentrant replacement function 'gethostbyname2_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'gethostbyname2' called. For threadsafe applications it is recommended to use the reentrant replacement function 'gethostbyname2_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'gethostbyname2' called. For threadsafe
+applications it is recommended to use the reentrant replacement
+function 'gethostbyname2_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>gethostbyname2Called</internalKey>
     <severity>MINOR</severity>
@@ -6734,13 +7427,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>gethostentCalled</key>
-    <name>Non reentrant function 'gethostent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'gethostent_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'gethostent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'gethostent_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'gethostent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'gethostent_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'gethostent' called. For threadsafe
+applications it is recommended to use the reentrant replacement
+function 'gethostent_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>gethostentCalled</internalKey>
     <severity>MINOR</severity>
@@ -6750,13 +7448,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getloginCalled</key>
-    <name>Non reentrant function 'getlogin' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getlogin_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getlogin' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getlogin_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getlogin' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getlogin_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getlogin' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'getlogin_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getloginCalled</internalKey>
     <severity>MINOR</severity>
@@ -6766,13 +7469,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getnetbyaddrCalled</key>
-    <name>Non reentrant function 'getnetbyaddr' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetbyaddr_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getnetbyaddr' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetbyaddr_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getnetbyaddr' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetbyaddr_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getnetbyaddr' called. For threadsafe
+applications it is recommended to use the reentrant replacement
+function 'getnetbyaddr_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getnetbyaddrCalled</internalKey>
     <severity>MINOR</severity>
@@ -6782,13 +7490,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getnetbynameCalled</key>
-    <name>Non reentrant function 'getnetbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetbyname_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getnetbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetbyname_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getnetbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetbyname_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getnetbyname' called. For threadsafe
+applications it is recommended to use the reentrant replacement
+function 'getnetbyname_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getnetbynameCalled</internalKey>
     <severity>MINOR</severity>
@@ -6798,13 +7511,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getnetentCalled</key>
-    <name>Non reentrant function 'getnetent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetent_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getnetent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetent_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getnetent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetent_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getnetent' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'getnetent_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getnetentCalled</internalKey>
     <severity>MINOR</severity>
@@ -6814,13 +7532,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getnetgrentCalled</key>
-    <name>Non reentrant function 'getnetgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetgrent_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getnetgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetgrent_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getnetgrent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getnetgrent_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getnetgrent' called. For threadsafe
+applications it is recommended to use the reentrant replacement
+function 'getnetgrent_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getnetgrentCalled</internalKey>
     <severity>MINOR</severity>
@@ -6830,13 +7553,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getprotobynameCalled</key>
-    <name>Non reentrant function 'getprotobyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getprotobyname_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getprotobyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getprotobyname_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getprotobyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getprotobyname_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getprotobyname' called. For threadsafe
+applications it is recommended to use the reentrant replacement
+function 'getprotobyname_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getprotobynameCalled</internalKey>
     <severity>MINOR</severity>
@@ -6846,13 +7574,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getprotobynumberCalled</key>
-    <name>Non reentrant function 'getprotobynumber' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getprotobynumber_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getprotobynumber' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getprotobynumber_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getprotobynumber' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getprotobynumber_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getprotobynumber' called. For threadsafe
+applications it is recommended to use the reentrant replacement
+function 'getprotobynumber_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getprotobynumberCalled</internalKey>
     <severity>MINOR</severity>
@@ -6862,13 +7595,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getprotoentCalled</key>
-    <name>Non reentrant function 'getprotoent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getprotoent_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getprotoent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getprotoent_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getprotoent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getprotoent_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getprotoent' called. For threadsafe
+applications it is recommended to use the reentrant replacement
+function 'getprotoent_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getprotoentCalled</internalKey>
     <severity>MINOR</severity>
@@ -6878,13 +7616,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getpwentCalled</key>
-    <name>Non reentrant function 'getpwent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwent_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getpwent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwent_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getpwent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwent_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getpwent' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'getpwent_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getpwentCalled</internalKey>
     <severity>MINOR</severity>
@@ -6894,13 +7637,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getpwnamCalled</key>
-    <name>Non reentrant function 'getpwnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwnam_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getpwnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwnam_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getpwnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwnam_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getpwnam' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'getpwnam_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getpwnamCalled</internalKey>
     <severity>MINOR</severity>
@@ -6910,13 +7658,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getpwuidCalled</key>
-    <name>Non reentrant function 'getpwuid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwuid_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getpwuid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwuid_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getpwuid' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwuid_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getpwuid' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'getpwuid_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getpwuidCalled</internalKey>
     <severity>MINOR</severity>
@@ -6926,13 +7679,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getrpcbynameCalled</key>
-    <name>Non reentrant function 'getrpcbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcbyname_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getrpcbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcbyname_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getrpcbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcbyname_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getrpcbyname' called. For threadsafe
+applications it is recommended to use the reentrant replacement
+function 'getrpcbyname_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getrpcbynameCalled</internalKey>
     <severity>MINOR</severity>
@@ -6942,13 +7700,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getrpcbynumberCalled</key>
-    <name>Non reentrant function 'getrpcbynumber' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcbynumber_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getrpcbynumber' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcbynumber_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getrpcbynumber' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcbynumber_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getrpcbynumber' called. For threadsafe
+applications it is recommended to use the reentrant replacement
+function 'getrpcbynumber_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getrpcbynumberCalled</internalKey>
     <severity>MINOR</severity>
@@ -6958,13 +7721,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getrpcentCalled</key>
-    <name>Non reentrant function 'getrpcent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcent_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getrpcent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcent_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getrpcent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getrpcent_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getrpcent' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'getrpcent_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getrpcentCalled</internalKey>
     <severity>MINOR</severity>
@@ -6974,13 +7742,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getsCalled</key>
-    <name>Obsolete function 'gets' called. It is recommended to use 'fgets' or 'gets_s' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolete function 'gets' called. It is recommended to use 'fgets' or 'gets_s' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolete function 'gets' called. It is recommended to use 'fgets' or 'gets_s' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+The obsolete function 'gets' is called. With 'gets' you'll get a
+buffer overrun if the input data exceeds the size of the buffer. It is
+recommended to use the functions 'fgets' or 'gets_s' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getsCalled</internalKey>
     <severity>MINOR</severity>
@@ -6990,13 +7763,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getservbynameCalled</key>
-    <name>Non reentrant function 'getservbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservbyname_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getservbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservbyname_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getservbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservbyname_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getservbyname' called. For threadsafe
+applications it is recommended to use the reentrant replacement
+function 'getservbyname_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getservbynameCalled</internalKey>
     <severity>MINOR</severity>
@@ -7006,13 +7784,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getservbyportCalled</key>
-    <name>Non reentrant function 'getservbyport' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservbyport_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getservbyport' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservbyport_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getservbyport' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservbyport_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getservbyport' called. For threadsafe
+applications it is recommended to use the reentrant replacement
+function 'getservbyport_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getservbyportCalled</internalKey>
     <severity>MINOR</severity>
@@ -7022,13 +7805,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getserventCalled</key>
-    <name>Non reentrant function 'getservent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservent_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getservent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservent_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getservent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservent_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getservent' called. For threadsafe
+applications it is recommended to use the reentrant replacement
+function 'getservent_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getserventCalled</internalKey>
     <severity>MINOR</severity>
@@ -7038,13 +7826,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getspentCalled</key>
-    <name>Non reentrant function 'getspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getspent_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getspent_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getspent_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getspent' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'getspent_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getspentCalled</internalKey>
     <severity>MINOR</severity>
@@ -7054,13 +7847,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getspnamCalled</key>
-    <name>Non reentrant function 'getspnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getspnam_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'getspnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getspnam_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'getspnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getspnam_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'getspnam' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'getspnam_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getspnamCalled</internalKey>
     <severity>MINOR</severity>
@@ -7070,13 +7868,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>getwdCalled</key>
-    <name>Obsolescent function 'getwd' called. It is recommended to use 'getcwd' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'getwd' called. It is recommended to use 'getcwd' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'getwd' called. It is recommended to use 'getcwd' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'getwd' called. It is recommended to use 'getcwd'
+instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>getwdCalled</internalKey>
     <severity>MINOR</severity>
@@ -7086,13 +7888,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>indexCalled</key>
-    <name>Obsolescent function 'index' called. It is recommended to use 'strchr' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'index' called. It is recommended to use 'strchr' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'index' called. It is recommended to use 'strchr' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'index' called. It is recommended to use 'strchr'
+instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>indexCalled</internalKey>
     <severity>MINOR</severity>
@@ -7102,13 +7908,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>lstrcatCalled</key>
-    <name>Due to security concerns it is not recommended to use this function, see MSDN for details.</name>
-    <description><![CDATA[
-        <p>
-  Due to security concerns it is not recommended to use this function, see MSDN for details.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Due to security concerns it is not recommended to use this function, see MSDN for details</name>
+    <description>
+      <![CDATA[
+      <p>
+Due to security concerns it is not recommended to use this function,
+see MSDN for details.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>lstrcatCalled</internalKey>
     <severity>MINOR</severity>
@@ -7118,13 +7928,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>makecontextCalled</key>
-    <name>Obsolescent function 'makecontext' called. Applications are recommended to be rewritten to use POSIX threads.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'makecontext' called. Applications are recommended to be rewritten to use POSIX threads.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'makecontext' called. Applications are recommended to be rewritten to use POSIX threads</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'makecontext' called. Applications are
+recommended to be rewritten to use POSIX threads.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>makecontextCalled</internalKey>
     <severity>MINOR</severity>
@@ -7134,13 +7948,19 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>mktempCalled</key>
-    <name>Obsolete function 'mktemp' called. It is recommended to use 'mkstemp' or 'mkdtemp' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolete function 'mktemp' called. It is recommended to use 'mkstemp' or 'mkdtemp' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolete function 'mktemp' called. It is recommended to use 'mkstemp' or 'mkdtemp' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+The function 'mktemp' is considered to be dangerous due to race
+conditions and some implementations generating only up to 26 different
+filenames out of each template. This function has been removed in
+POSIX.1-2008. Use 'mkstemp' or 'mkdtemp' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>mktempCalled</internalKey>
     <severity>MINOR</severity>
@@ -7150,13 +7970,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>pthread_attr_getstackaddrCalled</key>
-    <name>Obsolescent function 'pthread_attr_getstackaddr' called. It is recommended to use 'pthread_attr_getstack' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'pthread_attr_getstackaddr' called. It is recommended to use 'pthread_attr_getstack' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'pthread_attr_getstackaddr' called. It is recommended to use 'pthread_attr_getstack' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'pthread_attr_getstackaddr' called. It is
+recommended to use 'pthread_attr_getstack' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>pthread_attr_getstackaddrCalled</internalKey>
     <severity>MINOR</severity>
@@ -7166,13 +7990,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>pthread_attr_setstackaddrCalled</key>
-    <name>Obsolescent function 'pthread_attr_setstackaddr' called. It is recommended to use 'pthread_attr_setstack' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'pthread_attr_setstackaddr' called. It is recommended to use 'pthread_attr_setstack' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'pthread_attr_setstackaddr' called. It is recommended to use 'pthread_attr_setstack' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'pthread_attr_setstackaddr' called. It is
+recommended to use 'pthread_attr_setstack' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>pthread_attr_setstackaddrCalled</internalKey>
     <severity>MINOR</severity>
@@ -7182,13 +8010,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>rand_rCalled</key>
-    <name>Obsolescent function 'rand_r' called. It is recommended to use 'rand' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'rand_r' called. It is recommended to use 'rand' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'rand_r' called. It is recommended to use 'rand' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'rand_r' called. It is recommended to use 'rand'
+instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>rand_rCalled</internalKey>
     <severity>MINOR</severity>
@@ -7198,13 +8030,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>readdirCalled</key>
-    <name>Non reentrant function 'readdir' called. For threadsafe applications it is recommended to use the reentrant replacement function 'readdir_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'readdir' called. For threadsafe applications it is recommended to use the reentrant replacement function 'readdir_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'readdir' called. For threadsafe applications it is recommended to use the reentrant replacement function 'readdir_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'readdir' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'readdir_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>readdirCalled</internalKey>
     <severity>MINOR</severity>
@@ -7214,13 +8051,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>rindexCalled</key>
-    <name>Obsolescent function 'rindex' called. It is recommended to use 'strrchr' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'rindex' called. It is recommended to use 'strrchr' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'rindex' called. It is recommended to use 'strrchr' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'rindex' called. It is recommended to use
+'strrchr' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>rindexCalled</internalKey>
     <severity>MINOR</severity>
@@ -7230,13 +8071,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>scalbCalled</key>
-    <name>Obsolescent function 'scalb' called. It is recommended to use 'scalbln', 'scalblnf', 'scalbln', 'scalbn', 'scalbnf' or 'scalbnl' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'scalb' called. It is recommended to use 'scalbln', 'scalblnf', 'scalbln', 'scalbn', 'scalbnf' or 'scalbnl' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'scalb' called. It is recommended to use 'scalbln', 'scalblnf', 'scalbln', 'scalbn', 'scalbnf' or 'scalbnl' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'scalb' called. It is recommended to use
+'scalbln', 'scalblnf', 'scalbln', 'scalbn', 'scalbnf' or 'scalbnl'
+instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>scalbCalled</internalKey>
     <severity>MINOR</severity>
@@ -7246,13 +8092,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>sgetspentCalled</key>
-    <name>Non reentrant function 'sgetspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'sgetspent_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'sgetspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'sgetspent_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'sgetspent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'sgetspent_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'sgetspent' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'sgetspent_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>sgetspentCalled</internalKey>
     <severity>MINOR</severity>
@@ -7262,14 +8113,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>sizeofFunctionCall</key>
-    <name>Found function call inside sizeof().</name>
-    <description><![CDATA[
-        <p>
-  Found function call inside sizeof().
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/682.html" target="_blank">CWE-682</a></p>
-      ]]></description>
+    <name>Found function call inside sizeof()</name>
+    <description>
+      <![CDATA[
+      <p>
+Found function call inside sizeof().
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/682.html" target="_blank">CWE-682: Incorrect Calculation</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
+    <tag>bug</tag>
     <internalKey>sizeofFunctionCall</internalKey>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -7278,13 +8133,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>std::asctimeCalled</key>
-    <name>Obsolete function 'std::asctime' called. It is recommended to use 'strftime' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolete function 'std::asctime' called. It is recommended to use 'strftime' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolete function 'std::asctime' called. It is recommended to use 'strftime' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolete function 'std::asctime' called. It is recommended to use
+'strftime' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>std::asctimeCalled</internalKey>
     <severity>MINOR</severity>
@@ -7294,13 +8153,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>std::strtokCalled</key>
-    <name>Non reentrant function 'strtok' called. For threadsafe applications it is recommended to use the reentrant replacement function 'strtok_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'strtok' called. For threadsafe applications it is recommended to use the reentrant replacement function 'strtok_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'strtok' called. For threadsafe applications it is recommended to use the reentrant replacement function 'strtok_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'strtok' called. For threadsafe applications it
+is recommended to use the reentrant replacement function 'strtok_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>std::strtokCalled</internalKey>
     <severity>MINOR</severity>
@@ -7310,13 +8173,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>strlwrCalled</key>
-    <name>Obsolete function 'strlwr' called. It is recommended to use '_strlwr' or '_strlwr_s' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolete function 'strlwr' called. It is recommended to use '_strlwr' or '_strlwr_s' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolete function 'strlwr' called. It is recommended to use '_strlwr' or '_strlwr_s' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolete function 'strlwr' called. It is recommended to use '_strlwr'
+or '_strlwr_s' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>strlwrCalled</internalKey>
     <severity>MINOR</severity>
@@ -7326,13 +8193,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>struprCalled</key>
-    <name>Obsolete function 'strupr' called. It is recommended to use '_strupr' or '_strupr_s' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolete function 'strupr' called. It is recommended to use '_strupr' or '_strupr_s' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolete function 'strupr' called. It is recommended to use '_strupr' or '_strupr_s' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolete function 'strupr' called. It is recommended to use '_strupr'
+or '_strupr_s' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>struprCalled</internalKey>
     <severity>MINOR</severity>
@@ -7342,13 +8213,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>swapcontextCalled</key>
-    <name>Obsolescent function 'swapcontext' called. Applications are recommended to be rewritten to use POSIX threads.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'swapcontext' called. Applications are recommended to be rewritten to use POSIX threads.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'swapcontext' called. Applications are recommended to be rewritten to use POSIX threads</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'swapcontext' called. Applications are
+recommended to be rewritten to use POSIX threads.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>swapcontextCalled</internalKey>
     <severity>MINOR</severity>
@@ -7358,13 +8233,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>tempnamCalled</key>
-    <name>Non reentrant function 'tempnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'tempnam_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'tempnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'tempnam_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'tempnam' called. For threadsafe applications it is recommended to use the reentrant replacement function 'tempnam_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'tempnam' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'tempnam_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>tempnamCalled</internalKey>
     <severity>MINOR</severity>
@@ -7374,13 +8254,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>tmpnam_rCalled</key>
-    <name>Obsolescent function 'tmpnam_r' called. It is recommended to use 'tmpfile', 'mkstemp' or 'mkdtemp' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'tmpnam_r' called. It is recommended to use 'tmpfile', 'mkstemp' or 'mkdtemp' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'tmpnam_r' called. It is recommended to use 'tmpfile', 'mkstemp' or 'mkdtemp' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'tmpnam_r' called. It is recommended to use
+'tmpfile', 'mkstemp' or 'mkdtemp' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>tmpnam_rCalled</internalKey>
     <severity>MINOR</severity>
@@ -7390,13 +8274,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>ttynameCalled</key>
-    <name>Non reentrant function 'ttyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'ttyname_r'.</name>
-    <description><![CDATA[
-        <p>
-  Non reentrant function 'ttyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'ttyname_r'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Non reentrant function 'ttyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'ttyname_r'</name>
+    <description>
+      <![CDATA[
+      <p>
+Non reentrant function 'ttyname' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'ttyname_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>ttynameCalled</internalKey>
     <severity>MINOR</severity>
@@ -7406,13 +8295,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>ualarmCalled</key>
-    <name>Obsolescent function 'ualarm' called. It is recommended to use 'timer_create', 'timer_delete', 'timer_getoverrun', 'timer_gettime' or 'timer_settime' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'ualarm' called. It is recommended to use 'timer_create', 'timer_delete', 'timer_getoverrun', 'timer_gettime' or 'timer_settime' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'ualarm' called. It is recommended to use 'timer_create', 'timer_delete', 'timer_getoverrun', 'timer_gettime' or 'timer_settime' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'ualarm' called. It is recommended to use
+'timer_create', 'timer_delete', 'timer_getoverrun', 'timer_gettime' or
+'timer_settime' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>ualarmCalled</internalKey>
     <severity>MINOR</severity>
@@ -7422,13 +8316,19 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>usleepCalled</key>
-    <name>Obsolescent function 'usleep' called. It is recommended to use 'nanosleep' or 'setitimer' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'usleep' called. It is recommended to use 'nanosleep' or 'setitimer' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'usleep' called. It is recommended to use 'nanosleep' or 'setitimer' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+The obsolescent function 'usleep' is called. POSIX.1-2001 declares
+usleep() function obsolescent and POSIX.1-2008 removes it. It is
+recommended that new applications use the 'nanosleep' or 'setitimer'
+function.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>usleepCalled</internalKey>
     <severity>MINOR</severity>
@@ -7438,13 +8338,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>utimeCalled</key>
-    <name>Obsolescent function 'utime' called. It is recommended to use 'utimensat' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'utime' called. It is recommended to use 'utimensat' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'utime' called. It is recommended to use 'utimensat' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'utime' called. It is recommended to use
+'utimensat' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>utimeCalled</internalKey>
     <severity>MINOR</severity>
@@ -7454,13 +8358,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>vforkCalled</key>
-    <name>Obsolescent function 'vfork' called. It is recommended to use 'fork' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'vfork' called. It is recommended to use 'fork' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'vfork' called. It is recommended to use 'fork' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'vfork' called. It is recommended to use 'fork'
+instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>vforkCalled</internalKey>
     <severity>MINOR</severity>
@@ -7470,13 +8378,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wcswcsCalled</key>
-    <name>Obsolescent function 'wcswcs' called. It is recommended to use 'wcsstr' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolescent function 'wcswcs' called. It is recommended to use 'wcsstr' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolescent function 'wcswcs' called. It is recommended to use 'wcsstr' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolescent function 'wcswcs' called. It is recommended to use
+'wcsstr' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wcswcsCalled</internalKey>
     <severity>MINOR</severity>
@@ -7486,13 +8398,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxApp::MacOpenFileCalled</key>
-    <name>This function is deprecated and kept mostly for backwards compatibility. Please override 'wxApp::MacOpenFiles' method instead in any new code.</name>
-    <description><![CDATA[
-        <p>
-  This function is deprecated and kept mostly for backwards compatibility. Please override 'wxApp::MacOpenFiles' method instead in any new code.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function is deprecated and kept mostly for backwards compatibility. Please override 'wxApp::MacOpenFiles' method instead in any new code</name>
+    <description>
+      <![CDATA[
+      <p>
+This function is deprecated and kept mostly for backwards
+compatibility. Please override 'wxApp::MacOpenFiles' method instead in
+any new code.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxApp::MacOpenFileCalled</internalKey>
     <severity>MINOR</severity>
@@ -7502,13 +8419,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxArtProvider::InsertCalled</key>
-    <name>This function is deprecated and kept mostly for backwards compatibility. Please override 'PushBack' method instead in any new code.</name>
-    <description><![CDATA[
-        <p>
-  This function is deprecated and kept mostly for backwards compatibility. Please override 'PushBack' method instead in any new code.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function is deprecated and kept mostly for backwards compatibility. Please override 'PushBack' method instead in any new code</name>
+    <description>
+      <![CDATA[
+      <p>
+This function is deprecated and kept mostly for backwards
+compatibility. Please override 'PushBack' method instead in any new
+code.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxArtProvider::InsertCalled</internalKey>
     <severity>MINOR</severity>
@@ -7518,13 +8440,19 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxCalendarCtrl::EnableYearChangeCalled</key>
-    <name>This function should be used instead of changing 'wxCAL_NO_YEAR_CHANGE' style bit directly. It allows or disallows the user to change the year interactively. Only in generic 'wxCalendarCtrl'.</name>
-    <description><![CDATA[
-        <p>
-  This function should be used instead of changing 'wxCAL_NO_YEAR_CHANGE' style bit directly. It allows or disallows the user to change the year interactively. Only in generic 'wxCalendarCtrl'.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function should be used instead of changing 'wxCAL_NO_YEAR_CHANGE' style bit directly. It allows or disallows the user to change the year interactively. Only in generic 'wxCalendarCtrl'</name>
+    <description>
+      <![CDATA[
+      <p>
+This function should be used instead of changing
+'wxCAL_NO_YEAR_CHANGE' style bit directly. It allows or disallows the
+user to change the year interactively. Only in generic
+'wxCalendarCtrl'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxCalendarCtrl::EnableYearChangeCalled</internalKey>
     <severity>MINOR</severity>
@@ -7534,13 +8462,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxComboCtrl::GetTextIndentCalled</key>
-    <name>This function is deprecated and kept mostly for backwards compatibility. Please override 'GetMargins()' method instead in any new code.</name>
-    <description><![CDATA[
-        <p>
-  This function is deprecated and kept mostly for backwards compatibility. Please override 'GetMargins()' method instead in any new code.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function is deprecated and kept mostly for backwards compatibility. Please override 'GetMargins()' method instead in any new code</name>
+    <description>
+      <![CDATA[
+      <p>
+This function is deprecated and kept mostly for backwards
+compatibility. Please override 'GetMargins()' method instead in any
+new code.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxComboCtrl::GetTextIndentCalled</internalKey>
     <severity>MINOR</severity>
@@ -7550,13 +8483,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxComboCtrl::HidePopupCalled</key>
-    <name>This function is deprecated and kept mostly for backwards compatibility. Please override 'Dismiss()' method instead in any new code.</name>
-    <description><![CDATA[
-        <p>
-  This function is deprecated and kept mostly for backwards compatibility. Please override 'Dismiss()' method instead in any new code.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function is deprecated and kept mostly for backwards compatibility. Please override 'Dismiss()' method instead in any new code</name>
+    <description>
+      <![CDATA[
+      <p>
+This function is deprecated and kept mostly for backwards
+compatibility. Please override 'Dismiss()' method instead in any new
+code.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxComboCtrl::HidePopupCalled</internalKey>
     <severity>MINOR</severity>
@@ -7566,13 +8504,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxComboCtrl::SetTextIndentCalled</key>
-    <name>This function is deprecated and kept mostly for backwards compatibility. Please override 'SetMargins()' method instead in any new code.</name>
-    <description><![CDATA[
-        <p>
-  This function is deprecated and kept mostly for backwards compatibility. Please override 'SetMargins()' method instead in any new code.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function is deprecated and kept mostly for backwards compatibility. Please override 'SetMargins()' method instead in any new code</name>
+    <description>
+      <![CDATA[
+      <p>
+This function is deprecated and kept mostly for backwards
+compatibility. Please override 'SetMargins()' method instead in any
+new code.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxComboCtrl::SetTextIndentCalled</internalKey>
     <severity>MINOR</severity>
@@ -7582,13 +8525,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxComboCtrl::ShowPopupCalled</key>
-    <name>This function is deprecated and kept mostly for backwards compatibility. Please override 'Popup()' method instead in any new code.</name>
-    <description><![CDATA[
-        <p>
-  This function is deprecated and kept mostly for backwards compatibility. Please override 'Popup()' method instead in any new code.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function is deprecated and kept mostly for backwards compatibility. Please override 'Popup()' method instead in any new code</name>
+    <description>
+      <![CDATA[
+      <p>
+This function is deprecated and kept mostly for backwards
+compatibility. Please override 'Popup()' method instead in any new
+code.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxComboCtrl::ShowPopupCalled</internalKey>
     <severity>MINOR</severity>
@@ -7598,13 +8546,19 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxDataViewCustomRenderer::ActivateCalled</key>
-    <name>This function is deprecated and kept mostly for backwards compatibility. Please override 'wxDataViewCustomRenderer::ActivateCell()' method instead in any new code.</name>
-    <description><![CDATA[
-        <p>
-  This function is deprecated and kept mostly for backwards compatibility. Please override 'wxDataViewCustomRenderer::ActivateCell()' method instead in any new code.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function is deprecated and kept mostly for backwards compatibility. Please override 'wxDataViewCustomRenderer::ActivateCell()' method instead in any new code</name>
+    <description>
+      <![CDATA[
+      <p>
+This function is deprecated and kept mostly for backwards
+compatibility. Please override
+'wxDataViewCustomRenderer::ActivateCell()' method instead in any new
+code.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxDataViewCustomRenderer::ActivateCalled</internalKey>
     <severity>MINOR</severity>
@@ -7614,13 +8568,16 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxDebugContext::GetLevelCalled</key>
-    <name>This function is deprecated and is replaced by 'wxLog' functionality.</name>
-    <description><![CDATA[
-        <p>
-  This function is deprecated and is replaced by 'wxLog' functionality.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function is deprecated and is replaced by 'wxLog' functionality</name>
+    <description>
+      <![CDATA[
+      <p>
+This function is deprecated and is replaced by 'wxLog' functionality.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxDebugContext::GetLevelCalled</internalKey>
     <severity>MINOR</severity>
@@ -7630,13 +8587,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxDos2UnixFilenameCalled</key>
-    <name>This function is deprecated. Construct a 'wxFileName' with 'wxPATH_DOS' and then use 'wxFileName::GetFullPath(wxPATH_UNIX)' instead.</name>
-    <description><![CDATA[
-        <p>
-  This function is deprecated. Construct a 'wxFileName' with 'wxPATH_DOS' and then use 'wxFileName::GetFullPath(wxPATH_UNIX)' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function is deprecated. Construct a 'wxFileName' with 'wxPATH_DOS' and then use 'wxFileName::GetFullPath(wxPATH_UNIX)' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+This function is deprecated. Construct a 'wxFileName' with
+'wxPATH_DOS' and then use 'wxFileName::GetFullPath(wxPATH_UNIX)'
+instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxDos2UnixFilenameCalled</internalKey>
     <severity>MINOR</severity>
@@ -7646,13 +8608,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxFileNameFromPathCalled</key>
-    <name>This function is deprecated. Please use 'wxFileName::SplitPath()' instead.</name>
-    <description><![CDATA[
-        <p>
-  This function is deprecated. Please use 'wxFileName::SplitPath()' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function is deprecated. Please use 'wxFileName::SplitPath()' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+This function is deprecated. Please use 'wxFileName::SplitPath()'
+instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxFileNameFromPathCalled</internalKey>
     <severity>MINOR</severity>
@@ -7662,13 +8628,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxGetWorkingDirectoryCalled</key>
-    <name>Obsolete function 'wxGetWorkingDirectory' called. It is recommended to use 'wxGetCwd' instead.</name>
-    <description><![CDATA[
-        <p>
-  Obsolete function 'wxGetWorkingDirectory' called. It is recommended to use 'wxGetCwd' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>Obsolete function 'wxGetWorkingDirectory' called. It is recommended to use 'wxGetCwd' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+Obsolete function 'wxGetWorkingDirectory' called. It is recommended to
+use 'wxGetCwd' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxGetWorkingDirectoryCalled</internalKey>
     <severity>MINOR</severity>
@@ -7678,13 +8648,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxGrid::SetCellAlignmentCalled</key>
-    <name>This function is deprecated. Please use 'wxGrid::SetCellAlignment(row, col, horiz, vert)' instead.</name>
-    <description><![CDATA[
-        <p>
-  This function is deprecated. Please use 'wxGrid::SetCellAlignment(row, col, horiz, vert)' instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function is deprecated. Please use 'wxGrid::SetCellAlignment(row, col, horiz, vert)' instead</name>
+    <description>
+      <![CDATA[
+      <p>
+This function is deprecated. Please use 'wxGrid::SetCellAlignment(row,
+col, horiz, vert)' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxGrid::SetCellAlignmentCalled</internalKey>
     <severity>MINOR</severity>
@@ -7694,13 +8668,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxSizerItem::SetSizerCalled</key>
-    <name>This function is deprecated. This function does not free the old sizer which may result in memory leaks, use 'wxSizerItem::AssignSizer' which does free it instead.</name>
-    <description><![CDATA[
-        <p>
-  This function is deprecated. This function does not free the old sizer which may result in memory leaks, use 'wxSizerItem::AssignSizer' which does free it instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function is deprecated. This function does not free the old sizer which may result in memory leaks, use 'wxSizerItem::AssignSizer' which does free it instead</name>
+    <description>
+      <![CDATA[
+      <p>
+This function is deprecated. This function does not free the old sizer
+which may result in memory leaks, use 'wxSizerItem::AssignSizer' which
+does free it instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxSizerItem::SetSizerCalled</internalKey>
     <severity>MINOR</severity>
@@ -7710,13 +8689,18 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxSizerItem::SetSpacerCalled</key>
-    <name>This function is deprecated. This function does not free the old sizer which may result in memory leaks, use 'wxSizerItem::AssignSpacer' which does free it instead.</name>
-    <description><![CDATA[
-        <p>
-  This function is deprecated. This function does not free the old sizer which may result in memory leaks, use 'wxSizerItem::AssignSpacer' which does free it instead.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function is deprecated. This function does not free the old sizer which may result in memory leaks, use 'wxSizerItem::AssignSpacer' which does free it instead</name>
+    <description>
+      <![CDATA[
+      <p>
+This function is deprecated. This function does not free the old sizer
+which may result in memory leaks, use 'wxSizerItem::AssignSpacer'
+which does free it instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxSizerItem::SetSpacerCalled</internalKey>
     <severity>MINOR</severity>
@@ -7726,13 +8710,16 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxSizerItem::SetWindowCalled</key>
-    <name>This function is deprecated.</name>
-    <description><![CDATA[
-        <p>
-  This function is deprecated.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This function is deprecated</name>
+    <description>
+      <![CDATA[
+      <p>
+This function is deprecated.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxSizerItem::SetWindowCalled</internalKey>
     <severity>MINOR</severity>
@@ -7742,13 +8729,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxString::IsNullCalled</key>
-    <name>This is the same as 'wxString::IsEmpty' and is kept for wxWidgets 1.xx compatibility. You should not use it in new code.</name>
-    <description><![CDATA[
-        <p>
-  This is the same as 'wxString::IsEmpty' and is kept for wxWidgets 1.xx compatibility. You should not use it in new code.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This is the same as 'wxString::IsEmpty' and is kept for wxWidgets 1.xx compatibility. You should not use it in new code</name>
+    <description>
+      <![CDATA[
+      <p>
+This is the same as 'wxString::IsEmpty' and is kept for wxWidgets 1.xx
+compatibility. You should not use it in new code.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxString::IsNullCalled</internalKey>
     <severity>MINOR</severity>
@@ -7758,13 +8749,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxString::LengthCalled</key>
-    <name>This is the same as 'wxString::Len' and is kept for wxWidgets 1.xx compatibility. You should not use it in new code.</name>
-    <description><![CDATA[
-        <p>
-  This is the same as 'wxString::Len' and is kept for wxWidgets 1.xx compatibility. You should not use it in new code.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This is the same as 'wxString::Len' and is kept for wxWidgets 1.xx compatibility. You should not use it in new code</name>
+    <description>
+      <![CDATA[
+      <p>
+This is the same as 'wxString::Len' and is kept for wxWidgets 1.xx
+compatibility. You should not use it in new code.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxString::LengthCalled</internalKey>
     <severity>MINOR</severity>
@@ -7774,13 +8769,17 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>wxString::LowerCaseCalled</key>
-    <name>This is the same as 'wxString::MakeLower' and is kept for wxWidgets 1.xx compatibility. You should not use it in new code.</name>
-    <description><![CDATA[
-        <p>
-  This is the same as 'wxString::MakeLower' and is kept for wxWidgets 1.xx compatibility. You should not use it in new code.
-  </p><h2>References</h2>
-  <p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-      ]]></description>
+    <name>This is the same as 'wxString::MakeLower' and is kept for wxWidgets 1.xx compatibility. You should not use it in new code</name>
+    <description>
+      <![CDATA[
+      <p>
+This is the same as 'wxString::MakeLower' and is kept for wxWidgets
+1.xx compatibility. You should not use it in new code.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
+    </description>
     <tag>cwe</tag>
     <internalKey>wxString::LowerCaseCalled</internalKey>
     <severity>MINOR</severity>
@@ -7790,13 +8789,16 @@ The expression 'strcmp(x,"def") != 0' is suspicious. It overlaps 'strcmp(x,"abc"
   </rule>
   <rule>
     <key>asctimeCalled</key>
-    <name>Obsolete function 'asctime' called</name>
+    <name>Obsolete function 'asctime' called. It is recommended to use 'strftime' instead</name>
     <description>
-<![CDATA[<p>
-Obsolete function 'asctime' called. It is recommended to use 'strftime' instead.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-]]>
+      <![CDATA[
+      <p>
+Obsolete function 'asctime' called. It is recommended to use
+'strftime' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>asctimeCalled</internalKey>
@@ -7807,13 +8809,16 @@ Obsolete function 'asctime' called. It is recommended to use 'strftime' instead.
   </rule>
   <rule>
     <key>gethostbynameCalled</key>
-    <name>Obsolescent function 'gethostbyname' called</name>
+    <name>Obsolescent function 'gethostbyname' called. It is recommended to use 'getaddrinfo' instead</name>
     <description>
-<![CDATA[<p>
-Obsolescent function 'gethostbyname' called. It is recommended to use 'getaddrinfo' instead.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-]]>
+      <![CDATA[
+      <p>
+Obsolescent function 'gethostbyname' called. It is recommended to use
+'getaddrinfo' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>gethostbynameCalled</internalKey>
@@ -7824,13 +8829,17 @@ Obsolescent function 'gethostbyname' called. It is recommended to use 'getaddrin
   </rule>
   <rule>
     <key>localtimeCalled</key>
-    <name>Non reentrant function 'localtime' called</name>
+    <name>Non reentrant function 'localtime' called. For threadsafe applications it is recommended to use the reentrant replacement function 'localtime_r'</name>
     <description>
-<![CDATA[<p>
-Non reentrant function 'localtime' called. For threadsafe applications it is recommended to use the reentrant replacement function 'localtime_r'.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-]]>
+      <![CDATA[
+      <p>
+Non reentrant function 'localtime' called. For threadsafe applications
+it is recommended to use the reentrant replacement function
+'localtime_r'.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>localtimeCalled</internalKey>
@@ -7858,13 +8867,16 @@ Non reentrant function 'strtok' called. For threadsafe applications it is recomm
   </rule>
   <rule>
     <key>tmpnamCalled</key>
-    <name>Obsolescent function 'tmpnam' called</name>
+    <name>Obsolescent function 'tmpnam' called. It is recommended to use 'tmpfile', 'mkstemp' or 'mkdtemp' instead</name>
     <description>
-<![CDATA[<p>
-Obsolescent function 'tmpnam' called. It is recommended to use 'tmpfile', 'mkstemp' or 'mkdtemp' instead.
-</p><h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Functions</a></p>
-]]>
+      <![CDATA[
+      <p>
+Obsolescent function 'tmpnam' called. It is recommended to use
+'tmpfile', 'mkstemp' or 'mkdtemp' instead.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/477.html" target="_blank">CWE-477: Use of Obsolete Function</a></p>
+    ]]>
     </description>
     <tag>cwe</tag>
     <internalKey>tmpnamCalled</internalKey>
@@ -7877,9 +8889,13 @@ Obsolescent function 'tmpnam' called. It is recommended to use 'tmpfile', 'mkste
     <key>unhandledExceptionSpecification</key>
     <name>Unhandled exception specification</name>
     <description>
-<![CDATA[<p>
-Unhandled exception specification when calling function 'fname'. Either use a try/catch around the function call, or add a exception specification for 'fname' also.
-</p><h2>References</h2>
+      <![CDATA[
+      <p>
+Unhandled exception specification when calling function foo(). Either
+use a try/catch around the function call, or add a exception
+specification for funcname() also.
+</p>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/703.html" target="_blank">CWE-703: Improper Check or Handling of Exceptional Conditions</a></p>
 ]]>
     </description>
@@ -7892,12 +8908,11 @@ Unhandled exception specification when calling function 'fname'. Either use a tr
   </rule>
   <rule>
     <key>purgedConfiguration</key>
-    <name>The configuration 'MACRO' was not checked because its code equals another one</name>
+    <name>The configuration 'define' was not checked because its code equals another one</name>
     <description>
-<![CDATA[<p>
-The configuration 'MACRO' was not checked because its code equals another one.
-</p>
-]]>
+      <![CDATA[
+      The configuration 'define' was not checked because its code equals another one.
+    ]]>
     </description>
     <internalKey>purgedConfiguration</internalKey>
     <severity>INFO</severity>

--- a/cxx-sensors/src/tools/generate_cppcheck_resources.sh
+++ b/cxx-sensors/src/tools/generate_cppcheck_resources.sh
@@ -13,7 +13,9 @@ for CFG in ${CFG_DIR}*.cfg; do
    [ -e "${CFG}" ] && CPPCHECK_LIBRARY_ARGS="${CPPCHECK_LIBRARY_ARGS} --library=${CFG}" || echo "no *.cfg files exist in ${CFG_DIR}; no library specific rules will be generated!"
 done
 
+wget https://cwe.mitre.org/data/xml/cwec_v3.1.xml.zip --output-document=cwec_v3.1.xml.zip && unzip -j -o cwec_v3.1.xml.zip
+
 cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist > cppcheck-errorlist.xml
-cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist | python cppcheck_createrules.py rules > cppcheck.xml
+cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist | python cppcheck_createrules.py rules cwec_v3.1.xml > cppcheck.xml
 cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist | python cppcheck_createrules.py profile > cppcheck-profile.xml
 python cppcheck_createrules.py comparerules ../../../cxx-sensors/src/main/resources/cppcheck.xml cppcheck.xml > cppcheck-comparison.md


### PR DESCRIPTION
 review cppcheck.xml - align with the up-to-date error list

* enhance auto-generation of cppcheck.xml from cppcheck --errorlist
* perform 'diff': generated rules vs rules from HEAD
* align as far as possible  messages, references and formatting
* fix copy-n-paste errors and formatting issues

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1455)
<!-- Reviewable:end -->
