### PR TITLE
introduce HTML tidy checks for HTML descriptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
         - oraclejdk8
 
 env:
-        - SONARHOME=/tmp/sonarqube-6.7.2   SONARAPI=SqApi67
+        - SONARHOME=/tmp/sonarqube-6.7.3   SONARAPI=SqApi67
         - SONARHOME=/tmp/sonarqube-7.0     SONARAPI=SqApi67
 
 matrix:
@@ -39,8 +39,8 @@ before_install:
 
 install:
         - cd /tmp
-        - travis_retry wget -q https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-6.7.2.zip
-        - unzip -qq sonarqube-6.7.2.zip
+        - travis_retry wget -q https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-6.7.3.zip
+        - unzip -qq sonarqube-6.7.3.zip
         - travis_retry wget -q https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-7.0.zip
         - unzip -qq sonarqube-7.0.zip
         - travis_retry wget -q https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.0.3.778.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,10 @@ install:
       }
       if (!(Test-Path -Path "C:\sonarqube" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-6.7.2.zip',
-          'C:\sonarqube-6.7.2.zip'
+          'https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-6.7.3.zip',
+          'C:\sonarqube-6.7.3.zip'
         )
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonarqube-6.7.2.zip", "C:\sonarqube")
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonarqube-6.7.3.zip", "C:\sonarqube")
       }
   - ps: |
       If ($env:Platform -Match "x86") {
@@ -49,7 +49,7 @@ install:
   - cmd: SET PATH=C:\maven\apache-maven-3.2.5\bin;%JAVA_HOME%\bin;C:\sonar-scanner\sonar-scanner-3.0.3.778\bin;%PATH%
   - cmd: SET M2_HOME=C:\maven\apache-maven-3.2.5
   - cmd: SET MAVEN_HOME=C:\maven\apache-maven-3.2.5
-  - cmd: SET SONARHOME=C:\sonarqube\sonarqube-6.7.2
+  - cmd: SET SONARHOME=C:\sonarqube\sonarqube-6.7.3
   - cmd: SET TestDataFolder=C:\projects\sonar-cxx\integration-tests\testdata
   - cmd: SET
 
@@ -81,4 +81,4 @@ on_failure:
   - ps: Get-ChildItem cxx-checks\target\surefire-reports\*.txt | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   - ps: Get-ChildItem sonar-cxx-plugin\target\surefire-reports\*.txt | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   - ps: Get-ChildItem *.log | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-  - ps: Get-ChildItem C:\sonarqube\sonarqube-6.7.2\logs\* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+  - ps: Get-ChildItem C:\sonarqube\sonarqube-6.7.3\logs\* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/cxx-sensors/src/main/resources/clangsa.xml
+++ b/cxx-sensors/src/main/resources/clangsa.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <rules>
   <!-- C and C++ rules for Clang Static Analyzer. https://clang-analyzer.llvm.org/
 Rules list was generated based on clang version 5.0.0 (tags/RELEASE_500/final) -->

--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -969,9 +969,9 @@ Finds string constructors that are suspicious and probably errors.
   <key>misc-string-integer-assignment</key>
   <name>misc-string-integer-assignment</name>
   <description><![CDATA[<p>
-The check finds assignments of an integer to ``std::basic_string<CharT>``
+The check finds assignments of an integer to ``std::basic_string&lt;CharT&gt;``
 (``std::string``, ``std::wstring``, etc.). The source of the problem is the
-following assignment operator of ``std::basic_string<CharT>``: ``basic_string& operator=( CharT ch );``
+following assignment operator of ``std::basic_string&lt;CharT&gt;``: ``basic_string& operator=( CharT ch );``
   </p>
     <h2>References</h2>
 
@@ -1716,7 +1716,7 @@ Finds static function and variable definitions in anonymous namespace.
   <key>readability-uniqueptr-delete-release</key>
   <name>readability-uniqueptr-delete-release</name>
   <description><![CDATA[<p>
-Replace ``delete <unique_ptr>.release()`` with ``<unique_ptr> = nullptr``.
+Replace ``delete &lt;unique_ptr&gt;.release()`` with ``&lt;unique_ptr&gt; = nullptr``.
 The latter is shorter, simpler and does not require use of raw pointer APIs.
   </p>
     <h2>References</h2>

--- a/cxx-sensors/src/main/resources/compiler-gcc.xml
+++ b/cxx-sensors/src/main/resources/compiler-gcc.xml
@@ -487,7 +487,7 @@ Follow these steps to make your custom Custom rules available in SonarQube:
   <rule>
     <key>-Wclass-memaccess</key>
     <name>Warn when the destination of a call to a raw memory function violate const-correctness or encapsulation, or corrupt the virtual table</name>
-    <description>
+    <description><![CDATA[<p>
     Warn when the destination of a call to a raw memory function such as memset or memcpy is an object
     of class type writing into which might bypass the class non-trivial or deleted constructor or copy
     assignment, violate const-correctness or encapsulation, or corrupt the virtual table. Modifying
@@ -495,12 +495,13 @@ Follow these steps to make your custom Custom rules available in SonarQube:
     class. For example, the call to memset below is undefined becase it modifies a non-trivial class
     object and is, therefore, diagnosed. The safe way to either initialize or clear the storage of
     objects of such types is by using the appropriate constructor or assignment operator, if one is
-    available.
-
+    available.</p>
+<pre>
     std::string str = "abc";
     memset (&amp;str, 0, 3);
-
+</pre>
     The -Wclass-memaccess option is enabled by -Wall.
+    ]]>
     </description>
     <internalKey>-Wclass-memaccess</internalKey>
     <severity>CRITICAL</severity>
@@ -1610,12 +1611,12 @@ Follow these steps to make your custom Custom rules available in SonarQube:
   <rule>
     <key>-Wliteral-suffix</key>
     <name>Warn when a string or character literal is followed by a ud-suffix which does not begin with an underscore</name>
-    <description>
+    <description><![CDATA[<p>
     Warn when a string or character literal is followed by a ud-suffix which does
     not begin with an underscore. As a conforming extension, GCC treats such
     suffixes as separate preprocessing tokens in order to maintain backwards
-    compatibility with code that uses formatting macros from &gt;inttypes.h&gt;. For example:
-
+    compatibility with code that uses formatting macros from &gt;inttypes.h&gt;. For example:</p>
+<pre>
     #define __STDC_FORMAT_MACROS
     #include &lt;inttypes.h&gt;
     #include &lt;stdio.h&gt;
@@ -1624,13 +1625,14 @@ Follow these steps to make your custom Custom rules available in SonarQube:
       int64_t i64 = 123;
       printf("My int64: %" PRId64"\n", i64);
     }
-
+</pre>
     In this case, PRId64 is treated as a separate preprocessing token.
 
     Additionally, warn when a user-defined literal operator is declared with a
     literal suffix identifier that doesn’t begin with an underscore. Literal
     suffix identifiers that don’t begin with an underscore are reserved for
     future standardization.
+    ]]>
     </description>
     <internalKey>-Wliteral-suffix</internalKey>
     <severity>CRITICAL</severity>
@@ -1904,10 +1906,12 @@ Follow these steps to make your custom Custom rules available in SonarQube:
   <rule>
     <key>-Wmissing-parameter-type</key>
     <name>Warn about function parameters declared without a type specifier in K&amp;R-style functions</name>
-    <description>
+    <description><![CDATA[
     A function parameter is declared without a type specifier in K&amp;R-style functions:
-
+<pre>
             void foo(bar) { }
+</pre>
+]]>
     </description>
     <internalKey>-Wmissing-parameter-type</internalKey>
     <severity>CRITICAL</severity>
@@ -2938,14 +2942,15 @@ Follow these steps to make your custom Custom rules available in SonarQube:
   <rule>
     <key>-Wsizeof-pointer-memaccess</key>
     <name>Warn for suspicious length parameters to certain string and memory built-in functions if the argument uses sizeof</name>
-    <description>
+    <description><![CDATA[<p>
     Warn for suspicious length parameters to certain string and memory
     built-in functions if the argument uses sizeof. This warning warns e.g.
     about memset (ptr, 0, sizeof (ptr)); if ptr is not an array, but a
     pointer, and suggests a possible fix, or about
-    memcpy (&amp;foo, ptr, sizeof (&amp;foo));.
+    memcpy (&amp;foo, ptr, sizeof (&amp;foo));.</p>
 
-    This warning is enabled by -Wall
+    <p>This warning is enabled by -Wall</p>
+]]>
     </description>
     <internalKey>-Wsizeof-pointer-memaccess</internalKey>
     <severity>CRITICAL</severity>
@@ -2997,27 +3002,28 @@ Follow these steps to make your custom Custom rules available in SonarQube:
   <rule>
     <key>-Wstrict-aliasing</key>
     <name>Warn about code which might break strict aliasing rules</name>
-    <description>
+    <description><![CDATA[<p>
     Warn about code which might break the strict aliasing rules that the compiler is using
     for optimization. The warning does not catch all cases, but does attempt to catch the more common
     pitfalls. Higher levels correspond to higher accuracy (fewer false positives). Higher levels also
     correspond to more effort, similar to the way -O works. -Wstrict-aliasing is equivalent to
-    -Wstrict-aliasing=n, with n=3.
+    -Wstrict-aliasing=n, with n=3.</p>
 
-    Level 1: Most aggressive, quick, least accurate.  Possibly useful when higher levels do not warn but
+    <p>Level 1: Most aggressive, quick, least accurate.  Possibly useful when higher levels do not warn but
     -fstrict-aliasing still breaks the code, as it has very few false negatives.  However, it has many
     false positives.  Warns for all pointer conversions between possibly incompatible types, even if
-    never dereferenced.  Runs in the frontend only.
+    never dereferenced.  Runs in the frontend only.</p>
 
-    Level 2: Aggressive, quick, not too precise.  May still have many false positives (not as many as
+    <p>Level 2: Aggressive, quick, not too precise.  May still have many false positives (not as many as
     level 1 though), and few false negatives (but possibly more than level 1).  Unlike level 1, it
-    only warns when an address is taken.  Warns about incomplete types.  Runs in the frontend only.
+    only warns when an address is taken.  Warns about incomplete types.  Runs in the frontend only.</p>
 
-    Level 3 (default for -Wstrict-aliasing): Should have very few false positives and few false negatives.
+    <p>Level 3 (default for -Wstrict-aliasing): Should have very few false positives and few false negatives.
     Slightly slower than levels 1 or 2 when optimization is enabled. Takes care of the common pun+dereference
     pattern in the frontend: "*(int*)&amp;some_float". If optimization is enabled, it also runs in the
     backend, where it deals with multiple statement cases using flow-sensitive points-to information.
-    Only warns when the converted pointer is dereferenced. Does not warn about incomplete types.
+    Only warns when the converted pointer is dereferenced. Does not warn about incomplete types.</p>
+]]>
     </description>
     <internalKey>-Wstrict-aliasing</internalKey>
     <severity>CRITICAL</severity>
@@ -3519,47 +3525,50 @@ Follow these steps to make your custom Custom rules available in SonarQube:
   <rule>
     <key>-Wtraditional</key>
     <name>Warn about features not present in traditional C</name>
-    <description>
+    <description><![CDATA[<p>
     Warn about certain constructs that behave differently in traditional and ISO C. Also
     warn about ISO C constructs that have no traditional C equivalent, and/or problematic constructs
-    which should be avoided.
-      * Macro parameters that appear within string literals in the macro body.  In traditional C macro
-        replacement takes place within string literals, but does not in ISO C.
-      * In traditional C, some preprocessor directives did not exist.  Traditional preprocessors would
+    which should be avoided.</p>
+    <ul>
+    <li>Macro parameters that appear within string literals in the macro body.  In traditional C macro
+        replacement takes place within string literals, but does not in ISO C.</li>
+    <li>In traditional C, some preprocessor directives did not exist.  Traditional preprocessors would
         only consider a line to be a directive if the # appeared in column 1 on the line.  Therefore
         -Wtraditional warns about directives that traditional C understands but would ignore because the #
         does not appear as the first character on the line. It also suggests you hide directives like #pragma
         not understood by traditional C by indenting them.  Some traditional implementations would not
-        recognize #elif, so it suggests avoiding it altogether.
-      * A function-like macro that appears without arguments.
-      * The unary plus operator.
-      * The U integer constant suffix, or the F or L floating point constant suffixes.  (Traditional C
+        recognize #elif, so it suggests avoiding it altogether.</li>
+    <li>A function-like macro that appears without arguments.</li>
+    <li>The unary plus operator.</li>
+    <li>The U integer constant suffix, or the F or L floating point constant suffixes.  (Traditional C
         does support the L suffix on integer constants.)  Note, these suffixes appear in macros defined
         in the system headers of most modern systems, e.g. the _MIN/_MAX macros in "&lt;limits.h&gt;".
         Use of these macros in user code might normally lead to spurious warnings, however GCC's integrated
-        preprocessor has enough context to avoid warning in these cases.
-      * A function declared external in one block and then used after the end of the block.
-      * A "switch" statement has an operand of type "long".
-      * A non-"static" function declaration follows a "static" one.  This construct is not accepted by
-        some traditional C compilers.
-      * The ISO type of an integer constant has a different width or signedness from its traditional type.
+        preprocessor has enough context to avoid warning in these cases.</li>
+    <li>A function declared external in one block and then used after the end of the block.</li>
+    <li>A "switch" statement has an operand of type "long".</li>
+    <li>A non-"static" function declaration follows a "static" one.  This construct is not accepted by
+        some traditional C compilers.</li>
+    <li>The ISO type of an integer constant has a different width or signedness from its traditional type.
         This warning is only issued if the base of the constant is ten.  I.e. hexadecimal or octal values,
-        which typically represent bit patterns, are not warned about.
-      * Usage of ISO string concatenation is detected.
-      * Initialization of automatic aggregates.
-      * Identifier conflicts with labels.  Traditional C lacks a separate namespace for labels.
-      * Initialization of unions.  If the initializer is zero, the warning is omitted.  This is done under
+        which typically represent bit patterns, are not warned about.</li>
+    <li>Usage of ISO string concatenation is detected.</li>
+    <li>Initialization of automatic aggregates.</li>
+    <li>Identifier conflicts with labels.  Traditional C lacks a separate namespace for labels.</li>
+    <li>Initialization of unions.  If the initializer is zero, the warning is omitted.  This is done under
         the assumption that the zero initializer in user code appears conditioned on e.g. "__STDC__" to
         avoid missing initializer warnings and relies on default initialization to zero in the traditional
-        C case.
-      * Conversions by prototypes between fixed/floating point values and vice versa.  The absence of
+        C case.</li>
+    <li>Conversions by prototypes between fixed/floating point values and vice versa.  The absence of
         these prototypes when compiling with traditional C would cause serious problems.  This is a subset
-        of the possible conversion warnings, for the full set use -Wtraditional-conversion.
-      * Use of ISO C style function definitions.  This warning intentionally is not issued for prototype
+        of the possible conversion warnings, for the full set use -Wtraditional-conversion.</li>
+    <li>Use of ISO C style function definitions.  This warning intentionally is not issued for prototype
         declarations or variadic functions because these ISO C features will appear in your code when
         using libiberty's traditional C compatibility macros, "PARAMS" and "VPARAMS".  This warning is
         also bypassed for nested functions because that feature is already a GCC extension and thus not
-        relevant to traditional C compatibility.
+        relevant to traditional C compatibility.</li>
+    </ul>
+]]>
     </description>
     <internalKey>-Wtraditional</internalKey>
     <severity>CRITICAL</severity>

--- a/cxx-sensors/src/main/resources/compiler-vc.xml
+++ b/cxx-sensors/src/main/resources/compiler-vc.xml
@@ -1098,7 +1098,7 @@ A function or pointer to function has a UDT (user-defined type, which is a class
 - All calls to this function occur from C++.
 - The definition of the function is in C++.
 </p><h2>MSDN Documentation</h2>
-<p><a href="https://msdn.microsoft.com/en-us/library/aa734013.aspx target="_blank">https://msdn.microsoft.com/en-us/library/aa734013.aspx</a></p>
+<p><a href="https://msdn.microsoft.com/en-us/library/aa734013.aspx" target="_blank">https://msdn.microsoft.com/en-us/library/aa734013.aspx</a></p>
 ]]>
     </description>
     <internalKey>C4190</internalKey>
@@ -1110,18 +1110,18 @@ A function or pointer to function has a UDT (user-defined type, which is a class
   <rule>
     <key>C4191</key>
     <name>C4191: 'operator/operation' : unsafe conversion from 'type of expression' to 'type required'</name>
-    <description><![CDATA[<p>
+    <description><![CDATA[
 <p>Several operations involving function pointers are considered unsafe: 
 </p><ul>
 <li>Function types with different calling conventions.</li>
 <li>Function types with different return conventions.</li>
 <li>Argument or return types with different sizes, type categories, or classifications.</li>
-<li>Differing argument list lengths (on <i><b>__cdecl</i></b>, only on cast from longer list to shorter list, even if shorter is varargs).</li>
-<li>Pointer to data (other than <i><b>void*</i></b>) aliased against a pointer to function.</li>
+<li>Differing argument list lengths (on <i><b>__cdecl</b></i>, only on cast from longer list to shorter list, even if shorter is varargs).</li>
+<li>Pointer to data (other than <i><b>void*</b></i>) aliased against a pointer to function.</li>
 <li>Any other type difference that would yield an error or warning on a <i><b>reinterpret_cast</b></i>.</li>
 </ul>
 <p>Calling this function through the result pointer might cause your program to crash.</p>
-</p><h2>MSDN Documentation</h2>
+<h2>MSDN Documentation</h2>
 <p><a href="https://msdn.microsoft.com/en-us/library/aa734013.aspx" target="_blank">https://msdn.microsoft.com/en-us/library/aa734013.aspx</a></p>
 ]]>
     </description>
@@ -2249,10 +2249,10 @@ If a shift count is negative or too large, the behavior of the resulting image i
     <key>C4295</key>
     <name>C4295: ' array ' : array is too small to include a terminating null character</name>
     <description><![CDATA[<p>
-An array was initialized but the last character in the array is not a null; accessing the array may produce unexpected results.
-</p><h2>MSDN Documentation</h2>
+An array was initialized but the last character in the array is not a null; accessing the array may produce unexpected results.</p>
+<h2>MSDN Documentation</h2>
 <p><a href="https://msdn.microsoft.com/en-us/library/t12y6ed4.aspx" target="_blank">https://msdn.microsoft.com/en-us/library/t12y6ed4.aspx</a></p>
-</p><h2>References</h2>
+<h2>References</h2>
 <p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=47677453" target="_blank">ARR30-C. Do not form or use out-of-bounds pointers or array subscripts</a></p>
 <p><a href="https://cwe.mitre.org/data/definitions/788.html" target="_blank">CWE-788: Access of Memory Location After End of Buffer</a></p>
 ]]>
@@ -2497,7 +2497,7 @@ There is a conflict between the format specified and the number of parameters. F
 <pre><code>
   printf("%d %d\n", 1); //C4317
 </code></pre>
-</p><h2>MSDN Documentation</h2>
+<h2>MSDN Documentation</h2>
 <p><a href="http://blogs.msdn.com/b/vcblog/archive/2014/11/12/improvements-to-warnings-in-the-c-compiler.aspx" target="_blank">http://blogs.msdn.com/b/vcblog/archive/2014/11/12/improvements-to-warnings-in-the-c-compiler.aspx</a></p>
 ]]>
     </description>
@@ -3624,7 +3624,7 @@ There is a conflict between the format specified and the number of parameters. F
 <pre><code>
   printf("%d\n", 1, 2); //C4422
 </code></pre>
-</p><h2>MSDN Documentation</h2>
+<h2>MSDN Documentation</h2>
 <p><a href="http://blogs.msdn.com/b/vcblog/archive/2014/11/12/improvements-to-warnings-in-the-c-compiler.aspx" target="_blank">http://blogs.msdn.com/b/vcblog/archive/2014/11/12/improvements-to-warnings-in-the-c-compiler.aspx</a></p>
 ]]>
     </description>
@@ -3642,9 +3642,9 @@ There is a conflict between the format specified and the number of parameters. F
 Some specifiers that aren't allowed to be used in some variants of printf. For example printf_s disallows '%n'.</p>
 <pre><code>
     int n; 
-    printf_s("Test %n", &n); //C4426
+    printf_s("Test %n", &amp;n); //C4426
 </code></pre>
-</p><h2>MSDN Documentation</h2>
+<h2>MSDN Documentation</h2>
 <p><a href="http://blogs.msdn.com/b/vcblog/archive/2014/11/12/improvements-to-warnings-in-the-c-compiler.aspx" target="_blank">http://blogs.msdn.com/b/vcblog/archive/2014/11/12/improvements-to-warnings-in-the-c-compiler.aspx</a></p>
 ]]>
     </description>
@@ -3995,8 +3995,8 @@ have no effect under /clr.
     <key>C4471</key>
     <name>C4471: forward declaration of an unscoped enumeration must have an underlying type</name>
     <description>
-    <![CDATA[
-A forward declaration of an unscoped enumeration must have an underlying type( int assumed ).
+    <![CDATA[<p>
+A forward declaration of an unscoped enumeration must have an underlying type( int assumed ).</p>
 <pre><code>
 // unscoped enum
 enum class C {x,y}; //scoped, base is int by default
@@ -4004,8 +4004,8 @@ enum class C {x,y}; //scoped, base is int by default
 enum class Z: char {x,y}; //scoped, base is char
 // forward declaration
 enum class Direction: short; //enum base is short
-</pre></code>
-</p><h2>MSDN Documentation</h2>
+</code></pre>
+<h2>MSDN Documentation</h2>
 <p><a href="https://msdn.microsoft.com/en-us/library/23k5d385.aspx" target="_blank">https://msdn.microsoft.com/en-us/library/23k5d385.aspx</a></p>
 ]]>
     </description>
@@ -4019,7 +4019,7 @@ enum class Direction: short; //enum base is short
     <key>C4473</key>
     <name>C4473: '&lt;function&gt;' : not enough arguments passed for format string</name>
     <description>
-    <![CDATA[
+    <![CDATA[<p>
 Missing variadic arguments can be as big of a security concern as incorrect types, because they may cause your program to read garbage from the stack.
 </p><h2>MSDN Documentation</h2>
 <p><a href="http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4473" target="_blank">http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4473</a></p>
@@ -4039,7 +4039,7 @@ Missing variadic arguments can be as big of a security concern as incorrect type
     <key>C4474</key>
     <name>C4474: '&lt;function&gt;' : too many arguments passed for format string</name>
     <description>
-    <![CDATA[
+    <![CDATA[<p>
 Compiling this with default flags wouldn’t result in any diagnostic messages, giving you a false sense of security, but you can clearly see that there are problems here. Unfortunately, always giving a warning when a format string is not a string literal turned out to generate too many warnings on valid use cases (e.g. localization), so as a compromise we decided to provide this warning as off by default.
 </p><h2>MSDN Documentation</h2>
 <p><a href="http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4474" target="_blank">http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4474</a></p>
@@ -4060,7 +4060,7 @@ Compiling this with default flags wouldn’t result in any diagnostic messages, 
     <name>C4475: '&lt;function&gt;' : length modifier '&lt;length&gt;' cannot be used with type field character '&lt;conversion-specifier&gt;' in format specifier</name>
     <description>
     <![CDATA[
-</p><h2>MSDN Documentation</h2>
+<h2>MSDN Documentation</h2>
 <p><a href="http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4475" target="_blank">http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4475</a></p>
 ]]>
     </description>
@@ -4075,7 +4075,7 @@ Compiling this with default flags wouldn’t result in any diagnostic messages, 
     <name>C4476: '&lt;function&gt;' : unknown type field character '&lt;conversion-specifier&gt;' in format specifier</name>
     <description>
     <![CDATA[
-</p><h2>MSDN Documentation</h2>
+<h2>MSDN Documentation</h2>
 <p><a href="http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4476" target="_blank">http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4476</a></p>
 ]]>
     </description>
@@ -4090,7 +4090,7 @@ Compiling this with default flags wouldn’t result in any diagnostic messages, 
     <name>C4477: '&lt;function&gt;' :format string '&lt;format-string&gt;' requires an argument of type '&lt;type&gt;', but variadic argument &lt;position&gt; has type '&lt;type&gt;'</name>
     <description>
     <![CDATA[
-</p><h2>MSDN Documentation</h2>
+<h2>MSDN Documentation</h2>
 <p><a href="http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4477" target="_blank">http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4477</a></p>
 ]]>
     </description>
@@ -4106,7 +4106,7 @@ Compiling this with default flags wouldn’t result in any diagnostic messages, 
     <name>C4478: '&lt;function&gt;' : positional and non-positional placeholders cannot be mixed in the same format string</name>
     <description>
     <![CDATA[
-</p><h2>MSDN Documentation</h2>
+<h2>MSDN Documentation</h2>
 <p><a href="http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4478" target="_blank">http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4478</a></p>
 ]]>
     </description>
@@ -5069,7 +5069,7 @@ A function was redefined or redeclared and the second definition or declaration 
     <description><![CDATA[<p>
       The __fastcall function-calling convention cannot be used with the /clr compiler option. The compiler ignores the calls to __fastcall. To fix this warning, either remove the calls to __fastcall or compile without /clr. 
 </p><h2>MSDN Documentation</h2>
-<p><a href="" target="_blank"></a></p>
+<p><a href="https://msdn.microsoft.com/en-us/library/fb18b15e.aspx" target="_blank">https://msdn.microsoft.com/en-us/library/fb18b15e.aspx</a></p>
 ]]>
     </description>
     <internalKey>C4561</internalKey>
@@ -5084,7 +5084,7 @@ A function was redefined or redeclared and the second definition or declaration 
     <description><![CDATA[<p>
 The compiler detected a method with one or more parameters with default values. The default value(s) for the parameters will be ignored when the method is invoked; explicitly specify values for those parameters. If you do not explicitly specify values for those parameters, the C++ compiler will generate an error.
 </p><h2>MSDN Documentation</h2>
-<p><a href="https://msdn.microsoft.com/en-us/library/fb18b15e.aspx" target="_blank">https://msdn.microsoft.com/en-us/library/fb18b15e.aspx</a></p>
+<p><a href="https://msdn.microsoft.com/en-us/library/8ehbb95s.aspx" target="_blank">https://msdn.microsoft.com/en-us/library/8ehbb95s.aspx</a></p>
 ]]>
     </description>
     <internalKey>C4564</internalKey>
@@ -6371,8 +6371,7 @@ This warning is, by default, issued as an error. C4772 can not be suppressed wit
   <rule>
     <key>C4774</key>
     <name>C4774: '&lt;function&gt;' : format string expected in argument &lt;position&gt; is not a string literal</name>
-    <description><![CDATA[<p>
-</p><h2>MSDN Documentation</h2>
+    <description><![CDATA[<h2>MSDN Documentation</h2>
 <p><a href="http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4774" target="_blank">http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4774</a></p>
 ]]>
     </description>
@@ -6385,8 +6384,7 @@ This warning is, by default, issued as an error. C4772 can not be suppressed wit
   <rule>
     <key>C4775</key>
     <name>C4775: nonstandard extension used in format string '&lt;format-string&gt;' of function '&lt;function&gt;'</name>
-    <description><![CDATA[<p>
-</p><h2>MSDN Documentation</h2>
+    <description><![CDATA[<h2>MSDN Documentation</h2>
 <p><a href="http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4775" target="_blank">http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4775</a></p>
 ]]>
     </description>
@@ -6399,8 +6397,7 @@ This warning is, by default, issued as an error. C4772 can not be suppressed wit
   <rule>
     <key>C4776</key>
     <name>C4776: ‘%&lt;conversion-specifier&gt;' is not allowed in the format string of function '&lt;function&gt;'</name>
-    <description><![CDATA[<p>
-</p><h2>MSDN Documentation</h2>
+    <description><![CDATA[<h2>MSDN Documentation</h2>
 <p><a href="http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4776" target="_blank">http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4776</a></p>
 ]]>
     </description>
@@ -6413,8 +6410,7 @@ This warning is, by default, issued as an error. C4772 can not be suppressed wit
   <rule>
     <key>C4777</key>
     <name>C4777: '&lt;function&gt;' : format string '&lt;format-string&gt;' requires an argument of type '&lt;type&gt;', but variadic argument &lt;position&gt; has type '&lt;type&gt;'</name>
-    <description><![CDATA[<p>
-</p><h2>MSDN Documentation</h2>
+    <description><![CDATA[<h2>MSDN Documentation</h2>
 <p><a href="http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4777" target="_blank">http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4777</a></p>
 ]]>
     </description>
@@ -6427,8 +6423,7 @@ This warning is, by default, issued as an error. C4772 can not be suppressed wit
   <rule>
     <key>C4778</key>
     <name>C4778: '&lt;function&gt;' : unterminated format string '&lt;format-string&gt;'</name>
-    <description><![CDATA[<p>
-</p><h2>MSDN Documentation</h2>
+    <description><![CDATA[<h2>MSDN Documentation</h2>
 <p><a href="http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4778" target="_blank">http://blogs.msdn.com/b/vcblog/archive/2015/06/22/format-specifiers-checking.aspx#C4778</a></p>
 ]]>
     </description>
@@ -6791,7 +6786,7 @@ To correct this error
     <description><![CDATA[<p>
 Implicit conversion might not be sufficient and the precision might be different e.g. double to float. Use explicit type cast if this is intended. 
 </p><h2>MSDN Documentation</h2>
-<p><a href="" target="_blank"></a></p>
+<p><a href="https://msdn.microsoft.com/en-us/library/mt763968.aspx" target="_blank">https://msdn.microsoft.com/en-us/library/mt763968.aspx</a></p>
 ]]>
     </description>
     <internalKey>C4838</internalKey>
@@ -7130,7 +7125,7 @@ This warning is reported when an uninitialized local variable is used before it 
 This warning indicates that a null pointer is being dereferenced. If the pointer value is invalid, the result is undefined.
 </p><h2>MSDN Documentation</h2>
 <p><a href="https://msdn.microsoft.com/en-us/library/2ayc37ac.aspx" target="_blank">https://msdn.microsoft.com/en-us/library/2ayc37ac.aspx</a></p>
-</p><h2>References</h2>
+<h2>References</h2>
 <p><a href="https://www.securecoding.cert.org/confluence/display/c/EXP34-C.+Do+not+dereference+null+pointers" target="_blank">EXP34-C. Do not dereference null pointers</a></p>
 <p><a href="https://cwe.mitre.org/data/definitions/476.html" target="_blank">CWE-476: NULL Pointer Dereference</a></p>
 ]]>
@@ -7199,7 +7194,7 @@ This warning indicates that the specified function has been called in such a way
 Most C standard library and Win32 string handling functions require and produce zero-terminated strings. A few 'counted string' functions (including strncpy, wcsncpy, _mbsncpy, _snprintf, and snwprintf) do not produce zero-terminated strings if they exactly fill their buffer. In this case, a subsequent call to a string function that expects a zero-terminated string will go beyond the end of the buffer looking for the zero. The program should make sure that the string ends with a zero. In general, you should pass a length to the 'counted string' function one smaller than the size of the buffer and then explicitly assign zero to the last character in the buffer.
 </p><h2>MSDN Documentation</h2>
 <p><a href="https://msdn.microsoft.com/en-us/library/5dx7ef8x.aspx" target="_blank">https://msdn.microsoft.com/en-us/library/5dx7ef8x.aspx</a></p>
-</p><h2>References</h2>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/170.html" target="_blank">CWE-170: Improper Null Termination</a></p>
 ]]>
     </description>
@@ -7413,7 +7408,7 @@ One common cause of this defect is using an array's size as an index into the ar
 This warning indicates that a parameter pointing to a stack buffer of known size is being passed into a function that copies more bytes into it than that size. This situation will cause a buffer overrun. This defect is likely to cause an exploitable security hole or a program crash.
 </p><h2>MSDN Documentation</h2>
 <p><a href="https://msdn.microsoft.com/en-us/subscriptions/administration/6cb2bae4(v=vs.90)" target="_blank">https://msdn.microsoft.com/en-us/subscriptions/administration/6cb2bae4(v=vs.90)</a></p>
-</p><h2>References</h2>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/788.html" target="_blank">CWE-788: Access of Memory Location After End of Buffer</a></p>
 ]]>
     </description>
@@ -7474,7 +7469,7 @@ This warning is generated when:
 - Both the variable type and the formal parameter type are some variety of pointer-to-wide char.
 </p><h2>MSDN Documentation</h2>
 <p><a href="https://msdn.microsoft.com/en-us/subscriptions/downloads/e7ca7stt(v=vs.90).aspx" target="_blank">https://msdn.microsoft.com/en-us/subscriptions/downloads/e7ca7stt(v=vs.90).aspx</a></p>
-</p><h2>References</h2>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/788.html" target="_blank">CWE-788: Access of Memory Location After End of Buffer</a></p>
 ]]>
     </description>
@@ -7793,7 +7788,7 @@ Objects that have null DACLs can have their security descriptors altered by mali
 Even if everyone needs access to an object, the object should be secured so that only administrators can alter its security. If only the creator needs access to an object, a DACL should not be set on the object; the system will choose an appropriate default.
 </p><h2>MSDN Documentation</h2>
 <p><a href="https://msdn.microsoft.com/en-us/library/c5se1z6d.aspx" target="_blank">https://msdn.microsoft.com/en-us/library/c5se1z6d.aspx</a></p>
-</p><h2>References</h2>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/475.html" target="_blank">CWE-475: Undefined Behavior for Input to API</a></p>
 ]]>
     </description>
@@ -8064,7 +8059,7 @@ This warning indicates a potentially incorrect cast from an ANSI string (char_t*
 This warning indicates that the application name parameter is null and there might be spaces in the executable path name. In this case, unless the executable name is "fully qualified," there is likely to be a security problem. A malicious user might insert a rogue executable with the same name earlier in the path. To correct this warning, you can specify the application name instead of passing null or if you do pass null for the application name, use quotation marks around the executable path.
 </p><h2>MSDN Documentation</h2>
 <p><a href="https://msdn.microsoft.com/en-us/library/4b4tecce.aspx" target="_blank">https://msdn.microsoft.com/en-us/library/4b4tecce.aspx</a></p>
-</p><h2>References</h2>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/475.html" target="_blank">CWE-475: Undefined Behavior for Input to API</a></p>
 ]]>
     </description>
@@ -9055,7 +9050,7 @@ This warning indicates that the writable extent of the specified buffer might be
 This warning is raised if an annotated function parameter is being passed an unexpected value. For example, passing a potentially null value to a parameter that is marked with _In_ annotation generates this warning.
 </p><h2>MSDN Documentation</h2>
 <p><a href="https://msdn.microsoft.com/en-us/library/k204dhw5.aspx" target="_blank">https://msdn.microsoft.com/en-us/library/k204dhw5.aspx</a></p>
-</p><h2>References</h2>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/475.html" target="_blank">CWE-475: Undefined Behavior for Input to API</a></p>
 ]]>
     </description>
@@ -10047,7 +10042,7 @@ see also:</p>
     <key>C26404</key>
     <name>C26404: DONT_DELETE_INVALID</name>
     <description><![CDATA[<p>
-Do not delete an owner<T> which may be in invalid state.
+Do not delete an owner&lt;T&gt; which may be in invalid state.
 
 see also:</p>
 <p><a href="https://docs.microsoft.com/en-us/visualstudio/code-quality/c26404" target="_blank">C26404 DONT_DELETE_INVALID</a></p>
@@ -10082,7 +10077,7 @@ see also:</p>
     <key>C26406</key>
     <name>C26406: DONT_ASSIGN_RAW_TO_OWNER</name>
     <description><![CDATA[<p>
-Do not assign a raw pointer to an owner<T>.
+Do not assign a raw pointer to an owner&lt;T&gt;.
 
 see also:</p>
 <p><a href="https://docs.microsoft.com/en-us/visualstudio/code-quality/c26406" target="_blank">C26406 DONT_ASSIGN_RAW_TO_OWNER</a></p>
@@ -10137,7 +10132,7 @@ see also:</p>
     <key>C26409</key>
     <name>C26409: NO_NEW_DELETE</name>
     <description><![CDATA[<p>
-Avoid calling new and delete explicitly, use std::make_unique<T> instead.
+Avoid calling new and delete explicitly, use std::make_unique&lt;T&gt; instead.
 
 see also:</p>
 <p><a href="https://docs.microsoft.com/en-us/visualstudio/code-quality/c26409" target="_blank">C26409 NO_NEW_DELETE</a></p>
@@ -10159,7 +10154,7 @@ The parameter '%parameter%' is a reference to const unique pointer, use const T*
 
 see also:</p>
 <p><a href="https://docs.microsoft.com/en-us/visualstudio/code-quality/c26410" target="_blank">C26410 NO_REF_TO_CONST_UNIQUE_PTR</a></p>
-<p><a href="hhttps://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-uniqueptrparam" target="_blank">Core Guideline - R.32: Take a unique_ptr<widget> parameter to express that a function assumes ownership of a widget</a></p>
+<p><a href="hhttps://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-uniqueptrparam" target="_blank">Core Guideline - R.32: Take a unique_ptr&lt;widget&gt; parameter to express that a function assumes ownership of a widget</a></p>
 ]]>
     </description>
     <internalKey>C26410</internalKey>
@@ -10177,7 +10172,7 @@ No reference to unique pointer.
 
 see also:</p>
 <p><a href="https://docs.microsoft.com/en-us/visualstudio/code-quality/c26411" target="_blank">C26411 NO_REF_TO_UNIQUE_PTR</a></p>
-<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-reseat" target="_blank">Core Guideline - R.33: Take a unique_ptr<widget>& parameter to express that a function reseats thewidget</a></p>
+<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-reseat" target="_blank">Core Guideline - R.33: Take a unique_ptr&lt;widget&gt;& parameter to express that a function reseats thewidget</a></p>
 ]]>
     </description>
     <internalKey>C26411</internalKey>
@@ -10245,7 +10240,7 @@ Using a smart pointer type to pass data to a function indicates that the target 
 Passing a shared pointer by rvalue reference is usually unnecessary. Unless it is an implementation of move semantics for a shared pointer type itself, shared pointer objects can be safely passed by value. Using rvalue reference may be also an indication that unique pointer is more appropriate since it clearly transfers unique ownership from caller to callee.
 </p><h2>Microsoft Documentation</h2>
 <p><a href="https://docs.microsoft.com/en-us/visualstudio/code-quality/c26416" target="_blank">C26416 NO_RVALUE_REF_SHARED_PTR</a></p>
-<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-sharedptrparam-owner" target="_blank">Core Guideline - R.34: Take a shared_ptr<widget> parameter to express that a function is part owner</a></p>
+<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-sharedptrparam-owner" target="_blank">Core Guideline - R.34: Take a shared_ptr&lt;widget&gt; parameter to express that a function is part owner</a></p>
 ]]>
     </description>
     <internalKey>C26416</internalKey>
@@ -10262,7 +10257,7 @@ Passing a shared pointer by rvalue reference is usually unnecessary. Unless it i
 Passing shared pointers by reference may be useful in scenarios where callee code updates target of the smart pointer object and its caller expects to see such update. Using a reference solely to reduce costs of passing a shared pointer is questionable. If callee code only accesses target object and never manages its lifetime, it is safer to pass raw pointer or reference, rather than to expose resource management details.
 </p><h2>Microsoft Documentation</h2>
 <p><a href="https://docs.microsoft.com/en-us/visualstudio/code-quality/c26417" target="_blank">C26417 NO_LVALUE_REF_SHARED_PTR</a></p>
-<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-sharedptrparam" target="_blank">Core Guideline - R.35: Take a shared_ptr<widget>& parameter to express that a function might reseat the shared pointer</a></p>
+<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-sharedptrparam" target="_blank">Core Guideline - R.35: Take a shared_ptr&lt;widget&gt;& parameter to express that a function might reseat the shared pointer</a></p>
 ]]>
     </description>
     <internalKey>C26417</internalKey>
@@ -10279,7 +10274,7 @@ Passing shared pointers by reference may be useful in scenarios where callee cod
 If shared pointer parameter is passed by value or reference to a constant object it is expected that function will take control of its target object’s lifetime without affecting of the caller. The code should either copy or move the shared pointer parameter to another shared pointer object or pass it further to other code by invoking functions which accept shared pointers. If this is not the case, then plain pointer or reference may be feasible.
 </p><h2>Microsoft Documentation</h2>
 <p><a href="https://docs.microsoft.com/en-us/visualstudio/code-quality/c26418" target="_blank">C26418 NO_VALUE_OR_CONST_REF_SHARED_PTR</a></p>
-<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-sharedptrparam-const" target="_blank">Core Guideline - R.36: Take a const shared_ptr<widget>& parameter to express that it might retain a reference count to the object ???</a></p>
+<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-sharedptrparam-const" target="_blank">Core Guideline - R.36: Take a const shared_ptr&lt;widget&gt;& parameter to express that it might retain a reference count to the object ???</a></p>
 ]]>
     </description>
     <internalKey>C26418</internalKey>
@@ -10365,7 +10360,7 @@ Global objects may be initialized in an inconsistent or undefined order which me
 It is a common practice to use asserts to enforce assumptions about validity of pointer values. The problem with asserts is that they do not expose assumptions through the interface (e.g. in return types or parameters). Asserts are also harder to maintain and keep in sync with other code changes. The recommendation is to use gsl::not_null from the Guidelines Support Library as a marker of resources which should never have null value. The rule USE_NOTNULL helps to identify places that omit checks for nullness and hence can be updated to use gsl::not_null.
 </p><h2>Microsoft Documentation</h2>
 <p><a href="https://docs.microsoft.com/en-us/visualstudio/code-quality/c26429" target="_blank">C26429: USE_NOTNULL</a></p>
-<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f23-use-a-not_nullt-to-indicate-that-null-is-not-a-valid-value" target="_blank">Core Guideline - F.23: Use a not_null<T> to indicate that "null" is not a valid value</a></p>
+<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f23-use-a-not_nullt-to-indicate-that-null-is-not-a-valid-value" target="_blank">Core Guideline - F.23: Use a not_null&lt;T&gt; to indicate that "null" is not a valid value</a></p>
 ]]>
     </description>
     <internalKey>C26429</internalKey>
@@ -10382,7 +10377,7 @@ It is a common practice to use asserts to enforce assumptions about validity of 
 If code ever checks nullness of pointer variables it should do this consistently and validate pointers on all paths. Sometimes overaggressive checking for nullness is still better than possibility of a hard crash in one of the complicated branches. Ideally such code should be refactored to be less complex (by splitting into multiple functions) and to rely on markers like gsl::not_null (see Guidelines Support Library) to isolate parts of algorithm that can make safe assumption about valid pointer values. The rule TEST_ON_ALL_PATHS helps to find places where nullness checks are either inconsistent (hence assumptions may require review) or actual bugs where potential null value can bypass nullness check in some of the code paths.
 </p><h2>Microsoft Documentation</h2>
 <p><a href="https://docs.microsoft.com/en-us/visualstudio/code-quality/c26430" target="_blank">C26430 TEST_ON_ALL_PATHS</a></p>
-<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f23-use-a-not_nullt-to-indicate-that-null-is-not-a-valid-value" target="_blank">Core Guideline - F.23: Use a not_null<T> to indicate that "null" is not a valid value</a></p>
+<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f23-use-a-not_nullt-to-indicate-that-null-is-not-a-valid-value" target="_blank">Core Guideline - F.23: Use a not_null&lt;T&gt; to indicate that "null" is not a valid value</a></p>
 ]]>
     </description>
     <internalKey>C26430</internalKey>
@@ -10399,7 +10394,7 @@ If code ever checks nullness of pointer variables it should do this consistently
 The marker type gsl::not_null from Guidelines Support Library is used to clearly indicate values which are never null pointers. It causes a hard failure if such assumption is not held at runtime. So, obviously, there is no need to check for nullness if expression evaluates to a result of type gsl::not_null.
 </p><h2>Microsoft Documentation</h2>
 <p><a href="https://docs.microsoft.com/en-us/visualstudio/code-quality/c26431" target="_blank">C26431: DONT_TEST_NOTNULL</a></p>
-<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f23-use-a-not_nullt-to-indicate-that-null-is-not-a-valid-value" target="_blank">Core Guideline - F.23: Use a not_null<T> to indicate that "null" is not a valid value</a></p>
+<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f23-use-a-not_nullt-to-indicate-that-null-is-not-a-valid-value" target="_blank">Core Guideline - F.23: Use a not_null&lt;T&gt; to indicate that "null" is not a valid value</a></p>
 ]]>
     </description>
     <internalKey>C26431</internalKey>
@@ -10790,7 +10785,7 @@ Con.3: By default, pass pointers and references to consts</a></p>
     <key>C26461</key>
     <name>C26461: USE_CONST_POINTER_ARGUMENTS</name>
     <description><![CDATA[<p>
-By default, pass pointers and references to consts
+By default, pass pointers and references to consts</p>
 <pre><code>
 // Expect 26461: The input pointer argument b in function f7 can be marked as const
 int f7(const int *a, int *b)
@@ -10812,7 +10807,7 @@ S0 f8(int *p, int *)
     return{};
 }
 </code></pre>
-see also:</p>
+see also:
 <p><a href="https://docs.microsoft.com/en-us/visualstudio/code-quality/c26461" target="_blank">C26461 C26461 USE_CONST_POINTER_ARGUMENTS</a></p>
 <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#con3-by-default-pass-pointers-and-references-to-consts" target="_blank">Core Guideline - Con.3: By default, pass pointers and references to consts</a></p>
 ]]>
@@ -11232,7 +11227,7 @@ see also:</p>
     <key>C26496</key>
     <name>C26496: USE_CONST_FOR_VARIABLE</name>
     <description><![CDATA[<p>
-The variable '%variable%' is assigned only once, mark it as const.
+The variable '%variable%' is assigned only once, mark it as const.</p>
 <pre><code>
 int f5()
 {
@@ -11243,7 +11238,7 @@ int f5()
         return m;
     return a;
 }</code></pre>
-see also:</p>
+see also:
 <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#con4-use-const-to-define-objects-with-values-that-do-not-change-after-construction" target="_blank">Core Guideline - Con.4: Use const to define objects with values that do not change after construction</a></p>
 ]]>
     </description>
@@ -11257,7 +11252,7 @@ see also:</p>
     <key>C26497</key>
     <name>C26497: USE_CONSTEXPR_FOR_FUNCTION</name>
     <description><![CDATA[<p>
- If a function may have to be evaluated at compile time, declare it constexpr
+If a function may have to be evaluated at compile time, declare it constexpr</p>
 <pre><code>
 // Expect 26497: could be marked constexpr if compile-time evaluation is desired
 int f1(int a, int b)
@@ -11279,7 +11274,7 @@ void f3()
     const int m2 = f2(10, 20);
 }
 }</code></pre>
-see also:</p>
+see also:
 <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rf-constexpr" target="_blank">Core Guideline - F.4: If a function may have to be evaluated at compile time, declare it constexpr</a></p>
 ]]>
     </description>
@@ -14133,7 +14128,7 @@ This warning indicates that a function is being used that has been banned, and h
     <key>C28721</key>
     <name>C28721: Deprecated performance counter architecture</name>
     <description><![CDATA[<p>
-A deprecated performance counter architecture is used: <symptom>.
+A deprecated performance counter architecture is used: &lt;symptom&gt;.
 </p><h2>Microsoft Documentation</h2>
 <p><a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/28721-deprecated-performance-counter-architecture" target="_blank">https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/28721-deprecated-performance-counter-architecture</a></p>
 ]]>

--- a/cxx-sensors/src/main/resources/cppcheck.xml
+++ b/cxx-sensors/src/main/resources/cppcheck.xml
@@ -484,7 +484,7 @@ created.
       <p>
 The class::operator= does not conform to standard C/C++ behaviour. To
 conform to standard C/C++ behaviour, return a reference to self (such
-as: <code>'class &class::operator=(..) { .. return *this; }'</code>. For safety
+as: <code>'class &amp;class::operator=(..) { .. return *this; }'</code>. For safety
 reasons it might be better to not fix this message. If you think that
 safety is always more important than conformance then please
 ignore/suppress this message. For more details about this topic, see
@@ -1921,7 +1921,7 @@ Instance of 'varname' object is destroyed immediately.
       <p>
 Using 'sizeof' for array given as function argument returns the size
 of a pointer. It does not return the size of the whole array in bytes
-as might be expected. For example, this code:
+as might be expected. For example, this code:</p>
 <pre>
 int f(char a[100]) {
   return sizeof(a);
@@ -1930,7 +1930,6 @@ int f(char a[100]) {
 returns 4 (in
 32-bit systems) or 8 (in 64-bit systems) instead of 100 (the size of
 the array in bytes).
-</p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/467.html" target="_blank">CWE-467: Use of sizeof() on a Pointer Type</a></p>
     ]]>
@@ -2058,7 +2057,7 @@ Redundant code: Found a statement that begins with type constant.
       <![CDATA[
       <p>
 When using 'char' variables in bit operations, sign extension can
-generate unexpected results. For example:
+generate unexpected results. For example:</p>
 <pre>
 char c = 0x80;
 int i = 0 | c;
@@ -2066,7 +2065,6 @@ if (i & 0x8000)
   printf("not expected");
 </pre>
 The "not expected" will be printed on the screen.
-</p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
     ]]>
@@ -2088,7 +2086,7 @@ The "not expected" will be printed on the screen.
 The scope of the variable 'varname' can be reduced. Warning: Be
 careful when fixing this message, especially when there are inner
 loops. Here is an example where cppcheck will write that the scope for
-'i' can be reduced:
+'i' can be reduced:</p>
 <pre>
 void f(int x)
 {
@@ -2097,14 +2095,13 @@ void f(int x)
     // it's safe to move 'int i = 0;' here
     for (int n = 0; n < 10; ++n) {
        // it is possible but not safe to move 'int i = 0;' here
-       do_something(&i);
+       do_something(&amp;i);
     }
    }
 }
 </pre>
 When you see this message it is always safe to
 reduce the variable scope 1 level.
-</p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
     ]]>
@@ -2263,7 +2260,7 @@ Sample program
 that can crash:
 </p>
 <pre>
-#include <stdio.h>
+#include &lt;stdio.h&gt;
 int main()
 {
   char c[5];
@@ -2274,7 +2271,7 @@ int main()
 <p>
 Typing
 in 5 or more characters may make the program crash. The correct usage
-here is 'scanf("%4s", c);', as the maximum field width does not
+here is <code>scanf("%4s", c);</code>, as the maximum field width does not
 include the terminating null byte.
 </p>
 <p>
@@ -2365,7 +2362,6 @@ The code <code>a+b?c:d</code> should be written as either <code>(a+b)?c:d</code>
     <name>Suspicious condition (assignment + comparison)</name>
     <description>
 <![CDATA[
-<p>
 <ul>
 <li>Suspicious condition (assignment + comparison), it can be clarified with parentheses.</li>
 <li>Suspicious expression. Boolean result is used in bitwise operation. The operator '!'
@@ -2375,7 +2371,6 @@ It is recommended that the expression is clarified with parentheses.</li>
 Comparison operators have higher precedence than bitwise operators.
 Please clarify the condition with parentheses.</li>
 </ul>
-</p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
 ]]>
@@ -4932,13 +4927,12 @@ members remain uninitialized. Consider using 'new' instead.
     <description>
 <![CDATA[
 <p>
-Mismatching bitmasks. Result is always 0
+Mismatching bitmasks. Result is always 0</p>
 <pre>
 X = Y & 0xf0; 
 Z = X & 0x1;
 </pre>
 results => Z=0
-</p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: Indicator of Poor Code Quality</a></p>
 ]]>
@@ -5063,10 +5057,10 @@ use this little code example on 64bit platforms. If the output
 includes "ERROR", the sentinel had only 4 out of 8 bytes initialized
 to zero and was not detected as the final argument to stop argument
 processing via va_arg(). Changing the 0 to (void*)0 or 0L will make
-the "ERROR" output go away.
+the "ERROR" output go away.</p>
 <pre>
-#include <stdarg.h>
-#include <stdio.h>
+#include &lt;stdarg.h&gt;
+#include &lt;stdio.h&gt;
 
 void f(char *s, ...) {
   va_list ap;
@@ -5090,7 +5084,7 @@ void g() {
 void h() {
   int i;
   volatile unsigned char a[1000];
-  for (i = 0; i<sizeof(a); i++)
+  for (i = 0; i &lt; sizeof(a); i++)
     a[i] = -1;
 }
 
@@ -5100,7 +5094,7 @@ int main() {
   return 0;
 }
 </pre>
-</p><h2>References</h2>
+<h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/475.html" target="_blank">CWE-475: Undefined Behavior for Input to API</a></p>
 ]]>
     </description>
@@ -5215,7 +5209,7 @@ calculations, the behaviour is undefined. Arithmetic operations on
 Comma is used in return statement. When comma is used in a return
 statement it can easily be misread as a semicolon. For example in the
 code below the value of 'b' is returned if the condition is true, but
-it is easy to think that 'a+1' is returned:
+it is easy to think that 'a+1' is returned:</p>
 <pre>
   if (x)
     return a + 1,
@@ -5224,7 +5218,6 @@ it is easy to think that 'a+1' is returned:
 However it can be useful to use comma in
 macros. Cppcheck does not warn when such a macro is then used in a
 return statement, it is less likely such code is misunderstood.
-</p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
     ]]>
@@ -5767,7 +5760,7 @@ dereference it?
       <![CDATA[
       <p>
 Dead pointer usage. Pointer 'pointer' is dead if it has been assigned
-'&x'.
+'&amp;x'.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/825.html" target="_blank">CWE-825: Expired Pointer Dereference</a></p>
@@ -6637,7 +6630,7 @@ switch()?
       <![CDATA[
       <p>
 Unsafe allocation. If funcName() throws, memory could be leaked. Use
-make_shared<T>() / make_unique<T>() instead.
+make_shared&lt;T&gt;() / make_unique&lt;T&gt;() instead.
 </p>
 <h2>References</h2>
 <p><a href="https://cwe.mitre.org/data/definitions/401.html" target="_blank">CWE-401: Improper Release of Memory Before Removing Last Reference ('Memory Leak')</a></p>

--- a/cxx-sensors/src/main/resources/pclint.xml
+++ b/cxx-sensors/src/main/resources/pclint.xml
@@ -143,7 +143,10 @@ Follow these steps to make your custom Custom rules available in SonarQube:
   <rule>
     <key>12</key>
     <name>L0012: Need &lt; or &quot;</name>
-    <description>After a #include is detected and after macro substitution is performed, a file specification of the form &lt;filename&gt; or "filename" is expected.</description>
+    <description><![CDATA[
+After a #include is detected and after macro substitution is performed, a file specification of the form &lt;filename&gt; or "filename" is expected.
+]]>
+    </description>
     <tag>bug</tag>
     <internalKey>12</internalKey>
     <severity>CRITICAL</severity>
@@ -1394,7 +1397,10 @@ Follow these steps to make your custom Custom rules available in SonarQube:
   <rule>
     <key>132</key>
     <name>L0132: Expected function definition</name>
-    <description>A function declaration with identifiers between parentheses is the start of an old-style function definition (K&amp;R style). This is normally followed by optional declarations and a left brace to signal the start of the function body. Either replace the identifier(s) with type(s) or complete the function with a function body.</description>
+    <description><![CDATA[
+A function declaration with identifiers between parentheses is the start of an old-style function definition (K&amp;R style). This is normally followed by optional declarations and a left brace to signal the start of the function body. Either replace the identifier(s) with type(s) or complete the function with a function body.
+]]>
+    </description>
     <internalKey>132</internalKey>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -1503,13 +1509,13 @@ Follow these steps to make your custom Custom rules available in SonarQube:
     <name>L0142: case constant 'String' used previously in this switch</name>
     <description><![CDATA[
 <p>A duplicate case constant was detected.  For example, the following code will be diagnosed as a repetition of case constant '1'.</p>
-<pre><tt>
+<pre><code>
            switch( n )
                {
                case 1:  m = 25;    break;
                case 2-1: m = 27;   break;
                }
-</tt></pre>
+</code></pre>
 ]]></description>
     <tag>bug</tag>
     <internalKey>142</internalKey>
@@ -1724,13 +1730,13 @@ Follow these steps to make your custom Custom rules available in SonarQube:
     <name>L0165: An [unscoped] enumeration cannot be forward-declared (int is assumed)</name>
     <description><![CDATA[
 <p>An [unscoped] enumeration cannot be forward-declared [without an enum-base] (int is assumed) -- This message is issued at the point of a forward-declaration of an enumeration like so:</p>
-<pre><tt>
+<pre><code>
                enum E; // Error
-</tt></pre>
+</code></pre>
 <p>This is prohibited by ISO C and ISO C++98.  In C++0x, we can modify this example to be well-formed by explicitly indicating the underlying integral type; example:</p>
-<pre><tt>
+<pre><code>
                enum E : unsigned short; // Ok
-</tt></pre>
+</code></pre>
 <p>If you are not using C++0x and/or your compiler supports the construct you may simply suppress this message with a -e165.</p>]]></description>
     <internalKey>165</internalKey>
     <severity>CRITICAL</severity>
@@ -1754,9 +1760,9 @@ Follow these steps to make your custom Custom rules available in SonarQube:
     <name>L0169: mode(String) requests an (integral/floating point) type of size N, but no such type exists.</name>
     <description><![CDATA[<p>(Please check -s options in the Lint configuration.)
 This occurs for a use of the GCC attribute mode() as in:</p>
-<pre><tt>
+<pre><code>
            __attribute__((mode(DF)));
-</tt></pre>
+</code></pre>
 <p>This is supposed to match a built-in scalar type whose size is the size indicated in the message. If this message is issued, it probably means that size options have not been set to match the compile configuration; see Section 5.3, Size and Alignment Options.</p>
 ]]></description>
     <tag>bug</tag>
@@ -1771,15 +1777,15 @@ This occurs for a use of the GCC attribute mode() as in:</p>
     <name>L0170: Explicit type-specifier required for symbol 'Symbol', int assumed</name>
     <description><![CDATA[
 <p>A declaration did not have an explicit type as required by C99 or C++. int was assumed. This could easily happen if an intended comma was replaced by a semicolon.  For example, if instead of typing:</p>
-<pre><tt>
+<pre><code>
            double       radius,
                         diameter;
-</tt></pre>
+</code></pre>
 <p>the programmer had typed:</p>
-<pre><tt>
+<pre><code>
            double       radius;
                         diameter;
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <tag>convention</tag>
     <internalKey>170</internalKey>
     <severity>CRITICAL</severity>
@@ -2372,19 +2378,22 @@ An assignment was made to a pointer variable (designated by Symbol) which appear
     <key>429</key>
     <name>L0429: Custodial pointer 'Symbol' (Location) has not been freed or returned</name>
     <description>
-<![CDATA[<p>A pointer of auto storage class was allocated storage which was neither freed nor returned to the caller. This represents a "memory leak". A pointer is considered custodial if it uniquely points to the storage area. It is not considered custodial if it has been copied. Thus:
-<pre><tt> 
+<![CDATA[<p>A pointer of auto storage class was allocated storage which was neither freed nor returned to the caller. This represents a "memory leak". A pointer is considered custodial if it uniquely points to the storage area. It is not considered custodial if it has been copied. Thus:</p>
+<pre><code> 
     int *p = new int[20]; // p is a custodial pointer 
     int *q = p; // p is no longer custodial 
     p = new int[20]; // p again becomes custodial 
     q = p + 0; // p remains custodial
-</tt></pre>
+</code></pre>
+<p>
 Here p does not lose its custodial property by merely participating in an arithmetic operation.
-A pointer can lose its custodial property by passing the pointer to a function. If the parameter of the function is typed pointer to const or if the function is a library function, that assumption is not made. For example 
+A pointer can lose its custodial property by passing the pointer to a function. If the parameter of the function is typed pointer to const or if the function is a library function, that assumption is not made. For example</p> 
+<pre><code> 
   p = malloc(10); 
   strcpy (p, "hello");
+</code></pre>
 Then p still has custody of storage allocated.
-It is possible to indicate via semantic options that a function will take custody of a pointer.</p>
+<p>It is possible to indicate via semantic options that a function will take custody of a pointer.</p>
 <h2>References</h2>
 <p><a href="https://www.securecoding.cert.org/confluence/display/c/MEM31-C.+Free+dynamically+allocated+memory+when+no+longer+needed" target="_blank">MEM31-C. Free dynamically allocated memory when no longer needed</a></p>
     ]]></description>
@@ -2419,16 +2428,16 @@ It is possible to indicate via semantic options that a function will take custod
     <key>432</key>
     <name>L0432: Suspicious argument to malloc</name>
     <description><![CDATA[<p>The following pattern was detected:</p>
-<pre><tt>
+<pre><code>
     malloc( strlen(e+1) )
-</tt></pre>
+</code></pre>
 <p>    where e is some expression. This is suspicious because it closely resembles the commonly used pattern:</p>
-<pre><tt>
+<pre><code>
     malloc( strlen(e)+1 )
-</tt></pre>
+</code></pre>
 <p>    If you really intended to use the first pattern then an equivalent expression that will not raise this error is:</p>
-<pre><tt>
-    malloc( strlen(e)-1 )</tt></pre>]]></description>
+<pre><code>
+    malloc( strlen(e)-1 )</code></pre>]]></description>
     <internalKey>432</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -2441,16 +2450,16 @@ It is possible to indicate via semantic options that a function will take custod
     <description><![CDATA[
 <p>An allocation was assigned to a pointer whose reach extends beyond the area that was allocated. This would usually happen only with library allocation routines such as malloc and calloc.
 For example:</p>
-<pre><tt>
+<pre><code>
     int *p = malloc(1);
-</tt></pre>
-<p>    This message is also provided for user-declared allocation functions. For example, if a user's own allocation function is provided with the following semantic:</p>
-<pre><tt>
+</code></pre>
+<p>This message is also provided for user-declared allocation functions. For example, if a user's own allocation function is provided with the following semantic:</p>
+<pre><code>
     -sem(ouralloc,@P==malloc(1n))
-</tt></pre>
-<p>    We would report the same message. Please note that it is necessary to designate that the returned area is freshly allocated (ala malloc).
+</code></pre>
+<p>We would report the same message. Please note that it is necessary to designate that the returned area is freshly allocated (ala malloc).
     This message is always given in conjunction with the more general Informational Message 826.</p>
-</p><h2>References</h2>
+<h2>References</h2>
 <p><a href="https://www.securecoding.cert.org/confluence/display/c/MEM35-C.+Allocate+sufficient+memory+for+an+object" target="_blank">MEM35-C. Allocate sufficient memory for an object</a></p>
 ]]>
     </description>
@@ -2491,7 +2500,7 @@ For example:</p>
     <name>L0436: Apparent preprocessor directive in invocation of macro 'Symbol'</name>
     <description><![CDATA[
 <p>This is issued in the context of an invocation of a function-like macro.</p>
-<pre><tt>
+<pre><code>
     Example:
 
            #define FOO(p) p
@@ -2499,7 +2508,7 @@ For example:</p>
            FOO(
                    #define X Y
               )
-</tt></pre>
+</code></pre>
 <p>According to the ISO Standards, this results in undefined behavior.</p>
 
 <p>       By the rules of Standard C the preprocessing directive is
@@ -2557,7 +2566,10 @@ For example:</p>
   <rule>
     <key>442</key>
     <name>L0442: for clause irregularity: testing direction inconsistent with increment direction</name>
-    <description>A for clause was encountered that appeared to have a parity problem. For example: for( i = 0; i &lt; 10; i&lt;/name&gt;&lt;description&gt; ) ... Here the test for i less than 10 seems inconsistent with the 3rd expression of the for clause which decreases the value of i. This same message would be given if i were being increased by the 3rd expression and was being tested for being greater than some value in the 2nd expression.</description>
+    <description><![CDATA[
+A for clause was encountered that appeared to have a parity problem. For example: for( i = 0; i &lt; 10; i&lt;/name&gt;&lt;description&gt; ) ... Here the test for i less than 10 seems inconsistent with the 3rd expression of the for clause which decreases the value of i. This same message would be given if i were being increased by the 3rd expression and was being tested for being greater than some value in the 2nd expression.
+]]>
+    </description>
     <internalKey>442</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -2599,12 +2611,12 @@ For example:</p>
     <name>L0446: side effect in initializer</name>
     <description><![CDATA[
 <p>An initializer containing a side effect can be potentially troublesome. For example, given the code:</p>
-<pre><tt>
+<pre><code>
            void f( int i )
                {
                int a[2] = {i++, i++};
                }
-</tt></pre>
+</code></pre>
 <p>       The values of the array elements are unspecified because the order of evaluation is unspecified by the C standard.</p>]]></description>
     <internalKey>446</internalKey>
     <severity>MAJOR</severity>
@@ -2825,13 +2837,13 @@ For example:</p>
     <key>488</key>
     <name>L0488: Symbol 'Symbol' has same implicit enumerator value 'String' as enumerator 'Symbol'</name>
     <description><![CDATA[<p>Two enumerators have the same value and at least one received that value implicitly. For example:</p>
-<pre><tt>
+<pre><code>
            enum colors { red, blue, green = 1 };
-</tt></pre>
+</code></pre>
 <p>       will elicit this informational message while</p>
-<pre><tt>
+<pre><code>
            enum colors { red, blue = 1, green = 1 };
-</tt></pre>
+</code></pre>
 <p>       will not.</p>]]></description>
     <internalKey>488</internalKey>
     <severity>MAJOR</severity>
@@ -2853,11 +2865,13 @@ For example:</p>
     <key>491</key>
     <name>L0491: non-standard use of 'defined' preprocessor operator</name>
     <description><![CDATA[<p>The ISO standards restrict the use of the defined preprocessor keyword to either</p>
-<pre><tt>
+<pre><code>
            defined(identifier)
            defined identifier
-</pre></tt>
-<p>Additionally, the preprocessor operator may not result from the expansion of another macro. This diagnostic highlights departures from these requirements as non-portable code.</p>]]></description>
+</code></pre>
+<p>Additionally, the preprocessor operator may not result from the expansion of another macro. This diagnostic highlights departures from these requirements as non-portable code.</p>
+]]>
+    </description>
     <internalKey>491</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3019,7 +3033,10 @@ For example:</p>
   <rule>
     <key>517</key>
     <name>L0517: defined not K&amp;R</name>
-    <description>The defined function (not a K&amp;R construct) was employed and the K&amp;R preprocessor flag (+fkp) was set. Either do not set the flag or do not use defined.</description>
+    <description><![CDATA[
+The defined function (not a K&amp;R construct) was employed and the K&amp;R preprocessor flag (+fkp) was set. Either do not set the flag or do not use defined.
+]]>
+    </description>
     <internalKey>517</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3263,9 +3280,14 @@ For example:</p>
   <rule>
     <key>545</key>
     <name>L0545: Suspicious use of &amp;</name>
-    <description>An attempt was made to take the address of an array name. At one time such an expression was officially illegal (K&amp;R C [1]), was not consistently implemented, and was, therefore, suspect. However, the expression is legal in ANSI C and designates a pointer to an array. For example, given
-    int a[10]; int (*p) [10];
-    Then a and &amp;a, as pointers, both represent the same bit pattern, but whereas a is a pointer to int, &amp;a is a pointer to array 10 of int. Of the two only &amp;a may be assigned to p without complaint. If you are using the &amp; operator in this way, we recommend that you disable this message.</description>
+    <description><![CDATA[
+An attempt was made to take the address of an array name. At one time such an expression was officially illegal (K&amp;R C [1]), was not consistently implemented, and was, therefore, suspect. However, the expression is legal in ANSI C and designates a pointer to an array. For example, given
+<pre>
+int a[10]; int (*p) [10];
+</pre>
+Then a and &amp;a, as pointers, both represent the same bit pattern, but whereas a is a pointer to int, &amp;a is a pointer to array 10 of int. Of the two only &amp;a may be assigned to p without complaint. If you are using the &amp; operator in this way, we recommend that you disable this message.
+]]>
+    </description>
     <internalKey>545</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3362,7 +3384,10 @@ Conventionally all variables in preprocessor expressions should be pre-defined. 
   <rule>
     <key>555</key>
     <name>L0555: #elif not K&amp;R</name>
-    <description>The #elif directive was used and the K&amp;R preprocessor flag (+fkp) was set. Either do not set the flag or do not use #elif.</description>
+    <description><![CDATA[
+    The #elif directive was used and the K&amp;R preprocessor flag (+fkp) was set. Either do not set the flag or do not use #elif.
+]]>
+    </description>
     <internalKey>555</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3372,7 +3397,10 @@ Conventionally all variables in preprocessor expressions should be pre-defined. 
   <rule>
     <key>556</key>
     <name>L0556: indented #</name>
-    <description>A preprocessor directive appeared indented within a line and the K&amp;R preprocessor flag (+fkp) was set. Either do not set the flag or do not indent the #.</description>
+    <description><![CDATA[
+A preprocessor directive appeared indented within a line and the K&amp;R preprocessor flag (+fkp) was set. Either do not set the flag or do not indent the #.
+]]>
+    </description>
     <internalKey>556</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3402,9 +3430,14 @@ Conventionally all variables in preprocessor expressions should be pre-defined. 
   <rule>
     <key>559</key>
     <name>L0559: size of argument number Integer inconsistent with format</name>
-    <description>The given argument (to printf, sprintf, or fprintf) was inconsistent with that which was anticipated as the result of analyzing the format string. Argument counts begin at 1 and include file, string and format specifications. For example,
-    sprintf( buffer, "%f", 371 )
-    will show an error in argument number 3 because constant 371 is not floating point.</description>
+    <description><![CDATA[
+The given argument (to printf, sprintf, or fprintf) was inconsistent with that which was anticipated as the result of analyzing the format string. Argument counts begin at 1 and include file, string and format specifications. For example,
+<pre>
+sprintf( buffer, "%f", 371 )
+</pre>
+will show an error in argument number 3 because constant 371 is not floating point.
+]]>
+    </description>
     <internalKey>559</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3414,10 +3447,15 @@ Conventionally all variables in preprocessor expressions should be pre-defined. 
   <rule>
     <key>560</key>
     <name>L0560: argument no. Integer should be a pointer</name>
-    <description>The given argument (to one of the scanf or printf family of functions) should be a pointer. For the scanf family, all arguments corresponding to a format specification should be pointers to areas that are to be modified (receive the results of scanning). For the printf family, arguments corresponding to %s or %n also need to be pointers.
-    Argument counts begin at 1 and include file, string and format specifications. For example
-    scanf( "%f", 3.5 )
-    will generate the message that argument no. 2 should be a pointer.</description>
+    <description><![CDATA[
+The given argument (to one of the scanf or printf family of functions) should be a pointer. For the scanf family, all arguments corresponding to a format specification should be pointers to areas that are to be modified (receive the results of scanning). For the printf family, arguments corresponding to %s or %n also need to be pointers.
+Argument counts begin at 1 and include file, string and format specifications. For example
+<pre>
+scanf( "%f", 3.5 )
+</pre>
+will generate the message that argument no. 2 should be a pointer.
+]]>
+    </description>
     <internalKey>560</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3427,9 +3465,14 @@ Conventionally all variables in preprocessor expressions should be pre-defined. 
   <rule>
     <key>561</key>
     <name>L0561: (arg. no. Integer) indirect object inconsistent with format</name>
-    <description>The given argument (to scanf, sscanf, or fscanf) was a pointer to an object that was inconsistent with that which was anticipated as the result of analyzing the format string. Argument counts begin at 1 and include file, string and format specifications. For example if n is declared as int then:
-    scanf( "%c", &amp;n )
-    will elicit this message for argument number 2.</description>
+    <description><![CDATA[
+The given argument (to scanf, sscanf, or fscanf) was a pointer to an object that was inconsistent with that which was anticipated as the result of analyzing the format string. Argument counts begin at 1 and include file, string and format specifications. For example if n is declared as int then:
+<pre>
+scanf( "%c", &amp;n )
+</pre>
+will elicit this message for argument number 2.
+]]>
+    </description>
     <internalKey>561</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3503,10 +3546,10 @@ Conventionally all variables in preprocessor expressions should be pre-defined. 
     <name>L0568: nonnegative quantity is never less than zero.</name>
     <description><![CDATA[
 <p>Comparisons of the form:</p>
-<pre><tt>
+<pre><code>
     u &gt;= 0 0 &lt;= u
     u &lt; 0 0 &gt; u
-</tt></pre>
+</code></pre>
 <p>are suspicious if u is an unsigned quantity or a quantity judged to be never less then 0. See also message 775.</p>]]></description>
     <internalKey>568</internalKey>
     <severity>MAJOR</severity>
@@ -3567,17 +3610,17 @@ Conventionally all variables in preprocessor expressions should be pre-defined. 
     <name>L0573: Signed-unsigned mix with divide</name>
     <description><![CDATA[
 <p>one of the operands to / or % was signed and the other unsigned; moreover the signed quantity could be negative. For example:</p>
-<pre><tt>
+<pre><code>
     u / n
-</tt></pre>
+</code></pre>
 <p>where u is unsigned and n is signed will elicit this message whereas:</p>
-<pre><tt>
+<pre><code>
     u / 4
-</tt></pre>
+</code></pre>
 <p>will not, even though 4 is nominally an int. It is not a good idea to mix unsigned quantities with signed quantities in any case (a 737 will also be issued) but, with division, a negative value can create havoc. For example, the innocent looking:</p>
-<pre><tt>
+<pre><code>
     n = n / u
-</tt></pre>
+</code></pre>
 <p>will, if n is -2 and u is 2, not assign -1 to n but will assign some very large value.</p>
 <p>To resolve this problem, either cast the integer to unsigned if you know it can never be less than zero or cast the unsigned to an integer if you know it can never exceed the maximum integer.</p>]]></description>
     <internalKey>573</internalKey>
@@ -3591,25 +3634,25 @@ Conventionally all variables in preprocessor expressions should be pre-defined. 
     <name>L0574: Signed-unsigned mix with relational</name>
     <description><![CDATA[
 <p>The four relational operators are:</p>
-<pre><tt>
+<pre><code>
 &gt; &gt;= &lt; &lt;=
-</tt></pre>
+</code></pre>
 <p>One of the operands to a relational operator was signed and the other unsigned; also, the signed quantity could be negative. For example:</p>
-<pre><tt>
+<pre><code>
     if( u &gt; n ) ...
-</tt></pre>
+</code></pre>
 <p>where u is unsigned and n is signed will elicit this message whereas:</p>
-<pre><tt>
+<pre><code>
     if( u &gt; 12 ) ...
-</tt></pre>
+</code></pre>
 <p>will not (even though 12 is officially an int it is obvious that it is not negative). It is not a good idea to mix unsigned quantities with signed quantities in any case (a 737 will also be issued) but, with the four relationals, a negative value can produce obscure results. For example, if the conditional:</p>
-<pre><tt>
+<pre><code>
     if( n &lt; 0 ) ...
-</tt></pre>
+</code></pre>
 <p>is true then the similar appearing:</p>
-<pre><tt>
+<pre><code>
     u = 0; if( n &lt; u ) ...
-</tt></pre>
+</code></pre>
 <p>is false because the promotion to unsigned makes n very large.</p>
 <p>To resolve this problem, either cast the integer to unsigned if you know it can never be less than zero or cast the unsigned to an int if you know it can never exceed the maximum int.</p>]]></description>
     <internalKey>574</internalKey>
@@ -3714,12 +3757,12 @@ Conventionally all variables in preprocessor expressions should be pre-defined. 
     <name>L0585: The sequence (??Char) is not a valid Trigraph sequence</name>
     <description><![CDATA[<p>This warning is issued whenever a pair of '?' characters is seen within a string (or character) constant but that pair is not followed by a character which would make the triple a valid Trigraph sequence. Did the programmer intend this to be a Trigraph sequence and merely err? Even if no Trigraph were intended, it can easily be mistaken by the reader of the code to be a Trigraph. Moreover, what assurances do we have that in the future the invalid Trigraph might not become a valid Trigraph and change the meaning of the string? To protect yourself from such an event you may place a backslash between the '?' characters. Alternatively you may use concatenation of string constants.</p>
 <p>For example:</p>
-<pre><tt>
+<pre><code>
     pattern = "(???) ???-????"; // warning 585
     pattern = "(?\?\?) ?\?\?-?\?\?\?"; // no warning
     #define Q "?"
     pattern = "(" Q Q Q ") " Q Q Q "-" Q Q Q Q // no warning
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>585</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3797,17 +3840,17 @@ Conventionally all variables in preprocessor expressions should be pre-defined. 
     <description>
 <![CDATA[<p>
 A printf/scanf style function received a non-literal format specifier without trailing arguments. For example:</p> 
-<pre><tt>
+<pre><code>
   char msg[100]; 
     ... 
   printf( msg ); 
-</tt></pre>
+</code></pre>
 <p>This can easily be rewritten to the relatively safe:</p>
-<pre><tt>
+<pre><code>
   char msg[100]; 
     ... 
   printf( "%s", msg ); 
-</tt></pre>
+</code></pre>
 <p>The danger lies in the fact that msg can contain hidden format codes. If msg is read from user input, then in the first example, a naive user could cause a glitch or a crash and a malicious user might exploit this to undermine system security. Since the unsafe form can easily be transformed into the safe form the latter should always be used.
 </p>]]>
     </description>
@@ -3824,13 +3867,13 @@ A printf/scanf style function received a non-literal format specifier without tr
     <description>
 <![CDATA[<p>
 This is the 'possible' version of message 429. A pointer of auto storage class was allocated storage and not all paths leading to a return statement or to the end of the function contained either a free or a return of the pointer. Hence there is a potential memory leak. For example:</p>
-<pre><tt>
+<pre><code>
   void f( int n ) 
     { 
     int *p = new int; 
     if( n ) delete p; 
     } // message 593 
-</tt></pre>
+</code></pre>
 <p>In this example an allocation is made and, if n is 0, no delete will have been made.
 Please see message 429 for an explanation of "custodial" and ways of regulating when pointer variables retain custody of allocations.
 </p>]]>
@@ -3846,9 +3889,9 @@ Please see message 429 for an explanation of "custodial" and ways of regulating 
     <name>L0598: Excessive shift value (precision Integer shifted left by Integer)</name>
     <description><![CDATA[
 <p>A quantity is being shifted to the left by a value greater than or equal to the precision of that quantity or by a negative value. For example,</p>
-<pre><tt>
+<pre><code>
          i &lt;&lt; 32
-</tt></pre>
+</code></pre>
 <p>will elicit this message if i is typed int and where int is 32 bits wide or less (the usual case). Such shift results in undefined behavior.</p>
 <p>To suppress the message you may cast the shifted quantity to a type whose length is at least the length of the shift value.</p>]]></description>
     <internalKey>598</internalKey>
@@ -3903,33 +3946,33 @@ Please see message 429 for an explanation of "custodial" and ways of regulating 
     <name>L0605: Increase in pointer capability (Context)</name>
     <description><![CDATA[
 <p>This warning is typically caused by assigning a (pointer to const) to an ordinary pointer. For example:</p>
-<pre><tt>
+<pre><code>
     int *p;
     const int *q;
     p = q; /* 605 */
-</tt></pre>
+</code></pre>
 <p>The message will be inhibited if a cast is used as in:</p>
-<pre><tt>
+<pre><code>
     p = (int *) q;
-</tt></pre>
+</code></pre>
 <p>An increase in capability is indicated because the const pointed to by q can now be modified through p. This message can be given for the volatile qualifier as well as the const qualifier and may be given for arbitrary pointer depths (pointers to pointers, pointers to arrays, etc.).
 If the number of pointer levels exceeds one, things get murky in a hurry. For example:</p>
-<pre><tt>
+<pre><code>
     const char ** ppc;
     char ** pp;
     pp = ppc; /* 605 - clearly not safe */
     ppc = pp; /* 605 - looks safe but it's not */
-</tt></pre>
+</code></pre>
 <p>It was not realized by the C community until very recently that assigning pp to ppc was dangerous. The problem is that after the above assignment, a pointer to a const char can be assigned indirectly through ppc and accessed through pp which can then modify the const char.
 The message speaks of an "increase in capability" in assigning to ppc, which seems counter intuitive because the indirect pointer has less capability. However, assigning the pointer does not destroy the old one and the combination of the two pointers represents a net increase in capability.
 The message may also be given for function pointer assignments when the prototype of one function contains a pointer of higher capability than a corresponding pointer in another prototype. There is a curious inversion here whereby a prototype of lower capability translates into a function of greater trust and hence greater capability (a Trojan Horse). For example, let</p>
-<pre><tt>
+<pre><code>
     void warrior( char * );
-</tt></pre>
+</code></pre>
 <p>be a function that destroys its argument. Consider the function:</p>
-<pre><tt>
+<pre><code>
     void Troy( void (*horse)(const char *) );
-</tt></pre>
+</code></pre>
 <p>Troy() will call horse() with an argument that it considers precious believing the horse() will do no harm. Before compilers knew better and believing that adding in a const to the destination never hurt anything, earlier compilers allowed the Greeks to pass warrior() to Troy and the rest, as they say, is history.</p>]]></description>
     <internalKey>605</internalKey>
     <severity>MAJOR</severity>
@@ -4364,16 +4407,25 @@ The message may also be given for function pointer assignments when the prototyp
   <rule>
     <key>647</key>
     <name>L0647: Suspicious truncation</name>
-    <description>This message is issued when it appears that there may have been an unintended loss of information during an operation involving int or unsigned int the result of which is later converted to long. It is issued only for systems in which int is smaller than long. For example:
-    (long) (n &lt;&lt; 8)
-    might elicit this message if n is unsigned int, whereas
-    (long) n &lt;&lt; 8
-    would not. In the first case, the shift is done at int precision and the high order 8 bits are lost even though there is a subsequent conversion to a type that might hold all the bits. In the second case, the shifted bits are retained.
-    The operations that are scrutinized and reported upon by this message are: shift left, multiplication, and bit-wise complementation. Addition and subtraction are covered by Informational message 776.&lt;/description&gt;&lt;/rule&gt;
-    The conversion to long may be done explicitly with a cast as shown or implicitly via assignment, return, argument passing or initialization.
-    The message can be suppressed by casting. You may cast one of the operands so that the operation is done in full precision as is given by the second example above. Alternatively, if you decide there is really no problem here (for now or in the future), you may cast the result of the operation to some form of int. For example, you might write:
-    (long) (unsigned) (n &lt;&lt; 8)
-    In this way PC-lint/FlexeLint will know you are aware of and approve of the truncation.</description>
+    <description><![CDATA[
+<p>This message is issued when it appears that there may have been an unintended loss of information during an operation involving int or unsigned int the result of which is later converted to long. It is issued only for systems in which int is smaller than long. For example:</p>
+<pre>
+(long) (n &lt;&lt; 8)
+</pre>
+might elicit this message if n is unsigned int, whereas
+<pre>
+(long) n &lt;&lt; 8
+</pre>
+would not. In the first case, the shift is done at int precision and the high order 8 bits are lost even though there is a subsequent conversion to a type that might hold all the bits. In the second case, the shifted bits are retained.
+<p>The operations that are scrutinized and reported upon by this message are: shift left, multiplication, and bit-wise complementation. Addition and subtraction are covered by Informational message 776.&lt;/description&gt;&lt;/rule&gt;</p>
+<p>The conversion to long may be done explicitly with a cast as shown or implicitly via assignment, return, argument passing or initialization.</p>
+<p>The message can be suppressed by casting. You may cast one of the operands so that the operation is done in full precision as is given by the second example above. Alternatively, if you decide there is really no problem here (for now or in the future), you may cast the result of the operation to some form of int. For example, you might write:</p>
+<pre>
+(long) (unsigned) (n &lt;&lt; 8)
+</pre>
+In this way PC-lint/FlexeLint will know you are aware of and approve of the truncation.
+]]>
+    </description>
     <internalKey>647</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -4528,13 +4580,13 @@ The message may also be given for function pointer assignments when the prototyp
     <name>L0661: possible access of out-of-bounds pointer ('Integer' beyond end of data) by operator 'String'</name>
     <description>
 <![CDATA[<p>
-An out-of-bounds pointer may have been accessed. See message 415 for a description of the parameters Integer and String. For example:
-<pre><tt> 
+An out-of-bounds pointer may have been accessed. See message 415 for a description of the parameters Integer and String. For example:</p>
+<pre><code> 
   int a[10]; 
   if( n &lt;= 10 ) a[n] = 0;
-</tt></pre>
+</code></pre>
 Here the programmer presumably should have written n&lt;10. This message is similar to messages 415 and 796 but differs from them by the degree of probability.
-</p><h2>References</h2>
+<h2>References</h2>
 <p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=47677453" target="_blank">ARR30-C. Do not form or use out-of-bounds pointers or array subscripts</a></p>
 ]]>
     </description>
@@ -4552,13 +4604,13 @@ Here the programmer presumably should have written n&lt;10. This message is simi
     <name>L0662: possible creation of out-of-bounds pointer ('Integer' beyond end of data) by operator 'String'</name>
     <description>
 <![CDATA[<p>
-An out-of-bounds pointer may have been created. See message 415 for a description of the parameters Integer and String. For example: 
-<pre><tt>
+An out-of-bounds pointer may have been created. See message 415 for a description of the parameters Integer and String. For example:</p>
+<pre><code>
   int a[10]; 
   if( n &lt;= 20 ) f( a + n );
-</tt></pre>
+</code></pre>
 Here, it appears as though an illicit pointer is being created, but PC-lint/FlexeLint cannot be certain. See also messages 416 and 797.
-</p><h2>References</h2>
+<h2>References</h2>
 <p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=47677453" target="_blank">ARR30-C. Do not form or use out-of-bounds pointers or array subscripts</a></p>
 ]]>
     </description>
@@ -4829,10 +4881,13 @@ An assignment was made to a pointer variable (designated by Symbol) which may al
   <rule>
     <key>684</key>
     <name>L0684: Passing address of auto variable 'Symbol' into caller space</name>
-    <description>The address of an auto variable was passed via assignment into a location specified by the caller to the function. For example: void f( int *a[] ) { int n; a[1] = &amp;n; }
-    Here the address of an auto variable (n) is being passed into the second element of the array passed to the function f. This looks suspicious because upon return the array will contain a pointer to a variable whose lifetime is over. It is possible that this is benign since it could be that the caller to f() is merely passing in a working space to be discarded upon return. If this is the case, you can suppress the message for function f() using the option
-    -efunc(684,f).
-    See also Warning 604.</description>
+    <description><![CDATA[
+The address of an auto variable was passed via assignment into a location specified by the caller to the function. For example: void f( int *a[] ) { int n; a[1] = &amp;n; }
+Here the address of an auto variable (n) is being passed into the second element of the array passed to the function f. This looks suspicious because upon return the array will contain a pointer to a variable whose lifetime is over. It is possible that this is benign since it could be that the caller to f() is merely passing in a working space to be discarded upon return. If this is the case, you can suppress the message for function f() using the option
+-efunc(684,f).
+See also Warning 604.
+]]>
+    </description>
     <internalKey>684</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -4842,11 +4897,16 @@ An assignment was made to a pointer variable (designated by Symbol) which may al
   <rule>
     <key>685</key>
     <name>L0685: Relational operator 'String,' always evaluates to 'String'</name>
-    <description>The first String is one of '&gt;', '&gt;=', '&lt;' or '&lt;=' and identifies the relational operator. The second string is one of 'True' or 'False,0&gt;'. The message is given when an expression is compared to a constant and the precision of the expression indicates that the test will always succeed or always fail. For example, char ch; ... if( ch &gt;= -128 ) ...
-    In this example, the precision of char ch is 8 bits signed (assuming the fcu flag has been left in the OFF state) and hence it has a range of values from -128 to 127 inclusive. Hence the test is always True.
-    Note that, technically, ch is promoted to int before comparing with the constant. For the purpose of this comparison we consider only the underlying precision. As another example, if u is an unsigned int then
-    if( (u &amp; 0xFF) &gt; 0xFF ) ...
-    will also raise a 685 because the expression on the left hand side has an effective precision of 16 bits.</description>
+    <description><![CDATA[
+The first String is one of '&gt;', '&gt;=', '&lt;' or '&lt;=' and identifies the relational operator. The second string is one of 'True' or 'False,0&gt;'. The message is given when an expression is compared to a constant and the precision of the expression indicates that the test will always succeed or always fail. For example, char ch; ... if( ch &gt;= -128 ) ...
+In this example, the precision of char ch is 8 bits signed (assuming the fcu flag has been left in the OFF state) and hence it has a range of values from -128 to 127 inclusive. Hence the test is always True.
+Note that, technically, ch is promoted to int before comparing with the constant. For the purpose of this comparison we consider only the underlying precision. As another example, if u is an unsigned int then
+<pre>
+if( (u &amp; 0xFF) &gt; 0xFF ) ...
+</pre>
+will also raise a 685 because the expression on the left hand side has an effective precision of 16 bits.
+]]>
+    </description>
     <internalKey>685</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -5960,8 +6020,11 @@ where, for example, ch is an unsigned char. These can be suppressed by using the
   <rule>
     <key>794</key>
     <name>L0794: Conceivable use of null pointer 'Symbol' in [left/right] argument to operator 'String' Reference</name>
-    <description>From information gleaned from earlier statements it is conceivable that a null pointer (a pointer whose value is 0) can be used in a context where null pointers are inappropriate. In the case of binary operators one of the words 'left' or 'right' is used to designate which operand is null. Symbol identifies the pointer variable that may be NULL. This is similar to messages 413 and 613 and differs from them in that the likelihood is not as great. For example: int *p = 0; int i; for( i = 0; i &lt; n; i++ ) p = &amp;a[i]; *p = 0;
-    If the body of the for loop is never taken then p remains null.</description>
+    <description><![CDATA[
+From information gleaned from earlier statements it is conceivable that a null pointer (a pointer whose value is 0) can be used in a context where null pointers are inappropriate. In the case of binary operators one of the words 'left' or 'right' is used to designate which operand is null. Symbol identifies the pointer variable that may be NULL. This is similar to messages 413 and 613 and differs from them in that the likelihood is not as great. For example: int *p = 0; int i; for( i = 0; i &lt; n; i++ ) p = &amp;a[i]; *p = 0;
+If the body of the for loop is never taken then p remains null.
+]]>
+    </description>
     <internalKey>794</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -5983,16 +6046,16 @@ where, for example, ch is an unsigned char. These can be suppressed by using the
     <name>L0796: Conceivable access of out-of-bounds pointer ('Integer' beyond end of data) by operator 'String'</name>
     <description>
 <![CDATA[<p>
-An out-of-bounds pointer may conceivably have been accessed. See message 415 for a description of the parameters Integer and String. For example: 
-<pre><tt>
+An out-of-bounds pointer may conceivably have been accessed. See message 415 for a description of the parameters Integer and String. For example:</p>
+<pre><code>
   int a[10]; 
   int j = 100; 
   for( i = 0; i &lt; n; i++ ) 
     j = n; 
   a[j] = 0;
-</tt></pre>
+</code></pre>
 Here, the access to a[j] is flagged because it is conceivable that the for loop is not executed leaving the unacceptable index of 100 in variable j. This message is similar to messages 415 and 661 but differing from them by the degree of probability.
-</p><h2>References</h2>
+<h2>References</h2>
 <p><a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=47677453" target="_blank">ARR30-C. Do not form or use out-of-bounds pointers or array subscripts</a></p>
 ]]>
     </description>
@@ -6568,9 +6631,14 @@ This message is issued for several library functions (such as fwrite, memcmp, et
   <rule>
     <key>866</key>
     <name>L0866: Unusual use of 'String' in argument to sizeof</name>
-    <description>An expression used as an argument to sizeof() counts as "unusual" if it is not a constant, a symbol, a function call, a member access, a subscript operation (with indices of zero or one), or a dereference of the result of a symbol, scoped symbol, array subscript operation, or function call. Also, since unary '+' could legitimately be used to determine the size of a promoted expression, it does not fall under the category of "unusual". Example: char A[10]; unsigned end = sizeof(A - 1); // 866; Programmer probably meant // 'sizeof(A) - 1' size_of_promoted_char = sizeof(+A[0]); // '+' makes a difference here size_t s1 = sizeof( end+1 ); // 866: use +end to get promoted type size_t s2 = sizeof( +(end+1) ); // OK, we won't complain struct B *p; // B is some POD. B b1;
-    memcpy( p, &amp;b1, sizeof(&amp;b1) ); // 866; intended to take sizeof(b1)
-    size_t s3 = sizeof(A[0]); // OK, get the size of an element. size_t s4 = sizeof(A[2]); // 866; Not incorrect, but ... // unusual in a sizeof().</description>
+    <description><![CDATA[
+An expression used as an argument to sizeof() counts as "unusual" if it is not a constant, a symbol, a function call, a member access, a subscript operation (with indices of zero or one), or a dereference of the result of a symbol, scoped symbol, array subscript operation, or function call. Also, since unary '+' could legitimately be used to determine the size of a promoted expression, it does not fall under the category of "unusual". Example: char A[10]; unsigned end = sizeof(A - 1); // 866; Programmer probably meant // 'sizeof(A) - 1' size_of_promoted_char = sizeof(+A[0]); // '+' makes a difference here size_t s1 = sizeof( end+1 ); // 866: use +end to get promoted type size_t s2 = sizeof( +(end+1) ); // OK, we won't complain struct B *p; // B is some POD. B b1;
+<pre>
+memcpy( p, &amp;b1, sizeof(&amp;b1) ); // 866; intended to take sizeof(b1)
+size_t s3 = sizeof(A[0]); // OK, get the size of an element. size_t s4 = sizeof(A[2]); // 866; Not incorrect, but ... // unusual in a sizeof().
+</pre>
+]]>
+    </description>
     <internalKey>866</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -6902,7 +6970,10 @@ This message is issued for several library functions (such as fwrite, memcmp, et
   <rule>
     <key>936</key>
     <name>L0936: old-style function definition for function 'Symbol'</name>
-    <description>An "old-style" function definition is one in which the types are not included between parentheses. Only names are provided between parentheses with the type information following the right parenthesis. This is the only style allowed by K&amp;R.</description>
+    <description><![CDATA[
+An "old-style" function definition is one in which the types are not included between parentheses. Only names are provided between parentheses with the type information following the right parenthesis. This is the only style allowed by K&amp;R.
+]]>
+    </description>
     <internalKey>936</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6942,9 +7013,14 @@ This message is issued for several library functions (such as fwrite, memcmp, et
   <rule>
     <key>940</key>
     <name>L0940: omitted braces within an initializer</name>
-    <description>An initializer for a sub-aggregate does not have braces. For example:
-    int a[2][2] = { 1, 2, 3, 4 };
-    This is legal C but may violate local programming standards. The worst violations are covered by Warning 651.</description>
+    <description><![CDATA[
+An initializer for a sub-aggregate does not have braces. For example:
+<pre>
+int a[2][2] = { 1, 2, 3, 4 };
+</pre>
+This is legal C but may violate local programming standards. The worst violations are covered by Warning 651.
+]]>
+    </description>
     <internalKey>940</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6954,7 +7030,10 @@ This message is issued for several library functions (such as fwrite, memcmp, et
   <rule>
     <key>941</key>
     <name>L0941: Result 0 due to operand(s) equaling 0 in operation 'String'</name>
-    <description>The result of a constant evaluation is 0 owing to one of the operands of a binary operation being 0. This is less severe than Info 778 wherein neither operand is 0. For example, expression (2&amp;1) yields a 778 whereas expression (2&amp;0) yields a 941.</description>
+    <description><![CDATA[
+The result of a constant evaluation is 0 owing to one of the operands of a binary operation being 0. This is less severe than Info 778 wherein neither operand is 0. For example, expression (2&amp;1) yields a 778 whereas expression (2&amp;0) yields a 941.
+]]>
+    </description>
     <internalKey>941</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6984,7 +7063,10 @@ This message is issued for several library functions (such as fwrite, memcmp, et
   <rule>
     <key>944</key>
     <name>L0944: [left/right/] argument for operator 'String' always evaluates to [True/False]</name>
-    <description>The indicated operator (given by String has an argument that appears to always evaluate to either 'True' or 'False' (as indicated in the message). This is given for Boolean operators (||and &amp;&amp; and for Unary operator !) and information is gleaned from a variety of sources including prior assignment statements and initializers. Compare this with message 506 which is based on testing constants or combinations of constants.</description>
+    <description><![CDATA[
+The indicated operator (given by String has an argument that appears to always evaluate to either 'True' or 'False' (as indicated in the message). This is given for Boolean operators (||and &amp;&amp; and for Unary operator !) and information is gleaned from a variety of sources including prior assignment statements and initializers. Compare this with message 506 which is based on testing constants or combinations of constants.
+]]>
+    </description>
     <internalKey>944</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7006,7 +7088,10 @@ This message is issued for several library functions (such as fwrite, memcmp, et
   <rule>
     <key>946</key>
     <name>L0946: Relational or subtract operator applied to pointers</name>
-    <description>A relational operator (one of &gt;, &gt;=, &lt;, &lt;=) or the subtract operator has been applied to a pair of pointers. The reason this is of note is that when large model pointers are compared (in one of the four ways above) or subtracted, only the offset portion of the pointers is subject to the arithmetic. It is presumed that the segment portion is the same. If this presumption is not accurate then disaster looms. By enabling this message you can focus in on the potential trouble spots.</description>
+    <description><![CDATA[
+A relational operator (one of &gt;, &gt;=, &lt;, &lt;=) or the subtract operator has been applied to a pair of pointers. The reason this is of note is that when large model pointers are compared (in one of the four ways above) or subtracted, only the offset portion of the pointers is subject to the arithmetic. It is presumed that the segment portion is the same. If this presumption is not accurate then disaster looms. By enabling this message you can focus in on the potential trouble spots.
+]]>
+    </description>
     <internalKey>946</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7028,7 +7113,10 @@ This message is issued for several library functions (such as fwrite, memcmp, et
   <rule>
     <key>948</key>
     <name>L0948: Operator 'String' always evaluates to [True/False]</name>
-    <description>The operator named in the message is one of four relational operators or two equality operators in the list: &gt; &gt;= &lt; &lt;= == != The arguments are such that it appears that the operator always evaluates to either True or to False (as indicated in the message). This is similar to message 944. Indeed there is some overlap with that message. Message 944 is issued in the context where a Boolean is expected (such as the left hand side of a ? operator) but may not involve a relational operator. Message 948 is issued in the case of a relational (or equality) operator but not necessarily in a situation that requires a Boolean.</description>
+    <description><![CDATA[
+The operator named in the message is one of four relational operators or two equality operators in the list: &gt; &gt;= &lt; &lt;= == != The arguments are such that it appears that the operator always evaluates to either True or to False (as indicated in the message). This is similar to message 944. Indeed there is some overlap with that message. Message 944 is issued in the context where a Boolean is expected (such as the left hand side of a ? operator) but may not involve a relational operator. Message 948 is issued in the case of a relational (or equality) operator but not necessarily in a situation that requires a Boolean.
+]]>
+    </description>
     <internalKey>948</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7059,15 +7147,24 @@ This message is issued for several library functions (such as fwrite, memcmp, et
   <rule>
     <key>952</key>
     <name>L0952: Parameter 'Symbol' (Location) could be declared const</name>
-    <description>A parameter is not modified by a function. For example:
-    int f( char *p, int n ) { return *p = n; }
-    can be redeclared as:
-    int f( char * const p, const int n ) { return *p = n; }
-    There are few advantages to declaring an unchanging parameter a const. It signals to the person reading the code that a parameter is unchanging, but, in the estimate of most, reduces legibility. For this reason the message has been given an Elective Note status.
-    However, there is a style of programming that encourages declaring parameters const. For the above example, this style would declare f as
-    int f( char * p, int n);
-    and would use the const qualifier only in the definition. Note that the two forms are compatible according to the standard. The declaration is considered the interface specification where the const's do not matter. The const's do matter in the definition of the function which is considered the implementation. Message 952 could be used to support this style.
-    Marking a parameter as const does not affect the type of argument that can be passed to the parameter. In particular, it does not mean that only const arguments may be passed. This is in contrast to declaring a parameter as pointer to const or reference to const. For these situations, Informational messages are issued (818 and 1764 respectively) and these do affect the kinds of arguments that may be passed. See also messages 953 and 954.</description>
+    <description><![CDATA[
+A parameter is not modified by a function. For example:
+<pre>
+int f( char *p, int n ) { return *p = n; }
+</pre>
+can be redeclared as:
+<pre>
+int f( char * const p, const int n ) { return *p = n; }
+</pre>
+There are few advantages to declaring an unchanging parameter a const. It signals to the person reading the code that a parameter is unchanging, but, in the estimate of most, reduces legibility. For this reason the message has been given an Elective Note status.
+However, there is a style of programming that encourages declaring parameters const. For the above example, this style would declare f as
+<pre>
+int f( char * p, int n);
+</pre>
+and would use the const qualifier only in the definition. Note that the two forms are compatible according to the standard. The declaration is considered the interface specification where the const's do not matter. The const's do matter in the definition of the function which is considered the implementation. Message 952 could be used to support this style.
+Marking a parameter as const does not affect the type of argument that can be passed to the parameter. In particular, it does not mean that only const arguments may be passed. This is in contrast to declaring a parameter as pointer to const or reference to const. For these situations, Informational messages are issued (818 and 1764 respectively) and these do affect the kinds of arguments that may be passed. See also messages 953 and 954.
+]]>
+    </description>
     <internalKey>952</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7161,7 +7258,7 @@ This message is issued for several library functions (such as fwrite, memcmp, et
     <name>L0960: Violates MISRA Year Required Rule Name, String</name>
     <description><![CDATA[<p>MISRA is the "Guidelines for the use of the C Language in Vehicle Based Software". [10] The first version of the MISRA Standard was released in 1998 and the second in 2004. Lint references the rules from each version of the Standard using integers for 1998 and in decimal form for 2004, as per the Standard numbering style.</p>
     <p>The list of required checks made for both MISRA 1998 and 2004 are:</p>
-<pre><tt>
+<pre><code>
        (Rule 16/12.12) Bit representation of a floating point type used.
        (Rule 19/7.1) Octal constant used.
        (Rule 22/8.7) Could define variable at block scope.
@@ -7228,15 +7325,15 @@ This message is issued for several library functions (such as fwrite, memcmp, et
 
        (Rule 18.4) Unions shall not be used.
        (Rule 19.13) '#/##' operator used in macro.
-</tt></pre>
+</code></pre>
 
 <p>MISRA 1998 checking is achieved using the -misra(1) option. For
 MISRA 2004 checks, use -misra(2)</p>
 
 <p>You may disable individual rules to your taste by using the Rule number in an esym option.</p> <p>For example:</p>
-<pre><tt>
+<pre><code>
     -esym( 960, 75, 8? )
-</tt></pre>
+</code></pre>
 <p>will suppress MISRA rules 75 and any of the those between 80 and 89 inclusive that are issued as the result of a 960. See [10] for information on the MISRA guidelines.</p>
 ]]></description>
     <internalKey>960</internalKey>
@@ -7355,12 +7452,15 @@ MISRA 2004 checks, use -misra(2)</p>
   <rule>
     <key>974</key>
     <name>L0974: Worst case function for stack usage: String</name>
-    <description>This message, issued at global wrap-up, will report on the function that requires the most stack. The stack required consists of the amount of auto storage the function requires plus the amounts required in any chain of functions called. The worst case chain is always reported.
-    To obtain a report of all the functions, use the +stack option.
-    Reasonable allowances are made for function call overhead and the stack requirements of external functions. These assumptions can be controlled via the +stack option.
-    If recursion is detected it will be reported here, as this is considered worse than any finite case. The next worse case is that the stack can't be determined because a function makes a call through a function pointer. The function is said to be non-deterministic. If neither of these conditions prevail, the function that heads the worst case chain of calls will be reported upon.
-    The message will normally provide you with the name of a called function. If the function is recursive this will provide you with the first call of a recursive loop. To determine the full loop, you will need a full stack report as obtained with the +stack option. You need a suboption of the form &amp;file=file to specify a file which will contain a record for each function for which a definition was found. You will be able to follow the chain of calls to determine the recursive path.
-    If you can assure yourself through code analysis that there is an upper bound to the amount of stack utilized by some recursive function, then you can employ the +stack option to specify the bound for this function. The function will no longer be considered recursive but rather finite. In this way, possibly through a sequence of options, you can progressively eliminate apparent recursion and in that way arrive at a safe upper bound for stack usage. Similar considerations apply for non-deterministic functions.</description>
+    <description><![CDATA[
+This message, issued at global wrap-up, will report on the function that requires the most stack. The stack required consists of the amount of auto storage the function requires plus the amounts required in any chain of functions called. The worst case chain is always reported.
+To obtain a report of all the functions, use the +stack option.
+Reasonable allowances are made for function call overhead and the stack requirements of external functions. These assumptions can be controlled via the +stack option.
+If recursion is detected it will be reported here, as this is considered worse than any finite case. The next worse case is that the stack can't be determined because a function makes a call through a function pointer. The function is said to be non-deterministic. If neither of these conditions prevail, the function that heads the worst case chain of calls will be reported upon.
+The message will normally provide you with the name of a called function. If the function is recursive this will provide you with the first call of a recursive loop. To determine the full loop, you will need a full stack report as obtained with the +stack option. You need a suboption of the form &amp;file=file to specify a file which will contain a record for each function for which a definition was found. You will be able to follow the chain of calls to determine the recursive path.
+If you can assure yourself through code analysis that there is an upper bound to the amount of stack utilized by some recursive function, then you can employ the +stack option to specify the bound for this function. The function will no longer be considered recursive but rather finite. In this way, possibly through a sequence of options, you can progressively eliminate apparent recursion and in that way arrive at a safe upper bound for stack usage. Similar considerations apply for non-deterministic functions.
+]]>
+    </description>
     <internalKey>974</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7463,9 +7563,9 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1009</key>
     <name>L1009: operator String not redefinable</name>
     <description><![CDATA[<p>The three operators:</p>
-<pre><tt>
+<pre><code>
         .*   ?   .
-</tt></pre>
+</code></pre>
 <p>are not redefinable and may not be overloaded [11, 13.4].</p>]]></description>
     <internalKey>1009</internalKey>
     <severity>CRITICAL</severity>
@@ -7577,11 +7677,11 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1020</key>
     <name>L1020: template specialization for 'Symbol' declared without a 'template&lt;&gt;' prefix</name>
     <description><![CDATA[<p>A class template specialization is generally preceded by a 'template<>' clause as in:</p>
-<pre><tt>
-               template< class T > class A { };       // a template
-               template<> class A<int> { };           // a specialization
-</tt></pre>
-<p>If the 'template<>' is omitted, you will get this message but it will still be interpreted as a specialization.  Before the standardization of template syntax was completed, a template specialization did not require this clause and its absence is still permitted by some compilers.
+<pre><code>
+               template&lt; class T &gt; class A { };       // a template
+               template&lt;&gt; class A&lt;int&gt; { };           // a specialization
+</code></pre>
+<p>If the 'template&lt;&gt;' is omitted, you will get this message but it will still be interpreted as a specialization.  Before the standardization of template syntax was completed, a template specialization did not require this clause and its absence is still permitted by some compilers.
 </p>]]></description>
     <internalKey>1020</internalKey>
     <severity>CRITICAL</severity>
@@ -7603,9 +7703,9 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1022</key>
     <name>L1022: Function: 'String' must be a class member</name>
     <description><![CDATA[<p>There are four operators which may not be defined except as class members. These are:</p>
-<pre><tt>
+<pre><code>
                =  ()  []  ->
-</tt></pre>
+</code></pre>
 <p>The parameter String indicates which it is.  [11, #3.4.3 and #3.4.6]
 </p>]]></description>
     <internalKey>1022</internalKey>
@@ -7658,9 +7758,9 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1027</key>
     <name>L1027: Non-consecutive default arguments in function 'String', assumed 0</name>
     <description><![CDATA[<p>Default arguments need to be consecutive.  For example</p>
-<pre><tt>
+<pre><code>
              void f(int i=0, int j, int k=0);
-</tt></pre>
+</code></pre>
 <p>is illegal.  [11, #2.6]
 </p>]]></description>
     <internalKey>1027</internalKey>
@@ -7852,7 +7952,10 @@ MISRA 2004 checks, use -misra(2)</p>
   <rule>
     <key>1048</key>
     <name>L1048: expected a constant expression</name>
-    <description>Within a template argument list a constant expression was expected. An expression of the form T&lt;arg1,arg2,...&gt; was encountered and arg i for some i corresponds to a non-class parameter in the original template declaration. Such arguments need to be constants. [10, ?14.5]</description>
+    <description><![CDATA[
+Within a template argument list a constant expression was expected. An expression of the form T&lt;arg1,arg2,...&gt; was encountered and arg i for some i corresponds to a non-class parameter in the original template declaration. Such arguments need to be constants. [10, ?14.5]
+]]>
+    </description>
     <internalKey>1048</internalKey>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -7912,7 +8015,10 @@ MISRA 2004 checks, use -misra(2)</p>
   <rule>
     <key>1054</key>
     <name>L1054: template variable declaration expects a type, int assumed</name>
-    <description>An expression of the form T&lt;arg,arg,...&gt; was encountered. One of the arguments corresponding to a type parameter in the original template declaration is not a type. [10, ?14.5]</description>
+    <description><![CDATA[
+An expression of the form T&lt;arg,arg,...&gt; was encountered. One of the arguments corresponding to a type parameter in the original template declaration is not a type. [10, ?14.5]
+]]>
+    </description>
     <internalKey>1054</internalKey>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -8003,9 +8109,9 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1063</key>
     <name>L1063: Argument to copy constructor for class 'Symbol' should be a reference</name>
     <description><![CDATA[<p>A constructor for a class closely resembles a copy constructor.  A copy constructor for class X is typically declared as:</p>
-<pre><tt>
+<pre><code>
              X( const X &)
-</tt></pre>
+</code></pre>
 <p>If you leave off the '&' then a copy constructor would be needed just to copy the argument into the copy constructor.  This is a runaway recursion.  [11,#2.1]
 </p>]]></description>
     <internalKey>1063</internalKey>
@@ -8118,9 +8224,9 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1074</key>
     <name>L1074: Expected a namespace identifier</name>
     <description><![CDATA[<p>In a declaration of the form:</p>
-<pre><tt>
+<pre><code>
              namespace name = scoped-identifier
-</tt></pre>
+</code></pre>
 <p>the scoped-identifier must identify a namespace.
 </p>]]></description>
     <internalKey>1074</internalKey>
@@ -8153,9 +8259,9 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1077</key>
     <name>L1077: Could not evaluate default template parameter 'String'</name>
     <description><![CDATA[<p>The evaluation of template parameters is deferred until needed. Thus:</p>
-<pre><tt>
+<pre><code>
              template< class T = abc > class A { /* ... */ };
-</tt></pre>
+</code></pre>
 <p>will be greeted with an Error 1077 only if an instantiation of A<> requires evaluation of the default argument and if that evaluation cannot be made.  In that event int is assumed for type parameters and 0 is assumed for object parameters.
 </p>]]></description>
     <internalKey>1077</internalKey>
@@ -8168,9 +8274,9 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1078</key>
     <name>L1078: class 'Symbol' should not have itself as a base class</name>
     <description><![CDATA[<p>The following situation will trigger this message.</p>
-<pre><tt>
+<pre><code>
              class A : public A { };
-</tt></pre>
+</code></pre>
 <p>You can't define A in terms of itself as there is no escape from the recursive plummet.
 </p>]]></description>
     <internalKey>1078</internalKey>
@@ -8182,13 +8288,13 @@ MISRA 2004 checks, use -misra(2)</p>
   <rule>
     <key>1079</key>
     <name>L1079: Could not find '&gt;' or ',' to terminate template parameter at Location</name>
-    <description><![CDATA[<p>The default value for a template parameter appears to be malformed.  For example, suppose the user mistakenly substituted a ']' for a '>' producing the following:</p>
-<pre><tt>
-             template <class T = A< int ] >
+    <description><![CDATA[<p>The default value for a template parameter appears to be malformed.  For example, suppose the user mistakenly substituted a ']' for a '&gt;' producing the following:</p>
+<pre><code>
+             template &lt;class T = A&lt; int ] &gt;
                  class X
                      {
                      };
-</tt></pre>
+</code></pre>
 <p>This will cause PC-lint/FlexeLint to process to the end of the file looking (in vain) for the terminating pointy bracket.  Not finding it will cause this message to be printed.  Fortunately, the message will bear the Location of the malformed template.
 </p>]]></description>
     <internalKey>1079</internalKey>
@@ -8201,11 +8307,11 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1080</key>
     <name>L1080: Definition for class 'Name' is not in scope</name>
     <description><![CDATA[<p>This message would be issued whenever a class definition were required and it were not available.  For example:</p>
-<pre><tt>
+<pre><code>
              class X;        // declare class X
              X *p;           // OK, no definition required
              X a;            // Error 1080
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1080</internalKey>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -8216,11 +8322,11 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1081</key>
     <name>L1081: Object parameter does not contain the address of a variable</name>
    <description><![CDATA[<p>A template argument that is passed to a pointer parameter is supposed to identify a symbol.  The expression passed does not do so. For example</p>
-<pre><tt>
-               template< int *P > class A { ... };
+<pre><code>
+               template&lt; int *P &gt; class A { ... };
                int a[10];
-               A< a+2 > x;     // a+2 does not represent a symbol
-</tt></pre>]]></description>
+               A&lt; a+2 &gt; x;     // a+2 does not represent a symbol
+</code></pre>]]></description>
     <internalKey>1081</internalKey>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -8231,11 +8337,11 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1082</key>
     <name>L1082: Object parameter for a reference type should be an external symbol</name>
     <description><![CDATA[<p>A template argument that is passed to a reference parameter is supposed to identify an external symbol.  The expression passed does not do so.  For example</p>
-<pre><tt>
-               template< int &I > class A { ... };
+<pre><code>
+               template&lt; int &amp;I &gt; class A { ... };
                int a[10];
-               A< a[2] > x;     // a[2] does not represent a symbol
-</tt></pre>
+               A&lt; a[2] &gt; x;     // a[2] does not represent a symbol
+</code></pre>
 <p>See also message 1081.
 </p>]]></description>
     <internalKey>1082</internalKey>
@@ -8263,13 +8369,13 @@ MISRA 2004 checks, use -misra(2)</p>
 <ul><li>If one of the matching partial specializations is more specialized than all others then it is used for the instantiation.</li>
 <li>Otherwise, the program is ill-formed, so Lint issues message 1084.</li> </ul>
 <p>In the message, the matching partial specializations are provided as the list of candidates.  Example:</p>
-<pre><tt>
-               template<class T1, class T2, int I> class A {};             //#1
-               template<class T1, class T2, int I> class A<T1*, T2, I> {}; //#2
-               template<class T1, class T2, int I> class A<T1, T2*, I> {}; //#3
-               A<int*, int*, 2> a; // ambiguous: matches #2 and #3
+<pre><code>
+               template&lt;class T1, class T2, int I&gt; class A {};             //#1
+               template&lt;class T1, class T2, int I&gt; class A&lt;T1*, T2, I&gt; {}; //#2
+               template&lt;class T1, class T2, int I&gt; class A&lt;T1, T2*, I&gt; {}; //#3
+               A&lt;int*, int*, 2&gt; a; // ambiguous: matches #2 and #3
                                    // (and neither template is more specialized than the other)
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1084</internalKey>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -8280,13 +8386,13 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1085</key>
     <name>L1085: Invalid definition of 'String'</name>
     <description><![CDATA[<p>An attempt was made to define a member of a template before the template was defined. Example:</p>
-<pre><tt>
-               template<class T, class U> struct A
+<pre><code>
+               template&lt;class T, class U&gt; struct A
                        {
                        void
                        };
-               template<class U, class T> void A<T,U>::f(){} // Error 1085
-</tt></pre>
+               template&lt;class U, class T&gt; void A&lt;T,U&gt;::f(){} // Error 1085
+</code></pre>
 <p>In this case, the template argument list is out of order; T and U have been interchanged.
 </p>]]></description>
     <internalKey>1085</internalKey>
@@ -8309,17 +8415,17 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1087</key>
     <name>L1087: Previous declaration of 'Name' (Location) is incompatible with 'Name' (Location) which was introduced by the current using-declaration</name>
     <description><![CDATA[<p>A using declaration such as:</p>
-<pre><tt>
+<pre><code>
              using NS::name;
-</tt></pre>
+</code></pre>
 <p>seems to be in error.  It introduces a name that clashes with the name introduced earlier by another using-declaration.  E.g.:</p>
 
-<pre><tt>
+<pre><code>
                namespace N { int i;}
                namespace Q { void i();}
                using N::i;
                using Q::i; // Error 1087 issued here.
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1087</internalKey>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -8330,14 +8436,14 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1088</key>
     <name>L1088: A using-declaration must name a qualified-id</name>
     <description><![CDATA[<p>This error is issued when a using-declaration references a name without the :: scope resolution operator; e.g.:</p>
-<pre><tt>
+<pre><code>
                class A { protected: int n; };
                class B : public A {
                public:
                    using n; // Error 1088: should be 'using A::n;'
                };
-</tt></pre>
-<p>See Section <ref,14. Added Bibliography,14.>, [34], 7.3.3 namespace.udecl.
+</code></pre>
+<p>See Section &lt;ref,14. Added Bibliography,14.&gt;, [34], 7.3.3 namespace.udecl.
 </p>]]></description>
     <internalKey>1088</internalKey>
     <severity>CRITICAL</severity>
@@ -8349,22 +8455,22 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1089</key>
     <name>L1089: A using-declaration must not name a namespace</name>
     <description><![CDATA[<p>This error is issued when the rightmost part of the qualified-id in a using-declaration is the name of a namespace.  E.g.:</p>
-<pre><tt>
+<pre><code>
                namespace N { namespace Q{ void g(); } }
                void f() {
                    using ::N::Q; // Error 1089
                    Q::g();
                }
-</tt></pre>
+</code></pre>
 <p>Instead, use a namespace-alias-definition:</p>
-<pre><tt>
+<pre><code>
                namespace N { namespace Q{ void g(); } }
                void f() {
                    namespace Q = ::N::Q; // OK
                    Q::g(); // OK, calls ::N::Q::g().
                }
-</tt></pre>
-<p>See Section <ref,14. Added Bibliography,14.>, [35], Issue 460.
+</code></pre>
+<p>See Section &lt;ref,14. Added Bibliography,14.&gt;, [35], Issue 460.
 </p>]]></description>
     <internalKey>1089</internalKey>
     <severity>CRITICAL</severity>
@@ -8376,34 +8482,34 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1090</key>
     <name>L1090: A using-declaration must not name a template-id</name>
     <description><![CDATA[<p>This error is issued when the rightmost part of the qualified-id in a using-declaration is a template-id.  E.g.:</p>
-<pre><tt>
-               template<class T> class A {
+<pre><code>
+               template&lt;class T&gt; class A {
                protected:
-                   template<class U> class B{};
+                   template&lt;class U&gt; class B{};
                };
 
-               struct D : public A<int> {
+               struct D : public A&lt;int&gt; {
                public:
-                   using A<int>::B<char*>; // Error 1090
+                   using A&lt;int&gt;::B&lt;char*&gt;; // Error 1090
                    };
 
-               D::B<char*> bc;
-</tt></pre>
+               D::B&lt;char*&gt; bc;
+</code></pre>
 <p>Instead, refer to the template name without template arguments:</p>
-<pre><tt>
-               template<class T> class A {
+<pre><code>
+               template&lt;class T&gt; class A {
                protected:
-                   template<class U> class B{};
+                   template&lt;class U&gt; class B{};
                };
 
-               struct D : public A<int> {
+               struct D : public A&lt;int&gt; {
                public:
-                   using A<int>::B; // OK
+                   using A&lt;int&gt;::B; // OK
                    };
 
-               D::B<char*> bc; // OK
-</tt></pre>
-<p>See Section <ref,14. Added Bibliography,14.>, [34], 7.3.3 namespace.udecl.
+               D::B&lt;char*&gt; bc; // OK
+</code></pre>
+<p>See Section &lt;ref,14. Added Bibliography,14.&gt;, [34], 7.3.3 namespace.udecl.
 </p>]]></description>
     <internalKey>1090</internalKey>
     <severity>CRITICAL</severity>
@@ -8415,7 +8521,7 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1091</key>
     <name>L1091: 'Name' is not a base class of 'Name'</name>
     <description><![CDATA[<p>This error is issued when the nested-name-specifier of the qualified-id in a using-declaration does not name a base class of the class containing the using-declaration; e.g.:</p>
-<pre><tt>
+<pre><code>
                struct N {
                    void f();
                }
@@ -8425,8 +8531,8 @@ MISRA 2004 checks, use -misra(2)</p>
                public:
                    using N::f; // Error 1091
                };
-</tt></pre>
-<p>See Section <ref,14. Added Bibliography,14.>, [35], Issue 400.
+</code></pre>
+<p>See Section &lt;ref,14. Added Bibliography,14.&gt;, [35], Issue 400.
 </p>]]></description>
     <internalKey>1091</internalKey>
     <severity>CRITICAL</severity>
@@ -8438,7 +8544,7 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1092</key>
     <name>L1092: A using-declaration that names a class member must be a member-declaration</name>
     <description><![CDATA[<p>This error is issued when the nested-name-specifier of the qualified-id in a using-declaration names a class but the using-declaration does not appear where class members are declared.  E.g.:</p>
-<pre><tt>
+<pre><code>
                struct A { void f(); };
 
                struct B : A{
@@ -8446,8 +8552,8 @@ MISRA 2004 checks, use -misra(2)</p>
                        using A::f; // Error 1092
                    }
                };
-</tt></pre>
-<p>See Section <ref,14. Added Bibliography,14.>, [34], 7.3.3 namespace.udecl.
+</code></pre>
+<p>See Section &lt;ref,14. Added Bibliography,14.&gt;, [34], 7.3.3 namespace.udecl.
 </p>]]></description>
     <internalKey>1092</internalKey>
     <severity>CRITICAL</severity>
@@ -8478,21 +8584,21 @@ MISRA 2004 checks, use -misra(2)</p>
   <rule>
     <key>1095</key>
     <name>L1095: Effective type 'Type' of non-type template parameter #Integer (corresponding to argument expression 'String') depends on an unspecialized parameter of this partial specialization</name>
-    <description><![CDATA[<p>The ISO C++ Standard says that "the type of a template parameter corresponding to a specialized non-type argument shall not be dependent on a parameter of the specialization." See Section <ref,14. Added Bibliography,14.>, [34], 14.5.4 temp.class.spec. Example:</p>
-<pre><tt>
+    <description><![CDATA[<p>The ISO C++ Standard says that "the type of a template parameter corresponding to a specialized non-type argument shall not be dependent on a parameter of the specialization." See Section &lt;ref,14. Added Bibliography,14.&gt;, [34], 14.5.4 temp.class.spec. Example:</p>
+<pre><code>
            // primary template:
-           template<class T, T N, class U> struct B;
+           template&lt;class T, T N, class U&gt; struct B;
 
            // PS #1:
-           template<class U> struct B<int,257,U>; // Ok
+           template&lt;class U&gt; struct B&lt;int,257,U&gt;; // Ok
 
            // PS #2:
-           template<class U> struct B<bool,257,U>; // Ok, same as:
-           template<class U> struct B<bool,true,U>; // Ok (redeclaration of #2)
+           template&lt;class U&gt; struct B&lt;bool,257,U&gt;; // Ok, same as:
+           template&lt;class U&gt; struct B&lt;bool,true,U&gt;; // Ok (redeclaration of #2)
 
            // PS #3:
-           template<class U> struct B<T,257,U>; // Error 1095 here
-</tt></pre>
+           template&lt;class U&gt; struct B&lt;T,257,U&gt;; // Error 1095 here
+</code></pre>
 <p>In PS #3, the value 257 is the 'specialized non-type argument' and its corresponding parameter is 'N' whose type is T which was not made concrete.  But in PS #1 and PS #2, T was given the concrete types 'int' and 'bool', respectively.
 </p>]]></description>
     <internalKey>1095</internalKey>
@@ -8506,7 +8612,7 @@ MISRA 2004 checks, use -misra(2)</p>
     <name>L1096: A target ctor must be the only mem-initializer in the mem-initializer-list of a delegating ctor</name>
     <description><![CDATA[
 <p>C++0x requires that if a constructor delegates to another constructor, then the mem-initializer (the region between the colon and the function body) must contain only one item, and that item must be a call to another constructor (which is called the "target constructor").  Example:</p>
-<pre><tt>
+<pre><code>
            struct A
                {
                int n;
@@ -8516,7 +8622,7 @@ MISRA 2004 checks, use -misra(2)</p>
                    n(42),  A(32)  // Error 1096
                    {}
                };
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1096</internalKey>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -8527,13 +8633,13 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1097</key>
     <name>L1097: Delegating ctor delegates directly to itself, causing infinite recursion</name>
     <description><![CDATA[<p>Example:</p>
-<pre><tt>
+<pre><code>
            struct A
                {
                int n;
                A(int x) : A(x){} // Error 1097
                };
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1097</internalKey>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -8545,17 +8651,17 @@ MISRA 2004 checks, use -misra(2)</p>
     <name>L1098: Function template specialization 'Symbol' does not match any function template</name>
     <description><![CDATA[
 <p>This message is issued for a declaration where the user apparently intended to name a specialization of a function template (e.g., in an explicit specialization, an explicit instantiation or a friend declaration of specialization), but no previously-declared function template is matched.  Example:</p>
-<pre><tt>
-               template<class T> void f( const T& ); // #1
+<pre><code>
+               template&lt;class T&gt; void f( const T& ); // #1
 
                struct A{};
-               template<> void f( const A& ); // Ok
+               template&lt;&gt; void f( const A& ); // Ok
                // (A is the deduced argument to T.)
 
                struct B{};
-               template<> void f( const B ); // Error 1097.
+               template&lt;&gt; void f( const B ); // Error 1097.
                // (A template argument cannot be deduced for T.)
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1098</internalKey>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -8567,26 +8673,26 @@ MISRA 2004 checks, use -misra(2)</p>
     <name>L1099: Ambiguous function template specialization 'Symbol'</name>
     <description><![CDATA[
 <p>This message is issued for a declaration where the user apparently intended to name a specialization of a function template (e.g., in an explicit specialization, an explicit instantiation or a friend declaration of specialization), but the specialization matches multiple function templates, and none of the matched templates is more specialized than all of the other matching templates.  The candidates (i.e., the matching templates) are provided in the message.  Example:</p>
-<pre><tt>
-               template<class T> struct A {};
+<pre><code>
+               template&lt;class T&gt; struct A {};
 
-               template<class T, class U> void f( T*, U    ); // #1
-               template<class T, class U> void f( T,  A<U> ); // #2
+               template&lt;class T, class U&gt; void f( T*, U    ); // #1
+               template&lt;class T, class U&gt; void f( T,  A&lt;U&gt; ); // #2
 
                struct B{};
-               template<> void f( B, A<B> ); // Ok
+               template&lt;&gt; void f( B, A&lt;B&gt; ); // Ok
                // #1 does not match but #2 does.
 
-               template<> void f( char*, A<int> ); // Error 1099
+               template&lt;&gt; void f( char*, A&lt;int&gt; ); // Error 1099
                // Both #1 and #2 match and neither is more specialized than the
                // other.
-</tt></pre>
+</code></pre>
 <p>This situation can be avoided in at least a couple of ways. One way is to explicitly specify one or more template arguments.  Example:</p>
-<pre><tt>
+<pre><code>
                // continuing from above...
-               template<> void f<char*>( char*, A<int> ); // Ok
+               template&lt;&gt; void f&lt;char*&gt;( char*, A&lt;int&gt; ); // Ok
                // #1 does not match but #2 does.
-</tt></pre>
+</code></pre>
 <p>Another way is to use SFINAE tactics in the declaration of one or more function templates, e.g. with boost::enable_if </p>]]></description>
     <internalKey>1099</internalKey>
     <severity>CRITICAL</severity>
@@ -8598,14 +8704,14 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1100</key>
     <name>L1100: Declaration of 'Symbol' does not declare an explicit specialization, explicit instantiation or friend</name>
     <description><![CDATA[<p>In a declaration that explicitly specifies template arguments with angle brackets immediately after the name of a function template, the declaration must declare either an explicit specialization, explicit instantiation or friend.  (Note, an explicit specialization always begins with 'template<>' and an explicit instantiation always begins with 'template'---without angle brackets after the keyword 'template'.)</p>
-<pre><tt>
-               template<class T> struct A {};
+<pre><code>
+               template&lt;class T&gt; struct A {};
 
-               template<class T> inline void f( A<T> ); // #1
-               void f( A<int> ); // #2 // Ok, declares an ordinary function
+               template&lt;class T&gt; inline void f( A&lt;T&gt; ); // #1
+               void f( A&lt;int&gt; ); // #2 // Ok, declares an ordinary function
 
-               void f<char>( A<char> ); // Error 1100
-</tt></pre>]]></description>
+               void f&lt;char&gt;( A&lt;char&gt; ); // Error 1100
+</code></pre>]]></description>
     <internalKey>1100</internalKey>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -8616,21 +8722,21 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1101</key>
     <name>L1101: Type of variable 'Symbol' cannot be deduced from its initializer</name>
     <description><![CDATA[<p>Example:</p>
-<pre><tt>
+<pre><code>
                int f(void);
                int f(char*);
                auto n = f; // Error
-</tt></pre>
+</code></pre>
 <p>In terms of deduction, this is equivalent to:</p>
-<pre><tt>
+<pre><code>
                int f(void);
                int f(char*);
-               template<class T> void g( const T& );
+               template&lt;class T&gt; void g( const T& );
                void h( void )
                    {
                    g( f ); // Error
                    }
-</tt></pre>
+</code></pre>
 <p>Here,  'f' refers to multiple overloaded functions, so it is an ambiguous reference and T cannot be deduced.  (Code like this could still be well-formed however, e.g. if g is overloaded with a non-template function whose parameter type is 'ptr-to-function returning int taking (char*)'.)
 </p>]]></description>
     <internalKey>1101</internalKey>
@@ -8643,7 +8749,7 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1102</key>
     <name>L1102: auto type deduced inconsistently: 'Type' for 'Symbol' but 'Type' for 'Symbol'</name>
     <description><![CDATA[<p>When multiple variables are defined in the same declaration, and when that declaration uses the keyword auto as the type-specifier (a feature of C++0x), the type for which auto is a placeholder must be the same for each variable.  Example:</p>
-<pre><tt>
+<pre><code>
                float g(void);
                char* s();
                auto a = 42; // Ok, auto is 'int'
@@ -8651,38 +8757,38 @@ MISRA 2004 checks, use -misra(2)</p>
                auto c = 'q',
                     *d = s(); // Ok, auto is 'char' (for both c and d)
                auto x = 42, y = g(); // Error 1102 here
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1102</internalKey>
     <severity>CRITICAL</severity>  </rule>
   <rule>
     <key>1103</key>
     <name>L1103: Type 'Type' is not allowed as an enum-base</name>
     <description><![CDATA[<p>When an enumeration type is declared with an explicit underlying type, that type must be integral.  Example:</p>
-<pre><tt>
+<pre><code>
                enum A : bool; // ok
                enum B : short; // ok
                enum C : unsigned long long; // ok
                enum D : float; // Error 1103
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1103</internalKey>
     <severity>CRITICAL</severity>  </rule>
   <rule>
     <key>1104</key>
     <name>L1104: A reference to enumeration 'Symbol' should not use 'String'</name>
     <description><![CDATA[<p>Although an enumeration may be declared or defined using a scope indicator or an underlying type indicator, these should not be applied when simply referencing the enumeration.  E.g.</p>
-<pre><tt>
+<pre><code>
                enum class A { red, green };
                enum class A x;         // Error: don't need 'class'
                enum A : unsigned { red, green };
                enum A : unsigned y;    // Error: don't need ': unsigned'
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1104</internalKey>
     <severity>CRITICAL</severity>  </rule>
   <rule>
     <key>1105</key>
     <name>L1105: Use of ref qualification of 'Symbol' inconsistent with overloaded function 'Symbol' (Location)"</name>
     <description><![CDATA[<p>If an explicit ref qualifier ('&' or '&&') of a nonstatic member function is employed, an explicit ref qualifier needs to be used with every member of the overload set.  Thus:</p>
-<pre><tt>
+<pre><code>
                class A
                    {
                    void f(int) &;  // ok (so far)
@@ -8691,16 +8797,16 @@ MISRA 2004 checks, use -misra(2)</p>
                    void g(int);    // ok (fresh function)
                    void g(double); // still ok
                    };
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1105</internalKey>
     <severity>CRITICAL</severity>  </rule>
   <rule>
     <key>1106</key>
     <name>L1106: Initializing value 'String' of enumerator 'Name' cannot be represented by the enumeration's underlying type 'Type'</name>
     <description><![CDATA[<p>An enumerator is being initialized with a value that is inappropriate to the declared type of the initializer. Example:</p>
-<pre><tt>
+<pre><code>
                enum E : unsigned char { e = 256 };
-</tt></pre>
+</code></pre>
 <p>The value 256 cannot be represented by an unsigned char.
 </p>]]></description>
     <internalKey>1106</internalKey>
@@ -8709,10 +8815,10 @@ MISRA 2004 checks, use -misra(2)</p>
     <key>1107</key>
     <name>L1107: Mixing two different kinds of string literals</name>
     <description><![CDATA[<p>Two string literals are being concatenated which have different types. Examples:</p>
-<pre><tt>
+<pre><code>
                char *s = u"abc" U"def";
                char *q = L"ghi" u"jkl";
-</tt></pre>
+</code></pre>
 <p>This message is issued for mixing strings of char16_t, char32_t, and/or wchar_t (as shown).  Literal string concatenation of any of these with an ordinary character literal is permitted and will receive Informational 707.
 </p>]]></description>
     <internalKey>1107</internalKey>
@@ -8726,14 +8832,14 @@ MISRA 2004 checks, use -misra(2)</p>
     <name>L1108: Use of deleted function 'Symbol' defined at 'Location'</name>
     <description><![CDATA[<p>
 This message is issued when a deleted function is used.  Example:</p>
-<pre><tt>
+<pre><code>
                void f( int ) = delete;
                void f( double );
                void g( double d, int n ) {
                    f( d ); // Ok
                    f( n ); // Error
                }
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1108</internalKey>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -8745,20 +8851,20 @@ This message is issued when a deleted function is used.  Example:</p>
     <name>L1110: Cycle detected: explicit application of 'Name'::operator-&gt; causes infinite implicit applications of the same operator</name>
     <description><![CDATA[
 <p>When an overloaded operator-> is used as in</p>
-<pre><tt>
-               a->b
-</tt></pre>
+<pre><code>
+               a-&gt;b
+</code></pre>
 <p>it is effectively expanded to:</p>
-<pre><tt>
-               a.operator->()->b
-</tt></pre>
+<pre><code>
+               a.operator-&gt;()-&gt;b
+</code></pre>
 <p>And this expansion repeats until an operator-> is found that does not yield a class type.  But in the process of evaluating this expansion, it might be found that one  of the operators returns a class type for which an overloaded operator-> was already expanded; in that case, Error 1110 is triggered. Example:</p>
-<pre><tt>
+<pre><code>
                struct B;
-               struct A { struct B& operator->(); };
-               struct B { struct A& operator->(); };
-               int  f( A & p ) { p->g(); } // Error
-</tt></pre>]]></description>
+               struct A { struct B& operator-&gt;(); };
+               struct B { struct A& operator-&gt;(); };
+               int  f( A & p ) { p-&gt;g(); } // Error
+</code></pre>]]></description>
     <internalKey>1110</internalKey>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -8770,55 +8876,55 @@ This message is issued when a deleted function is used.  Example:</p>
     <name>L1111: ISO C++ requires an explicit specialization/instantiation to appear at namespace scope</name>
     <description><![CDATA[
 <p>This message is issued at the beginning of each explicit specialization/instantiation that does not appear at namespace scope.  Example:</p>
-<pre><tt>
+<pre><code>
                struct A {
-                   template <typename U> struct B {};
+                   template &lt;typename U&gt; struct B {};
 
-                   // template <>  // Would be ill-formed by ISO C++.
-                   //     struct B<int> {};
+                   // template &lt;&gt;  // Would be ill-formed by ISO C++.
+                   //     struct B&lt;int&gt; {};
                };
-               template<> struct A::B<int> {}; // Ok.
-</tt></pre>
+               template&lt;&gt; struct A::B&lt;int&gt; {}; // Ok.
+</code></pre>
 <p>There is an additional limitation with member class templates of class templates.  As with members of a non-template class, one cannot write a specialization at class scope.   Example:</p>
-<pre><tt>
-               template<typename T> struct G {
-                   template <typename U> struct H {};
-                   // template <>  // Would be ill-formed by ISO C++.
-                   //     struct H<int> {};
+<pre><code>
+               template&lt;typename T&gt; struct G {
+                   template &lt;typename U&gt; struct H {};
+                   // template &lt;&gt;  // Would be ill-formed by ISO C++.
+                   //     struct H&lt;int&gt; {};
                };
-</tt></pre>
+</code></pre>
 <p> But the language specification does not even allow this to be expressed in a namespace-scope definition; there is no way to write an explicit specialization that is a member of a class template.  Example:</p>
-<pre><tt>
-               template<typename T> struct J {
-                   template <typename U> struct K {};
+<pre><code>
+               template&lt;typename T&gt; struct J {
+                   template &lt;typename U&gt; struct K {};
                };
-               // template<typename T>
-               //     template <>  // Would be ill-formed by ISO C++;
-               //         struct J<T>::K<int> {};
-</tt></pre>
+               // template&lt;typename T&gt;
+               //     template &lt;&gt;  // Would be ill-formed by ISO C++;
+               //         struct J&lt;T&gt;::K&lt;int&gt; {};
+</code></pre>
 <p>This is because the rules for explicit specializations say that 'template<>' is not allowed to appear after a non-empty template-parameter-list within the same declaration.  However, one may write an explicit specialization that is a member of an implicitly-instantiated specialization of a class template. Example:</p>
-<pre><tt>
-               template<typename T> struct L {
-                   template <typename U> struct M {};
+<pre><code>
+               template&lt;typename T&gt; struct L {
+                   template &lt;typename U&gt; struct M {};
                };
-               template <> template <> struct L<char>::M<int> {}; // Ok
-</tt></pre>
-<p>Here, the body of the class L<char> is automatically generated by implicit instantiation (otherwise the reference to 'L<char>::M' would be ill-formed), while the body of L<char>::M<int> is provided in the explicit specialization.
+               template &lt;&gt; template &lt;&gt; struct L&lt;char&gt;::M&lt;int&gt; {}; // Ok
+</code></pre>
+<p>Here, the body of the class L&lt;char&gt; is automatically generated by implicit instantiation (otherwise the reference to 'L&lt;char&gt;::M' would be ill-formed), while the body of L&lt;char&gt;:M&lt;int&gt; is provided in the explicit specialization.
 
 In March of 2009, the ISO C++ committee reviewed a report submitted against this example:</p>
-<pre><tt>
+<pre><code>
               struct A {
-                 template<class T> struct B;
-                 template <class T> struct B<T*> { }; // well-formed
-                 template <> struct B<int*> { }; // ill-formed
+                 template&lt;class T&gt; struct B;
+                 template &lt;class T&gt; struct B&lt;T*&gt; { }; // well-formed
+                 template &lt;&gt; struct B&lt;int*&gt; { }; // ill-formed
                };
-</tt></pre>
+</code></pre>
 <p>While it might seem odd that one is able to write the partial specialization but not the full specialization, the committee (which at the time was in a "feature-freeze" mode and trying to finalize a draft for the next International Standard) decided that this capability would need to be regarded as an "extension", meaning that it could be considered as a new feature in a future standard but not as a bug-fix for C++0x.
 
 Note that the Microsoft compiler implements this extension. For that reason, the Lint option</p>
-<pre><tt>
+<pre><code>
                -elib(1111)
-</tt></pre>
+</code></pre>
 <p>appears in recent versions of our configuration files for Microsoft compilers</p>]]></description>
     <internalKey>1111</internalKey>
     <severity>CRITICAL</severity>
@@ -8831,13 +8937,13 @@ Note that the Microsoft compiler implements this extension. For that reason, the
     <name>L1112: In a declaration, the form 'auto D(parms)-&gt;type' is the only valid way to use a trailing-return-type</name>
     <description><![CDATA[
 <p>In a declaration, the form 'auto D(parms)->type' (where D is either a name or a parenthesized region) is the only valid way to use a trailing-return-type -- For example, if you want to declare that f returns a pointer-to-int, you must write:</p>
-<pre><tt>
-               auto f() -> int *;
+<pre><code>
+               auto f() -&gt; int *;
 
          ... and not:
 
-               auto *f() -> int;
-</tt></pre>
+               auto *f() -&gt; int;
+</code></pre>
 <p>This also applies to a type-id (e.g., in a cast to a pointer-to-function, or as an argument to a template type-parameter)</p>]]></description>
     <internalKey>1112</internalKey>
     <severity>CRITICAL</severity>
@@ -8850,10 +8956,10 @@ Note that the Microsoft compiler implements this extension. For that reason, the
     <name>L1113: In this use of 'Template', type substitution failed for 'Type'</name>
     <description><![CDATA[<p>Type is the type of Template; it is used at the cited location with concrete arguments, but substitution failed.</p>
     <p>Example:</p>
-<pre><tt>
-           template<class T> using X = typename T::type;
-           typedef X<int> XI; // error 1113
-</tt></pre>
+<pre><code>
+           template&lt;class T&gt; using X = typename T::type;
+           typedef X&lt;int&gt; XI; // error 1113
+</code></pre>
 ]]></description>
     <internalKey>1113</internalKey>
     <severity>CRITICAL</severity>
@@ -8955,12 +9061,12 @@ Note that the Microsoft compiler implements this extension. For that reason, the
     <key>1125</key>
     <name>L1125: A type cannot be defined in a friend declaration</name>
     <description><![CDATA[<p>Example:</p>
-<pre><tt>
+<pre><code>
            class A {
              friend struct B;    // ok
              friend struct C {}; // error
            };
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1125</internalKey>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -9056,13 +9162,13 @@ Note that the Microsoft compiler implements this extension. For that reason, the
     <key>1404</key>
     <name>L1404: deleting an object of type 'Symbol' before type is defined</name>
     <description><![CDATA[<p>The following situation was detected:</p>
-<pre><tt>
+<pre><code>
             class X;   ...   X *p;  ...  delete p;
-</tt></pre>
+</code></pre>
 <p>That is, a placeholder declaration for a class is given and an object of that type is deleted before any definition is seen. This may or may not be followed by the actual class definition:</p>
-<pre><tt>
+<pre><code>
             class X { ... };
-</tt></pre>
+</code></pre>
 <p>A delete before the class is defined is dangerous because, among other things, any operator delete that may be defined within the class could be ignored.
 </p>]]></description>
     <internalKey>1404</internalKey>
@@ -9074,7 +9180,10 @@ Note that the Microsoft compiler implements this extension. For that reason, the
   <rule>
     <key>1405</key>
     <name>L1405: Header typeinfo must be included before typeid is used</name>
-    <description>According to Section 5.2.8 (para 6) of the C++ standard [10], "If the header &lt;typeinfo&gt; (18.5.1) is not included prior to a use of typeid, the program is ill-formed." A typeid was found in the program but the required include was not.</description>
+    <description><![CDATA[
+According to Section 5.2.8 (para 6) of the C++ standard [10], "If the header &lt;typeinfo&gt; (18.5.1) is not included prior to a use of typeid, the program is ill-formed." A typeid was found in the program but the required include was not.
+]]>
+    </description>
     <internalKey>1405</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -9116,7 +9225,7 @@ Note that the Microsoft compiler implements this extension. For that reason, the
     <key>1414</key>
     <name>L1414: Assigning address of auto variable 'Symbol' to member of this</name>
     <description><![CDATA[<p>The address of an auto variable was taken and assigned to a this member in a member function.  For example:</p>
-<pre><tt>
+<pre><code>
                struct A
                    {
                    char *x;
@@ -9126,7 +9235,7 @@ Note that the Microsoft compiler implements this extension. For that reason, the
                        x = y;          // warning 1414
                        }
                    };
-</tt></pre>
+</code></pre>
 <p>Here the address of y is being passed to member x but this is dangerous (if not ridiculous) since when the function returns, the storage allocated for y is deallocated and the pointer could very easily harm something.
 </p>]]></description>
     <internalKey>1414</internalKey>
@@ -9150,13 +9259,13 @@ Note that the Microsoft compiler implements this extension. For that reason, the
     <key>1416</key>
     <name>L1416: An uninitialized reference 'Symbol' is being used to initialize reference 'Symbol'</name>
     <description><![CDATA[<p>This message is usually issued when a reference to a member of a class is used to initialize a reference to another member of the same class before the first member was initialized.  For example:</p>
-<pre><tt>
+<pre><code>
                class C
                    {
-                   int &n, &m;
-                   C( int &k ) : n(m), m(k) { /* ... */ }
+                   int &amp;n, &amp;m;
+                   C( int &amp;k ) : n(m), m(k) { /* ... */ }
                    };
-</tt></pre>
+</code></pre>
 <p>Here m is initialized properly to be identical to k.  However, the initialization of n, taking place, as it does, before m is so initialized, is erroneous.  It is undefined what location n will reference.
 </p>]]></description>
     <internalKey>1416</internalKey>
@@ -9169,13 +9278,13 @@ Note that the Microsoft compiler implements this extension. For that reason, the
     <key>1417</key>
     <name>L1417: reference member 'Symbol' not initialized by constructor initializer list</name>
     <description><![CDATA[<p>This message is issued when a reference data member of a class does not appear in a mem-initializer.  For example, the following code will result in a Warning 1417 for symbol m since a mem-initializer is the only way that m can be reference initialized.</p>
-<pre><tt>
+<pre><code>
                class C
                    {
-                   int &n, &m;
-                   C( int &k ) : n(k) { /* ... */ }
+                   int &amp;n, &amp;m;
+                   C( int &amp;k ) : n(k) { /* ... */ }
                    };
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1417</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -9236,13 +9345,13 @@ Note that the Microsoft compiler implements this extension. For that reason, the
     <key>1505</key>
     <name>L1505: no access specifier provided, 'String' assumed</name>
     <description><![CDATA[<p>A base class specifier provides no access specifier (public, private or protected).  An explicit access specifier is always recommended since the default behavior is often not what is expected.  For example:</p>
-<pre><tt>
+<pre><code>
             class A : B { int a; };
-</tt></pre>
+</code></pre>
 <p>would make B a private base class by default.</p>
-<pre><tt>
+<pre><code>
             class A : private B { int a; };
-</tt></pre>
+</code></pre>
 <p>is preferred if that's what you want.  [11,#1.1]
 </p>]]></description>
     <internalKey>1505</internalKey>
@@ -9355,10 +9464,10 @@ Note that the Microsoft compiler implements this extension. For that reason, the
     <key>1520</key>
     <name>L1520: Multiple assignment operators for class 'Symbol'</name>
     <description><![CDATA[<p>More than one assignment operator has been declared for a given class.  For example, for class X there may have been declared:</p>
-<pre><tt>
+<pre><code>
              void operator=(X);
              void operator=(X) const;
-</tt></pre>
+</code></pre>
 <p>Which is to be used for assignment?
 </p>]]></description>
     <internalKey>1520</internalKey>
@@ -9431,24 +9540,24 @@ Note that the Microsoft compiler implements this extension. For that reason, the
     <key>1529</key>
     <name>L1529: Symbol 'Symbol' not first checking for assignment to this</name>
     <description><![CDATA[<p>The assignment operator does not appear to be checking for assignment of the value of a variable to itself (assignment to this). Specifically PC-lint/FlexeLint is looking for one of:</p>
-<pre><tt>
-                 if( &arg == this )
-                 if( &arg != this )
-                 if( this == &arg )
-                 if( this != &arg )
-</tt></pre>
+<pre><code>
+                 if( &amp;arg == this )
+                 if( &amp;arg != this )
+                 if( this == &amp;arg )
+                 if( this != &amp;arg )
+</code></pre>
 <p>as the first statement of the function.
 
 It is important to check for a self assignment so as to know whether the old value should be subject to a delete operation. This is often overlooked by a class designer since it is counter-intuitive to assign to oneself.  But through the magic of aliasing (pointers, references, function arguments) it is possible for an unsuspecting programmer to stumble into a disguised self-assignment [12, Item 17].
 
 If you are currently using the following test</p>
-<pre><tt>
+<pre><code>
                  if( arg == *this)
-</tt></pre>
+</code></pre>
 <p>we recommend you replace this with the more efficient:</p>
-<pre><tt>
-                 if( &arg == this || arg == *this)
-</tt></pre>]]></description>
+<pre><code>
+                 if( &amp;arg == this || arg == *this)
+</code></pre>]]></description>
     <internalKey>1529</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -9509,20 +9618,20 @@ If you are currently using the following test</p>
     <key>1536</key>
     <name>L1536: Exposing low access member 'Symbol'</name>
     <description><![CDATA[<p>A member function is returning the non-const address of a member either directly or via a reference.  Moreover, the member's access (such as private or protected) is lower than the access of the function returning the address.  For example:</p>
-<pre><tt>
+<pre><code>
                  class X
                      {
                    private:
                      int a;
                    public:
-                     int *f() { return &a; }
+                     int *f() { return &amp;a; }
                      };
-</tt></pre>
+</code></pre>
 <p>This looks like a breach of the access system [12, Item 30].  You may lower the access rights of the function, raise the accessibility of the member or make the return value a const pointer or reference.  In the above example you could change the function to:
 </p>
-<pre><tt>
-                 const int *f() { return &a; }
-</tt></pre>]]></description>
+<pre><code>
+                 const int *f() { return &amp;a; }
+</code></pre>]]></description>
     <internalKey>1536</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -9533,13 +9642,13 @@ If you are currently using the following test</p>
     <key>1537</key>
     <name>L1537: const function returns pointer data member 'Symbol'</name>
     <description><![CDATA[<p>A const function is behaving suspiciously.  It is returning a pointer data member (or equivalently a pointer to data that is pointed to by a data member).  For example,</p>
-<pre><tt>
+<pre><code>
                  class X
                      {
                      int *p;
                      int *f() const { return p; }
                      };
-</tt></pre>
+</code></pre>
 <p>Since f is supposedly const and since p is presumptively pointing to data that is logically part of class X we certainly have the potential for a security breach.  Either return a pointer to const or remove the const modifier to the function.  [12, Item 29].
 
 Note, if a const function returns the address of a data member then a 605 (capability increase) is issued.
@@ -9559,14 +9668,14 @@ Note, if a const function returns the address of a data member then a 605 (capab
     <key>1538</key>
     <name>L1538: base class 'Name' absent from initializer list for copy constructor</name>
     <description><![CDATA[<p>The indicated base class did not appear in the initializer list for a copy constructor.  Was this an oversight? If the initializer list does not contain an initializer for a base class, the default constructor is used for the base class. This is not normally appropriate for a copy constructor.  The following is more typical:</p>
-<pre><tt>
+<pre><code>
                  class B { ... };
                  class D : public B
                      {
-                     D( const D &arg ) : B( arg ) { ... }
+                     D( const D &amp;arg ) : B( arg ) { ... }
                      ...
                      };
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1538</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -9630,16 +9739,16 @@ Note, if a const function returns the address of a data member then a 605 (capab
     <description><![CDATA[<p>A variable (identified by Symbol) was used in the run-time initialization of a static variable.  However this variable itself was initialized at run-time.  Since the order of initialization cannot be predicted this is the source of possible error.
 
 Whereas addresses are completely known at initialization time values may not be.  Whether the value or merely the address of a variable is used in the initialization of a second variable is not an easy thing to determine when an argument is passed by reference or via pointer.  For example,</p>
-<pre><tt>
+<pre><code>
              class X
                  {
-                 X( const X & );
+                 X( const X &amp; );
                  };
 
              extern X x1;
              X x2 = x1;
              X x1 = x2;
-</tt></pre>
+</code></pre>
 <p>It is theoretically possible, but unlikely, that the constructor X() is interested only in the address of its argument and not its current value.  If so, it only means you will be getting a spurious report which you can suppress based on variable name. However, if the const is missing when passing a reference parameter (or a pointer parameter) then we cannot easily assume that values are being used.  In this case no report will be issued.  The moral is that if you want to get the checking implied by this message you should make your constructor reference arguments const.
 </p>]]></description>
     <internalKey>1544</internalKey>
@@ -9668,13 +9777,13 @@ Whereas addresses are completely known at initialization time values may not be.
     <key>1547</key>
     <name>L1547: Assignment of array to pointer to base class (Context)</name>
     <description><![CDATA[<p>An assignment from an array of a derived class to a pointer to a base class was detected.  For example:</p>
-<pre><tt>
+<pre><code>
                  class B { };
                  class D : public B {};
                  D a[10];
                  B *p = a;      // Warning 1547
-                 B *q = &a[0];  // OK
-</tt></pre>
+                 B *q = &amp;a[0];  // OK
+</code></pre>
 <p>In this example p is being assigned the address of the first element of an array.  This is fraught with danger since access to any element other than the zeroeth must be considered an error (we presume that B and D actually have or have the potential to have different sizes).  [23, Item 3].
 
 We do not warn about the assignment to q because it appears that the programmer realizes the situation and wishes to confine q to the base object of the zeroeth element of a only.  As a further precaution against inappropriate array access, out of bounds warnings are issued for subsequent references to p[1] and q[1].
@@ -9731,12 +9840,12 @@ We do not warn about the assignment to q because it appears that the programmer 
     <description><![CDATA[<p>This warning is similar to Warning 1547 and is sometimes given in conjunction with it.  It uses value tracking to determine that an array (that could be dynamically allocated) is being assigned to a base class pointer.
 
 For example,</p>
-<pre><tt>
+<pre><code>
                  Derived *d = new Derived[10];
                  Base *b;
                  b = d;      // Warning 1552
-                 b = &d[0];  // OK
-</tt></pre>
+                 b = &amp;d[0];  // OK
+</code></pre>
 <p>[23, Item 3]  Also, see the article by Mark Nelson (Bug++ of the Month, Windows developer's Journal, May 1997, pp. 43-44).
 </p>]]></description>
     <internalKey>1552</internalKey>
@@ -9759,15 +9868,15 @@ For example,</p>
     <key>1554</key>
     <name>L1554: Direct pointer copy of member 'Symbol' within copy constructor: 'Symbol'</name>
     <description><![CDATA[<p>In a copy constructor a pointer was merely copied rather than recreated with new storage.  This can create a situation where two objects have the same data and this, in turn, causes problems when these objects are deleted or modified.  For example, the following class will draw this warning:</p>
-<pre><tt>
+<pre><code>
              class X
                  {
                  char *p;
-                 X( const X & x )
+                 X( const X &amp; x )
                      { p = x.p; }
                  ...
                  };
-</tt></pre>
+</code></pre>
 <p>Here, member p is expected to be recreated using new or some variant.
 </p>]]></description>
     <internalKey>1554</internalKey>
@@ -9780,15 +9889,15 @@ For example,</p>
     <key>1555</key>
     <name>L1555: Direct pointer copy of member 'Symbol' within copy assignment operator: 'Symbol'</name>
     <description><![CDATA[<p>In a copy assignment operator a pointer was merely copied rather than recreated with new storage.  This can create a situation where two objects have the same data and this, in turn, causes problems when these objects are deleted or modified.  For example, the following class will draw this warning:</p>
-<pre><tt>
+<pre><code>
              class X
                  {
                  char *p;
-                 X& operator=( const X & x )
+                 X&amp; operator=( const X &amp; x )
                      { p = x.p; }
                  ...
                  };
-</tt></pre>
+</code></pre>
 <p>Here, member p is expected to be recreated using new or some variant.
 </p>]]></description>
     <internalKey>1555</internalKey>
@@ -9801,9 +9910,9 @@ For example,</p>
     <key>1556</key>
     <name>L1556: 'new Type(integer)' is suspicious</name>
     <description><![CDATA[<p>A new expression had the form new T(Integer) where type T has no constructor.  For example:</p>
-<pre><tt>
+<pre><code>
              new int(10)
-</tt></pre>
+</code></pre>
 <p>will draw this warning.  The expression allocates an area of storage large enough to hold one integer.  It then initializes that integer to the value 10.  Could this have been a botched attempt to allocate an array of 10 integers?  Even if it was a deliberate attempt to allocate and initialize a single integer, a casual inspection of the code could easily lead a reader astray.
 
 The warning is only given when the type T has no constructor.  If T has a constructor then either a syntactic error will result because no constructor matches the argument or a match will be found.  In the latter case no warning will or should be issued.
@@ -9828,12 +9937,12 @@ The warning is only given when the type T has no constructor.  If T has a constr
     <key>1558</key>
     <name>L1558: virtual coupled with inline is an unusual combination</name>
     <description><![CDATA[<p>The function declared both 'virtual' and 'inline' has been detected. An example of such a situation is as follows:</p>
-<pre><tt>
+<pre><code>
                class C
                    {
                    virtual inline void f();   // Warning 1558
                    };
-</tt></pre>
+</code></pre>
 <p>Virtual functions by their nature require an address and so inlining such a function seems contradictory.  We recommend that the 'inline' function specifier be removed.
 </p>]]></description>
     <internalKey>1558</internalKey>
@@ -9868,21 +9977,21 @@ The warning is only given when the type T has no constructor.  If T has a constr
     <description><![CDATA[<p>A reference initialization is resulting in a capability gain that can cause a loss of const or volatile integrity.
 
 Typically the message is given on initializing a non-const reference with a const.  For example:</p>
-<pre><tt>
-           void f( int &x );
+<pre><code>
+           void f( int &amp;x );
            const int n = 0;
            ...
            f(n);
-</tt></pre>
+</code></pre>
 <p>Here, function f() could assign a value to its argument and thereby modify n which is declared to be const.
 
 The message can also be issued when a pointer is initialized. Consider the following example.</p>
-<pre><tt>
-           void h( const int *&q );
+<pre><code>
+           void h( const int *&amp;q );
            int *p;
            ...
            h(p);
-</tt></pre>
+</code></pre>
 <p>It might seem that passing a regular (i.e., non-const) pointer to a const int * could cause no harm.  That would be correct if it were not for the reference.  If function h() were to assign a pointer to const to its parameter q then upon return from the call, p could be used to modify const data.
 
 There are many subtle cases that can boggle the mind.  See the commentary to Message 605.
@@ -9897,10 +10006,10 @@ There are many subtle cases that can boggle the mind.  See the commentary to Mes
     <key>1562</key>
     <name>L1562: Exception specification for 'Symbol' is not a subset of 'Symbol' (Location)</name>
     <description><![CDATA[<p>The first symbol is that of an overriding virtual function for the second symbol.  The exception specification for the first was found not to be a subset of the second.  For example, it may be reasonable to have:</p>
-<pre><tt>
+<pre><code>
                struct B   { virtual void f() throw(B); };
                struct D:B { virtual void f() throw(D); };
-</tt></pre>
+</code></pre>
 <p>Here, although the exception specification is not identical, the exception D is considered a subset of the base class B.
 
 It would not be reasonable for D::f() to throw an exception outside the range of those thrown by B::f() because in general the compiler will only see calls to B::f() and it should be possible for the compiler to deduce what exceptions could be thrown by examining the static call
@@ -9915,17 +10024,17 @@ It would not be reasonable for D::f() to throw an exception outside the range of
     <key>1563</key>
     <name>L1563: Suspicious third argument to ?: operator</name>
     <description><![CDATA[<p>The third argument to ?: contained an unparenthesized assignment operator such as</p>
-<pre><tt>
+<pre><code>
                p ? a : b = 1
-</tt></pre>
+</code></pre>
 <p>If this is what was intended you should parenthesize the third argument as in:</p>
-<pre><tt>
+<pre><code>
                p ? a : (b = 1)
-</tt></pre>
+</code></pre>
 <p>Not only is the original form difficult to read but C, as opposed to C++, would parse this as:</p>
-<pre><tt>
+<pre><code>
                (p ? a : b) = 1
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1563</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -9936,9 +10045,9 @@ It would not be reasonable for D::f() to throw an exception outside the range of
     <key>1564</key>
     <name>L1564: Assigning a non-zero-one constant to a bool</name>
     <description><![CDATA[<p>The following looks suspicious.</p>
-<pre><tt>
+<pre><code>
                bool a = 34;
-</tt></pre>
+</code></pre>
 <p>Although there is an implicit conversion from integral to bool and assigning an integer varaible to a bool to obtain its Boolean meaning is legitimate, assigning an integer such as this looks suspicious.  As the message suggests, the warning is not given if the value assigned is either 0 or 1.  An Elective Note would be raised in that instance.
 </p>]]></description>
     <internalKey>1564</internalKey>
@@ -9961,18 +10070,18 @@ It would not be reasonable for D::f() to throw an exception outside the range of
     <key>1566</key>
     <name>L1566: member 'Symbol' (Location) might have been initialized by a separate function but no '-sem(Name,initializer)' was seen</name>
     <description><![CDATA[<p>A class data member (whose name and location are indicated in the message) was not directly initialized by a constructor.  It may have been initialized by a separately called member function.  If this is the case you may follow the advice given in the message and use a semantic option to inform PC-lint/FlexeLint that the separately called function is in fact an 'initializer'.  For example:</p>
-<pre><tt>
+<pre><code>
                class A {
                        int a;
                    public:
                        void f();
                        A() { f(); }
                        };
-</tt></pre>
+</code></pre>
 <p>Here f() is presumably serving as an initializer for the constructor A::A().  To inform PC-lint/FlexeLint of this situation, use the option:</p>
-<pre><tt>
+<pre><code>
                -sem( A::f, initializer )
-</tt></pre>
+</code></pre>
 <p>This will suppress Warning 1566 for any constructor of class A that calls A::f.
 </p>]]></description>
     <internalKey>1566</internalKey>
@@ -9985,13 +10094,13 @@ It would not be reasonable for D::f() to throw an exception outside the range of
     <key>1567</key>
     <name>L1567: Initialization of variable 'Symbol' (Location) is indeterminate as it uses variable 'Symbol' through calls: 'String'</name>
     <description><![CDATA[<p>A variable was dynamically initialized using an expression that contained a call to a function and that function referenced a variable that was also dynamically initialized and was in some other module.  For example:</p>
-<pre><tt>
+<pre><code>
                a.cpp:                  b.cpp:
 
                int g(void);            int f(void);
                int y = g();            int x = f();
                int f() { return y; }
-</tt></pre>
+</code></pre>
 <p>The initialization of both x and y are dynamic.  Although the order of dynamic initialization within a module is pre-ordained the order in which modules are initialized is not.  Therefore it is perfectly possible for b.cpp to be initialized before a.cpp. Thus when the call is made upon function f() to initialize x, variable y may not yet have been initialized.
 </p>]]></description>
     <internalKey>1567</internalKey>
@@ -10004,13 +10113,13 @@ It would not be reasonable for D::f() to throw an exception outside the range of
     <key>1568</key>
     <name>L1568: Variable 'Symbol' (Location) accesses variable 'Symbol' before the latter is initialized through calls: 'String'</name>
     <description><![CDATA[<p>A variable was dynamically initialized using an expression that contained a call to a function and that function referenced a variable that was also dynamically initialized but later in the module.  For example:</p>
-<pre><tt>
+<pre><code>
                int g(void);
                int f(void);
                int x = f();
                int y = g();
                int f() { return y; }
-</tt></pre>
+</code></pre>
 <p>The initialization of both x and y are dynamic.  The order of dynamic initialization within a module is in the order in which the initialization is specified.  Thus when the call is made upon function f() to initialize x, variable y will not yet have been initialized.
 </p>]]></description>
     <internalKey>1568</internalKey>
@@ -10023,9 +10132,9 @@ It would not be reasonable for D::f() to throw an exception outside the range of
     <key>1569</key>
     <name>L1569: Initializing a member reference with a temporary.</name>
     <description><![CDATA[<p>A member reference was initialized with a temporary.  For example:</p>
-<pre><tt>
-           struct A { int &n;  A() : n(3) {} };
-</tt></pre>
+<pre><code>
+           struct A { int &amp;n;  A() : n(3) {} };
+</code></pre>
 <p>The constructor A() contains an initializer list within which it initializes n.  But n will be bound to a temporary created by the compiler to hold the value 3.  The lifetime of this temporary is limited; it "persists until the constructor exits" [10 section class.temporary]
 </p>]]></description>
     <internalKey>1569</internalKey>
@@ -10038,9 +10147,9 @@ It would not be reasonable for D::f() to throw an exception outside the range of
     <key>1570</key>
     <name>L1570: Initializing a reference class member with an auto variable 'Symbol'</name>
     <description><![CDATA[<p>In a constructor initializer, a reference class member is being initialized to bind to an auto variable. Consider:</p>
-<pre><tt>
-           class X { int &n; X(int k) :n(k) {} };
-</tt></pre>
+<pre><code>
+           class X { int &amp;n; X(int k) :n(k) {} };
+</code></pre>
 <p>In this example member n is being bound to variable k which, although a parameter, is nonetheless placed into auto storage. But the lifetime of k is only the duration of the call to the constructor, whereas the lifetime of n is the lifetime of the class object constructed.
 </p>]]></description>
     <internalKey>1570</internalKey>
@@ -10063,9 +10172,9 @@ It would not be reasonable for D::f() to throw an exception outside the range of
     <key>1572</key>
     <name>L1572: Initializing a static reference variable with an auto variable 'Symbol'</name>
     <description><![CDATA[<p>A static variable has a lifetime that will exceed that of the auto variable that it has been bound to.  Consider</p>
-<pre><tt>
-           void f( int n ) { static int& r = n; ... }
-</tt></pre>
+<pre><code>
+           void f( int n ) { static int&amp; r = n; ... }
+</code></pre>
 <p>The reference r will be permanently bound to an auto variable n. The lifetime of n will not extend beyond the life of the function.  On the second and subsequent calls to function f the static variable r will be bound to a non-existent entity.
 </p>]]></description>
     <internalKey>1572</internalKey>
@@ -10078,29 +10187,29 @@ It would not be reasonable for D::f() to throw an exception outside the range of
     <key>1573</key>
     <name>L1573: Generic function template 'Symbol' declared in namespace associated with type 'Symbol' (Location)</name>
     <description><![CDATA[<p>When a class (or union or enum) is declared within a namespace that namespace is said to be associated with the type.  A Generic function template is any that has as parameters only intrinsic types or plain template arguments possibly adorned with reference or const or volatile qualification.  Consider</p>
-<pre><tt>
+<pre><code>
            namespace X
                {
                template< class T >
-                   void f( int, const T& );    // Generic
+                   void f( int, const T&amp; );    // Generic
                class A{};                      // Warning 1573
                }
-</tt></pre>
+</code></pre>
 <p>A call to function f that contained an argument of type X::A would, by ADL (Argument Dependent Lookup), need to also consider function X::f even though this function was not in the scope of the call.  In the past this has led to strange an unexpected results.
 
 Some designers adopt the strategy of embedding the class within a sub namespace and employing a using-declaration to make it available to users of the original namespace.  For example:</p>
-<pre><tt>
+<pre><code>
            namespace X
                {
                template< class T >
-                   void f( int, const T& );    // Generic
+                   void f( int, const T&amp; );    // Generic
                namespace X1
                    {
                    class A{};                  // No Warning
                    }
                using X1::A;
                }
-</tt></pre>
+</code></pre>
 <p>Now an argument of type X::A will not automatically trigger a consideration of X::f.
 </p>]]></description>
     <internalKey>1573</internalKey>
@@ -10114,13 +10223,13 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
     <name>L1574: Returning the address of an auto variable indirectly through reference variable 'Symbol'</name>
     <description><![CDATA[
 <p>Within a function whose return type is reference to some type, a return statement is returning a reference which has been initialized (possibly indirectly) with an auto variable.  For example:</p>
-<pre><tt>
-               int &f( int k )
+<pre><code>
+               int &amp;f( int k )
                    {
-                   int &r = k;
+                   int &amp;r = k;
                    return r;
                    }
-</tt></pre>]]></description>
+</code></pre>]]></description>
     <internalKey>1574</internalKey>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -10164,18 +10273,18 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
     <key>1579</key>
     <name>L1579: Pointer member 'Symbol' (Location) might have been freed by a separate function but no '-sem(Name,cleanup)' was seen</name>
     <description><![CDATA[<p>A class data member (whose name and location are indicated in the message) was not directly freed by the class destructor.  There was a chance that it was cleared by a separately called member function.  If this is the case you may follow the advice given in the message and use a semantic option to inform PC-lint/FlexeLint that the separately called function is in fact a 'cleanup' function.  For example:</p>
-<pre><tt>
+<pre><code>
                class A {
                        int *p;
                    public:
                        void release_ptrs();
                        ~A() { release_ptrs(); }
                        };
-</tt></pre>
+</code></pre>
 <p>Here release_ptrs() is presumably serving as a cleanup function for the destructor ~A::A().  To inform PC-lint/FlexeLint of this situation, use the option:</p>
-<pre><tt>
+<pre><code>
                -sem( A::release_ptrs, cleanup )
-</tt></pre>
+</code></pre>
 <p>A separate message (Warning 1578) will be issued if the cleanup function fails to clear all pointers.  See also Warning 1566.
 </p>]]></description>
     <internalKey>1579</internalKey>
@@ -10227,11 +10336,14 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1705</key>
     <name>L1705: static class members may be accessed by the scoping operator</name>
-    <description>A static class member was accessed using a class object and -&gt; or . notation. For example:
-    s.member or p-&gt;member
-    But an instance of the object is not necessary. It could just as easily have been referenced as:
-    X::member
-    where X is the class name. [10, ?9.4]</description>
+    <description><![CDATA[
+A static class member was accessed using a class object and -&gt; or . notation. For example:
+s.member or p-&gt;member
+But an instance of the object is not necessary. It could just as easily have been referenced as:
+X::member
+where X is the class name. [10, ?9.4]
+]]>
+    </description>
     <internalKey>1705</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10241,9 +10353,14 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1706</key>
     <name>L1706: Declaration with scope operator is unusual within a class</name>
-    <description>Class members within a class are not normally declared with the scope operator. For example:
-    class X { int X::n; ...
-    will elicit this message. If the (redundant) class specification (X::) were replaced by some different class specification and the declaration was not friend an error (1040) would be issued. [11, ?9.2]</description>
+    <description><![CDATA[
+Class members within a class are not normally declared with the scope operator. For example:
+<pre>
+class X { int X::n; ...
+</pre>
+will elicit this message. If the (redundant) class specification (X::) were replaced by some different class specification and the declaration was not friend an error (1040) would be issued. [11, ?9.2]
+]]>
+    </description>
     <internalKey>1706</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10378,9 +10495,14 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1719</key>
     <name>L1719: assignment operator for class 'Symbol' has non-reference parameter</name>
-    <description>The typical assignment operator for a class is of the form:
-    X&amp; operator =(const X &amp;)
-    If the argument is not a reference then your program is subject to implicit function calls and less efficient operation. [11, ?13.4.3]</description>
+    <description><![CDATA[
+The typical assignment operator for a class is of the form:
+<pre>
+X&amp; operator =(const X &amp;)
+</pre>
+If the argument is not a reference then your program is subject to implicit function calls and less efficient operation. [11, ?13.4.3]
+]]>
+    </description>
     <internalKey>1719</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10390,9 +10512,14 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1720</key>
     <name>L1720: assignment operator for class 'Symbol' has non-const parameter</name>
-    <description>The typical assignment operator for a class is of the form:
-    X&amp; operator =(const X &amp;)
-    If the argument is not const then your program will not be diagnosed as completely as it might otherwise be. [11, ?13.4.3]</description>
+    <description><![CDATA[
+The typical assignment operator for a class is of the form:
+<pre>
+X&amp; operator =(const X &amp;)
+</pre>
+If the argument is not const then your program will not be diagnosed as completely as it might otherwise be. [11, ?13.4.3]
+]]>
+    </description>
     <internalKey>1720</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10402,9 +10529,14 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1721</key>
     <name>L1721: operator =() for class 'Symbol' is not assignment operator</name>
-    <description>The assignment operator for a class has the form:
-    X&amp; operator =(const X &amp;)
-    A member function whose name is operator =, but which doesn't have that form, is not an assignment operator. This could be a source of subtle confusion for a program reader. If this is not an error you may selectively suppress this message for the given class. [11, ?13.4.3]</description>
+    <description><![CDATA[
+The assignment operator for a class has the form:
+<pre>
+X&amp; operator =(const X &amp;)
+</pre>
+A member function whose name is operator =, but which doesn't have that form, is not an assignment operator. This could be a source of subtle confusion for a program reader. If this is not an error you may selectively suppress this message for the given class. [11, ?13.4.3]
+]]>
+    </description>
     <internalKey>1721</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10414,11 +10546,18 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1722</key>
     <name>L1722: assignment operator for class 'Symbol' does not return a reference to class</name>
-    <description>The typical assignment operator for a class X is of the form:
-    X&amp; operator =(const X &amp;)
-    The reason for returning a reference to class is to support multiple assignment as in:
-    a = b = c
-    [11, ?13.4.3]</description>
+    <description><![CDATA[
+The typical assignment operator for a class X is of the form:
+<pre>
+X&amp; operator =(const X &amp;)
+</pre>
+The reason for returning a reference to class is to support multiple assignment as in:
+<pre>
+a = b = c
+</pre>
+[11, ?13.4.3]
+]]>
+    </description>
     <internalKey>1722</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10430,12 +10569,12 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
     <name>L1723: Template 'Symbol' arbitrarily selected.  Refer to Error 'Integer'</name>
     <description><![CDATA[<p>This is a supplemental message to the Error that immediately preceded, which was about a failure to select a single best partial specialization for an instantiation. Its purpose is to show some of the context of subsequent processing (which is now in a state of recovery).</p>
 <p>Example:</p>
-<pre><tt>
-           template<class T, class U> struct A;
-           template<class T, class U> struct A<T*, U> {  };
-           template<class T, class U> struct A<T, U*> {  };
-           A<int*, char*>  x; // Error 1084 followed by Info 1723
-</tt></pre>
+<pre><code>
+           template&lt;class T, class U&gt; struct A;
+           template&lt;class T, class U&gt; struct A&lt;T*, U&gt; {  };
+           template&lt;class T, class U&gt; struct A&lt;T, U*&gt; {  };
+           A&lt;int*, char*&gt;  x; // Error 1084 followed by Info 1723
+</code></pre>
 ]]></description>
     <internalKey>1723</internalKey>
     <severity>MINOR</severity>
@@ -10447,9 +10586,14 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1724</key>
     <name>L1724: Argument to copy constructor for class 'Symbol' should be a const reference</name>
-    <description>A copy constructor for class X is typically declared as:
-    X( const X &amp; );
-    If you leave off the 'const' then some diagnostics will not be possible. [19]</description>
+    <description><![CDATA[
+A copy constructor for class X is typically declared as:
+<pre>
+X( const X &amp; );
+</pre>
+If you leave off the 'const' then some diagnostics will not be possible. [19]
+]]>
+    </description>
     <internalKey>1724</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10665,10 +10809,13 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1746</key>
     <name>L1746: parameter 'Symbol' of function 'Symbol' could be made const reference</name>
-    <description>The indicated parameter is a candidate to be declared as a const reference. For example: void f( X x ) { // x not modified. }
-    Then the function definition can be replaced with: void f( const X &amp;x ) { // x not modified. }
-    The result is more efficient since less information needs to be placed onto the stack and a constructor need not be called.
-    The message is only given with class-like arguments (including struct's and union's) and only if the parameter is not subsequently modified or potentially modified by the function. The parameter is potentially modified if it is passed to a function whose corresponding parameter is a reference (not const) or if its address is passed to a non-const pointer. [12, Item 22].</description>
+    <description><![CDATA[
+The indicated parameter is a candidate to be declared as a const reference. For example: void f( X x ) { // x not modified. }
+Then the function definition can be replaced with: void f( const X &amp;x ) { // x not modified. }
+The result is more efficient since less information needs to be placed onto the stack and a constructor need not be called.
+The message is only given with class-like arguments (including struct's and union's) and only if the parameter is not subsequently modified or potentially modified by the function. The parameter is potentially modified if it is passed to a function whose corresponding parameter is a reference (not const) or if its address is passed to a non-const pointer. [12, Item 22].
+]]>
+    </description>
     <internalKey>1746</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10678,8 +10825,11 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1747</key>
     <name>L1747: binary operator 'Symbol' returning a reference</name>
-    <description>An operator-like function was found to be returning a reference. For example: X &amp;operator+ ( X &amp;, X &amp; );
-    This is almost always a bad idea. [12, Item 23]. You normally can't return a reference unless you allocate the object, but then who is going to delete it. The usual way this is declared is: X operator+ ( X &amp;, X &amp; );</description>
+    <description><![CDATA[
+An operator-like function was found to be returning a reference. For example: X &amp;operator+ ( X &amp;, X &amp; );
+This is almost always a bad idea. [12, Item 23]. You normally can't return a reference unless you allocate the object, but then who is going to delete it. The usual way this is declared is: X operator+ ( X &amp;, X &amp; );
+]]>
+    </description>
     <internalKey>1747</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10739,8 +10889,11 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1753</key>
     <name>L1753: Overloading special operator 'Symbol'</name>
-    <description>This message is issued whenever an attempt is made to declare one of these operators as having some user-defined meaning: operator || operator &amp;amp;amp;&amp;amp;amp; operator ,
-    The difficulty is that the working semantics of the overloaded operator is bound to be sufficiently different from the built-in operators, as to result in possible confusion on the part of the programmer. With the built-in versions of these operators, evaluation is strictly left-to-right. With the overloaded versions, this is not guaranteed. More critically, with the built-in versions of &amp;amp;amp;&amp;amp;amp; and ||, evaluation of the 2nd argument is conditional upon the result of the first. This will never be true of the overloaded version. [23, Item 7].</description>
+    <description><![CDATA[
+This message is issued whenever an attempt is made to declare one of these operators as having some user-defined meaning: operator || operator &amp;amp;amp;&amp;amp;amp; operator ,
+The difficulty is that the working semantics of the overloaded operator is bound to be sufficiently different from the built-in operators, as to result in possible confusion on the part of the programmer. With the built-in versions of these operators, evaluation is strictly left-to-right. With the overloaded versions, this is not guaranteed. More critically, with the built-in versions of &amp;amp;amp;&amp;amp;amp; and ||, evaluation of the 2nd argument is conditional upon the result of the first. This will never be true of the overloaded version. [23, Item 7].
+]]>
+    </description>
     <internalKey>1753</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10750,9 +10903,12 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1754</key>
     <name>L1754: Expected symbol 'Symbol' to be declared for class 'Symbol'</name>
-    <description>The first Symbol is of the form: operator op= where op is a binary operator. A binary operator op was declared for type X where X is identified by the second Symbol. For example, the appearance of: X operator+( const X &amp;, const X &amp; );
-    somewhere in the program would suggest that a += version appear as a member function of class X. This is not only to fulfill reasonable expectations on the part of the programmer but also because operator+= is likely to be more efficient than operator+ and because operator+ can be written in terms of operator+=. [23, Item 22]
-    The message is also given for member binary operators. In all cases the message is not given unless the return value matches the first argument (this is the implicit argument in the case of a member function).</description>
+    <description><![CDATA[
+The first Symbol is of the form: operator op= where op is a binary operator. A binary operator op was declared for type X where X is identified by the second Symbol. For example, the appearance of: X operator+( const X &amp;, const X &amp; );
+somewhere in the program would suggest that a += version appear as a member function of class X. This is not only to fulfill reasonable expectations on the part of the programmer but also because operator+= is likely to be more efficient than operator+ and because operator+ can be written in terms of operator+=. [23, Item 22]
+The message is also given for member binary operators. In all cases the message is not given unless the return value matches the first argument (this is the implicit argument in the case of a member function).
+]]>
+    </description>
     <internalKey>1754</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10786,8 +10942,11 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1758</key>
     <name>L1758: Prefix increment/decrement operator 'Symbol' returns a non-reference</name>
-    <description>To conform with most programming expectations, a prefix increment/decrement operator should return a reference. Returning a reference is both more flexible and more efficient [23, Item 6].
-    The expected form is as shown below: class X { X &amp; operator++(); // prefix operator X operator++( int ); // postfix operator ... };</description>
+    <description><![CDATA[
+To conform with most programming expectations, a prefix increment/decrement operator should return a reference. Returning a reference is both more flexible and more efficient [23, Item 6].
+The expected form is as shown below: class X { X &amp; operator++(); // prefix operator X operator++( int ); // postfix operator ... };
+]]>
+    </description>
     <internalKey>1758</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10837,10 +10996,13 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1763</key>
     <name>L1763: Member function 'Symbol' marked as const indirectly modifies class</name>
-    <description>The designated symbol is a member function declared as const. Though technically valid, the const may be misleading because the member function modifies (or exposes) information indirectly referenced by the object. For example: class X { char *pc; char &amp; get(int i) const { return pc[i]; } };
-    results in Info 1763 for function X::get. This is because the function exposes information indirectly held by the class X.
-    Experts [24] recommend that a pair of functions be made available in this situation: class X { char *pc; const char &amp; get(int i) const { return pc[i]; } char &amp; get(int i) { return pc[i]; } };
-    In this way, if the object is const then only the const function will be called which will return the protected reference. Related messages are also 1762 and 1962. See also [12, Item 29] for a further description.</description>
+    <description><![CDATA[
+The designated symbol is a member function declared as const. Though technically valid, the const may be misleading because the member function modifies (or exposes) information indirectly referenced by the object. For example: class X { char *pc; char &amp; get(int i) const { return pc[i]; } };
+results in Info 1763 for function X::get. This is because the function exposes information indirectly held by the class X.
+Experts [24] recommend that a pair of functions be made available in this situation: class X { char *pc; const char &amp; get(int i) const { return pc[i]; } char &amp; get(int i) { return pc[i]; } };
+In this way, if the object is const then only the const function will be called which will return the protected reference. Related messages are also 1762 and 1962. See also [12, Item 29] for a further description.
+]]>
+    </description>
     <internalKey>1763</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10850,12 +11012,19 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1764</key>
     <name>L1764: Reference parameter 'Symbol' (Location) could be declared const reference</name>
-    <description>As an example:
-    int f( int &amp; k ) { return k; }
-    can be redeclared as:
-    int f( const int &amp; k ) { return k; }
-    Declaring a parameter a reference to const offers advantages that a mere reference does not. In particular, you can pass constants, temporaries and const types into such a parameter where otherwise you may not. In addition it can offer better documentation.
-    Other situations in which a const can be added to a declaration are covered in messages 818, 952, 953 and 954.</description>
+    <description><![CDATA[
+As an example:
+<pre>
+int f( int &amp; k ) { return k; }
+</pre>
+can be redeclared as:
+<pre>
+int f( const int &amp; k ) { return k; }
+</pre>
+Declaring a parameter a reference to const offers advantages that a mere reference does not. In particular, you can pass constants, temporaries and const types into such a parameter where otherwise you may not. In addition it can offer better documentation.
+Other situations in which a const can be added to a declaration are covered in messages 818, 952, 953 and 954.
+]]>
+    </description>
     <internalKey>1764</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10920,8 +11089,11 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1773</key>
     <name>L1773: Attempt to cast away const (or volatile)</name>
-    <description>An attempt was made to cast away const. This can break the integrity of the const system. This message will be suppressed if you use const_cast. Thus: char *f( const char * p ) { if( test() ) return (char *) p; // Info 1773 else return const_cast&lt;char *&gt;(p); // OK }
-    See [12, Item 21].</description>
+    <description><![CDATA[
+An attempt was made to cast away const. This can break the integrity of the const system. This message will be suppressed if you use const_cast. Thus: char *f( const char * p ) { if( test() ) return (char *) p; // Info 1773 else return const_cast&lt;char *&gt;(p); // OK }
+See [12, Item 21].
+]]>
+    </description>
     <internalKey>1773</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10931,9 +11103,12 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1774</key>
     <name>L1774: Could use dynamic_cast to downcast ptr to polymorphic type 'Symbol'</name>
-    <description>A downcast was detected of a pointer to a polymorphic type (i.e., one with virtual functions). A dynamic_cast could be used to cast this pointer safely. For example: class B { virtual ~B(); }; class D : public B {}; ... D *f( B *p ) { return dynamic_cast&lt;D*&gt;(p); }
-    In the above example, if p is not a pointer to a D then the dynamic cast will result in a NULL pointer value. In this way, the validity of the conversion can be directly tested.
-    B needs to be a polymorphic type in order to use dynamic_cast. If B is not polymorphic, message 1939 is issued.</description>
+    <description><![CDATA[
+A downcast was detected of a pointer to a polymorphic type (i.e., one with virtual functions). A dynamic_cast could be used to cast this pointer safely. For example: class B { virtual ~B(); }; class D : public B {}; ... D *f( B *p ) { return dynamic_cast&lt;D*&gt;(p); }
+In the above example, if p is not a pointer to a D then the dynamic cast will result in a NULL pointer value. In this way, the validity of the conversion can be directly tested.
+B needs to be a polymorphic type in order to use dynamic_cast. If B is not polymorphic, message 1939 is issued.
+]]>
+    </description>
     <internalKey>1774</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10943,9 +11118,12 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1775</key>
     <name>L1775: catch block does not catch any declared exception</name>
-    <description>A catch handler does not seem to catch any exceptions. For example: try { f(); } catch( B&amp; ) {} catch( D&amp; ) {} // Info 1775 catch( ... ) {} catch( char * ) {} // Info 1775
-    If f() is declared to throw type D, and if B is a public base class of D, then the first catch handler will process that exception and the second handler will never be used. The fourth handler will also not be used since the third handler will catch all exceptions not caught by the first two.
-    If f() is not declared to throw an exception then Info 1775 will be issued for all four catch handlers.</description>
+    <description><![CDATA[
+A catch handler does not seem to catch any exceptions. For example: try { f(); } catch( B&amp; ) {} catch( D&amp; ) {} // Info 1775 catch( ... ) {} catch( char * ) {} // Info 1775
+If f() is declared to throw type D, and if B is a public base class of D, then the first catch handler will process that exception and the second handler will never be used. The fourth handler will also not be used since the third handler will catch all exceptions not caught by the first two.
+If f() is not declared to throw an exception then Info 1775 will be issued for all four catch handlers.
+]]>
+    </description>
     <internalKey>1775</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10955,11 +11133,16 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1776</key>
     <name>L1776: Converting string literals to Type is not const safe (Context)</name>
-    <description>A string literal, according to Standard C++ is typed an array of const char. This message is issued when such a literal is assigned to a non-const pointer. For example:
-    char *p = "string";
-    will trigger this message. This pointer could then be used to modify the string literal and that could produce some very strange behavior.
-    Such an assignment is legal but "deprecated" by the C++ Standard. The reason for not ruling it illegal is that numerous existing functions have their arguments typed as char * and this would break working code.
-    Note that this message is only given for string literals. If an expression is typed as pointer to const char in some way other than via string literal, then an assignment of that pointer to a non-const pointer will receive a more severe warning.</description>
+    <description><![CDATA[
+A string literal, according to Standard C++ is typed an array of const char. This message is issued when such a literal is assigned to a non-const pointer. For example:
+<pre>
+char *p = "string";
+</pre>
+will trigger this message. This pointer could then be used to modify the string literal and that could produce some very strange behavior.
+Such an assignment is legal but "deprecated" by the C++ Standard. The reason for not ruling it illegal is that numerous existing functions have their arguments typed as char * and this would break working code.
+Note that this message is only given for string literals. If an expression is typed as pointer to const char in some way other than via string literal, then an assignment of that pointer to a non-const pointer will receive a more severe warning.
+]]>
+    </description>
     <internalKey>1776</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10969,9 +11152,12 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1777</key>
     <name>L1777: Template recursion limit (Integer) reached, use -tr_limit(n)</name>
-    <description>It is possible to write a recursive template that will contain a recursive invocation without an escape clause. For example:
-    template &lt;class T&gt; class A { A&lt; A &gt; x; }; A&lt;int&gt; a; This will result in attempts to instantiate: A&lt;int&gt; A&lt;A&lt;int&gt;&gt; A&lt;A&lt;A&lt;int&gt;&gt;&gt; ... Using the -vt option (turning on template verbosity) you will see the sequence in action. Accordingly we have devised a scheme to break the recursion when an arbitrary depth of recursion has been reached (at this writing 75). This depth is reported in the message. As the message suggests, this limit can be adjusted so that it equals some other value.
-    When the limit is reached, a complete type is not used in the definition of the last specialization in the sequence but processing goes on. The message can be suppressed in most cases with no ill effects.</description>
+    <description><![CDATA[
+It is possible to write a recursive template that will contain a recursive invocation without an escape clause. For example:
+template &lt;class T&gt; class A { A&lt; A &gt; x; }; A&lt;int&gt; a; This will result in attempts to instantiate: A&lt;int&gt; A&lt;A&lt;int&gt;&gt; A&lt;A&lt;A&lt;int&gt;&gt;&gt; ... Using the -vt option (turning on template verbosity) you will see the sequence in action. Accordingly we have devised a scheme to break the recursion when an arbitrary depth of recursion has been reached (at this writing 75). This depth is reported in the message. As the message suggests, this limit can be adjusted so that it equals some other value.
+When the limit is reached, a complete type is not used in the definition of the last specialization in the sequence but processing goes on. The message can be suppressed in most cases with no ill effects.
+]]>
+    </description>
     <internalKey>1777</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10991,8 +11177,11 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1780</key>
     <name>L1780: Returning address of reference parameter 'Symbol'</name>
-    <description>The address of a parameter that has been declared as being a reference to a const is being returned from a function. The danger of this is that the reference may designate a temporary variable that will not persist long after the call. For example: const int *f( const int &amp; n ) { return &amp;n; } int g(); const int *p = f( g() ); Here, p points to a temporary value whose duration is not guaranteed. If the reference is not const then you will get Elective Note 1940.
-    This is an example of the Linton Convention as described by Murray [21].</description>
+    <description><![CDATA[
+The address of a parameter that has been declared as being a reference to a const is being returned from a function. The danger of this is that the reference may designate a temporary variable that will not persist long after the call. For example: const int *f( const int &amp; n ) { return &amp;n; } int g(); const int *p = f( g() ); Here, p points to a temporary value whose duration is not guaranteed. If the reference is not const then you will get Elective Note 1940.
+This is an example of the Linton Convention as described by Murray [21].
+]]>
+    </description>
     <internalKey>1780</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11002,8 +11191,11 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1781</key>
     <name>L1781: Passing address of reference parameter 'Symbol' into caller address space</name>
-    <description>The address of a parameter that has been declared as being a reference to a const is being assigned to a place outside the function. The danger of this is that the reference may designate a temporary variable that will not persist long after the call. For example: void f( const int &amp; n, const int **pp ) { *pp = &amp;n; } int g(); const int *p; ... f( g(), &amp;p ); Here, p will be made to point to a temporary value whose duration is not guaranteed. If the reference is not const then you will get Elective Note 1940.
-    This is an example of the Linton Convention as described by Murray [21].</description>
+    <description><![CDATA[
+The address of a parameter that has been declared as being a reference to a const is being assigned to a place outside the function. The danger of this is that the reference may designate a temporary variable that will not persist long after the call. For example: void f( const int &amp; n, const int **pp ) { *pp = &amp;n; } int g(); const int *p; ... f( g(), &amp;p ); Here, p will be made to point to a temporary value whose duration is not guaranteed. If the reference is not const then you will get Elective Note 1940.
+This is an example of the Linton Convention as described by Murray [21].
+]]>
+    </description>
     <internalKey>1781</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11013,8 +11205,11 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1782</key>
     <name>L1782: Assigning address of reference parameter 'Symbol' to a static variable</name>
-    <description>The address of a parameter that has been declared as being a reference to a const is being assigned to a static variable. The danger of this is that the reference may designate a temporary variable that will not persist long after the call. For example: const int *p; void f( const int &amp; n ) { p = &amp;n; } int g(); ... f( g() ); Here, p will be made to point to a temporary value whose duration is not guaranteed. If the reference is not const then you will get Elective Note 1940.
-    This is an example of the Linton Convention as described by Murray [21].</description>
+    <description><![CDATA[
+The address of a parameter that has been declared as being a reference to a const is being assigned to a static variable. The danger of this is that the reference may designate a temporary variable that will not persist long after the call. For example: const int *p; void f( const int &amp; n ) { p = &amp;n; } int g(); ... f( g() ); Here, p will be made to point to a temporary value whose duration is not guaranteed. If the reference is not const then you will get Elective Note 1940.
+This is an example of the Linton Convention as described by Murray [21].
+]]>
+    </description>
     <internalKey>1782</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11118,9 +11313,12 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1793</key>
     <name>L1793: While calling 'Symbol': Initializing the implict object parameter 'Type' (a non-const reference) with a non-lvalue</name>
-    <description>A non-static and non-const member function was called and an rvalue (a temporary object) of class type was used to initialize the implicit object parameter. This is legal (and possibly intentional) but suspicious. Consider the following. struct A { void f(); }; ... A().f(); // Info 1793 ... In the above the 'non-static, non-const member function' is A::f(). The 'implicit object parameter' for the call to A::f() is A(), a temporary. Since the A::f() is non-const it presumably modifies A(). But since A() is a temporary, any such change is lost. It would at first blush appear to be a mistake.
-    The Standard normally disallows binding a non-const reference to an rvalue (see Error 1058 in the manual), but as a special case allows it for the binding of the implicit object parameter in member function calls. Some popular libraries take advantage of this rule in a legitimate way. For example, the GNU implementation of std::vector&lt;bool&gt;::operator[] returns a temporary object of type std::_Bit_reference -- a class type with a non-const member operator=(). _Bit_reference serves a dual purpose. If a value is assigned to it, it modifies the original class through its operator=(). If a value is extracted from it, it obtains that value from the original class through its operator bool().
-    Probably the best policy to take with this message is to examine instances of it and if this is a library invocation or a specially designed class, then suppress the message with a -esym() option.</description>
+    <description><![CDATA[
+A non-static and non-const member function was called and an rvalue (a temporary object) of class type was used to initialize the implicit object parameter. This is legal (and possibly intentional) but suspicious. Consider the following. struct A { void f(); }; ... A().f(); // Info 1793 ... In the above the 'non-static, non-const member function' is A::f(). The 'implicit object parameter' for the call to A::f() is A(), a temporary. Since the A::f() is non-const it presumably modifies A(). But since A() is a temporary, any such change is lost. It would at first blush appear to be a mistake.
+The Standard normally disallows binding a non-const reference to an rvalue (see Error 1058 in the manual), but as a special case allows it for the binding of the implicit object parameter in member function calls. Some popular libraries take advantage of this rule in a legitimate way. For example, the GNU implementation of std::vector&lt;bool&gt;::operator[] returns a temporary object of type std::_Bit_reference -- a class type with a non-const member operator=(). _Bit_reference serves a dual purpose. If a value is assigned to it, it modifies the original class through its operator=(). If a value is extracted from it, it obtains that value from the original class through its operator bool().
+Probably the best policy to take with this message is to examine instances of it and if this is a library invocation or a specially designed class, then suppress the message with a -esym() option.
+]]>
+    </description>
     <internalKey>1793</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11130,7 +11328,10 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1794</key>
     <name>L1794: Using-declaration introduces 'Name' (Location), which has the same parameter list as 'Name' (Location), which was also introduced here by previous using-declaration 'Name' (Location)</name>
-    <description>This kind of scenario is perhaps best explained by way of example: struct A{}; // Library 1: namespace N { int f(const A&amp;); int f(char*); } // Library 2: namespace Q { int f(const A&amp;); int f(int); } // Non-library code: using N::f; using Q::f; // Info 1794 here According to the ISO Standard, 14. Added Bibliography, [34], the names of N::f(A) and Q::f(A) will coexist in the global namespace (along with the names of the other overloads of f). This alone does not make the program ill-formed. (For that you would have to make some use of the name 'f' that resulted in overload resolution where f(A) is selected.) However, a user of N and Q may be surprised to find that both library namespaces supply a function f that operates on ::A objects, and that both have been introduced into the same scope. So to avoid confusion, the user may opt to do away with the using-declarations and just refer to the various f()'s with qualified-ids.</description>
+    <description><![CDATA[
+This kind of scenario is perhaps best explained by way of example: struct A{}; // Library 1: namespace N { int f(const A&amp;); int f(char*); } // Library 2: namespace Q { int f(const A&amp;); int f(int); } // Non-library code: using N::f; using Q::f; // Info 1794 here According to the ISO Standard, 14. Added Bibliography, [34], the names of N::f(A) and Q::f(A) will coexist in the global namespace (along with the names of the other overloads of f). This alone does not make the program ill-formed. (For that you would have to make some use of the name 'f' that resulted in overload resolution where f(A) is selected.) However, a user of N and Q may be surprised to find that both library namespaces supply a function f that operates on ::A objects, and that both have been introduced into the same scope. So to avoid confusion, the user may opt to do away with the using-declarations and just refer to the various f()'s with qualified-ids.
+]]>
+    </description>
     <internalKey>1794</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11151,8 +11352,11 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1796</key>
     <name>L1796: Explicit specialization of overloaded function template 'Symbol'</name>
-    <description>A pair of overloaded function templates was followed by an explicit specialization. For example: template&lt; class T &gt; void f( T ); template&lt; class T &gt; void f( T* ); template&lt;&gt; void f( char * p ) { printf( "%s\n", p ); }
-    Confusion can arise in determining which of the two function templates the specialization is actually specializing. This will lead to unexpected results when processing overload resolution since the specialization does not directly compete with the templates. Both function templates compete with each other and it can be difficult to ascertain whether the specialization is invoked in any particular call.</description>
+    <description><![CDATA[
+A pair of overloaded function templates was followed by an explicit specialization. For example: template&lt; class T &gt; void f( T ); template&lt; class T &gt; void f( T* ); template&lt;&gt; void f( char * p ) { printf( "%s\n", p ); }
+Confusion can arise in determining which of the two function templates the specialization is actually specializing. This will lead to unexpected results when processing overload resolution since the specialization does not directly compete with the templates. Both function templates compete with each other and it can be difficult to ascertain whether the specialization is invoked in any particular call.
+]]>
+    </description>
     <internalKey>1796</internalKey>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11284,9 +11488,14 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
   <rule>
     <key>1917</key>
     <name>L1917: Empty prototype for String, assumed '(void)'</name>
-    <description>This message is given when an empty prototype is detected either for a function definition or for a namespace declaration (the String specifies which). Whereas we give an Informational Message (1717) when a (non-member) declaration contains no prototype, we give a much milder Elective Note when a definition does the same. For example:
-    int f(); // Info 1717 int f() { return 1; } // Elective Note 1917
-    The reason for this is that the declaration form has a different meaning in C and C++. In C it is an incomplete declaration saying nothing about arguments. In C++ the declaration says there are no arguments. The definition, however, means the same in both languages. See also message 1918. [11, ?8.2.5]</description>
+    <description><![CDATA[
+This message is given when an empty prototype is detected either for a function definition or for a namespace declaration (the String specifies which). Whereas we give an Informational Message (1717) when a (non-member) declaration contains no prototype, we give a much milder Elective Note when a definition does the same. For example:
+<pre>
+int f(); // Info 1717 int f() { return 1; } // Elective Note 1917
+</pre>
+The reason for this is that the declaration form has a different meaning in C and C++. In C it is an incomplete declaration saying nothing about arguments. In C++ the declaration says there are no arguments. The definition, however, means the same in both languages. See also message 1918. [11, ?8.2.5]
+]]>
+    </description>
     <internalKey>1917</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11328,13 +11537,15 @@ Some designers adopt the strategy of embedding the class within a sub namespace 
     <name>L1921: Symbol 'Symbol' not checking argument against sizeof(class)</name>
     <description>
 <![CDATA[<p>
-This note is given for either operator new or operator delete when defined as member functions. As member functions they are called when new (or delete) is applied to a class type or any derived class type. The difficulty is with the derived class type. Any specialized allocator is likely to be useless for a derived class type and hence experts suggest that a test be made of the size_t argument against sizeof(class). Specifically PC-lint/FlexeLint is looking for one of:
+This note is given for either operator new or operator delete when defined as member functions. As member functions they are called when new (or delete) is applied to a class type or any derived class type. The difficulty is with the derived class type. Any specialized allocator is likely to be useless for a derived class type and hence experts suggest that a test be made of the size_t argument against sizeof(class). Specifically PC-lint/FlexeLint is looking for one of:</p>
+<pre>
     if( arg == sizeof(class) ) 
     if( arg != sizeof(class) ) 
     if( sizeof(class) == arg ) 
     if( sizeof(class) != arg )
+</pre>
 or the equivalent. If any such function is found that is a member of a class that is the base of a derivation, then in addition to Note 1921, we issue Warning 1531. (see Steve Simpson, "More on Memory Management", Dr. Dobb's Journal, August 1994, p. 10).
-</p><h2>References</h2>
+<h2>References</h2>
 <p><a href="https://www.securecoding.cert.org/confluence/display/cplusplus/MEM00-CPP.+Overloaded+new+operators+should+check+that+their+size+argument+matches+the+size+of+their+class" target="_blank">MEM00-CPP. Overloaded new operators should check that their size argument matches the size of their class</a></p>
 ]]>
   </description>
@@ -11350,11 +11561,13 @@ or the equivalent. If any such function is found that is a member of a class tha
     <name>L1922: Symbol 'Symbol' not checking argument for NULL</name>
     <description>
 <![CDATA[<p>
-This message is given for a function operator delete which is not checking its parameter for being the NULL pointer. We would normally expect to see some such check as:
+This message is given for a function operator delete which is not checking its parameter for being the NULL pointer. We would normally expect to see some such check as:</p>
+<pre>
     if( arg ) 
     if( arg == 0 ) 
     if( arg != NULL )
-etc. Classes which have destructors will normally filter out passing the NULL pointer into the operator delete so that this message is only in the Elective Note category. If there is no destructor you obtain a warning. See Warning 1532.</p>]]>
+</pre>
+etc. Classes which have destructors will normally filter out passing the NULL pointer into the operator delete so that this message is only in the Elective Note category. If there is no destructor you obtain a warning. See Warning 1532.]]>
   </description>
     <internalKey>1922</internalKey>
     <severity>INFO</severity>
@@ -11376,7 +11589,10 @@ etc. Classes which have destructors will normally filter out passing the NULL po
   <rule>
     <key>1924</key>
     <name>L1924: C-style cast</name>
-    <description>A C-style cast was detected. This can be replaced by one of the newer C++ casts having the form: Name&lt;Type&gt;(Expression) where Name is one of static_cast, dynamic_cast, const_cast or reinterpret_cast. [23, Item 2].</description>
+    <description><![CDATA[
+A C-style cast was detected. This can be replaced by one of the newer C++ casts having the form: Name&lt;Type&gt;(Expression) where Name is one of static_cast, dynamic_cast, const_cast or reinterpret_cast. [23, Item 2].
+]]>
+    </description>
     <internalKey>1924</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11469,9 +11685,14 @@ etc. Classes which have destructors will normally filter out passing the NULL po
   <rule>
     <key>1933</key>
     <name>L1933: Call to unqualified virtual function 'Symbol' from non-static member function</name>
-    <description>A classical C++ gotcha is the calling of a virtual function from within a constructor or a destructor. When we discover a direct call from a constructor or destructor to a virtual function we issue Warning 1506. But what about indirect calls. Suppose a constructor calls a function that in turn, perhaps through several levels of call, calls a virtual function. This could be difficult to detect. Dan Saks [24] has suggested a compromise Guideline that "imposes few, if any, practical restrictions". The Guideline, implemented by this Elective Note, issues a message whenever an unqualified virtual function is called by any other (non-static) member function (for the same 'this' object). For example: class X { virtual void f(); void g(); };
-    void X::g() { f(); // Note 1933 X::f(); // ok -- non virtual call. }
-    Even if total abstinence is unwarranted, turning on message 1933 occasionally can be helpful in detecting situations when constructors or destructors call virtual functions.</description>
+    <description><![CDATA[
+A classical C++ gotcha is the calling of a virtual function from within a constructor or a destructor. When we discover a direct call from a constructor or destructor to a virtual function we issue Warning 1506. But what about indirect calls. Suppose a constructor calls a function that in turn, perhaps through several levels of call, calls a virtual function. This could be difficult to detect. Dan Saks [24] has suggested a compromise Guideline that "imposes few, if any, practical restrictions". The Guideline, implemented by this Elective Note, issues a message whenever an unqualified virtual function is called by any other (non-static) member function (for the same 'this' object). For example: class X { virtual void f(); void g(); };
+<pre>
+void X::g() { f(); // Note 1933 X::f(); // ok -- non virtual call. }
+</pre>
+Even if total abstinence is unwarranted, turning on message 1933 occasionally can be helpful in detecting situations when constructors or destructors call virtual functions.
+]]>
+    </description>
     <internalKey>1933</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11492,9 +11713,14 @@ etc. Classes which have destructors will normally filter out passing the NULL po
   <rule>
     <key>1935</key>
     <name>L1935: Dynamic initialization for class object 'Symbol1' (references 'Symbol2')</name>
-    <description>A static class-like object whose name is Symbol1 is dynamically initialized by referencing Symbol2 (the latter is normally a constructor for the former). The reason for noting this initialization is that the order of inter-module dynamic initializations is not defined. (Within a module, however, the intializations are done in the order of appearance.) Hence, if the constructor is itself dependent on dynamic initialization occurring in another module the behavior is undefined. For example: class X { X(): ... };
+    <description><![CDATA[
+A static class-like object whose name is Symbol1 is dynamically initialized by referencing Symbol2 (the latter is normally a constructor for the former). The reason for noting this initialization is that the order of inter-module dynamic initializations is not defined. (Within a module, however, the intializations are done in the order of appearance.) Hence, if the constructor is itself dependent on dynamic initialization occurring in another module the behavior is undefined. For example: class X { X(): ... };
+<pre>
     X x:
-    This will elicit Elective Note 1935 that x is being initialized dynamically by a call to X::X(). Now, if this constructor were to be accessing information that depended on the order of evaluation (such as accessing the value of x itself) the result would be undefined. We have no evidence of this at this point. and for this reason the message is in the Elective Note category. However, programmers with a suspected order-of-initialization problem will probably want to turn this on. See also 1936, 1937, 1544 and 1545.</description>
+</pre>
+This will elicit Elective Note 1935 that x is being initialized dynamically by a call to X::X(). Now, if this constructor were to be accessing information that depended on the order of evaluation (such as accessing the value of x itself) the result would be undefined. We have no evidence of this at this point. and for this reason the message is in the Elective Note category. However, programmers with a suspected order-of-initialization problem will probably want to turn this on. See also 1936, 1937, 1544 and 1545.
+]]>
+    </description>
     <internalKey>1935</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11545,8 +11771,11 @@ etc. Classes which have destructors will normally filter out passing the NULL po
   <rule>
     <key>1940</key>
     <name>L1940: Address of reference parameter 'Symbol' transferred outside of function</name>
-    <description>The address of a reference parameter is being transferred (either via a return statement, assigned to a static, or assigned through a pointer parameter) to a point where it can persist beyond the lifetime of the function. These are all violations of the Linton Convention (see Murray [21]).
-    The particular instance at hand is with a reference to a non-const and as such is not considered as dangerous as with a reference to a const. (See 1780, 1781 and 1782 in Section 13.8 Informational Messages for those cases). For example: int *f( int &amp;n ) { return &amp;n; } int g(); int *p = f( g() ); would create a problem were it not for the fact that this is diagnosed as a non-lvalue being assigned to a reference to non-const.</description>
+    <description><![CDATA[
+The address of a reference parameter is being transferred (either via a return statement, assigned to a static, or assigned through a pointer parameter) to a point where it can persist beyond the lifetime of the function. These are all violations of the Linton Convention (see Murray [21]).
+The particular instance at hand is with a reference to a non-const and as such is not considered as dangerous as with a reference to a const. (See 1780, 1781 and 1782 in Section 13.8 Informational Messages for those cases). For example: int *f( int &amp;n ) { return &amp;n; } int g(); int *p = f( g() ); would create a problem were it not for the fact that this is diagnosed as a non-lvalue being assigned to a reference to non-const.
+]]>
+    </description>
     <internalKey>1940</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11568,8 +11797,11 @@ etc. Classes which have destructors will normally filter out passing the NULL po
   <rule>
     <key>1942</key>
     <name>L1942: Unqualified name 'Symbol' subject to misinterpretation owing to dependent base class</name>
-    <description>An unqualified name used within a class template was not found within the class and, moreover, the class has at least one dependent base class. There is a potential ambiguity here. According to the standard, the dependent base class should not be searched either at template definition time or at template instantiation time. Nonetheless, some implementations do make that search at instantiation time. Even if the compiler is conforming, the implementator or even a reader of the code may think the base class is searched leading to confusion.
-    To eliminate the ambiguity, the name should be fully qualified (or referenced using this). For example: class X; template&lt; class T &gt; class A : T { X *p; bool f() { return y; } }; Both the reference to X (on line 5) and to y (one line 6) will be flagged. One possible modification is: class X; template&lt; class T &gt; class A : T { ::X *p; bool f() { return this-&gt;y; } }; This solidifies and disambiguates the code. The reference to X is guaranteed to be the X on line 1 and can no longer be high-jacked by the base class. Also, since y is not a member of A, the class will not instantiate unless y is found to be a member of the base class.</description>
+    <description><![CDATA[
+An unqualified name used within a class template was not found within the class and, moreover, the class has at least one dependent base class. There is a potential ambiguity here. According to the standard, the dependent base class should not be searched either at template definition time or at template instantiation time. Nonetheless, some implementations do make that search at instantiation time. Even if the compiler is conforming, the implementator or even a reader of the code may think the base class is searched leading to confusion.
+To eliminate the ambiguity, the name should be fully qualified (or referenced using this). For example: class X; template&lt; class T &gt; class A : T { X *p; bool f() { return y; } }; Both the reference to X (on line 5) and to y (one line 6) will be flagged. One possible modification is: class X; template&lt; class T &gt; class A : T { ::X *p; bool f() { return this-&gt;y; } }; This solidifies and disambiguates the code. The reference to X is guaranteed to be the X on line 1 and can no longer be high-jacked by the base class. Also, since y is not a member of A, the class will not instantiate unless y is found to be a member of the base class.
+]]>
+    </description>
     <internalKey>1942</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11582,7 +11814,7 @@ etc. Classes which have destructors will normally filter out passing the NULL po
     <description><![CDATA[
 <p>In addition to a C coding standard, MISRA has also compiled a C++ one. We suggest use of the options file au-misra-cpp.lnt to activate these and other MISRA C++ messages.</p>
 <p>The list of checks made are as follows:</p>
-<pre><tt>
+<pre><code>
        (Rule 0-1-8)  Void return type for function without external side-effects.
        (Rule 2-13-2) Octal constant or escape sequence used.
        (Rule 2-13-4) Lower case literal suffix.
@@ -11646,7 +11878,7 @@ etc. Classes which have destructors will normally filter out passing the NULL po
        (Rule 16-2-4) Header file name with non-standard character: .
        (Rule 16-3-1) Multiple use of '#' and/or '##' operators in macro definition.
        (Rule 17-0-2) Re-use of reserved identifier
-</tt></pre>
+</code></pre>
 <p>You may disable individual rules to your taste by using the Rule number in an esym option; see Message 960.</p>
  ]]></description>
     <internalKey>1960</internalKey>
@@ -11684,7 +11916,7 @@ etc. Classes which have destructors will normally filter out passing the NULL po
     <name>L1963: Violates MISRA C++ Advisory Rule Name, String</name>
     <description><![CDATA[<p>This message is issued for some violations of the MISRA C++ advisory guidelines. We suggest use of the options file au-misra-cpp.lnt to activate these and other MISRA C++ messages.</p>
 <p>The list of checks made are as follows:</p>
-<pre><tt>
+<pre><code>
        (Rule 2-5-1)  Possible digraph used.
        (Rule 5-0-2)  Dependence placed on C's operator precedence.
        (Rule 5-2-10) Increment or decrement combined with another operator.
@@ -11692,7 +11924,7 @@ etc. Classes which have destructors will normally filter out passing the NULL po
        (Rule 15-0-2) Throwing a pointer expression.
        (Rule 16-2-5) Header file name with non-standard character.
        (Rule 16-3-2) No use of '#' or '##'.
-</tt></pre>
+</code></pre>
 ]]></description>
     <internalKey>1963</internalKey>
     <severity>INFO</severity>
@@ -11758,8 +11990,11 @@ etc. Classes which have destructors will normally filter out passing the NULL po
   <rule>
     <key>9007</key>
     <name>L9007: side effects on right hand of logical operator, 'String'</name>
-    <description>The right hand side of the || and &amp;&amp; operators is evaluated only if the left hand side evaluates to a certain value.
-    Consequently, code which expects the right hand side to be evaluated regardless of the left hand side can produce unanticipated results.</description>
+    <description><![CDATA[
+The right hand side of the || and &amp;&amp; operators is evaluated only if the left hand side evaluates to a certain value.
+Consequently, code which expects the right hand side to be evaluated regardless of the left hand side can produce unanticipated results.
+]]>
+    </description>
     <internalKey>9007</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -12095,22 +12330,22 @@ etc. Classes which have destructors will normally filter out passing the NULL po
     <name>L9041: goto 'Symbol' appears in block 'String' which is not nested in block 'String' which contains the label.</name>
     <description><![CDATA[
 <p>It has been deemed safer by some experts that the block (i.e. compound statement) containing the goto should be the same as or nested within the block containing the label. Thus</p>
-<pre><tt>
+<pre><code>
            {  label:  {  goto label;  }  }
-</tt></pre>
+</code></pre>
 <p>is permitted but</p>
-<pre><tt>
+<pre><code>
            {  goto label;  {  label:  }  }
-</tt></pre>
+</code></pre>
 <p>is not.  To assist the programmer, the message refers to the blocks using an identification code (Example: "1.2.1").  This identification scheme is defined as follows.</p>
 <ul>
  <li>The outer block has an identification of 1.</li>
  <li>If a particular block is identified by x then its immediate subblocks, if any, are identified as x.1, x.2, x.3, etc.</li>
  </ul>
 <p>Thus in the following 'code',</p>
-<pre><tt>
+<pre><code>
            {  {  }  { { label: } { } } }
-</tt></pre>
+</code></pre>
 <p>label: lies in block 1.2.1.</p>]]></description>
     <internalKey>9041</internalKey>
     <severity>INFO</severity>
@@ -12930,7 +13165,10 @@ etc. Classes which have destructors will normally filter out passing the NULL po
   <rule>
     <key>9131</key>
     <name>L9131: non-postfix expression used with logical operator</name>
-    <description>Using only postfix-expressions with logical operators helps to improve readability of the code. Note, this message is not given if the expression consists of either a sequence of only logical &amp;&amp; or a sequence of only logical ||.</description>
+    <description><![CDATA[
+Using only postfix-expressions with logical operators helps to improve readability of the code. Note, this message is not given if the expression consists of either a sequence of only logical &amp;&amp; or a sequence of only logical ||.
+]]>
+    </description>
     <internalKey>9131</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -12952,7 +13190,10 @@ etc. Classes which have destructors will normally filter out passing the NULL po
   <rule>
     <key>9133</key>
     <name>L9133: boolean expression required for operator 'String'</name>
-    <description>The use of non-bool operands with !, &amp;&amp;, or || is unlikely to be meaningful or intended. A more likely scenario is the programmer meant to use such an operand with one of the bitwise operators.</description>
+    <description><![CDATA[
+The use of non-bool operands with !, &amp;&amp;, or || is unlikely to be meaningful or intended. A more likely scenario is the programmer meant to use such an operand with one of the bitwise operators.
+]]>
+    </description>
     <internalKey>9133</internalKey>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -13740,12 +13981,16 @@ etc. Classes which have destructors will normally filter out passing the NULL po
   <rule>
     <key>M10.1</key>
     <name>M10.1: loss of precision / possible loss of fraction (MISRA C)</name>
-    <description>
+    <description><![CDATA[
     The value of an expression of integer type shall not be implicitly converted to a different underlying type if:
-    a) it is not a conversion to a wider integer type of the same signedness, or
-    b) the expression is complex, or
-    c) the expression is not constant and is a function argument, or
-    d) the expression is not constant and is a return expression</description>
+<ol type="a">
+    <li>it is not a conversion to a wider integer type of the same signedness, or</li>
+    <li>the expression is complex, or</li>
+    <li>the expression is not constant and is a function argument, or</li>
+    <li>the expression is not constant and is a return expression</li>
+</ol>
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M10.1</internalKey>
     <severity>INFO</severity>
@@ -13792,8 +14037,10 @@ etc. Classes which have destructors will normally filter out passing the NULL po
   <rule>
     <key>M10.5</key>
     <name>M10.5: recasting required for &lt;&lt; and - operators (MISRA C)</name>
-    <description>
-    recasting required for &lt;&lt; and - operators</description>
+    <description><![CDATA[
+recasting required for &lt;&lt; and - operators
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M10.5</internalKey>
     <severity>INFO</severity>
@@ -14404,8 +14651,10 @@ etc. Classes which have destructors will normally filter out passing the NULL po
   <rule>
     <key>M16.9</key>
     <name>M16.9: function identifier used without "&amp;" or parenthesized parameter list (MISRA C)</name>
-    <description>
-    function identifier used without "&amp;" or parenthesized parameter list</description>
+    <description><![CDATA[
+function identifier used without "&amp;" or parenthesized parameter list
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M16.9</internalKey>
     <severity>INFO</severity>
@@ -14548,8 +14797,10 @@ etc. Classes which have destructors will normally filter out passing the NULL po
   <rule>
     <key>M19.3</key>
     <name>M19.3: need &lt; or " after #include (MISRA C)</name>
-    <description>
-    need &lt; or " after #include</description>
+    <description><![CDATA[
+need &lt; or " after #include
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M19.3</internalKey>
     <severity>INFO</severity>
@@ -15354,8 +15605,11 @@ etc. Classes which have destructors will normally filter out passing the NULL po
   <rule>
     <key>M4-5-1</key>
     <name>M4-5-1: Boolean expression used with non-permitted operator (MISRA C++)</name>
-    <description>(Required) Expressions with type bool shall not be used as operands to built-in operators other than the assignment operator =, the logical operators
-&amp;&amp;, ||, !, the equality operators == and !=, the unary &amp; operator, and the conditional operator.</description>
+    <description><![CDATA[
+(Required) Expressions with type bool shall not be used as operands to built-in operators other than the assignment operator =, the logical operators
+&amp;&amp;, ||, !, the equality operators == and !=, the unary &amp; operator, and the conditional operator.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M4-5-1</internalKey>
     <severity>INFO</severity>
@@ -15371,8 +15625,11 @@ operator =, the equality operators == and !=, the unary & operator, and the rela
   <rule>
     <key>M4-5-3</key>
     <name>M4-5-3: Plain char used with prohibited operator (MISRA C++)</name>
-    <description>(Required) Expressions with type (plain) char and wchar_t shall not be used as operands to built-in operators other than the assignment operator =,
-the equality operators == and !=, and the unary &amp; operator.</description>
+    <description><![CDATA[
+(Required) Expressions with type (plain) char and wchar_t shall not be used as operands to built-in operators other than the assignment operator =,
+the equality operators == and !=, and the unary &amp; operator.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M4-5-3</internalKey>
     <severity>INFO</severity>
@@ -15497,8 +15754,11 @@ the equality operators == and !=, and the unary &amp; operator.</description>
   <rule>
     <key>M5-0-10</key>
     <name>M5-0-10: Recasting required for operators '~' and '&lt;&lt;' (MISRA C++)</name>
-    <description>(Required) If the bitwise operators ~ and &lt;&lt; are applied to an operand with an underlying type of unsigned char or unsigned short, the result shall be
-immediately cast to the underlying type of the operand.</description>
+    <description><![CDATA[
+(Required) If the bitwise operators ~ and &lt;&lt; are applied to an operand with an underlying type of unsigned char or unsigned short, the result shall be
+immediately cast to the underlying type of the operand.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M5-0-10</internalKey>
     <severity>INFO</severity>
@@ -15586,7 +15846,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M5-0-18</key>
     <name>M5-0-18: Relational operator applied to pointers (MISRA C++)</name>
-    <description>(Required) &gt;, &gt;=, &lt;, &lt;= shall not be applied to objects of pointer type, except where they point to the same array.</description>
+    <description><![CDATA[
+(Required) &gt;, &gt;=, &lt;, &lt;= shall not be applied to objects of pointer type, except where they point to the same array.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M5-0-18</internalKey>
     <severity>INFO</severity>
@@ -15623,7 +15886,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M5-2-1</key>
     <name>M5-2-1: non-postfix expression used with logical operator (MISRA C++)</name>
-    <description>(Required) Each operand of a logical &amp;&amp; or || shall be a postfix-expression.</description>
+    <description><![CDATA[
+(Required) Each operand of a logical &amp;&amp; or || shall be a postfix-expression.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M5-2-1</internalKey>
     <severity>INFO</severity>
@@ -15726,7 +15992,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M5-2-11</key>
     <name>M5-2-11: overloading special operators – ',' '&amp;&amp;' '||' (MISRA C++)</name>
-    <description>(Required) The comma operator, '&amp;&amp;' operator and the '||' operator shall not be overloaded.</description>
+    <description><![CDATA[
+(Required) The comma operator, '&amp;&amp;' operator and the '||' operator shall not be overloaded.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M5-2-11</internalKey>
     <severity>INFO</severity>
@@ -15748,7 +16017,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M5-3-1</key>
     <name>M5-3-1: boolean expression required for operator: '||'; the -strong(B,...) option can help provide Boolean-by-enforcement (MISRA C++)</name>
-    <description>(Required) Each operand of the ! operator, the logical &amp;&amp; or the logical || operators shall have type bool.</description>
+    <description><![CDATA[
+(Required) Each operand of the ! operator, the logical &amp;&amp; or the logical || operators shall have type bool.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M5-3-1</internalKey>
     <severity>INFO</severity>
@@ -15770,7 +16042,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M5-3-3</key>
     <name>M5-3-3: Overloading unary &amp; (MISRA C++)</name>
-    <description>(Required) The unary &amp; operator shall not be overloaded.</description>
+    <description><![CDATA[
+(Required) The unary &amp; operator shall not be overloaded.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M5-3-3</internalKey>
     <severity>INFO</severity>
@@ -15803,7 +16078,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M5-14-1</key>
     <name>M5-14-1: Side effects on right hand side of logical operator (MISRA C++)</name>
-    <description>(Required) The right hand operand of a logical &amp;&amp; or || operator shall not contain side effects.</description>
+    <description><![CDATA[
+(Required) The right hand operand of a logical &amp;&amp; or || operator shall not contain side effects.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M5-14-1</internalKey>
     <severity>INFO</severity>
@@ -16053,7 +16331,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M7-3-1</key>
     <name>M7-3-1: Global declarations other than main(), namespace declarations, extern &quot;C&quot; declarations and arithmetic typedefs (MISRA C++)</name>
-    <description>(Required) The global namespace shall only contain main, namespace declarations and extern &quot;C&quot; declarations.</description>
+    <description><![CDATA[
+(Required) The global namespace shall only contain main, namespace declarations and extern &quot;C&quot; declarations.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M7-3-1</internalKey>
     <severity>INFO</severity>
@@ -16230,7 +16511,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M8-4-4</key>
     <name>M8-4-4: Function parameter list differs from prior declaration (MISRA C++)</name>
-    <description>(Required) A function identifier shall either be used to call the function or it shall be preceded by &amp;.</description>
+    <description><![CDATA[
+(Required) A function identifier shall either be used to call the function or it shall be preceded by &amp;.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M8-4-4</internalKey>
     <severity>INFO</severity>
@@ -16865,7 +17149,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M16-2-6</key>
     <name>M16-2-6: need &amp;&lt; or &quot; after #include (MISRA C++)</name>
-    <description>(Required) The #include directive shall be followed by either a &lt;filename&gt; or &quot;filename&quot; sequence.</description>
+    <description><![CDATA[
+(Required) The #include directive shall be followed by either a &lt;filename&gt; or &quot;filename&quot; sequence.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M16-2-6</internalKey>
     <severity>INFO</severity>
@@ -16961,7 +17248,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M18-0-2</key>
     <name>M18-0-2: Do not use atof, atoi, atol (MISRA C++)</name>
-    <description>(Required) The library functions atof, atoi and atol from library &lt;cstdlib&gt; shall not be used.</description>
+    <description><![CDATA[
+(Required) The library functions atof, atoi and atol from library &lt;cstdlib&gt; shall not be used.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M18-0-2</internalKey>
     <severity>INFO</severity>
@@ -16972,7 +17262,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M18-0-3</key>
     <name>M18-0-3: Do not use abort, exit, getenv, system (MISRA C++)</name>
-    <description>(Required) The library functions abort, exit, getenv and system from library &lt;cstdlib&gt; shall not be used.</description>
+    <description><![CDATA[
+(Required) The library functions abort, exit, getenv and system from library &lt;cstdlib&gt; shall not be used.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M18-0-3</internalKey>
     <severity>INFO</severity>
@@ -16983,7 +17276,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M18-0-4</key>
     <name>M18-0-4: Do not use functions in ctime header (MISRA C++)</name>
-    <description>(Required) The time handling functions of library &lt;ctime&gt; shall not be used.</description>
+    <description><![CDATA[
+(Required) The time handling functions of library &lt;ctime&gt; shall not be used.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M18-0-4</internalKey>
     <severity>INFO</severity>
@@ -16994,7 +17290,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M18-0-5</key>
     <name>M18-0-5: Do not use inbounded functions in cstring header (MISRA C++)</name>
-    <description>(Required) The unbounded functions of library &lt;cstring&gt; shall not be used.</description>
+    <description><![CDATA[
+(Required) The unbounded functions of library &lt;cstring&gt; shall not be used.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M18-0-5</internalKey>
     <severity>INFO</severity>
@@ -17027,7 +17326,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M18-7-1</key>
     <name>M18-7-1: Do not use csignal functions (MISRA C++)</name>
-    <description>(Required) The signal handling facilities of &lt;csignal&gt; shall not be used.</description>
+    <description><![CDATA[
+(Required) The signal handling facilities of &lt;csignal&gt; shall not be used.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M18-7-1</internalKey>
     <severity>INFO</severity>
@@ -17049,7 +17351,10 @@ immediately cast to the underlying type of the operand.</description>
   <rule>
     <key>M27-0-1</key>
     <name>M27-0-1: Do not use cstdio functions (MISRA C++)</name>
-    <description>(Required) The stream input/output library &lt;cstdio&gt; shall not be used.</description>
+    <description><![CDATA[
+(Required) The stream input/output library &lt;cstdio&gt; shall not be used.
+]]>
+    </description>
     <tag>misra</tag>
     <internalKey>M27-0-1</internalKey>
     <severity>INFO</severity>
@@ -17877,7 +18182,10 @@ immediately cast to the underlying type of the operand.</description>
 	<rule>
 		<key>M2012-13.5</key>
 		<name>M2012-13.5: Side effects on right hand of logical operator (MISRA C 2012)</name>
-		<description>(Advisory) The right hand operand of a logical &amp;&amp; or || operator shall not contain persistent side effects </description>
+		<description><![CDATA[
+(Advisory) The right hand operand of a logical &amp;&amp; or || operator shall not contain persistent side effects 
+]]>
+		</description>
 		<tag>misrac3</tag>
 		<internalKey>M2012-13.5</internalKey>
 		<severity>MAJOR</severity>
@@ -18101,7 +18409,10 @@ immediately cast to the underlying type of the operand.</description>
 	<rule>
 		<key>M2012-17.1</key>
 		<name>M2012-17.1: Usage of   stdarg.h   is forbidden (MISRA C 2012)</name>
-		<description>(Required) The features of &lt;stdarg.h&gt; shall not be used </description>
+		<description><![CDATA[
+(Required) The features of &lt;stdarg.h&gt; shall not be used 
+]]>
+		</description>
 		<tag>misrac3</tag>
 		<internalKey>M2012-17.1</internalKey>
 		<severity>CRITICAL</severity>
@@ -18212,7 +18523,10 @@ immediately cast to the underlying type of the operand.</description>
 	<rule>
 		<key>M2012-18.3</key>
 		<name>M2012-18.3: Relational or subtract operator applied to pointers  (MISRA C 2012)</name>
-		<description>(Required) The relational operators &gt;, &gt;=, &lt; and &lt;= shall not be applied to objects of pointer type except where they point into the same object</description>
+		<description><![CDATA[
+(Required) The relational operators &gt;, &gt;=, &lt; and &lt;= shall not be applied to objects of pointer type except where they point into the same object
+]]>
+		</description>
 		<tag>misrac3</tag>
 		<internalKey>M2012-18.3</internalKey>
 		<severity>CRITICAL</severity>
@@ -18324,7 +18638,10 @@ immediately cast to the underlying type of the operand.</description>
 	<rule>
 		<key>M2012-20.3</key>
 		<name>M2012-20.3: #include followed by wrong sequence (MISRA C 2012)</name>
-		<description>(Required) The #include directive shall be followed by either a &lt;filename&gt; or "filename" sequence</description>
+		<description><![CDATA[
+(Required) The #include directive shall be followed by either a &lt;filename&gt; or "filename" sequence
+]]>
+		</description>
 		<tag>misrac3</tag>
 		<internalKey>M2012-20.3</internalKey>
 		<severity>CRITICAL</severity>
@@ -18479,7 +18796,10 @@ immediately cast to the underlying type of the operand.</description>
 	<rule>
 		<key>M2012-21.3</key>
 		<name>M2012-21.3: Usage of memory allocation and deallocation from   stdlib.h   is forbidden (MISRA C 2012)</name>
-		<description>(Required) The memory allocation and deallocation functions of &lt;stdlib.h&gt; shall not be used</description>
+		<description><![CDATA[
+(Required) The memory allocation and deallocation functions of &lt;stdlib.h&gt; shall not be used
+]]>
+		</description>
 		<tag>misrac3</tag>
 		<internalKey>M2012-21.3</internalKey>
 		<severity>CRITICAL</severity>
@@ -18490,7 +18810,10 @@ immediately cast to the underlying type of the operand.</description>
 	<rule>
 		<key>M2012-21.4</key>
 		<name>M2012-21.4: Usage of   setjmp.h   is forbidden (MISRA C 2012)</name>
-		<description>(Required) The standard header file &lt;setjmp.h&gt; shall not be used </description>
+		<description><![CDATA[
+(Required) The standard header file &lt;setjmp.h&gt; shall not be used 
+]]>
+		</description>
 		<tag>misrac3</tag>
 		<internalKey>M2012-21.4</internalKey>
 		<severity>CRITICAL</severity>
@@ -18501,7 +18824,10 @@ immediately cast to the underlying type of the operand.</description>
 	<rule>
 		<key>M2012-21.5</key>
 		<name>M2012-21.5: Usage of   signal.h   is forbidden (MISRA C 2012)</name>
-		<description>(Required) The standard header file &lt;signal.h&gt; shall not be used</description>
+		<description><![CDATA[
+(Required) The standard header file &lt;signal.h&gt; shall not be used
+]]>
+		</description>
 		<tag>misrac3</tag>
 		<internalKey>M2012-21.5</internalKey>
 		<severity>CRITICAL</severity>
@@ -18523,7 +18849,10 @@ immediately cast to the underlying type of the operand.</description>
 	<rule>
 		<key>M2012-21.7</key>
 		<name>M2012-21.7: Usage of atol, atol and atoll is forbidden (MISRA C 2012)</name>
-		<description>(Required) The atof, atoi, atol and atoll functions of &lt;stdlib.h&gt; shall not be used</description>
+		<description><![CDATA[
+(Required) The atof, atoi, atol and atoll functions of &lt;stdlib.h&gt; shall not be used
+]]>
+		</description>
 		<tag>misrac3</tag>
 		<internalKey>M2012-21.7</internalKey>
 		<severity>CRITICAL</severity>
@@ -18534,7 +18863,10 @@ immediately cast to the underlying type of the operand.</description>
 	<rule>
 		<key>M2012-21.8</key>
 		<name>M2012-21.8: Usage of abort, exit, getenv and system is forbidden (MISRA C 2012)</name>
-		<description>(Required) The library functions abort, exit, getenv and system of &lt;stdlib.h&gt; shall not be used</description>
+		<description><![CDATA[
+(Required) The library functions abort, exit, getenv and system of &lt;stdlib.h&gt; shall not be used
+]]>
+		</description>
 		<tag>misrac3</tag>
 		<internalKey>M2012-21.8</internalKey>
 		<severity>CRITICAL</severity>
@@ -18545,7 +18877,10 @@ immediately cast to the underlying type of the operand.</description>
 	<rule>
 		<key>M2012-21.9</key>
 		<name>M2012-21.9: Usage of bsearch and qsort is forbidden (MISRA C 2012)</name>
-		<description>(Required) The library functions bsearch and qsort of &lt;stdlib.h&gt; shall not be used</description>
+		<description><![CDATA[
+(Required) The library functions bsearch and qsort of &lt;stdlib.h&gt; shall not be used
+]]>
+		</description>
 		<tag>misrac3</tag>
 		<internalKey>M2012-21.9</internalKey>
 		<severity>CRITICAL</severity>
@@ -18567,7 +18902,10 @@ immediately cast to the underlying type of the operand.</description>
 	<rule>
 		<key>M2012-21.11</key>
 		<name>M2012-21.11: Usage of   tgmath.h   is forbidden (MISRA C 2012)</name>
-		<description>(Required) The standard header file &lt;tgmath.h&gt; shall not be used</description>
+		<description><![CDATA[
+(Required) The standard header file &lt;tgmath.h&gt; shall not be used
+]]>
+		</description>
 		<tag>misrac3</tag>
 		<internalKey>M2012-21.11</internalKey>
 		<severity>CRITICAL</severity>
@@ -18578,7 +18916,10 @@ immediately cast to the underlying type of the operand.</description>
 	<rule>
 		<key>M2012-21.12</key>
 		<name>M2012-21.12: Usage of exception handling from   fenv.h   is forbidden (MISRA C 2012)</name>
-		<description>(Advisory) The exception handling features of &lt;fenv.h&gt; should not be used</description>
+		<description><![CDATA[
+(Advisory) The exception handling features of &lt;fenv.h&gt; should not be used
+]]>
+		</description>
 		<tag>misrac3</tag>
 		<internalKey>M2012-21.12</internalKey>
 		<severity>MAJOR</severity>

--- a/cxx-sensors/src/tools/check_rules.sh
+++ b/cxx-sensors/src/tools/check_rules.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# use cppcheck_createrules.py in order to check the validity of created rules
+#
+# currently available checks:
+#
+# 1. xmllint - check if XML file is valid
+#
+# 2. tidy-html5 - check if rule description is written in valid HTML
+#    (see https://github.com/htacg/tidy-html5)
+#
+# use
+#    bash [path/]check_rules.sh
+# it will help the script to find the relative directory
+#
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+RULES_DIR="$(realpath $SCRIPT_DIR/../main/resources/)"
+RULES=( "clangsa.xml" "clangtidy.xml" "compiler-gcc.xml" "compiler-vc.xml" \
+"cppcheck.xml" "drmemory.xml" "external-rule.xml" "pclint.xml" \
+"rats.xml" "valgrind.xml" "vera++.xml" "external/intel_inspector_rules.xml")
+
+declare -i RC_CHECK=0
+for RULE in "${RULES[@]}"
+do
+   ABS_PATH_TO_RULE="${RULES_DIR}/${RULE}"
+   BASE_NAME="$(basename $ABS_PATH_TO_RULE)"
+   REPORT_PATH="${PWD}/${BASE_NAME}.tidy"
+   declare -i RC=0
+   $(python cppcheck_createrules.py check ${ABS_PATH_TO_RULE} > ${REPORT_PATH})
+   RC=$?
+   if [[ ${RC} -ne 0 ]]
+   then
+       echo "[ FAILED ] ${ABS_PATH_TO_RULE}: see ${REPORT_PATH}"
+   else
+       echo "[ PASSED ] ${ABS_PATH_TO_RULE}"
+   fi
+   RC_CHECK+=${RC}
+done
+
+exit ${RC_CHECK}

--- a/cxx-sensors/src/tools/cppcheck_createrules.py
+++ b/cxx-sensors/src/tools/cppcheck_createrules.py
@@ -25,6 +25,7 @@
 
 import sys
 import os
+import subprocess
 import xml.etree.ElementTree as et
 import textwrap
 
@@ -203,8 +204,77 @@ def makeDescriptionToCDATA(rule_t):
         description_tag.append(CDATA(desc))
 
 
+def call_xmllint(file_path):
+    command = ["xmllint", file_path]
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
+    if p.returncode != 0:
+        print "### XMLLINT", file_path
+        print "### ERR"
+        print err
+        print "### OUT"
+        print out
+        print "\n"
+        return True
+    return False
+
+
+def call_tidy(file_path):
+    command = ["/home/igalkin/workspace_myGITHUB/tidy-html5/build/cmake/tidy", file_path]
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
+    if p.returncode != 0:
+        print "### TIDY ", file_path
+        print "### ERR"
+        print err
+        print "### OUT"
+        print out
+        print "\n"
+        return True
+    return False
+
+
+def checkRules(path):
+    print "### CHECK ", path
+    has_xmllint_errors = call_xmllint(path)
+    if has_xmllint_errors:
+        return 1
+
+    has_tidy_errors = False
+    keys, keys_mapping = parseRules(path)
+    for key in keys:
+        for rule_tag in keys_mapping[key].iter('rule'):
+            for description_tag in rule_tag.iter('description'):
+                description_dump_path = "/tmp/" + key + ".ruledump"
+                with open(description_dump_path, "w") as f:
+                    html_start = u"""<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=\"utf-8\">
+    <title>MarkSheet</title>
+    <meta name= \"description\" content=\"A simple HTML and CSS tutorial\">
+  </head>
+  <body>
+"""
+                    html_stop = u"""
+  </body>
+</html>"""
+
+                    f.write(html_start)
+                    f.write(description_tag.text.encode("UTF-8"))
+                    f.write(html_stop)
+                is_tidy_error = call_tidy(description_dump_path)
+                has_tidy_errors = has_tidy_errors or is_tidy_error
+
+    if has_tidy_errors:
+        return 2
+
+    print "no errors found"
+    return 0
+
+
 def compareRules(old_path, new_path):
-    old_keys, old_keys_mapping = parseRules(old_path)
+    old_keys, _ = parseRules(old_path)
     new_keys, new_keys_mapping = parseRules(new_path)
     old_keys_set = set(old_keys)
     new_keys_set = set(new_keys)
@@ -309,6 +379,9 @@ elif sys.argv[1] == "profile":
     writeXML(root, sys.stdout)
 elif sys.argv[1] == "comparerules" and len(sys.argv) == 4:
     compareRules(sys.argv[2], sys.argv[3])
+elif sys.argv[1] == "check" and len(sys.argv) == 3:
+    rc = checkRules(sys.argv[2])
+    sys.exit(rc)
 else:
     print usage()
     exit()

--- a/cxx-sensors/src/tools/cppcheck_createrules.py
+++ b/cxx-sensors/src/tools/cppcheck_createrules.py
@@ -220,14 +220,14 @@ def call_xmllint(file_path):
 
 
 def call_tidy(file_path):
-    command = ["/home/igalkin/workspace_myGITHUB/tidy-html5/build/cmake/tidy", file_path]
+    command = ["tidy", file_path]
     p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = p.communicate()
     if p.returncode != 0:
         print "### TIDY ", file_path
         print "### ERR"
         print err
-        print "### OUT"
+        print "### SUGGESTION FOR FIXING"
         print out
         print "\n"
         return True
@@ -251,8 +251,7 @@ def checkRules(path):
 <html>
   <head>
     <meta charset=\"utf-8\">
-    <title>MarkSheet</title>
-    <meta name= \"description\" content=\"A simple HTML and CSS tutorial\">
+    <title>Rule Description</title>
   </head>
   <body>
 """

--- a/cxx-sensors/src/tools/generate_cppcheck_resources.sh
+++ b/cxx-sensors/src/tools/generate_cppcheck_resources.sh
@@ -13,9 +13,11 @@ for CFG in ${CFG_DIR}*.cfg; do
    [ -e "${CFG}" ] && CPPCHECK_LIBRARY_ARGS="${CPPCHECK_LIBRARY_ARGS} --library=${CFG}" || echo "no *.cfg files exist in ${CFG_DIR}; no library specific rules will be generated!"
 done
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 wget https://cwe.mitre.org/data/xml/cwec_v3.1.xml.zip --output-document=cwec_v3.1.xml.zip && unzip -j -o cwec_v3.1.xml.zip
 
-cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist > cppcheck-errorlist.xml
-cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist | python cppcheck_createrules.py rules cwec_v3.1.xml > cppcheck.xml
-cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist | python cppcheck_createrules.py profile > cppcheck-profile.xml
-python cppcheck_createrules.py comparerules ../../../cxx-sensors/src/main/resources/cppcheck.xml cppcheck.xml > cppcheck-comparison.md
+cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist --xml-version=2 > cppcheck-errorlist.xml
+cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist --xml-version=2 | python cppcheck_createrules.py rules cwec_v3.1.xml > cppcheck.xml
+cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist --xml-version=2 | python cppcheck_createrules.py profile > cppcheck-profile.xml
+python cppcheck_createrules.py comparerules $SCRIPT_DIR/../main/resources/cppcheck.xml cppcheck.xml > cppcheck-comparison.md


### PR DESCRIPTION
* create check_rules.sh and extend cppcheck_createrules.py

```python
for each rule.xml in cxx-sensors/main/resources:
    check rule.xml with xmllint
    parse rule.xml
        for each rule in rule.xml:
            dump rule.attr("description") to tmp.ruledump
            check tmp.ruledump with tiny-html5
```

* fix issues w.r.t. HTML formatting and escaping
* many important HTML issues were fixed, but also many [escaping] issues which SonarQube seems to tolerate

@guwirth is there a chance to activate check_rules.sh in continuous integration? FYI it uses [linux] tools (xmllint and tidy-html5), which probably have to installed additionally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1456)
<!-- Reviewable:end -->
