### PR TITLE
cache TooManyLinesOfCodeInFunctionCheck.getNumberOfLine

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxAstScanner.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxAstScanner.java
@@ -36,6 +36,7 @@ import org.sonar.cxx.parser.CxxParser;
 import org.sonar.cxx.visitors.CxxCharsetAwareVisitor;
 import org.sonar.cxx.visitors.CxxCognitiveComplexityVisitor;
 import org.sonar.cxx.visitors.CxxFileVisitor;
+import org.sonar.cxx.visitors.CxxLinesOfCodeInFunctionBodyVisitor;
 import org.sonar.cxx.visitors.CxxLinesOfCodeVisitor;
 import org.sonar.cxx.visitors.CxxParseErrorLoggerVisitor;
 import org.sonar.cxx.visitors.CxxPublicApiVisitor;
@@ -199,6 +200,7 @@ public final class CxxAstScanner {
     /* Metrics */
     builder.withSquidAstVisitor(new LinesVisitor<>(CxxMetric.LINES));
     builder.withSquidAstVisitor(new CxxLinesOfCodeVisitor<>(CxxMetric.LINES_OF_CODE));
+    builder.withSquidAstVisitor(new CxxLinesOfCodeInFunctionBodyVisitor<>());
     builder.withSquidAstVisitor(new CxxPublicApiVisitor<>(CxxMetric.PUBLIC_API,
       CxxMetric.PUBLIC_UNDOCUMENTED_API)
       .withHeaderFileSuffixes(conf.getHeaderFileSuffixes()));

--- a/cxx-squid/src/main/java/org/sonar/cxx/api/CxxMetric.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/api/CxxMetric.java
@@ -27,6 +27,7 @@ public enum CxxMetric implements MetricDef {
   FILES,
   LINES,
   LINES_OF_CODE,
+  LINES_OF_CODE_IN_FUNCTION_BODY,
   STATEMENTS,
   FUNCTIONS,
   CLASSES,

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxLinesOfCodeInFunctionBodyVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxLinesOfCodeInFunctionBodyVisitor.java
@@ -1,0 +1,65 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2018 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.visitors;
+
+import java.util.List;
+
+import org.sonar.cxx.api.CppPunctuator;
+import org.sonar.cxx.api.CxxMetric;
+import org.sonar.cxx.parser.CxxGrammarImpl;
+import org.sonar.squidbridge.SquidAstVisitor;
+
+import com.sonar.sslr.api.AstNode;
+import com.sonar.sslr.api.AstVisitor;
+import com.sonar.sslr.api.Grammar;
+
+/**
+ * Visitor that computes the NCLOCs in function body, leading and trailing {} do not count
+ *
+ * @param <GRAMMAR>
+ */
+public class CxxLinesOfCodeInFunctionBodyVisitor<GRAMMAR extends Grammar> extends SquidAstVisitor<GRAMMAR>
+    implements AstVisitor {
+
+  @Override
+  public void init() {
+    subscribeTo(CxxGrammarImpl.functionBody);
+  }
+
+  @Override
+  public void visitNode(AstNode node) {
+    List<AstNode> allChilds = node.getDescendants(CxxGrammarImpl.statement, CppPunctuator.CURLBR_LEFT,
+        CppPunctuator.CURLBR_RIGHT);
+    int lines = 1;
+    int firstLine = node.getTokenLine();
+    if (allChilds != null && !allChilds.isEmpty()) {
+      int previousLine = firstLine;
+      for (AstNode child : allChilds) {
+        int currentLine = child.getTokenLine();
+        if (currentLine != previousLine) {
+          lines++;
+          previousLine = currentLine;
+        }
+      }
+    }
+    getContext().peekSourceCode().add(CxxMetric.LINES_OF_CODE_IN_FUNCTION_BODY, lines);
+  }
+
+}

--- a/cxx-squid/src/test/java/org/sonar/cxx/api/CxxMetricTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/api/CxxMetricTest.java
@@ -27,7 +27,7 @@ public class CxxMetricTest {
   @Test
   public void test() {
     SoftAssertions softly = new SoftAssertions();
-    softly.assertThat(CxxMetric.values()).hasSize(11);
+    softly.assertThat(CxxMetric.values()).hasSize(12);
 
     for (CxxMetric metric : CxxMetric.values()) {
       softly.assertThat(metric.getName()).isEqualTo(metric.name());


### PR DESCRIPTION
this function is called 3 times for each function declaration
* TooManyLinesOfCodeInFunctionCheck
* CxxFunctionComplexitySquidSensor
* CxxFunctionSizeSquidSensor

solution: calculate only once and store this metric
in CxxMetric.LINES_OF_CODE_IN_FUNCION_BODY

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1503)
<!-- Reviewable:end -->
