### PR TITLE
CxxUnitTestResultsImportSensor: simplify and update

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/tests/dotnet/CxxUnitTestResultsAggregator.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/tests/dotnet/CxxUnitTestResultsAggregator.java
@@ -25,11 +25,10 @@ package org.sonar.cxx.sensors.tests.dotnet;
 // mailto:info AT sonarsource DOT com
 
 import java.io.File;
+
 import org.sonar.api.batch.ScannerSide;
-import org.sonar.api.config.Configuration;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
-import org.sonar.cxx.CxxLanguage;
 
 /**
  * CxxUnitTestResultsAggregator (from .Net test library)
@@ -37,10 +36,7 @@ import org.sonar.cxx.CxxLanguage;
 @ScannerSide
 public class CxxUnitTestResultsAggregator {
 
-  private static final String EXIST_CONFIGURATION_PARAMETER = "Exist configuration parameter: '{}':'{}'";
   private static final Logger LOG = Loggers.get(CxxUnitTestResultsAggregator.class);
-  private final UnitTestConfiguration unitTestConf;
-  private final Configuration settings;
   private final VisualStudioTestResultsFileParser visualStudioTestResultsFileParser;
   private final XUnitTestResultsFileParser xunitTestResultsFileParser;
   private final NUnitTestResultsFileParser nunitTestResultsFileParser;
@@ -50,71 +46,32 @@ public class CxxUnitTestResultsAggregator {
    * @param language C or C++
    * @param settings SQ Configuration
    */
-  public CxxUnitTestResultsAggregator(CxxLanguage language, Configuration settings) {
-    this(new UnitTestConfiguration(language), settings,
-      new VisualStudioTestResultsFileParser(),
-      new XUnitTestResultsFileParser(),
-      new NUnitTestResultsFileParser()
-    );
+  public CxxUnitTestResultsAggregator() {
+    this(new VisualStudioTestResultsFileParser(), new XUnitTestResultsFileParser(), new NUnitTestResultsFileParser());
   }
 
-  CxxUnitTestResultsAggregator(UnitTestConfiguration unitTestConf, Configuration settings,
-    VisualStudioTestResultsFileParser visualStudioTestResultsFileParser,
-    XUnitTestResultsFileParser xunitTestResultsFileParser,
-    NUnitTestResultsFileParser nunitTestResultsFileParser
-  ) {
-    this.unitTestConf = unitTestConf;
-    this.settings = settings;
+  CxxUnitTestResultsAggregator(VisualStudioTestResultsFileParser visualStudioTestResultsFileParser,
+      XUnitTestResultsFileParser xunitTestResultsFileParser, NUnitTestResultsFileParser nunitTestResultsFileParser) {
     this.visualStudioTestResultsFileParser = visualStudioTestResultsFileParser;
     this.xunitTestResultsFileParser = xunitTestResultsFileParser;
     this.nunitTestResultsFileParser = nunitTestResultsFileParser;
   }
 
-  boolean hasUnitTestResultsProperty() {
-    return hasVisualStudioTestResultsFile() || hasXUnitTestResultsFile() || hasNUnitTestResultsFile();
-  }
-
-  private boolean hasVisualStudioTestResultsFile() {
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(EXIST_CONFIGURATION_PARAMETER, unitTestConf.visualStudioTestResultsFilePropertyKey(),
-        settings.hasKey(unitTestConf.visualStudioTestResultsFilePropertyKey()));
-    }
-    return settings.hasKey(unitTestConf.visualStudioTestResultsFilePropertyKey());
-  }
-
-  private boolean hasXUnitTestResultsFile() {
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(EXIST_CONFIGURATION_PARAMETER, unitTestConf.xunitTestResultsFilePropertyKey(),
-        settings.hasKey(unitTestConf.xunitTestResultsFilePropertyKey()));
-    }
-    return settings.hasKey(unitTestConf.xunitTestResultsFilePropertyKey());
-  }
-
-  private boolean hasNUnitTestResultsFile() {
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(EXIST_CONFIGURATION_PARAMETER, unitTestConf.nunitTestResultsFilePropertyKey(),
-        settings.hasKey(unitTestConf.nunitTestResultsFilePropertyKey()));
-    }
-    return settings.hasKey(unitTestConf.nunitTestResultsFilePropertyKey());
-  }
-
-  UnitTestResults aggregate(WildcardPatternFileProvider wildcardPatternFileProvider, UnitTestResults unitTestResults) {
-    if (hasVisualStudioTestResultsFile()) {
-      aggregate(wildcardPatternFileProvider,
-        settings.getStringArray(unitTestConf.visualStudioTestResultsFilePropertyKey()),
-        visualStudioTestResultsFileParser, unitTestResults);
+  UnitTestResults aggregate(WildcardPatternFileProvider wildcardPatternFileProvider, UnitTestResults unitTestResults,
+      UnitTestConfiguration unitTestConf) {
+    if (unitTestConf.hasVisualStudioTestResultsFile()) {
+      aggregate(wildcardPatternFileProvider, unitTestConf.getVisualStudioTestResultsFiles(),
+          visualStudioTestResultsFileParser, unitTestResults);
     }
 
-    if (hasXUnitTestResultsFile()) {
-      aggregate(wildcardPatternFileProvider,
-        settings.getStringArray(unitTestConf.xunitTestResultsFilePropertyKey()),
-        xunitTestResultsFileParser, unitTestResults);
+    if (unitTestConf.hasXUnitTestResultsFile()) {
+      aggregate(wildcardPatternFileProvider, unitTestConf.getXUnitTestResultsFiles(), xunitTestResultsFileParser,
+          unitTestResults);
     }
 
-    if (hasNUnitTestResultsFile()) {
-      aggregate(wildcardPatternFileProvider,
-        settings.getStringArray(unitTestConf.nunitTestResultsFilePropertyKey()),
-        nunitTestResultsFileParser, unitTestResults);
+    if (unitTestConf.hasNUnitTestResultsFile()) {
+      aggregate(wildcardPatternFileProvider, unitTestConf.getNUnitTestResultsFiles(), nunitTestResultsFileParser,
+          unitTestResults);
     }
 
     return unitTestResults;

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/tests/dotnet/UnitTestConfiguration.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/tests/dotnet/UnitTestConfiguration.java
@@ -19,6 +19,10 @@
  */
 package org.sonar.cxx.sensors.tests.dotnet;
 
+import org.sonar.api.config.Configuration;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
 // origin https://github.com/SonarSource/sonar-dotnet-tests-library/
 // SonarQube .NET Tests Library
 // Copyright (C) 2014-2017 SonarSource SA
@@ -28,24 +32,60 @@ import org.sonar.cxx.CxxLanguage;
 
 public class UnitTestConfiguration {
 
-  private final CxxLanguage language;
+  private static final String EXIST_CONFIGURATION_PARAMETER = "Exist configuration parameter: '{}':'{}'";
+  private static final Logger LOG = Loggers.get(UnitTestConfiguration.class);
+
   public static final String VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY = "vstest.reportsPaths";
   public static final String XUNIT_TEST_RESULTS_PROPERTY_KEY = "xunit.reportsPaths";
   public static final String NUNIT_TEST_RESULTS_PROPERTY_KEY = "nunit.reportsPaths";
 
-  public UnitTestConfiguration(CxxLanguage language) {
-    this.language = language;
+  private final Configuration config;
+  private final String vsKeyEffective;
+  private final String xUnitKeyEffective;
+  private final String nUnitKeyEffective;
+
+  public UnitTestConfiguration(CxxLanguage language, Configuration config) {
+    this.config = config;
+    vsKeyEffective = language.getPluginProperty(VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY);
+    xUnitKeyEffective = language.getPluginProperty(XUNIT_TEST_RESULTS_PROPERTY_KEY);
+    nUnitKeyEffective = language.getPluginProperty(NUNIT_TEST_RESULTS_PROPERTY_KEY);
   }
 
-  String visualStudioTestResultsFilePropertyKey() {
-    return language.getPluginProperty(VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY);
+  boolean hasVisualStudioTestResultsFile() {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(EXIST_CONFIGURATION_PARAMETER, vsKeyEffective, config.hasKey(vsKeyEffective));
+    }
+    return config.hasKey(vsKeyEffective);
   }
 
-  String xunitTestResultsFilePropertyKey() {
-    return language.getPluginProperty(XUNIT_TEST_RESULTS_PROPERTY_KEY);
+  boolean hasXUnitTestResultsFile() {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(EXIST_CONFIGURATION_PARAMETER, xUnitKeyEffective, config.hasKey(xUnitKeyEffective));
+    }
+    return config.hasKey(xUnitKeyEffective);
   }
 
-  String nunitTestResultsFilePropertyKey() {
-    return language.getPluginProperty(NUNIT_TEST_RESULTS_PROPERTY_KEY);
+  boolean hasNUnitTestResultsFile() {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(EXIST_CONFIGURATION_PARAMETER, nUnitKeyEffective, config.hasKey(nUnitKeyEffective));
+    }
+    return config.hasKey(nUnitKeyEffective);
   }
+
+  boolean hasUnitTestResultsProperty() {
+    return hasVisualStudioTestResultsFile() || hasXUnitTestResultsFile() || hasNUnitTestResultsFile();
+  }
+
+  String[] getVisualStudioTestResultsFiles() {
+    return config.getStringArray(vsKeyEffective);
+  }
+
+  String[] getXUnitTestResultsFiles() {
+    return config.getStringArray(xUnitKeyEffective);
+  }
+
+  String[] getNUnitTestResultsFiles() {
+    return config.getStringArray(nUnitKeyEffective);
+  }
+
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/CxxUnitTestResultsAggregatorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/CxxUnitTestResultsAggregatorTest.java
@@ -70,34 +70,33 @@ public class CxxUnitTestResultsAggregatorTest {
     when(settings.hasKey(key1)).thenReturn(false);
     when(settings.hasKey(key2)).thenReturn(false);
     when(settings.hasKey(key3)).thenReturn(false);
-    assertThat(new CxxUnitTestResultsAggregator(language, settings).hasUnitTestResultsProperty()).isFalse();
+    assertThat(new UnitTestConfiguration(language, settings).hasUnitTestResultsProperty()).isFalse();
 
     when(settings.hasKey(key1)).thenReturn(true);
     when(settings.hasKey(key2)).thenReturn(false);
     when(settings.hasKey(key3)).thenReturn(false);
-    assertThat(new CxxUnitTestResultsAggregator(language, settings).hasUnitTestResultsProperty()).isTrue();
+    assertThat(new UnitTestConfiguration(language, settings).hasUnitTestResultsProperty()).isTrue();
 
     when(settings.hasKey(key1)).thenReturn(false);
     when(settings.hasKey(key2)).thenReturn(true);
     when(settings.hasKey(key3)).thenReturn(false);
-    assertThat(new CxxUnitTestResultsAggregator(language, settings).hasUnitTestResultsProperty()).isTrue();
+    assertThat(new UnitTestConfiguration(language, settings).hasUnitTestResultsProperty()).isTrue();
 
     when(settings.hasKey(key1)).thenReturn(false);
     when(settings.hasKey(key2)).thenReturn(false);
     when(settings.hasKey(key3)).thenReturn(true);
-    assertThat(new CxxUnitTestResultsAggregator(language, settings).hasUnitTestResultsProperty()).isTrue();
+    assertThat(new UnitTestConfiguration(language, settings).hasUnitTestResultsProperty()).isTrue();
 
     when(settings.hasKey(key1)).thenReturn(true);
     when(settings.hasKey(key2)).thenReturn(true);
     when(settings.hasKey(key3)).thenReturn(true);
-    assertThat(new CxxUnitTestResultsAggregator(language, settings).hasUnitTestResultsProperty()).isTrue();
+    assertThat(new UnitTestConfiguration(language, settings).hasUnitTestResultsProperty()).isTrue();
   }
 
   @Test
   public void aggregate() {
     WildcardPatternFileProvider wildcardPatternFileProvider = mock(WildcardPatternFileProvider.class);
     MapSettings settings = new MapSettings();
-    UnitTestConfiguration unitTestConf = new UnitTestConfiguration(language);
 
     // Visual Studio test results only
     settings.setProperty(key1, "foo.trx");
@@ -106,9 +105,9 @@ public class CxxUnitTestResultsAggregatorTest {
     XUnitTestResultsFileParser xunitTestResultsFileParser = mock(XUnitTestResultsFileParser.class);
     NUnitTestResultsFileParser nunitTestResultsFileParser = mock(NUnitTestResultsFileParser.class);
     UnitTestResults results = mock(UnitTestResults.class);
-    new CxxUnitTestResultsAggregator(unitTestConf, settings.asConfig(),
-      visualStudioTestResultsFileParser, xunitTestResultsFileParser, nunitTestResultsFileParser)
-      .aggregate(wildcardPatternFileProvider, results);
+    new CxxUnitTestResultsAggregator(visualStudioTestResultsFileParser, xunitTestResultsFileParser,
+        nunitTestResultsFileParser).aggregate(wildcardPatternFileProvider, results,
+            new UnitTestConfiguration(language, settings.asConfig()));
     verify(visualStudioTestResultsFileParser).accept(new File("foo.trx"), results);
 
     // XUnit test results only
@@ -119,9 +118,9 @@ public class CxxUnitTestResultsAggregatorTest {
     xunitTestResultsFileParser = mock(XUnitTestResultsFileParser.class);
     nunitTestResultsFileParser = mock(NUnitTestResultsFileParser.class);
     results = mock(UnitTestResults.class);
-    new CxxUnitTestResultsAggregator(unitTestConf, settings.asConfig(),
-      visualStudioTestResultsFileParser, xunitTestResultsFileParser, nunitTestResultsFileParser)
-      .aggregate(wildcardPatternFileProvider, results);
+    new CxxUnitTestResultsAggregator(visualStudioTestResultsFileParser, xunitTestResultsFileParser,
+        nunitTestResultsFileParser).aggregate(wildcardPatternFileProvider, results,
+            new UnitTestConfiguration(language, settings.asConfig()));
     verify(visualStudioTestResultsFileParser, Mockito.never()).accept(Mockito.any(File.class), Mockito.any(UnitTestResults.class));
     verify(xunitTestResultsFileParser).accept(new File("foo.xml"), results);
     verify(nunitTestResultsFileParser, Mockito.never()).accept(Mockito.any(File.class), Mockito.any(UnitTestResults.class));
@@ -138,9 +137,9 @@ public class CxxUnitTestResultsAggregatorTest {
     xunitTestResultsFileParser = mock(XUnitTestResultsFileParser.class);
     nunitTestResultsFileParser = mock(NUnitTestResultsFileParser.class);
     results = mock(UnitTestResults.class);
-    new CxxUnitTestResultsAggregator(unitTestConf, settings.asConfig(),
-      visualStudioTestResultsFileParser, xunitTestResultsFileParser, nunitTestResultsFileParser)
-      .aggregate(wildcardPatternFileProvider, results);
+    new CxxUnitTestResultsAggregator(visualStudioTestResultsFileParser, xunitTestResultsFileParser,
+        nunitTestResultsFileParser).aggregate(wildcardPatternFileProvider, results,
+            new UnitTestConfiguration(language, settings.asConfig()));
     verify(visualStudioTestResultsFileParser).accept(new File("foo.trx"), results);
     verify(xunitTestResultsFileParser).accept(new File("foo.xml"), results);
     verify(nunitTestResultsFileParser).accept(new File("foo1.xml"), results);
@@ -151,13 +150,13 @@ public class CxxUnitTestResultsAggregatorTest {
     xunitTestResultsFileParser = mock(XUnitTestResultsFileParser.class);
     nunitTestResultsFileParser = mock(NUnitTestResultsFileParser.class);
     results = mock(UnitTestResults.class);
-    new CxxUnitTestResultsAggregator(unitTestConf, settings.asConfig(),
-      visualStudioTestResultsFileParser, xunitTestResultsFileParser, nunitTestResultsFileParser)
-      .aggregate(wildcardPatternFileProvider, results);
+    new CxxUnitTestResultsAggregator(visualStudioTestResultsFileParser, xunitTestResultsFileParser,
+        nunitTestResultsFileParser).aggregate(wildcardPatternFileProvider, results,
+            new UnitTestConfiguration(language, settings.asConfig()));
     verify(visualStudioTestResultsFileParser, Mockito.never()).accept(Mockito.any(File.class), Mockito.any(UnitTestResults.class));
     verify(xunitTestResultsFileParser, Mockito.never()).accept(Mockito.any(File.class), Mockito.any(UnitTestResults.class));
     verify(nunitTestResultsFileParser, Mockito.never()).accept(Mockito.any(File.class), Mockito.any(UnitTestResults.class));
-    
+
     // Multiple files configured
     Mockito.reset(wildcardPatternFileProvider);
     settings.clear();
@@ -175,9 +174,9 @@ public class CxxUnitTestResultsAggregatorTest {
     nunitTestResultsFileParser = mock(NUnitTestResultsFileParser.class);
     results = mock(UnitTestResults.class);
 
-    new CxxUnitTestResultsAggregator(unitTestConf, settings.asConfig(),
-      visualStudioTestResultsFileParser, xunitTestResultsFileParser, nunitTestResultsFileParser)
-      .aggregate(wildcardPatternFileProvider, results);
+    new CxxUnitTestResultsAggregator(visualStudioTestResultsFileParser, xunitTestResultsFileParser,
+        nunitTestResultsFileParser).aggregate(wildcardPatternFileProvider, results,
+            new UnitTestConfiguration(language, settings.asConfig()));
 
     verify(wildcardPatternFileProvider).listFiles("*.trx");
     verify(wildcardPatternFileProvider).listFiles("bar.trx");

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -798,8 +798,8 @@ public final class CxxPlugin implements Plugin {
   public static class CxxUnitTestResultsImportSensorImpl extends CxxUnitTestResultsImportSensor {
 
     public CxxUnitTestResultsImportSensorImpl(Configuration settings,
-      CxxUnitTestResultsAggregator unitTestResultsAggregator, ProjectDefinition projectDef) {
-      super(unitTestResultsAggregator, projectDef, new CppLanguage(settings));
+        CxxUnitTestResultsAggregator unitTestResultsAggregator) {
+      super(unitTestResultsAggregator, new CppLanguage(settings));
     }
   }
 


### PR DESCRIPTION
this change is inspired by #1523

* the original code (https://github.com/SonarSource/sonar-dotnet-tests-library)
  was updated > 2 years ago and doesn't reflect the newest features
  of SensorDescriptor

E.g.

1. [SensorOptimizer](https://github.com/SonarSource/sonarqube/blob/master/sonar-scanner-engine/src/main/java/org/sonar/scanner/sensor/SensorOptimizer.java) can enable the sensor only when configuration
   satisfies some predicate. The old code however is always enabled
   the sensor.
2. SensorDescriptor was set to `global()`, however the original code
   was not modified. So additionaly there were checks of
   `ProjectDefinition`

+  More refactoring and simplification

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1532)
<!-- Reviewable:end -->
