### PR TITLE
remove scanOnlySpecifiedSources

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
@@ -77,7 +77,6 @@ public class CxxSquidSensor implements Sensor {
   public static final String C_FILES_PATTERNS_KEY = "cFilesPatterns";
   public static final String MISSING_INCLUDE_WARN = "missingIncludeWarnings";
   public static final String JSON_COMPILATION_DATABASE_KEY = "jsonCompilationDatabase";
-  public static final String SCAN_ONLY_SPECIFIED_SOURCES_KEY = "scanOnlySpecifiedSources";
 
   public static final String CPD_IGNORE_LITERALS_KEY = "cpd.ignoreLiterals";
   public static final String CPD_IGNORE_IDENTIFIERS_KEY = "cpd.ignoreIdentifiers";
@@ -145,23 +144,14 @@ public class CxxSquidSensor implements Sensor {
     AstScanner<Grammar> scanner = CxxAstScanner.create(this.language, cxxConf,
       visitors.toArray(new SquidAstVisitor[visitors.size()]));
 
-    List<File> files;
-    if (cxxConf.isScanOnlySpecifiedSources()) {
-      files = cxxConf.getCompilationUnitSourceFiles();
-    } else {
-      Iterable<InputFile> inputFiles = context.fileSystem().inputFiles(context.fileSystem().predicates()
-        .and(context.fileSystem().predicates()
-          .hasLanguage(this.language.getKey()), context.fileSystem().predicates()
-          .hasType(InputFile.Type.MAIN)));
+    Iterable<InputFile> inputFiles = context.fileSystem().inputFiles(context.fileSystem().predicates()
+      .and(context.fileSystem().predicates()
+        .hasLanguage(this.language.getKey()), context.fileSystem().predicates()
+        .hasType(InputFile.Type.MAIN)));
 
-      files = new ArrayList<>();
-      for (InputFile file : inputFiles) {
-        files.add(file.file()); //@todo: deprecated file.file()
-      }
-    }
-
-    if (LOG.isDebugEnabled() && !files.isEmpty()) {
-      LOG.debug("All source files (Type.MAIN): {}", files);
+    List<File> files = new ArrayList<>();
+    for (InputFile file : inputFiles) {
+      files.add(new File(file.uri().getPath()));
     }
 
     scanner.scanFiles(files);
@@ -184,8 +174,6 @@ public class CxxSquidSensor implements Sensor {
       .orElse(Boolean.FALSE));
     cxxConf.setJsonCompilationDatabaseFile(this.language.getStringOption(JSON_COMPILATION_DATABASE_KEY)
       .orElse(null));
-    cxxConf.setScanOnlySpecifiedSources(this.language.getBooleanOption(SCAN_ONLY_SPECIFIED_SOURCES_KEY)
-      .orElse(Boolean.FALSE));
 
     if (cxxConf.getJsonCompilationDatabaseFile() != null) {
       try {

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
@@ -50,7 +50,6 @@ public class CxxConfiguration extends SquidConfiguration {
   private List<String> cFilesPatterns = new ArrayList<>();
   private boolean missingIncludeWarningsEnabled = true;
   private String jsonCompilationDatabaseFile;
-  private boolean scanOnlySpecifiedSources;
   private CxxCompilationUnitSettings globalCompilationUnitSettings;
   private final Map<String, CxxCompilationUnitSettings> compilationUnitSettings = new HashMap<>();
 
@@ -224,14 +223,6 @@ public class CxxConfiguration extends SquidConfiguration {
 
   public void setJsonCompilationDatabaseFile(String jsonCompilationDatabaseFile) {
     this.jsonCompilationDatabaseFile = jsonCompilationDatabaseFile;
-  }
-
-  public boolean isScanOnlySpecifiedSources() {
-    return scanOnlySpecifiedSources;
-  }
-
-  public void setScanOnlySpecifiedSources(boolean scanOnlySpecifiedSources) {
-    this.scanOnlySpecifiedSources = scanOnlySpecifiedSources;
   }
 
   public CxxCompilationUnitSettings getGlobalCompilationUnitSettings() {

--- a/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
+++ b/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
@@ -84,7 +84,6 @@ public final class CPlugin implements Plugin {
   public static final String C_FILES_PATTERNS_KEY = LANG_PROP_PREFIX + "cFilesPatterns";
   public static final String MISSING_INCLUDE_WARN = LANG_PROP_PREFIX + "missingIncludeWarnings";
   public static final String JSON_COMPILATION_DATABASE_KEY = LANG_PROP_PREFIX + "jsonCompilationDatabase";
-  public static final String SCAN_ONLY_SPECIFIED_SOURCES_KEY = LANG_PROP_PREFIX + "scanOnlySpecifiedSources";
   public static final String CPD_IGNORE_LITERALS_KEY = LANG_PROP_PREFIX + "cpd.ignoreLiterals";
   public static final String CPD_IGNORE_IDENTIFIERS_KEY = LANG_PROP_PREFIX + "cpd.ignoreIdentifiers";
 
@@ -170,15 +169,6 @@ public final class CPlugin implements Plugin {
           + "and includes should be used for source files.")
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .index(9)
-        .build(),
-      PropertyDefinition.builder(CPlugin.SCAN_ONLY_SPECIFIED_SOURCES_KEY)
-        .defaultValue(Boolean.FALSE.toString())
-        .name("Scan only specified source files")
-        .description("Only scan source files defined in specification file. Eg. by JSON Compilation Database.")
-        .subCategory(subcateg)
-        .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .type(PropertyType.BOOLEAN)
-        .index(10)
         .build()
     ));
   }

--- a/sonar-c-plugin/src/test/java/org/sonar/plugins/c/CPluginTest.java
+++ b/sonar-c-plugin/src/test/java/org/sonar/plugins/c/CPluginTest.java
@@ -35,6 +35,6 @@ public class CPluginTest {
     Plugin.Context context = new Plugin.Context(runtime);
     CPlugin plugin = new CPlugin();
     plugin.define(context);
-    assertThat(context.getExtensions()).hasSize(68);
+    assertThat(context.getExtensions()).hasSize(67);
   }
 }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -87,7 +87,6 @@ public final class CxxPlugin implements Plugin {
   public static final String C_FILES_PATTERNS_KEY = LANG_PROP_PREFIX + "cFilesPatterns";
   public static final String MISSING_INCLUDE_WARN = LANG_PROP_PREFIX + "missingIncludeWarnings";
   public static final String JSON_COMPILATION_DATABASE_KEY = LANG_PROP_PREFIX + "jsonCompilationDatabase";
-  public static final String SCAN_ONLY_SPECIFIED_SOURCES_KEY = LANG_PROP_PREFIX + "scanOnlySpecifiedSources";
   public static final String CPD_IGNORE_LITERALS_KEY = LANG_PROP_PREFIX + "cpd.ignoreLiterals";
   public static final String CPD_IGNORE_IDENTIFIERS_KEY = LANG_PROP_PREFIX + "cpd.ignoreIdentifiers";
 
@@ -178,15 +177,6 @@ public final class CxxPlugin implements Plugin {
           + "used for source files.")
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .index(9)
-        .build(),
-      PropertyDefinition.builder(CxxPlugin.SCAN_ONLY_SPECIFIED_SOURCES_KEY)
-        .defaultValue(Boolean.FALSE.toString())
-        .name("Scan only specified source files")
-        .description("Only scan source files defined in specification file. Eg. by JSON Compilation Database.")
-        .subCategory(subcateg)
-        .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .type(PropertyType.BOOLEAN)
-        .index(10)
         .build()
     ));
   }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -35,6 +35,6 @@ public class CxxPluginTest {
     Plugin.Context context = new Plugin.Context(runtime);
     CxxPlugin plugin = new CxxPlugin();
     plugin.define(context);
-    assertThat(context.getExtensions()).hasSize(72);
+    assertThat(context.getExtensions()).hasSize(71);
   }
 }


### PR DESCRIPTION
Remove `scanOnlySpecifiedSources` because behaviour is not consistent. There is a conflict with `sonar.sources` and `sonar.tests` settings (see also #1474). In general this should be solved in a way to solve also #1365.

- close #1474
- close #1475