### PR TITLE
cppcheck sensor: fix handling of warnings with multiple locations

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CppcheckParserV2.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CppcheckParserV2.java
@@ -20,6 +20,9 @@
 package org.sonar.cxx.sensors.cppcheck;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import javax.annotation.Nullable;
 import javax.xml.stream.XMLStreamException;
 import org.codehaus.staxmate.in.SMHierarchicCursor;
@@ -28,6 +31,7 @@ import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.sensors.utils.CxxReportIssue;
+import org.sonar.cxx.sensors.utils.CxxReportLocation;
 import org.sonar.cxx.sensors.utils.EmptyReportException;
 import org.sonar.cxx.sensors.utils.StaxParser;
 
@@ -85,51 +89,9 @@ public class CppcheckParserV2 implements CppcheckParser {
             if (errorsCursor.getNext() != null) {
               parsed = true;
               SMInputCursor errorCursor = errorsCursor.childElementCursor("error");
+
               while (errorCursor.getNext() != null) {
-                String id = requireAttributeSet(errorCursor.getAttrValue("id"),
-                    "Missing mandatory attribute /results/errors/error[@id]");
-                String msg = requireAttributeSet(errorCursor.getAttrValue("msg"),
-                    "Missing mandatory attribute /results/errors/error[@msg]");
-                Boolean isInconclusive = "true".equals(errorCursor.getAttrValue("inconclusive"));
-                String issueText = createIssueText(msg, isInconclusive);
-                CxxReportIssue issue = null;
-
-                SMInputCursor locationCursor = errorCursor.childElementCursor("location");
-                while (locationCursor.getNext() != null) {
-                  String file = locationCursor.getAttrValue("file");
-                  String line = locationCursor.getAttrValue("line");
-                  String info = locationCursor.getAttrValue("info");
-
-                  if (file != null) {
-                    file = file.replace('\\', '/');
-                  }
-
-                  if ("*".equals(file)) {
-                    // findings on project level
-                    file = null;
-                    line = null;
-                    info = null;
-                  }
-
-                  if (issue == null) {
-                    // primary location
-                    issue = new CxxReportIssue(CxxCppCheckRuleRepository.KEY, id, file, line, issueText);
-                    // add the same file:line second time if there is additional
-                    // information about the flow/analysis
-                    if (info != null && !msg.equals(info)) {
-                      issue.addLocation(file, line, info);
-                    }
-                  } else if (info != null) {
-                    // secondary location
-                    issue.addLocation(file, line, info);
-                  }
-                }
-
-                // no <location> tags: issue raised on the whole module/project
-                if (issue == null) {
-                  issue = new CxxReportIssue(CxxCppCheckRuleRepository.KEY, id, null, null, issueText);
-                }
-                sensor.saveUniqueViolation(context, issue);
+                processErrorTag(context, errorCursor);
               }
             }
           }
@@ -140,6 +102,90 @@ public class CppcheckParserV2 implements CppcheckParser {
         if (!parsed) {
           throw new XMLStreamException();
         }
+      }
+
+      private void processErrorTag(final SensorContext context, SMInputCursor errorCursor) throws XMLStreamException {
+        String id = requireAttributeSet(errorCursor.getAttrValue("id"),
+            "Missing mandatory attribute /results/errors/error[@id]");
+        String msg = requireAttributeSet(errorCursor.getAttrValue("msg"),
+            "Missing mandatory attribute /results/errors/error[@msg]");
+        Boolean isInconclusive = "true".equals(errorCursor.getAttrValue("inconclusive"));
+        String issueText = createIssueText(msg, isInconclusive);
+        CxxReportIssue issue = null;
+
+        SMInputCursor locationCursor = errorCursor.childElementCursor("location");
+        while (locationCursor.getNext() != null) {
+          String file = locationCursor.getAttrValue("file");
+          String line = locationCursor.getAttrValue("line");
+          String info = locationCursor.getAttrValue("info");
+
+          if (file != null) {
+            file = file.replace('\\', '/');
+          }
+
+          if ("*".equals(file)) {
+            // findings on project level
+            file = null;
+            line = null;
+            info = null;
+          }
+
+          final boolean isLocationInProject = isLocationInProject(file, context);
+          if (issue == null) {
+            // primary location
+            // if primary location cannot be found in the current project (in
+            // the current module) we are not interested in this <error>
+            if (!isLocationInProject) {
+              LOG.warn("Cannot find the file '{}', skipping violations", file);
+              return;
+            }
+
+            issue = new CxxReportIssue(CxxCppCheckRuleRepository.KEY, id, file, line, issueText);
+            // add the same <file>:<line> second time if there is additional
+            // information about the flow/analysis
+            if (info != null && !msg.equals(info)) {
+              issue.addLocation(file, line, info);
+            }
+          } else if (info != null) {
+            // secondary location
+            // secondary location cannot reference a file, which is missing in
+            // the current project (in the current module). If such case occurs
+            // we'll use a primary location and move the affected path to the
+            // info
+            if (isLocationInProject) {
+              issue.addLocation(file, line, info);
+            } else {
+              CxxReportLocation primaryLocation = issue.getLocations().get(0);
+              String primaryFile = primaryLocation.getFile();
+              String primaryLine = primaryLocation.getLine();
+
+              StringBuilder extendedInfo = new StringBuilder();
+              extendedInfo.append(makeRelativePath(file, primaryFile)).append(":").append(line).append(" ")
+                  .append(info);
+              issue.addLocation(primaryFile, primaryLine, extendedInfo.toString());
+            }
+          }
+        }
+
+        // no <location> tags: issue raised on the whole module/project
+        if (issue == null) {
+          issue = new CxxReportIssue(CxxCppCheckRuleRepository.KEY, id, null, null, issueText);
+        }
+        sensor.saveUniqueViolation(context, issue);
+      }
+
+      private String makeRelativePath(String path, String basePath) {
+        try {
+          return Paths.get(basePath).relativize(Paths.get(path)).toString();
+        } catch (IllegalArgumentException e) {
+          return path;
+        }
+      }
+
+      private boolean isLocationInProject(String file, final SensorContext context) {
+        // file == null means that we are dealing with a warning for the whole
+        // project/module
+        return (file == null) || (sensor.getInputFileIfInProject(context, file) != null);
       }
     });
 

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxReportSensor.java
@@ -270,7 +270,7 @@ public abstract class CxxReportSensor implements Sensor {
     }
   }
 
-  protected InputFile getInputFileIfInProject(SensorContext sensorContext, String path) {
+  public InputFile getInputFileIfInProject(SensorContext sensorContext, String path) {
     String root = sensorContext.fileSystem().baseDir().getAbsolutePath();
     String normalPath = CxxUtils.normalizePathFull(path, root);
     if (normalPath == null || notFoundFiles.contains(normalPath)) {


### PR DESCRIPTION
close #1511

for each `<location>` in the `<error>` tag peform the existance check

1. primary locaton
```PYTHON
if not is_location_in_project(primary_location):
   #error is not relevant for this module - skip
   return
else:
   issue.add_location(primary_location)
```

2. secondary location
```PYTHON
if is_location_in_project(secondary_location):
    issue.add_location(secondary_location)
else:
    extended_info = seconary_location.file + ":" + secondary_location.line + " " + secondary_location.info
    fake_location = create(primary_location.file, primary_location.line, extended_info)
    issue.add_location(fake_location)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1512)
<!-- Reviewable:end -->
