### PR TITLE
simplify preprocessor if squid checks are disabled

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
@@ -117,6 +118,10 @@ public class CxxSquidSensor implements Sensor {
       .onlyOnFileType(InputFile.Type.MAIN);
   }
 
+  private boolean areSquidChecksEnabled(ActiveRules activeRules) {
+    return !activeRules.findByRepository(language.getRepositoryKey()).isEmpty();
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -134,6 +139,9 @@ public class CxxSquidSensor implements Sensor {
         this.language.getBooleanOption(CPD_IGNORE_IDENTIFIERS_KEY).orElse(Boolean.FALSE)));
 
     CxxConfiguration cxxConf = createConfiguration(context.fileSystem(), context);
+    if (!areSquidChecksEnabled(context.activeRules())) {
+      cxxConf.setSimplifiedPreprocessor();
+    }
     AstScanner<Grammar> scanner = CxxAstScanner.create(this.language, cxxConf,
       visitors.toArray(new SquidAstVisitor[visitors.size()]));
 

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/include-directories-project/src/main.cc
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/include-directories-project/src/main.cc
@@ -27,3 +27,7 @@ HEADER1
 HEADER2
 BAR //void bar(){}
 WIDGET //void widget(){}
+
+int main(int, char*) {
+  return 0;
+}

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
@@ -52,6 +52,18 @@ public class CxxConfiguration extends SquidConfiguration {
   private String jsonCompilationDatabaseFile;
   private CxxCompilationUnitSettings globalCompilationUnitSettings;
   private final Map<String, CxxCompilationUnitSettings> compilationUnitSettings = new HashMap<>();
+  private boolean isSimplifiedPreprocessor = false;
+
+  /**
+   * @return true iff handling of preprocessor directives is disabled
+   */
+  public boolean isSimplifiedPreprocessor() {
+    return isSimplifiedPreprocessor;
+  }
+
+  public void setSimplifiedPreprocessor() {
+    this.isSimplifiedPreprocessor = true;
+  }
 
   private final CxxVCppBuildLogParser cxxVCppParser;
 

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -424,6 +424,12 @@ public class CxxPreprocessor extends Preprocessor {
 
       AstNodeType lineKind = lineAst.getType();
 
+      if (conf.isSimplifiedPreprocessor()) {
+        LOG.debug("Preprocessor runs in simplified more; skip preprocessor directive {}", lineKind);
+        return new PreprocessorAction(1, Collections.singletonList(Trivia.createSkippedText(token)),
+            new ArrayList<Token>());
+      }
+
       if (lineKind.equals(ifdefLine)) {
         return handleIfdefLine(lineAst, token, rootFilePath);
       } else if (lineKind.equals(ifLine)) {

--- a/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithPreprocessingTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithPreprocessingTest.java
@@ -215,7 +215,7 @@ public class CxxLexerWithPreprocessingTest {
     softly.assertAll();
   }
 
-  @Test 
+  @Test
   public void expanding_hashhash_operator_sampleFromCPPStandard() {
     // TODO: think about implementing this behavior. This is a sample from the standard, which is
     // not working yet. Because the current implementation throws away all 'irrelevant'
@@ -226,7 +226,7 @@ public class CxxLexerWithPreprocessingTest {
      + "#define in_between(a) mkstr(a)\n"
      + "#define join(c, d) in_between(c hash_hash(x) d)\n"
      + "join(x,y)");
-     
+
      SoftAssertions softly = new SoftAssertions();
      softly.assertThat(tokens).hasSize(2); //"x ## y" + EOF
 //     softly.assertThat(tokens).anySatisfy(token ->assertThat(token).isValue("\"x ## y\"").hasType(CxxTokenType.STRING));
@@ -432,7 +432,7 @@ public class CxxLexerWithPreprocessingTest {
       + "#endif\n");
 
     SoftAssertions softly = new SoftAssertions();
-    softly.assertThat(tokens).noneMatch(token ->token.getValue().contentEquals("111") && token.getType().equals(CxxTokenType.NUMBER)); 
+    softly.assertThat(tokens).noneMatch(token ->token.getValue().contentEquals("111") && token.getType().equals(CxxTokenType.NUMBER));
     softly.assertThat(tokens).anySatisfy(token ->assertThat(token).isValue("222").hasType(CxxTokenType.NUMBER));
     softly.assertAll();
   }
@@ -447,7 +447,7 @@ public class CxxLexerWithPreprocessingTest {
       + "#endif\n");
 
     SoftAssertions softly = new SoftAssertions();
-    softly.assertThat(tokens).noneMatch(token ->token.getValue().contentEquals("222") && token.getType().equals(CxxTokenType.NUMBER)); 
+    softly.assertThat(tokens).noneMatch(token ->token.getValue().contentEquals("222") && token.getType().equals(CxxTokenType.NUMBER));
     softly.assertThat(tokens).anySatisfy(token ->assertThat(token).isValue("111").hasType(CxxTokenType.NUMBER));
     softly.assertAll();
   }
@@ -612,6 +612,7 @@ public class CxxLexerWithPreprocessingTest {
   public void externalMacrosCannotBeOverriden() {
     CxxConfiguration conf = mock(CxxConfiguration.class);
     when(conf.getDefines()).thenReturn(Arrays.asList("name goodvalue"));
+    when(conf.isSimplifiedPreprocessor()).thenReturn(false);
     CxxPreprocessor cxxpp = new CxxPreprocessor(mock(SquidAstVisitorContext.class), conf, language);
     lexer = CxxLexer.create(conf, cxxpp);
 


### PR DESCRIPTION
* the role of preprocessor (CxxPreprocessor) is negligible
* the evaluation of preprocessor directives plays some
  minimal role if AST is used for internal checks
  (SquidSensor)

* however if sonar-cxx imports external reports only, the AST
  is used just for highlighting and metrics calcualation
* whether preprocessor directives are evaluated or not
  has no effect on highlighting and almost no effect
  on the metrics

* sonar-cxx is positioned as a plugin for integration
  of external analyzers, yet users are facing
  many proprocessor warnings about missing includes

SUGGESTION:

If no internal checks are activated, let proprocessor run
in simplified mode. No preprocessor directives will be evalated

PROS:

* speed up
* no misleading warnings

CONS:

* metrics like "number of functions", "number of classes" etc
  might change if C/C++ code extensively uses preprocessor magic.
  E.g. if macros are used in order to generate functions or classes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1528)
<!-- Reviewable:end -->
