### PR TITLE
JoinStringsPreprocessor: store original tokens for highlighting

### DIFF
--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxHighlighterTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxHighlighterTest.java
@@ -83,8 +83,36 @@ public class CxxHighlighterTest {
     checkOnRange(86, 24, 6, TypeOfText.STRING); // u"..."
     checkOnRange(87, 24, 6, TypeOfText.STRING); // U"..."
 
-    checkOnRange(89, 24, 13, TypeOfText.STRING); // "hello" " world"
-    checkOnRange(90, 24, 13, TypeOfText.STRING); // u"" "hello world"
+    // "hello" " world"
+    checkOnRange(89, 24, 7, TypeOfText.STRING);
+    checkOnRange(89, 32, 8, TypeOfText.STRING);
+
+    // u"" "hello world"
+    checkOnRange(90, 24, 3, TypeOfText.STRING);
+    checkOnRange(90, 28, 13, TypeOfText.STRING);
+
+    // /*comment1*/ u"" /*comment2*/ "hello world" /*comment3*/; // issue #996
+    checkOnRange(91, 24, 12, TypeOfText.COMMENT);
+    checkOnRange(91, 37, 3, TypeOfText.STRING);
+    checkOnRange(91, 41, 12, TypeOfText.COMMENT);
+    checkOnRange(91, 54, 13, TypeOfText.STRING);
+    checkOnRange(91, 68, 12, TypeOfText.COMMENT);
+    checkOnRange(91, 82, 13, TypeOfText.COMMENT);
+
+    // /*comment4*/ "hello"
+    // /*comment5*/ " world" /*comment6*/;
+    checkOnRange(93, 24, 12, TypeOfText.COMMENT);
+    checkOnRange(93, 37, 7, TypeOfText.STRING);
+    checkOnRange(94, 24, 12, TypeOfText.COMMENT);
+    checkOnRange(94, 37, 8, TypeOfText.STRING);
+    checkOnRange(94, 46, 12, TypeOfText.COMMENT);
+
+    // "hello"
+    // "Mary"
+    // "Lou";
+    checkOnRange(96, 25, 7, TypeOfText.STRING);
+    checkOnRange(97, 25, 6, TypeOfText.STRING);
+    checkOnRange(98, 25, 5, TypeOfText.STRING);
   }
 
   @Test

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/highlighter.cc
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/highlighter.cc
@@ -89,6 +89,13 @@ void test3()
    const char     *t6 = "hello" " world";
    const wchar_t  *t7 = u"" "hello world";
    const wchar_t  *t8 = /*comment1*/ u"" /*comment2*/ "hello world" /*comment3*/; // issue #996
+
+   const char     *t9 = /*comment4*/ "hello"
+                        /*comment5*/ " world" /*comment6*/;
+
+   const char     *t10 = "hello"
+                         "Mary"
+                         "Lou";
 }
 
 /* EOF */


### PR DESCRIPTION
Fix highlighting issue #1468

* `JoinStringsPreprocessor` replaces adjacent string Tokens
  with a single concatenated one
* Previously the original Tokens were lost and proper highligting
  for multiline adjacent string literals were impossible
* Solution:
  a) store original Tokens as Trivia
  b) if such trivia was found during highlighting: highlight
     preserved Tokens

* ALSO minor refactoring and simplification of `JoinStringsPreprocessor`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1480)
<!-- Reviewable:end -->
