### PR TITLE
Fix #1521: rules repository ignored the language specific repository suffix

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepository.java
@@ -29,7 +29,7 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxClangSARuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String KEY = "ClangSA";
+  private static final String KEY = "ClangSA";
   public static final String CUSTOM_RULES_KEY = "clangsa.customRules";
   private static final String NAME = "Clang-SA";
 
@@ -39,6 +39,10 @@ public class CxxClangSARuleRepository extends CxxAbstractRuleRepository {
   public CxxClangSARuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader,
     CxxLanguage language) {
     super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+  }
+
+  public static String getRepositoryKey(CxxLanguage lang) {
+    return CxxAbstractRuleRepository.getRepositoryKey(KEY, lang);
   }
 
   @Override

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepository.java
@@ -29,7 +29,7 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxClangTidyRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String KEY = "ClangTidy";
+  private static final String KEY = "ClangTidy";
   public static final String CUSTOM_RULES_KEY = "clangtidy.customRules";
   private static final String NAME = "Clang-Tidy";
 
@@ -39,6 +39,10 @@ public class CxxClangTidyRuleRepository extends CxxAbstractRuleRepository {
   public CxxClangTidyRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader,
     CxxLanguage language) {
     super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+  }
+
+  public static String getRepositoryKey(CxxLanguage lang) {
+    return CxxAbstractRuleRepository.getRepositoryKey(KEY, lang);
   }
 
   @Override

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CompilerParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CompilerParser.java
@@ -40,13 +40,6 @@ public interface CompilerParser {
   String key();
 
   /**
-   * Get the key identifying the rules repository for this compiler.
-   *
-   * @return The key of the rules repository associated with this compiler.
-   */
-  String rulesRepositoryKey();
-
-  /**
    * Get the default regexp used to parse warning messages.
    *
    * @return The default regexp.

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerGccParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerGccParser.java
@@ -54,14 +54,6 @@ public class CxxCompilerGccParser implements CompilerParser {
    * {@inheritDoc}
    */
   @Override
-  public String rulesRepositoryKey() {
-    return CxxCompilerGccRuleRepository.KEY;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
   public String defaultRegexp() {
     return DEFAULT_REGEX_DEF;
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerGccRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerGccRuleRepository.java
@@ -29,7 +29,7 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxCompilerGccRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String KEY = "compiler-gcc";
+  private static final String KEY = "compiler-gcc";
   public static final String CUSTOM_RULES_KEY = "compiler-gcc.customRules";
   private static final String NAME = "Compiler-GCC";
 
@@ -38,6 +38,10 @@ public class CxxCompilerGccRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxCompilerGccRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader, CxxLanguage language) {
     super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+  }
+
+  public static String getRepositoryKey(CxxLanguage lang) {
+    return CxxAbstractRuleRepository.getRepositoryKey(KEY, lang);
   }
 
   @Override

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerGccSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerGccSensor.java
@@ -1,0 +1,52 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2018 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.sensors.compiler;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.config.Configuration;
+import org.sonar.cxx.CxxLanguage;
+
+public class CxxCompilerGccSensor extends CxxCompilerSensor {
+
+  private class IsGccParserConfigured implements Predicate<Configuration> {
+    @Override
+    public boolean test(Configuration config) {
+      if (!config.hasKey(getReportPathKey())) {
+        return false;
+      }
+      final Optional<String> parserValue = config.get(getLanguage().getPluginProperty(PARSER_KEY_DEF));
+      return parserValue.isPresent() && CxxCompilerGccParser.KEY_GCC.equals(parserValue.get());
+    }
+  };
+
+  public CxxCompilerGccSensor(CxxLanguage language) {
+    super(language, REPORT_PATH_KEY, CxxCompilerGccRuleRepository.getRepositoryKey(language),
+        new CxxCompilerGccParser());
+  }
+
+  @Override
+  public void describe(SensorDescriptor descriptor) {
+    descriptor.name(getLanguage().getName() + " CxxCompilerGccSensor").onlyOnLanguage(getLanguage().getKey())
+        .createIssuesForRuleRepositories(getReportPathKey()).onlyWhenConfiguration(new IsGccParserConfigured());
+  }
+}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensor.java
@@ -20,19 +20,16 @@
 package org.sonar.cxx.sensors.compiler;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.CxxMetricsFactory;
+import org.sonar.cxx.sensors.utils.CxxIssuesReportSensor;
 import org.sonar.cxx.sensors.utils.CxxReportIssue;
-import org.sonar.cxx.sensors.utils.CxxReportSensor;
 
 /**
  * compiler for C++ with advanced analysis features (e.g. for VC 2008 team edition or 2010/2012/2013/2015/2017 premium
@@ -40,7 +37,7 @@ import org.sonar.cxx.sensors.utils.CxxReportSensor;
  *
  * @author Bert
  */
-public class CxxCompilerSensor extends CxxReportSensor {
+public abstract class CxxCompilerSensor extends CxxIssuesReportSensor {
 
   private static final Logger LOG = Loggers.get(CxxCompilerSensor.class);
   public static final String REPORT_PATH_KEY = "compiler.reportPath";
@@ -49,67 +46,22 @@ public class CxxCompilerSensor extends CxxReportSensor {
   public static final String PARSER_KEY_DEF = "compiler.parser";
   public static final String DEFAULT_PARSER_DEF = CxxCompilerVcParser.KEY_VC;
   public static final String DEFAULT_CHARSET_DEF = "UTF-8";
-  public static final String KEY = "Compiler";
 
-  private final Map<String, CompilerParser> parsers = new HashMap<>();
+  private final CompilerParser parser;
 
-  /**
-   * CxxCompilerSensor for Visual Studio C++ Compiler Sensor
-   *
-   * @param language defines settings C or C++
-   */
-  public CxxCompilerSensor(CxxLanguage language) {
-    super(language);
-
-    addCompilerParser(new CxxCompilerVcParser());
-    addCompilerParser(new CxxCompilerGccParser());
-  }
-
-  @Override
-  public void describe(SensorDescriptor descriptor) {
-    descriptor
-      .name(language.getName() + " CompilerSensor")
-      .onlyOnLanguage(this.language.getKey())
-      .createIssuesForRuleRepositories(CxxCompilerGccRuleRepository.KEY, CxxCompilerVcRuleRepository.KEY)
-      .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathKey()));
-  }
-
-  @Override
-  public String getReportPathKey() {
-    return language.getPluginProperty(REPORT_PATH_KEY);
-  }
-
-  /**
-   * Add a compiler parser.
-   */
-  private void addCompilerParser(CompilerParser parser) {
-    parsers.put(parser.key(), parser);
-  }
-
-  /**
-   * Get the compiler parser to use.
-   *
-   * @return CompilerParser
-   */
-  protected CompilerParser getCompilerParser(SensorContext context) {
-    Optional<String> parserValue = context.config().get(this.language.getPluginProperty(PARSER_KEY_DEF));
-    String parserDefault = this.language.getPluginProperty(this.language.getPluginProperty(DEFAULT_PARSER_DEF));
-    CompilerParser parser = parsers.get(parserDefault);
-    if (parserValue.isPresent()) {
-      parser = parsers.get(parserValue.get());
-    }
-    LOG.info("C-Compiler parser: '{}'", parserValue);
-    return parser;
+  protected CxxCompilerSensor(CxxLanguage language, String propertiesKeyPathToReports, String ruleRepositoryKey,
+      CompilerParser parser) {
+    super(language, propertiesKeyPathToReports, ruleRepositoryKey);
+    this.parser = parser;
   }
 
   @Override
   protected void processReport(final SensorContext context, File report)
     throws javax.xml.stream.XMLStreamException {
-    final CompilerParser parser = getCompilerParser(context);
-    final String reportCharset = getContextStringProperty(context,
-      this.language.getPluginProperty(REPORT_CHARSET_DEF), parser.defaultCharset());
-    final String reportRegEx = getContextStringProperty(context,
-      this.language.getPluginProperty(REPORT_REGEX_DEF), parser.defaultRegexp());
+    final String reportCharset = getContextStringProperty(context, getLanguage().getPluginProperty(REPORT_CHARSET_DEF),
+        parser.defaultCharset());
+    final String reportRegEx = getContextStringProperty(context, getLanguage().getPluginProperty(REPORT_REGEX_DEF),
+        parser.defaultRegexp());
     final List<CompilerParser.Warning> warnings = new LinkedList<>();
 
     // Iterate through the lines of the input file
@@ -118,7 +70,7 @@ public class CxxCompilerSensor extends CxxReportSensor {
       parser.processReport(context, report, reportCharset, reportRegEx, warnings);
       for (CompilerParser.Warning w : warnings) {
         if (isInputValid(w)) {
-          CxxReportIssue issue = new CxxReportIssue(parser.rulesRepositoryKey(), w.id, w.filename, w.line, w.msg);
+          CxxReportIssue issue = new CxxReportIssue(w.id, w.filename, w.line, w.msg);
           saveUniqueViolation(context, issue);
         } else {
           LOG.warn("C-Compiler warning: '{}''{}'", w.id, w.msg);
@@ -134,12 +86,7 @@ public class CxxCompilerSensor extends CxxReportSensor {
   }
 
   @Override
-  protected String getSensorKey() {
-    return KEY;
-  }
-
-  @Override
-  protected Optional<CxxMetricsFactory.Key> getMetricKey() {
-    return Optional.of(CxxMetricsFactory.Key.COMPILER_SENSOR_ISSUES_KEY);
+  protected CxxMetricsFactory.Key getMetricKey() {
+    return CxxMetricsFactory.Key.COMPILER_SENSOR_ISSUES_KEY;
   }
 }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerVcParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerVcParser.java
@@ -56,14 +56,6 @@ public class CxxCompilerVcParser implements CompilerParser {
    * {@inheritDoc}
    */
   @Override
-  public String rulesRepositoryKey() {
-    return CxxCompilerVcRuleRepository.KEY;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
   public String defaultRegexp() {
     return DEFAULT_REGEX_DEF;
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerVcRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerVcRuleRepository.java
@@ -29,7 +29,7 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxCompilerVcRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String KEY = "compiler-vc";
+  private static final String KEY = "compiler-vc";
   public static final String CUSTOM_RULES_KEY = "compiler-vc.customRules";
   private static final String NAME = "Compiler-VC";
 
@@ -39,6 +39,10 @@ public class CxxCompilerVcRuleRepository extends CxxAbstractRuleRepository {
   public CxxCompilerVcRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader,
     CxxLanguage language) {
     super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+  }
+
+  public static String getRepositoryKey(CxxLanguage lang) {
+    return CxxAbstractRuleRepository.getRepositoryKey(KEY, lang);
   }
 
   @Override

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerVcSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerVcSensor.java
@@ -1,0 +1,55 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2018 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.sensors.compiler;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.config.Configuration;
+import org.sonar.cxx.CxxLanguage;
+
+public class CxxCompilerVcSensor extends CxxCompilerSensor {
+
+  private class IsVcParserConfigured implements Predicate<Configuration> {
+    @Override
+    public boolean test(Configuration config) {
+      if (!config.hasKey(getReportPathKey())) {
+        return false;
+      }
+      // VC parser is default, so basically enable it always if GCC is not
+      // configured
+      final Optional<String> parserValue = config.get(getLanguage().getPluginProperty(PARSER_KEY_DEF));
+      final boolean isGCCParserConfigured = parserValue.isPresent()
+          && CxxCompilerGccParser.KEY_GCC.equals(parserValue.get());
+      return !isGCCParserConfigured;
+    }
+  };
+
+  public CxxCompilerVcSensor(CxxLanguage language) {
+    super(language, REPORT_PATH_KEY, CxxCompilerVcRuleRepository.getRepositoryKey(language), new CxxCompilerVcParser());
+  }
+
+  @Override
+  public void describe(SensorDescriptor descriptor) {
+    descriptor.name(getLanguage().getName() + " CxxCompilerVcSensor").onlyOnLanguage(getLanguage().getKey())
+        .createIssuesForRuleRepositories(getReportPathKey()).onlyWhenConfiguration(new IsVcParserConfigured());
+  }
+}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CppcheckParserV1.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CppcheckParserV1.java
@@ -80,7 +80,7 @@ public class CppcheckParserV1 implements CppcheckParser {
             }
 
             if (isInputValid(id, msg)) {
-              CxxReportIssue issue = new CxxReportIssue(CxxCppCheckRuleRepository.KEY, id, file, line, msg);
+              CxxReportIssue issue = new CxxReportIssue(id, file, line, msg);
               sensor.saveUniqueViolation(context, issue);
             } else {
               LOG.warn("Skipping invalid violation: '{}'", msg);

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CppcheckParserV2.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CppcheckParserV2.java
@@ -20,11 +20,11 @@
 package org.sonar.cxx.sensors.cppcheck;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import javax.annotation.Nullable;
 import javax.xml.stream.XMLStreamException;
+
 import org.codehaus.staxmate.in.SMHierarchicCursor;
 import org.codehaus.staxmate.in.SMInputCursor;
 import org.sonar.api.batch.sensor.SensorContext;
@@ -140,7 +140,7 @@ public class CppcheckParserV2 implements CppcheckParser {
               return;
             }
 
-            issue = new CxxReportIssue(CxxCppCheckRuleRepository.KEY, id, file, line, issueText);
+            issue = new CxxReportIssue(id, file, line, issueText);
             // add the same <file>:<line> second time if there is additional
             // information about the flow/analysis
             if (info != null && !msg.equals(info)) {
@@ -169,7 +169,7 @@ public class CppcheckParserV2 implements CppcheckParser {
 
         // no <location> tags: issue raised on the whole module/project
         if (issue == null) {
-          issue = new CxxReportIssue(CxxCppCheckRuleRepository.KEY, id, null, null, issueText);
+          issue = new CxxReportIssue(id, null, null, issueText);
         }
         sensor.saveUniqueViolation(context, issue);
       }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepository.java
@@ -29,7 +29,7 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxCppCheckRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String KEY = "cppcheck";
+  private static final String KEY = "cppcheck";
   public static final String CUSTOM_RULES_KEY = "cppcheck.customRules";
   private static final String NAME = "Cppcheck";
 
@@ -38,6 +38,10 @@ public class CxxCppCheckRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxCppCheckRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader, CxxLanguage language) {
     super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+  }
+
+  public static String getRepositoryKey(CxxLanguage lang) {
+    return CxxAbstractRuleRepository.getRepositoryKey(KEY, lang);
   }
 
   @Override

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/CxxDrMemoryRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/CxxDrMemoryRuleRepository.java
@@ -29,7 +29,7 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxDrMemoryRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String KEY = "drmemory";
+  private static final String KEY = "drmemory";
   public static final String CUSTOM_RULES_KEY = "drmemory.customRules";
   private static final String NAME = "Dr Memory";
 
@@ -38,6 +38,10 @@ public class CxxDrMemoryRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxDrMemoryRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader, CxxLanguage language) {
     super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+  }
+
+  public static String getRepositoryKey(CxxLanguage lang) {
+    return CxxAbstractRuleRepository.getRepositoryKey(KEY, lang);
   }
 
   @Override

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/other/CxxOtherRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/other/CxxOtherRepository.java
@@ -25,6 +25,7 @@ import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
+import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
 
 /**
  * Loads the external rules configuration file.
@@ -32,7 +33,7 @@ import org.sonar.cxx.CxxLanguage;
 public class CxxOtherRepository implements RulesDefinition {
 
   private static final Logger LOG = Loggers.get(CxxOtherRepository.class);
-  public static final String KEY = "other";
+  private static final String KEY = "other";
   public static final String RULES_KEY = "other.rules";
   private final RulesDefinitionXmlLoader xmlRuleLoader;
   private static final String NAME = "Other";
@@ -48,10 +49,14 @@ public class CxxOtherRepository implements RulesDefinition {
     this.language = language;
   }
 
+  public static String getRepositoryKey(CxxLanguage lang) {
+    return CxxAbstractRuleRepository.getRepositoryKey(KEY, lang);
+  }
+
   @Override
   public void define(Context context) {
-    NewRepository repository = context.createRepository(KEY + this.language.getRepositorySuffix(), 
-                      this.language.getKey()).setName(NAME + this.language.getRepositorySuffix());
+    NewRepository repository = context.createRepository(getRepositoryKey(language), this.language.getKey())
+        .setName(NAME);
 
     xmlRuleLoader.load(repository, getClass().getResourceAsStream("/external-rule.xml"), "UTF-8");
     for (String ruleDefs : this.language.getStringArrayOption(RULES_KEY)) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/pclint/CxxPCLintRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/pclint/CxxPCLintRuleRepository.java
@@ -29,7 +29,7 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxPCLintRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String KEY = "pclint";
+  private static final String KEY = "pclint";
   public static final String CUSTOM_RULES_KEY = "pclint.customRules";
   private static final String NAME = "PC-lint";
 
@@ -38,6 +38,10 @@ public class CxxPCLintRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxPCLintRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader, CxxLanguage language) {
     super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+  }
+
+  public static String getRepositoryKey(CxxLanguage lang) {
+    return CxxAbstractRuleRepository.getRepositoryKey(KEY, lang);
   }
 
   @Override

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/rats/CxxRatsRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/rats/CxxRatsRuleRepository.java
@@ -29,7 +29,7 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxRatsRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String KEY = "rats";
+  private static final String KEY = "rats";
   public static final String CUSTOM_RULES_KEY = "rats.customRules";
   private static final String NAME = "RATS";
 
@@ -38,6 +38,10 @@ public class CxxRatsRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxRatsRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader, CxxLanguage language) {
     super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+  }
+
+  public static String getRepositoryKey(CxxLanguage lang) {
+    return CxxAbstractRuleRepository.getRepositoryKey(KEY, lang);
   }
 
   @Override

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/rats/CxxRatsSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/rats/CxxRatsSensor.java
@@ -21,30 +21,30 @@ package org.sonar.cxx.sensors.rats;
 
 import java.io.File;
 import java.util.List;
-import java.util.Optional;
 
 import javax.annotation.Nullable;
+
 import org.jdom2.Element;
 import org.jdom2.input.SAXBuilder;
+import org.jdom2.input.sax.XMLReaders;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.CxxMetricsFactory;
+import org.sonar.cxx.sensors.utils.CxxIssuesReportSensor;
 import org.sonar.cxx.sensors.utils.CxxReportIssue;
-import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.CxxUtils;
 
 /**
  * {@inheritDoc}
  */
-public class CxxRatsSensor extends CxxReportSensor {
+public class CxxRatsSensor extends CxxIssuesReportSensor {
 
   private static final Logger LOG = Loggers.get(CxxRatsSensor.class);
   private static final String MISSING_RATS_TYPE = "fixed size global buffer";
   public static final String REPORT_PATH_KEY = "rats.reportPath";
-  public static final String KEY = "Rats";
 
   /**
    * CxxRatsSensor for RATS Sensor
@@ -52,21 +52,16 @@ public class CxxRatsSensor extends CxxReportSensor {
    * @param language defines settings C or C++
    */
   public CxxRatsSensor(CxxLanguage language) {
-    super(language);
+    super(language, REPORT_PATH_KEY, CxxRatsRuleRepository.getRepositoryKey(language));
   }
 
   @Override
   public void describe(SensorDescriptor descriptor) {
     descriptor
-      .name(language.getName() + " RatsSensor")
-      .onlyOnLanguage(this.language.getKey())
-      .createIssuesForRuleRepository(CxxRatsRuleRepository.KEY)
+      .name(getLanguage().getName() + " RatsSensor")
+      .onlyOnLanguage(getLanguage().getKey())
+      .createIssuesForRuleRepository(getRuleRepositoryKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathKey()));
-  }
-
-  @Override
-  public String getReportPathKey() {
-    return this.language.getPluginProperty(REPORT_PATH_KEY);
   }
 
   @Override
@@ -75,26 +70,23 @@ public class CxxRatsSensor extends CxxReportSensor {
     LOG.debug("Parsing 'RATS' format");
 
     try {
-      SAXBuilder builder = new SAXBuilder(false);
+      SAXBuilder builder = new SAXBuilder(XMLReaders.NONVALIDATING);
       Element root = builder.build(report).getRootElement();
-      @SuppressWarnings("unchecked")
       List<Element> vulnerabilities = root.getChildren("vulnerability");
       for (Element vulnerability : vulnerabilities) {
         String type = getVulnerabilityType(vulnerability.getChild("type"));
         String message = vulnerability.getChild("message").getTextTrim();
 
-        @SuppressWarnings("unchecked")
         List<Element> files = vulnerability.getChildren("file");
 
         for (Element file : files) {
           String fileName = file.getChild("name").getTextTrim();
 
-          @SuppressWarnings("unchecked")
           List<Element> lines = file.getChildren("line");
           for (Element lineElem : lines) {
             String line = lineElem.getTextTrim();
 
-            CxxReportIssue issue = new CxxReportIssue(CxxRatsRuleRepository.KEY, type, fileName, line, message);
+            CxxReportIssue issue = new CxxReportIssue(type, fileName, line, message);
             saveUniqueViolation(context, issue);
           }
         }
@@ -113,12 +105,7 @@ public class CxxRatsSensor extends CxxReportSensor {
   }
 
   @Override
-  protected String getSensorKey() {
-    return KEY;
-  }
-
-  @Override
-  protected Optional<CxxMetricsFactory.Key> getMetricKey() {
-    return Optional.of(CxxMetricsFactory.Key.RATS_SENSOR_ISSUES_KEY);
+  protected CxxMetricsFactory.Key getMetricKey() {
+    return CxxMetricsFactory.Key.RATS_SENSOR_ISSUES_KEY;
   }
 }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/tests/xunit/CxxXunitSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/tests/xunit/CxxXunitSensor.java
@@ -24,12 +24,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
-import java.util.Optional;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamSource;
+
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.measures.CoreMetrics;
@@ -37,7 +37,6 @@ import org.sonar.api.utils.ParsingUtils;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
-import org.sonar.cxx.CxxMetricsFactory;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.CxxUtils;
 import org.sonar.cxx.sensors.utils.EmptyReportException;
@@ -50,7 +49,6 @@ public class CxxXunitSensor extends CxxReportSensor {
 
   private static final Logger LOG = Loggers.get(CxxXunitSensor.class);
   public static final String REPORT_PATH_KEY = "xunit.reportPath";
-  public static final String KEY = "Xunit";
   public static final String XSLT_URL_KEY = "xunit.xsltURL";
   private static final double PERCENT_BASE = 100D;
 
@@ -61,7 +59,7 @@ public class CxxXunitSensor extends CxxReportSensor {
    * @param language for C or C++
    */
   public CxxXunitSensor(CxxLanguage language) {
-    super(language);
+    super(language, REPORT_PATH_KEY);
     if (language.getStringOption(XSLT_URL_KEY).isPresent()) {
       xsltURL = language.getStringOption(XSLT_URL_KEY).orElse("xunit-report.xslt");
     }
@@ -70,14 +68,9 @@ public class CxxXunitSensor extends CxxReportSensor {
   @Override
   public void describe(SensorDescriptor descriptor) {
     descriptor
-      .name(language.getName() + " XunitSensor")
-      //.onlyOnLanguage(this.language.getKey())
+      .name(getLanguage().getName() + " XunitSensor")
+      //.onlyOnLanguage(getLanguage().getKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathKey()));
-  }
-
-  @Override
-  public String getReportPathKey() {
-    return this.language.getPluginProperty(REPORT_PATH_KEY);
   }
 
   /**
@@ -111,7 +104,7 @@ public class CxxXunitSensor extends CxxReportSensor {
         .append("'")
         .toString();
       LOG.error(msg);
-      CxxUtils.validateRecovery(e, this.language);
+      CxxUtils.validateRecovery(e, getLanguage());
     }
   }
 
@@ -172,7 +165,7 @@ public class CxxXunitSensor extends CxxReportSensor {
           .save();
       } catch (IllegalArgumentException ex) {
         LOG.error("Cannot save measure TESTS : '{}', ignoring measure", ex.getMessage());
-        CxxUtils.validateRecovery(ex, this.language);
+        CxxUtils.validateRecovery(ex, getLanguage());
       }
 
       try {
@@ -183,7 +176,7 @@ public class CxxXunitSensor extends CxxReportSensor {
           .save();
       } catch (IllegalArgumentException ex) {
         LOG.error("Cannot save measure TEST_ERRORS : '{}', ignoring measure", ex.getMessage());
-        CxxUtils.validateRecovery(ex, this.language);
+        CxxUtils.validateRecovery(ex, getLanguage());
       }
 
       try {
@@ -194,7 +187,7 @@ public class CxxXunitSensor extends CxxReportSensor {
           .save();
       } catch (IllegalArgumentException ex) {
         LOG.error("Cannot save measure TEST_FAILURES : '{}', ignoring measure", ex.getMessage());
-        CxxUtils.validateRecovery(ex, this.language);
+        CxxUtils.validateRecovery(ex, getLanguage());
       }
 
       try {
@@ -205,7 +198,7 @@ public class CxxXunitSensor extends CxxReportSensor {
           .save();
       } catch (IllegalArgumentException ex) {
         LOG.error("Cannot save measure SKIPPED_TESTS : '{}', ignoring measure", ex.getMessage());
-        CxxUtils.validateRecovery(ex, this.language);
+        CxxUtils.validateRecovery(ex, getLanguage());
       }
 
       try {
@@ -216,7 +209,7 @@ public class CxxXunitSensor extends CxxReportSensor {
           .save();
       } catch (IllegalArgumentException ex) {
         LOG.error("Cannot save measure TEST_SUCCESS_DENSITY : '{}', ignoring measure", ex.getMessage());
-        CxxUtils.validateRecovery(ex, this.language);
+        CxxUtils.validateRecovery(ex, getLanguage());
       }
 
       try {
@@ -227,7 +220,7 @@ public class CxxXunitSensor extends CxxReportSensor {
           .save();
       } catch (IllegalArgumentException ex) {
         LOG.error("Cannot save measure TEST_EXECUTION_TIME : '{}', ignoring measure", ex.getMessage());
-        CxxUtils.validateRecovery(ex, this.language);
+        CxxUtils.validateRecovery(ex, getLanguage());
       }
     } else {
       LOG.debug("The reports contain no testcases");
@@ -254,15 +247,5 @@ public class CxxXunitSensor extends CxxReportSensor {
     }
 
     return transformed;
-  }
-
-  @Override
-  protected String getSensorKey() {
-    return KEY;
-  }
-
-  @Override
-  protected Optional<CxxMetricsFactory.Key> getMetricKey() {
-    return Optional.empty();
   }
 }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxAbstractRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxAbstractRuleRepository.java
@@ -64,10 +64,14 @@ public abstract class CxxAbstractRuleRepository implements RulesDefinition {
     CxxLanguage language) {
     this.fileSystem = fileSystem;
     this.xmlRuleLoader = xmlRuleLoader;
-    this.repositoryKey = key + language.getRepositorySuffix();
+    this.repositoryKey = getRepositoryKey(key, language);
     this.repositoryName = name;
     this.customRepositoryKey = customKey;
     this.language = language;
+  }
+
+  public static String getRepositoryKey(String key, CxxLanguage lang) {
+    return key + lang.getRepositorySuffix();
   }
 
   @Override

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
@@ -1,0 +1,256 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2018 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.sensors.utils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.issue.NewIssue;
+import org.sonar.api.batch.sensor.issue.NewIssueLocation;
+import org.sonar.api.measures.Metric;
+import org.sonar.api.rule.RuleKey;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import org.sonar.cxx.CxxLanguage;
+import org.sonar.cxx.CxxMetricsFactory;
+
+/**
+ * This class is used as base for all sensors which import external reports,
+ * which contain issues. It hosts common logic such as saving issues in SonarQube
+ */
+public abstract class CxxIssuesReportSensor extends CxxReportSensor {
+
+  private static final Logger LOG = Loggers.get(CxxIssuesReportSensor.class);
+  private final Set<String> notFoundFiles = new HashSet<>();
+  private final Set<CxxReportIssue> uniqueIssues = new HashSet<>();
+  private final Map<InputFile, Integer> violationsPerFileCount = new HashMap<>();
+  private int violationsPerModuleCount;
+  private final String ruleRepositoryKey;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected CxxIssuesReportSensor(CxxLanguage language, String propertiesKeyPathToReports, String ruleRepositoryKey) {
+    super(language, propertiesKeyPathToReports);
+    this.ruleRepositoryKey = ruleRepositoryKey;
+  }
+
+  public String getRuleRepositoryKey()
+  {
+    return ruleRepositoryKey;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void execute(SensorContext context) {
+    try {
+      LOG.info("Searching reports by relative path with basedir '{}' and search prop '{}'",
+        context.fileSystem().baseDir(), getReportPathKey());
+      List<File> reports = getReports(context.config(), context.fileSystem().baseDir(), getReportPathKey());
+      violationsPerFileCount.clear();
+      violationsPerModuleCount = 0;
+
+      for (File report : reports) {
+        int prevViolationsCount = violationsPerModuleCount;
+        LOG.info("Processing report '{}'", report);
+        executeReport(context, report, prevViolationsCount);
+      }
+
+
+      Metric<Integer> metric = getLanguage().getMetric(this.getMetricKey());
+      LOG.info("{} processed = {}", metric.getKey(), violationsPerModuleCount);
+
+      for (Map.Entry<InputFile, Integer> entry : violationsPerFileCount.entrySet()) {
+        context.<Integer>newMeasure()
+          .forMetric(metric)
+          .on(entry.getKey())
+          .withValue(entry.getValue())
+          .save();
+      }
+
+      // this sensor could be executed on module without any files
+      // (possible for hierarchical multi-module projects)
+      // don't publish 0 as module metric,
+      // let AggregateMeasureComputer calculate the correct value
+      if ( violationsPerModuleCount != 0 ) {
+        context.<Integer>newMeasure()
+          .forMetric(metric)
+          .on(context.module())
+          .withValue(violationsPerModuleCount)
+          .save();
+      }
+    } catch (Exception e) {
+      String msg = new StringBuilder()
+        .append("Cannot feed the data into sonar, details: '")
+        .append(e)
+        .append("'")
+        .toString();
+      LOG.error(msg);
+      CxxUtils.validateRecovery(e, getLanguage());
+    }
+  }
+
+  /**
+   * @param context
+   * @param report
+   * @param prevViolationsCount
+   * @throws Exception
+   */
+  private void executeReport(SensorContext context, File report, int prevViolationsCount) throws Exception {
+    try {
+      processReport(context, report);
+      if (LOG.isDebugEnabled()) {
+        Metric<Integer> metric = getLanguage().getMetric(this.getMetricKey());
+        LOG.debug("{} processed = {}", metric.getKey(),
+          violationsPerModuleCount - prevViolationsCount);
+      }
+    } catch (EmptyReportException e) {
+      LOG.warn("The report '{}' seems to be empty, ignoring.", report);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Cannot read report", e);
+      }
+      CxxUtils.validateRecovery(e, getLanguage());
+    }
+  }
+
+  protected abstract void processReport(final SensorContext context, File report) throws Exception;
+
+  /**
+   * Saves code violation only if it wasn't already saved
+   *
+   * @param sensorContext
+   * @param issue
+   */
+  public void saveUniqueViolation(SensorContext sensorContext, CxxReportIssue issue) {
+    if (uniqueIssues.add(issue)) {
+      saveViolation(sensorContext, issue);
+    }
+  }
+
+  public InputFile getInputFileIfInProject(SensorContext sensorContext, String path) {
+    String root = sensorContext.fileSystem().baseDir().getAbsolutePath();
+    String normalPath = CxxUtils.normalizePathFull(path, root);
+    if (normalPath == null || notFoundFiles.contains(normalPath)) {
+      return null;
+    }
+    InputFile inputFile = sensorContext.fileSystem()
+        .inputFile(sensorContext.fileSystem().predicates().hasAbsolutePath(normalPath));
+    if (inputFile == null) {
+      notFoundFiles.add(normalPath);
+    }
+    return inputFile;
+  }
+
+  private NewIssueLocation createNewIssueLocationFile(SensorContext sensorContext, NewIssue newIssue,
+      CxxReportLocation location, Set<InputFile> affectedFiles) {
+    InputFile inputFile = getInputFileIfInProject(sensorContext, location.getFile());
+    if (inputFile != null) {
+      int lines = inputFile.lines();
+      int lineNr = Integer.max(1, getLineAsInt(location.getLine(), lines));
+      NewIssueLocation newIssueLocation = newIssue.newLocation().on(inputFile).at(inputFile.selectLine(lineNr))
+          .message(location.getInfo());
+      affectedFiles.add(inputFile);
+      return newIssueLocation;
+    } else {
+      LOG.warn("Cannot find the file '{}', skipping violations", location.getFile());
+      return null;
+    }
+  }
+
+  private static NewIssueLocation createNewIssueLocationModule(SensorContext sensorContext, NewIssue newIssue,
+      CxxReportLocation location) {
+    return newIssue.newLocation().on(sensorContext.module()).message(location.getInfo());
+  }
+
+  /**
+   * Saves a code violation which is detected in the given file/line and has given ruleId and message. Saves it to the
+   * given project and context. Project or file-level violations can be saved by passing null for the according
+   * parameters ('file' = null for project level, 'line' = null for file-level)
+   */
+  private void saveViolation(SensorContext sensorContext, CxxReportIssue issue) {
+    NewIssue newIssue = sensorContext.newIssue().forRule(RuleKey.of(getRuleRepositoryKey(), issue.getRuleId()));
+
+    Set<InputFile> affectedFiles = new HashSet<>();
+    List<NewIssueLocation> newIssueLocations = new ArrayList<>();
+
+    for (CxxReportLocation location : issue.getLocations()) {
+      if (location.getFile() != null && !location.getFile().isEmpty()) {
+        NewIssueLocation newIssueLocation = createNewIssueLocationFile(sensorContext, newIssue, location,
+            affectedFiles);
+        if (newIssueLocation != null) {
+          newIssueLocations.add(newIssueLocation);
+        }
+      } else {
+        NewIssueLocation newIssueLocation = createNewIssueLocationModule(sensorContext, newIssue, location);
+        newIssueLocations.add(newIssueLocation);
+      }
+    }
+
+    if (!newIssueLocations.isEmpty()) {
+      try {
+        newIssue.at(newIssueLocations.get(0));
+        for (int i = 1; i < newIssueLocations.size(); i++) {
+          newIssue.addLocation(newIssueLocations.get(i));
+        }
+        newIssue.save();
+
+        for (InputFile affectedFile : affectedFiles) {
+          violationsPerFileCount.merge(affectedFile, 1, Integer::sum);
+        }
+        violationsPerModuleCount++;
+      } catch (RuntimeException ex) {
+        LOG.error("Could not add the issue '{}':{}', skipping issue", issue.toString(), CxxUtils.getStackTrace(ex));
+        CxxUtils.validateRecovery(ex, getLanguage());
+      }
+    }
+  }
+
+  private int getLineAsInt(@Nullable String line, int maxLine) {
+    int lineNr = 0;
+    if (line != null) {
+      try {
+        lineNr = Integer.parseInt(line);
+        if (lineNr < 1) {
+          lineNr = 1;
+        } else if (lineNr > maxLine) { // https://jira.sonarsource.com/browse/SONAR-6792
+          lineNr = maxLine;
+        }
+      } catch (java.lang.NumberFormatException nfe) {
+        LOG.warn("Skipping invalid line number: {}", line);
+        CxxUtils.validateRecovery(nfe, getLanguage());
+        lineNr = -1;
+      }
+    }
+    return lineNr;
+  }
+
+  protected abstract CxxMetricsFactory.Key getMetricKey();
+}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxReportIssue.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxReportIssue.java
@@ -30,13 +30,11 @@ import javax.annotation.Nullable;
  * Issue with one or multiple locations
  */
 public class CxxReportIssue {
-  private final String ruleRepoKey;
   private final String ruleId;
   private final List<CxxReportLocation> locations;
 
-  public CxxReportIssue(String ruleRepoKey, String ruleId, @Nullable String file, @Nullable String line, String info) {
+  public CxxReportIssue(String ruleId, @Nullable String file, @Nullable String line, String info) {
     super();
-    this.ruleRepoKey = ruleRepoKey;
     this.ruleId = ruleId;
     this.locations = new ArrayList<>();
     addLocation(file, line, info);
@@ -44,10 +42,6 @@ public class CxxReportIssue {
 
   public final void addLocation(@Nullable String file, @Nullable String line, String info) {
     locations.add(new CxxReportLocation(file, line, info));
-  }
-
-  public String getRuleRepoKey() {
-    return ruleRepoKey;
   }
 
   public String getRuleId() {
@@ -61,13 +55,12 @@ public class CxxReportIssue {
   @Override
   public String toString() {
     String locationsToString = locations.stream().map(Object::toString).collect(Collectors.joining(", "));
-    return "CxxReportIssue [ruleRepoKey=" + ruleRepoKey + ", ruleId=" + ruleId + ", locations=" + locationsToString
-        + "]";
+    return "CxxReportIssue [ruleId=" + ruleId + ", locations=" + locationsToString + "]";
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(locations, ruleId, ruleRepoKey);
+    return Objects.hash(locations, ruleId);
   }
 
   @Override
@@ -82,7 +75,6 @@ public class CxxReportIssue {
       return false;
     }
     CxxReportIssue other = (CxxReportIssue) obj;
-    return Objects.equals(locations, other.locations) && Objects.equals(ruleId, other.ruleId)
-        && Objects.equals(ruleRepoKey, other.ruleRepoKey);
+    return Objects.equals(locations, other.locations) && Objects.equals(ruleId, other.ruleId);
   }
 }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/valgrind/CxxValgrindRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/valgrind/CxxValgrindRuleRepository.java
@@ -29,7 +29,7 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxValgrindRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String KEY = "valgrind";
+  private static final String KEY = "valgrind";
   public static final String CUSTOM_RULES_KEY = "valgrind.customRules";
   private static final String NAME = "Valgrind";
 
@@ -38,6 +38,10 @@ public class CxxValgrindRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxValgrindRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader, CxxLanguage language) {
     super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+  }
+
+  public static String getRepositoryKey(CxxLanguage lang) {
+    return CxxAbstractRuleRepository.getRepositoryKey(KEY, lang);
   }
 
   @Override

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxRuleRepository.java
@@ -29,7 +29,7 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxVeraxxRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String KEY = "vera++";
+  private static final String KEY = "vera++";
   public static final String CUSTOM_RULES_KEY = "vera++.customRules";
   private static final String NAME = "Vera++";
 
@@ -38,6 +38,10 @@ public class CxxVeraxxRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxVeraxxRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader, CxxLanguage language) {
     super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+  }
+
+  public static String getRepositoryKey(CxxLanguage lang) {
+    return CxxAbstractRuleRepository.getRepositoryKey(KEY, lang);
   }
 
   @Override

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxSensor.java
@@ -20,7 +20,6 @@
 package org.sonar.cxx.sensors.veraxx;
 
 import java.io.File;
-import java.util.Optional;
 
 import org.codehaus.staxmate.in.SMHierarchicCursor;
 import org.codehaus.staxmate.in.SMInputCursor;
@@ -30,8 +29,8 @@ import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.CxxMetricsFactory;
+import org.sonar.cxx.sensors.utils.CxxIssuesReportSensor;
 import org.sonar.cxx.sensors.utils.CxxReportIssue;
-import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.CxxUtils;
 import org.sonar.cxx.sensors.utils.EmptyReportException;
 import org.sonar.cxx.sensors.utils.StaxParser;
@@ -39,11 +38,10 @@ import org.sonar.cxx.sensors.utils.StaxParser;
 /**
  * {@inheritDoc}
  */
-public class CxxVeraxxSensor extends CxxReportSensor {
+public class CxxVeraxxSensor extends CxxIssuesReportSensor {
 
   private static final Logger LOG = Loggers.get(CxxVeraxxSensor.class);
   public static final String REPORT_PATH_KEY = "vera.reportPath";
-  public static final String KEY = "Vera++";
 
   /**
    * CxxVeraxxSensor for C++ Vera Sensor
@@ -51,21 +49,16 @@ public class CxxVeraxxSensor extends CxxReportSensor {
    * @param language defines settings C or C++
    */
   public CxxVeraxxSensor(CxxLanguage language) {
-    super(language);
+    super(language, REPORT_PATH_KEY, CxxVeraxxRuleRepository.getRepositoryKey(language));
   }
 
   @Override
   public void describe(SensorDescriptor descriptor) {
     descriptor
-      .name(language.getName() + " VeraxxSensor")
-      .onlyOnLanguage(this.language.getKey())
-      .createIssuesForRuleRepository(CxxVeraxxRuleRepository.KEY)
+      .name(getLanguage().getName() + " VeraxxSensor")
+      .onlyOnLanguage(getLanguage().getKey())
+      .createIssuesForRuleRepository(getRuleRepositoryKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathKey()));
-  }
-
-  @Override
-  public String getReportPathKey() {
-    return this.language.getPluginProperty(REPORT_PATH_KEY);
   }
 
   @Override
@@ -96,7 +89,7 @@ public class CxxVeraxxSensor extends CxxReportSensor {
                 String message = errorCursor.getAttrValue("message");
                 String source = errorCursor.getAttrValue("source");
 
-                CxxReportIssue issue = new CxxReportIssue(CxxVeraxxRuleRepository.KEY, source, name, line, message);
+                CxxReportIssue issue = new CxxReportIssue(source, name, line, message);
                 saveUniqueViolation(context, issue);
               } else {
                 if (LOG.isDebugEnabled()) {
@@ -117,12 +110,7 @@ public class CxxVeraxxSensor extends CxxReportSensor {
   }
 
   @Override
-  protected String getSensorKey() {
-    return KEY;
-  }
-
-  @Override
-  protected Optional<CxxMetricsFactory.Key> getMetricKey() {
-    return Optional.of(CxxMetricsFactory.Key.VERAXX_SENSOR_KEY);
+  protected CxxMetricsFactory.Key getMetricKey() {
+    return CxxMetricsFactory.Key.VERAXX_SENSOR_KEY;
   }
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepositoryTest.java
@@ -40,7 +40,7 @@ public class CxxClangSARuleRepositoryTest {
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
 
-    RulesDefinition.Repository repo = context.repository(CxxClangSARuleRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(CxxClangSARuleRepository.getRepositoryKey(language));
     assertEquals(111, repo.rules().size());
   }
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensorTest.java
@@ -155,7 +155,7 @@ public class CxxClangSASensorTest {
     SoftAssertions softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo(language.getName() + " ClangSASensor");
     softly.assertThat(descriptor.languages()).containsOnly(language.getKey());
-    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxClangSARuleRepository.KEY);
+    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxClangSARuleRepository.getRepositoryKey(language));
     softly.assertAll();
   }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
@@ -40,7 +40,7 @@ public class CxxClangTidyRuleRepositoryTest {
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
 
-    RulesDefinition.Repository repo = context.repository(CxxClangTidyRuleRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(CxxClangTidyRuleRepository.getRepositoryKey(language));
     assertEquals(155, repo.rules().size());
   }
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensorTest.java
@@ -105,11 +105,11 @@ public class CxxClangTidySensorTest {
     CxxClangTidySensor sensor = new CxxClangTidySensor(language);
     sensor.describe(descriptor);
 
-    SoftAssertions softly = new SoftAssertions(); 
+    SoftAssertions softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo(language.getName() + " ClangTidySensor");
     softly.assertThat(descriptor.languages()).containsOnly(language.getKey());
-    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxClangTidyRuleRepository.KEY);
+    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxClangTidyRuleRepository.getRepositoryKey(language));
     softly.assertAll();
   }
-  
+
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/CxxCompilerRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/CxxCompilerRuleRepositoryTest.java
@@ -41,7 +41,7 @@ public class CxxCompilerRuleRepositoryTest {
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
 
-    RulesDefinition.Repository repo = context.repository(CxxCompilerVcRuleRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(CxxCompilerVcRuleRepository.getRepositoryKey(language));
     assertThat(repo.rules()).hasSize(888);
   }
 
@@ -56,7 +56,7 @@ public class CxxCompilerRuleRepositoryTest {
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
 
-    RulesDefinition.Repository repo = context.repository(CxxCompilerGccRuleRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(CxxCompilerGccRuleRepository.getRepositoryKey(language));
     assertThat(repo.rules()).hasSize(230);
   }
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensorTest.java
@@ -66,7 +66,7 @@ public class CxxCompilerSensorTest {
     context.fileSystem().add(TestInputFileBuilder.create("ProjectKey", "src/zipmanager.cpp")
       .setLanguage("cpp").initMetadata("asd\nasdas\nasda\n").build());
 
-    CxxCompilerSensor sensor = new CxxCompilerSensor(language);
+    CxxCompilerSensor sensor = new CxxCompilerGccSensor(language);
     sensor.execute(context);
     assertThat(context.allIssues()).hasSize(4);
   }
@@ -83,7 +83,7 @@ public class CxxCompilerSensorTest {
     context.fileSystem().add(TestInputFileBuilder.create("ProjectKey", "zipmanager.cpp")
       .setLanguage("cpp").initMetadata("asd\nasdas\nasda\n").build());
 
-    CxxCompilerSensor sensor = new CxxCompilerSensor(language);
+    CxxCompilerSensor sensor = new CxxCompilerVcSensor(language);
     sensor.execute(context);
     assertThat(context.allIssues()).hasSize(9);
   }
@@ -102,7 +102,7 @@ public class CxxCompilerSensorTest {
     context.fileSystem().add(TestInputFileBuilder.create("ProjectKey", "Server/source/zip/zipmanager.cpp")
       .setLanguage("cpp").initMetadata("asd\nasdas\nasda\n").build());
 
-    CxxCompilerSensor sensor = new CxxCompilerSensor(language);
+    CxxCompilerSensor sensor = new CxxCompilerVcSensor(language);
     sensor.execute(context);
     assertThat(context.allIssues()).hasSize(9);
   }
@@ -120,7 +120,7 @@ public class CxxCompilerSensorTest {
     context.fileSystem().add(TestInputFileBuilder.create("ProjectKey", "Server/source/zip/zipmanager.cpp")
       .setLanguage("cpp").initMetadata("asd\nasdas\nasda\n").build());
 
-    CxxCompilerSensor sensor = new CxxCompilerSensor(language);
+    CxxCompilerSensor sensor = new CxxCompilerVcSensor(language);
     sensor.execute(context);
     assertThat(context.allIssues()).hasSize(9);
   }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/MockCxxCompilerSensor.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/MockCxxCompilerSensor.java
@@ -31,6 +31,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.profiles.RulesProfile;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.sensors.utils.CxxReportIssue;
@@ -38,11 +39,9 @@ import org.sonar.cxx.sensors.utils.CxxReportLocation;
 
 public class MockCxxCompilerSensor extends CxxCompilerSensor {
 
-  private final List<CompilerParser.Warning> warnings;
   public List<CompilerParser.Warning> savedWarnings;
 
-  @Override
-  protected CompilerParser getCompilerParser(SensorContext context) {
+  private static CompilerParser mocktCompilerParser(List<CompilerParser.Warning> warnings) {
 
     CompilerParser compileParser = mock(CompilerParser.class);
 
@@ -68,15 +67,13 @@ public class MockCxxCompilerSensor extends CxxCompilerSensor {
   }
 
   public MockCxxCompilerSensor(CxxLanguage language, FileSystem fs, RulesProfile profile, List<CompilerParser.Warning> warningsToProcess) {
-    super(language);
+    super(language, REPORT_PATH_KEY, "", mocktCompilerParser(warningsToProcess) );
 
-    warnings = warningsToProcess;
     savedWarnings = new LinkedList<>();
   }
 
   @Override
   public void saveUniqueViolation(SensorContext context, CxxReportIssue issue) {
-    String ruleRepoKey = issue.getRuleRepoKey();
     String ruleId = issue.getRuleId();
     CxxReportLocation primaryLocation = issue.getLocations().get(0);
     String file = primaryLocation.getFile();
@@ -85,6 +82,10 @@ public class MockCxxCompilerSensor extends CxxCompilerSensor {
 
     CompilerParser.Warning w = new CompilerParser.Warning(file, line, ruleId, msg);
     savedWarnings.add(w);
+  }
+
+  @Override
+  public void describe(SensorDescriptor descriptor) {
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
@@ -40,7 +40,7 @@ public class CxxCppCheckRuleRepositoryTest {
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
 
-    RulesDefinition.Repository repo = context.repository(CxxCppCheckRuleRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(CxxCppCheckRuleRepository.getRepositoryKey(language));
     assertEquals(484, repo.rules().size());
   }
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckSensorTest.java
@@ -163,7 +163,7 @@ public class CxxCppCheckSensorTest {
     SoftAssertions softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo(language.getName() + " CppCheckSensor");
     softly.assertThat(descriptor.languages()).containsOnly(language.getKey());
-    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxCppCheckRuleRepository.KEY);
+    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxCppCheckRuleRepository.getRepositoryKey(language));
     softly.assertAll();
   }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/CxxDrMemoryRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/CxxDrMemoryRuleRepositoryTest.java
@@ -43,7 +43,7 @@ public class CxxDrMemoryRuleRepositoryTest {
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
 
-    RulesDefinition.Repository repo = context.repository(CxxDrMemoryRuleRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(CxxDrMemoryRuleRepository.getRepositoryKey(language));
     List<Rule> rules = repo.rules();
     assertEquals(8, rules.size());
   }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/CxxDrMemorySensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/CxxDrMemorySensorTest.java
@@ -61,18 +61,18 @@ public class CxxDrMemorySensorTest {
     sensor.execute(context);
     assertThat(context.allIssues()).hasSize(1);
   }
-  
+
   @Test
   public void sensorDescriptor() {
     DefaultSensorDescriptor descriptor = new DefaultSensorDescriptor();
     CxxDrMemorySensor sensor = new CxxDrMemorySensor(language);
     sensor.describe(descriptor);
 
-    SoftAssertions softly = new SoftAssertions(); 
+    SoftAssertions softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo(language.getName() + " DrMemorySensor");
     softly.assertThat(descriptor.languages()).containsOnly(language.getKey());
-    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxDrMemoryRuleRepository.KEY);
+    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxDrMemoryRuleRepository.getRepositoryKey(language));
     softly.assertAll();
   }
-  
+
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherRepositoryTest.java
@@ -67,7 +67,7 @@ public class CxxOtherRepositoryTest {
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
 
-    RulesDefinition.Repository repo = context.repository(CxxOtherRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(CxxOtherRepository.getRepositoryKey(language));
     assertThat(repo.rules()).hasSize(1);
   }
 
@@ -84,7 +84,7 @@ public class CxxOtherRepositoryTest {
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
 
-    RulesDefinition.Repository repo = context.repository(CxxOtherRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(CxxOtherRepository.getRepositoryKey(language));
     assertThat(repo.rules()).hasSize(3);
   }
 
@@ -100,7 +100,7 @@ public class CxxOtherRepositoryTest {
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
 
-    RulesDefinition.Repository repo = context.repository(CxxOtherRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(CxxOtherRepository.getRepositoryKey(language));
     assertThat(repo.rules()).hasSize(1);
   }
 
@@ -116,7 +116,7 @@ public class CxxOtherRepositoryTest {
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
 
-    RulesDefinition.Repository repo = context.repository(CxxOtherRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(CxxOtherRepository.getRepositoryKey(language));
     Rule rule = repo.rule("key");
     assertThat(rule).isNotNull();
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherSensorTest.java
@@ -237,11 +237,11 @@ public class CxxOtherSensorTest {
     sensor = new CxxOtherSensor(language);
     sensor.describe(descriptor);
 
-    SoftAssertions softly = new SoftAssertions(); 
+    SoftAssertions softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo(language.getName() + " ExternalRulesSensor");
     softly.assertThat(descriptor.languages()).containsOnly(language.getKey());
-    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxOtherRepository.KEY);
+    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxOtherRepository.getRepositoryKey(language));
     softly.assertAll();
   }
-  
+
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/pclint/CxxPCLintRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/pclint/CxxPCLintRuleRepositoryTest.java
@@ -41,7 +41,7 @@ public class CxxPCLintRuleRepositoryTest {
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
 
-    RulesDefinition.Repository repo = context.repository(CxxPCLintRuleRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(CxxPCLintRuleRepository.getRepositoryKey(language));
     assertEquals(1590, repo.rules().size());
   }
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensorTest.java
@@ -169,18 +169,18 @@ public class CxxPCLintSensorTest {
     sensor.execute(context);
     assertThat(context.allIssues().size()).isZero();
   }
-  
+
   @Test
   public void sensorDescriptor() {
     DefaultSensorDescriptor descriptor = new DefaultSensorDescriptor();
     CxxPCLintSensor sensor = new CxxPCLintSensor(language);
     sensor.describe(descriptor);
 
-    SoftAssertions softly = new SoftAssertions(); 
+    SoftAssertions softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo(language.getName() + " PCLintSensor");
     softly.assertThat(descriptor.languages()).containsOnly(language.getKey());
-    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxPCLintRuleRepository.KEY);
+    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxPCLintRuleRepository.getRepositoryKey(language));
     softly.assertAll();
   }
-  
+
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/rats/CxxRatsRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/rats/CxxRatsRuleRepositoryTest.java
@@ -40,7 +40,7 @@ public class CxxRatsRuleRepositoryTest {
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
 
-    RulesDefinition.Repository repo = context.repository(CxxRatsRuleRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(CxxRatsRuleRepository.getRepositoryKey(language));
     assertThat(repo.rules()).hasSize(313);
   }
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/rats/CxxRatsSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/rats/CxxRatsSensorTest.java
@@ -60,18 +60,18 @@ public class CxxRatsSensorTest {
     sensor.execute(context);
     assertThat(context.allIssues()).hasSize(5);
   }
-  
+
   @Test
   public void sensorDescriptor() {
     DefaultSensorDescriptor descriptor = new DefaultSensorDescriptor();
     sensor = new CxxRatsSensor(language);
     sensor.describe(descriptor);
 
-    SoftAssertions softly = new SoftAssertions(); 
+    SoftAssertions softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo(language.getName() + " RatsSensor");
     softly.assertThat(descriptor.languages()).containsOnly(language.getKey());
-    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxRatsRuleRepository.KEY);
+    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxRatsRuleRepository.getRepositoryKey(language));
     softly.assertAll();
   }
-  
+
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportIssueTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportIssueTest.java
@@ -19,9 +19,10 @@
  */
 package org.sonar.cxx.sensors.utils;
 
-import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
 
 public class CxxReportIssueTest {
 
@@ -42,11 +43,11 @@ public class CxxReportIssueTest {
 
   @Test
   public void reportIssueEquality() {
-    CxxReportIssue issue0 = new CxxReportIssue("cppcheck", "nullPointer", "path0.cpp", "1", "Null pointer dereference: ptr");
+    CxxReportIssue issue0 = new CxxReportIssue("nullPointer", "path0.cpp", "1", "Null pointer dereference: ptr");
     issue0.addLocation("path0.cpp", "1", "Assignment &apos;ptr=nullptr&apos;, assigned value is 0");
 
-    CxxReportIssue issue1 = new CxxReportIssue("cppcheck", "exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
-    CxxReportIssue issue2 = new CxxReportIssue("cppcheck", "exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
+    CxxReportIssue issue1 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
+    CxxReportIssue issue2 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
 
     assertEquals(issue1, issue2);
     assertEquals(issue1.hashCode(), issue2.hashCode());

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportSensorTest.java
@@ -19,18 +19,17 @@
  */
 package org.sonar.cxx.sensors.utils;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.util.List;
-import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.cxx.CxxLanguage;
-import org.sonar.cxx.CxxMetricsFactory;
 
 public class CxxReportSensorTest {
 
@@ -45,7 +44,7 @@ public class CxxReportSensorTest {
   private class CxxReportSensorImpl extends CxxReportSensor {
 
     public CxxReportSensorImpl(CxxLanguage language, MapSettings settings) {
-      super(language);
+      super(language, "test.report");
     }
 
     @Override
@@ -55,21 +54,6 @@ public class CxxReportSensorTest {
     @Override
     public void describe(SensorDescriptor descriptor) {
       descriptor.onlyOnLanguage("c++").name("CxxReportSensorTest");
-    }
-
-    @Override
-    public String getReportPathKey() {
-      return "test.report";
-    }
-
-    @Override
-    protected String getSensorKey() {
-      return "testSensor";
-    }
-
-    @Override
-    protected Optional<CxxMetricsFactory.Key> getMetricKey() {
-      return Optional.empty();
     }
   };
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/CxxValgrindRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/CxxValgrindRuleRepositoryTest.java
@@ -40,7 +40,7 @@ public class CxxValgrindRuleRepositoryTest {
     CxxValgrindRuleRepository def = new CxxValgrindRuleRepository(mock(ServerFileSystem.class), new RulesDefinitionXmlLoader(), language);
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
-    RulesDefinition.Repository repo = context.repository(CxxValgrindRuleRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(CxxValgrindRuleRepository.getRepositoryKey(language));
     assertEquals(16, repo.rules().size());
   }
 
@@ -52,11 +52,12 @@ public class CxxValgrindRuleRepositoryTest {
     CxxLanguage language = TestUtils.mockCxxLanguage();
     CxxValgrindRuleRepository obj = new CxxValgrindRuleRepository(filesystem, new RulesDefinitionXmlLoader(), language);
     CxxValgrindRuleRepository def = spy(obj);
-    doReturn(extensionFile).when(def).getExtensions(CxxValgrindRuleRepository.KEY, "xml");
+    final String repositoryKey = CxxValgrindRuleRepository.getRepositoryKey(language);
+    doReturn(extensionFile).when(def).getExtensions(repositoryKey, "xml");
 
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
-    RulesDefinition.Repository repo = context.repository(CxxValgrindRuleRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(repositoryKey);
     assertEquals(18, repo.rules().size());
   }
 
@@ -68,11 +69,12 @@ public class CxxValgrindRuleRepositoryTest {
     CxxLanguage language = TestUtils.mockCxxLanguage();
     CxxValgrindRuleRepository obj = new CxxValgrindRuleRepository(filesystem, new RulesDefinitionXmlLoader(), language);
     CxxValgrindRuleRepository def = spy(obj);
-    doReturn(extensionFile).when(def).getExtensions(CxxValgrindRuleRepository.KEY, "xml");
+    final String repositoryKey = CxxValgrindRuleRepository.getRepositoryKey(language);
+    doReturn(extensionFile).when(def).getExtensions(repositoryKey, "xml");
 
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
-    RulesDefinition.Repository repo = context.repository(CxxValgrindRuleRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(repositoryKey);
     assertEquals(17, repo.rules().size());
   }
 
@@ -84,11 +86,12 @@ public class CxxValgrindRuleRepositoryTest {
     CxxLanguage language = TestUtils.mockCxxLanguage();
     CxxValgrindRuleRepository obj = new CxxValgrindRuleRepository(filesystem, new RulesDefinitionXmlLoader(), language);
     CxxValgrindRuleRepository def = spy(obj);
-    doReturn(extensionFile).when(def).getExtensions(CxxValgrindRuleRepository.KEY, "xml");
+    final String repositoryKey = CxxValgrindRuleRepository.getRepositoryKey(language);
+    doReturn(extensionFile).when(def).getExtensions(repositoryKey, "xml");
 
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
-    RulesDefinition.Repository repo = context.repository(CxxValgrindRuleRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(repositoryKey);
     assertEquals(16, repo.rules().size());
   }
 
@@ -100,11 +103,12 @@ public class CxxValgrindRuleRepositoryTest {
     CxxLanguage language = TestUtils.mockCxxLanguage();
     CxxValgrindRuleRepository obj = new CxxValgrindRuleRepository(filesystem, new RulesDefinitionXmlLoader(), language);
     CxxValgrindRuleRepository def = spy(obj);
-    doReturn(extensionFile).when(def).getExtensions(CxxValgrindRuleRepository.KEY, "xml");
+    final String repositoryKey = CxxValgrindRuleRepository.getRepositoryKey(language);
+    doReturn(extensionFile).when(def).getExtensions(repositoryKey, "xml");
 
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
-    RulesDefinition.Repository repo = context.repository(CxxValgrindRuleRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(repositoryKey);
     assertEquals(16, repo.rules().size());
   }
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/CxxValgrindSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/CxxValgrindSensorTest.java
@@ -35,7 +35,6 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.cxx.CxxLanguage;
-import org.sonar.cxx.sensors.rats.CxxRatsRuleRepository;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
 public class CxxValgrindSensorTest {
@@ -85,7 +84,7 @@ public class CxxValgrindSensorTest {
     SoftAssertions softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo(language.getName() + " ValgrindSensor");
     softly.assertThat(descriptor.languages()).containsOnly(language.getKey());
-    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxValgrindRuleRepository.KEY);
+    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxValgrindRuleRepository.getRepositoryKey(language));
     softly.assertAll();
   }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxRuleRepositoryTest.java
@@ -40,7 +40,7 @@ public class CxxVeraxxRuleRepositoryTest {
     RulesDefinition.Context context = new RulesDefinition.Context();
     def.define(context);
 
-    RulesDefinition.Repository repo = context.repository(CxxVeraxxRuleRepository.KEY);
+    RulesDefinition.Repository repo = context.repository(CxxVeraxxRuleRepository.getRepositoryKey(language));
     assertThat(repo.rules()).hasSize(28);
   }
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxSensorTest.java
@@ -79,10 +79,10 @@ public class CxxVeraxxSensorTest {
     CxxVeraxxSensor sensor = new CxxVeraxxSensor(language);
     sensor.describe(descriptor);
 
-    SoftAssertions softly = new SoftAssertions(); 
+    SoftAssertions softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo(language.getName() + " VeraxxSensor");
     softly.assertThat(descriptor.languages()).containsOnly(language.getKey());
-    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxVeraxxRuleRepository.KEY);
+    softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxVeraxxRuleRepository.getRepositoryKey(language));
     softly.assertAll();
   }
 }

--- a/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
+++ b/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
@@ -46,9 +46,11 @@ import org.sonar.cxx.sensors.clangtidy.CxxClangTidyRuleRepository;
 import org.sonar.cxx.sensors.clangtidy.CxxClangTidySensor;
 import org.sonar.cxx.sensors.compiler.CxxCompilerGccParser;
 import org.sonar.cxx.sensors.compiler.CxxCompilerGccRuleRepository;
+import org.sonar.cxx.sensors.compiler.CxxCompilerGccSensor;
 import org.sonar.cxx.sensors.compiler.CxxCompilerSensor;
 import org.sonar.cxx.sensors.compiler.CxxCompilerVcParser;
 import org.sonar.cxx.sensors.compiler.CxxCompilerVcRuleRepository;
+import org.sonar.cxx.sensors.compiler.CxxCompilerVcSensor;
 import org.sonar.cxx.sensors.coverage.CxxCoverageCache;
 import org.sonar.cxx.sensors.coverage.CxxCoverageSensor;
 import org.sonar.cxx.sensors.cppcheck.CxxCppCheckRuleRepository;
@@ -495,7 +497,8 @@ public final class CPlugin implements Plugin {
     l.add(CxxCppCheckSensorImpl.class);
     l.add(CxxPCLintSensorImpl.class);
     l.add(CxxDrMemorySensorImpl.class);
-    l.add(CxxCompilerSensorImpl.class);
+    l.add(CxxCompilerGccSensorImpl.class);
+    l.add(CxxCompilerVcSensorImpl.class);
     l.add(CxxVeraxxSensorImpl.class);
     l.add(CxxValgrindSensorImpl.class);
     l.add(CxxClangTidySensorImpl.class);
@@ -693,9 +696,16 @@ public final class CPlugin implements Plugin {
     }
   }
 
-  public static class CxxCompilerSensorImpl extends CxxCompilerSensor {
+  public static class CxxCompilerGccSensorImpl extends CxxCompilerGccSensor {
 
-    public CxxCompilerSensorImpl(Configuration settings) {
+    public CxxCompilerGccSensorImpl(Configuration settings) {
+      super(new CLanguage(settings));
+    }
+  }
+
+  public static class CxxCompilerVcSensorImpl extends CxxCompilerVcSensor {
+
+    public CxxCompilerVcSensorImpl(Configuration settings) {
       super(new CLanguage(settings));
     }
   }

--- a/sonar-c-plugin/src/test/java/org/sonar/plugins/c/CPluginTest.java
+++ b/sonar-c-plugin/src/test/java/org/sonar/plugins/c/CPluginTest.java
@@ -35,6 +35,6 @@ public class CPluginTest {
     Plugin.Context context = new Plugin.Context(runtime);
     CPlugin plugin = new CPlugin();
     plugin.define(context);
-    assertThat(context.getExtensions()).hasSize(69);
+    assertThat(context.getExtensions()).hasSize(70);
   }
 }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -47,9 +47,11 @@ import org.sonar.cxx.sensors.clangtidy.CxxClangTidyRuleRepository;
 import org.sonar.cxx.sensors.clangtidy.CxxClangTidySensor;
 import org.sonar.cxx.sensors.compiler.CxxCompilerGccParser;
 import org.sonar.cxx.sensors.compiler.CxxCompilerGccRuleRepository;
+import org.sonar.cxx.sensors.compiler.CxxCompilerGccSensor;
 import org.sonar.cxx.sensors.compiler.CxxCompilerSensor;
 import org.sonar.cxx.sensors.compiler.CxxCompilerVcParser;
 import org.sonar.cxx.sensors.compiler.CxxCompilerVcRuleRepository;
+import org.sonar.cxx.sensors.compiler.CxxCompilerVcSensor;
 import org.sonar.cxx.sensors.coverage.CxxCoverageCache;
 import org.sonar.cxx.sensors.coverage.CxxCoverageSensor;
 import org.sonar.cxx.sensors.cppcheck.CxxCppCheckRuleRepository;
@@ -546,7 +548,8 @@ public final class CxxPlugin implements Plugin {
     l.add(CxxCppCheckSensorImpl.class);
     l.add(CxxPCLintSensorImpl.class);
     l.add(CxxDrMemorySensorImpl.class);
-    l.add(CxxCompilerSensorImpl.class);
+    l.add(CxxCompilerGccSensorImpl.class);
+    l.add(CxxCompilerVcSensorImpl.class);
     l.add(CxxVeraxxSensorImpl.class);
     l.add(CxxValgrindSensorImpl.class);
     l.add(CxxClangTidySensorImpl.class);
@@ -743,9 +746,16 @@ public final class CxxPlugin implements Plugin {
     }
   }
 
-  public static class CxxCompilerSensorImpl extends CxxCompilerSensor {
+  public static class CxxCompilerGccSensorImpl extends CxxCompilerGccSensor {
 
-    public CxxCompilerSensorImpl(Configuration settings) {
+    public CxxCompilerGccSensorImpl(Configuration settings) {
+      super(new CppLanguage(settings));
+    }
+  }
+
+  public static class CxxCompilerVcSensorImpl extends CxxCompilerVcSensor {
+
+    public CxxCompilerVcSensorImpl(Configuration settings) {
       super(new CppLanguage(settings));
     }
   }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -35,6 +35,6 @@ public class CxxPluginTest {
     Plugin.Context context = new Plugin.Context(runtime);
     CxxPlugin plugin = new CxxPlugin();
     plugin.define(context);
-    assertThat(context.getExtensions()).hasSize(75);
+    assertThat(context.getExtensions()).hasSize(76);
   }
 }


### PR DESCRIPTION
close #1521

BUGFIX

* in order to allow the co-existance of C and C++ plugins, rules
  repositories were doubled

* the effective repository key was built as
  `SENSOR.KEY + LANGUAGE.REPOSITORY_SUFFIX`

* the usage of this format was inconsistent; in the majority of
  cases just `SENSOR.KEY` was used

* The problem affected only subclasses of `CxxReportSensor`. The class `CxxSquidSensor` solved the key ambiguity for the rules repository by means of `CxxLanguage.getRepositoryKey()`. This is not consistent IMHO.

REFACTORING

* simplify CxxReportSensor: use only one rules repository per sensor
    * split CxxReportSensor into CxxReportSensor and CxxIssuesReportSensor
    * split CxxCompilerSensor into CxxCompilerGccSensor and CxxCompilerVcSensor
    * remove repoKey from CxxReportIssue and move it to CxxIssuesReportSensor
    * misc refactoring and simplification

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1522)
<!-- Reviewable:end -->
