### PR TITLE
regex refactoring

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerVcParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerVcParser.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Scanner;
 import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.log.Logger;
@@ -40,6 +41,8 @@ public class CxxCompilerVcParser implements CompilerParser {
   // sample regex for VS2012/2013: "^.*>(?<filename>.*)\\((?<line>\\d+)\\):\\x20warning\\x20(?<id>C\\d+):(?<message>.*)$";
   // get value with e.g. scanner.match().group("filename");
   public static final String DEFAULT_CHARSET_DEF = "UTF-8"; // use "UTF-16" for VS2010 build log or TFS Team build log file
+
+  private static final Pattern jobNumberPrefixPattern = Pattern.compile("^\\d+>(.*)$");
 
   /**
    * {@inheritDoc}
@@ -101,8 +104,9 @@ public class CxxCompilerVcParser implements CompilerParser {
 
   private static String removeMPPrefix(String fpath) {
     // /MP (Build with Multiple Processes) will create a line prefix with the job number eg. '   42>'
-    if (fpath.matches("^\\d+>.*$")) {
-      return fpath.substring(fpath.indexOf('>') + 1, fpath.length());
+    Matcher m = jobNumberPrefixPattern.matcher(fpath);
+    if (m.matches()) {
+      return m.group(1);
     }
     return fpath;
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/DrMemoryParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/DrMemoryParser.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -108,11 +109,7 @@ public final class DrMemoryParser {
     }
 
     public List<Location> getStackTrace() {
-      return (ArrayList<Location>) ((ArrayList<Location>) stackTrace).clone();
-    }
-
-    public void setStackTrace(List<Location> stackTrace) {
-      this.stackTrace = new ArrayList<>(stackTrace);
+      return Collections.unmodifiableList(stackTrace);
     }
 
     public String getMessage() {
@@ -194,10 +191,11 @@ public final class DrMemoryParser {
       StringBuilder sb = new StringBuilder();
       String line;
       int cnt = 0;
+      final Pattern whitespacesOnly = Pattern.compile("^\\s*$");
 
       while ((line = br.readLine()) != null) {
         if (cnt > (TOP_COUNT)) {
-          if (line.matches("^\\s*$")) {
+          if (whitespacesOnly.matcher(line).matches()) {
             list.add(sb.toString());
             sb.setLength(0);
           } else {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensor.java
@@ -48,6 +48,9 @@ public class CxxPCLintSensor extends CxxReportSensor {
   private static final Logger LOG = Loggers.get(CxxPCLintSensor.class);
   public static final String REPORT_PATH_KEY = "pclint.reportPath";
   public static final String KEY = "PC-Lint";
+  public static final Pattern misraRulePattern = Pattern.compile(
+      // Rule nn.nn -or- Rule nn-nn-nn
+      "Rule\\x20(\\d{1,2}.\\d{1,2}|\\d{1,2}-\\d{1,2}-\\d{1,2})(,|\\])");
 
   /**
    * CxxPCLintSensor for PC-lint Sensor
@@ -99,7 +102,7 @@ public class CxxPCLintSensor extends CxxReportSensor {
 
             if (isInputValid(file, line, id, msg)) {
               if (msg.contains("MISRA")) {
-                //remap MISRA IDs. Only Unique rules for MISRA C 2004 and MISRA C/C++ 2008 
+                //remap MISRA IDs. Only Unique rules for MISRA C 2004 and MISRA C/C++ 2008
                 // have been created in the rule repository
                 if (msg.contains("MISRA 2004") || msg.contains("MISRA 2008")
                   || msg.contains("MISRA C++ 2008") || msg.contains("MISRA C++ Rule")) {
@@ -143,11 +146,7 @@ public class CxxPCLintSensor extends CxxReportSensor {
        * Concatenate M with the MISRA rule number to get the new rule id to save the violation to.
        */
       private String mapMisraRulesToUniqueSonarRules(String msg, Boolean isMisra2012) {
-        Pattern pattern = Pattern.compile(
-          // Rule nn.nn -or- Rule nn-nn-nn
-          "Rule\\x20(\\d{1,2}.\\d{1,2}|\\d{1,2}-\\d{1,2}-\\d{1,2})(,|\\])"
-        );
-        Matcher matcher = pattern.matcher(msg);
+        Matcher matcher = misraRulePattern.matcher(msg);
         if (matcher.find()) {
           String misraRule = matcher.group(1);
           String newKey;

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseCommandObject.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseCommandObject.java
@@ -21,6 +21,7 @@ package org.sonar.cxx.sensors.utils;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -136,7 +137,7 @@ public class JsonCompilationDatabaseCommandObject implements Serializable {
    * Extension to define include directories
    */
   public List<String> getIncludes() {
-    return (ArrayList<String>) includes.clone();
+    return Collections.unmodifiableList(includes);
   }
 
   public void setIncludes(List<String> includes) {


### PR DESCRIPTION
see also #1464

* extract compilation of regex out of loops
* apply groups instead of substrings
* use Path API instead for detecting of absolute paths

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1469)
<!-- Reviewable:end -->
