### PR TITLE
rewrite CxxCognitiveComplexityVisitor

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxAstScanner.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxAstScanner.java
@@ -236,10 +236,7 @@ public final class CxxAstScanner {
       .subscribeTo(complexityAstNodeType)
       .build());
 
-    builder.withSquidAstVisitor(CxxCognitiveComplexityVisitor.<Grammar>builder()
-      .setMetricDef(CxxMetric.COGNITIVE_COMPLEXITY)
-      .subscribeTo(CxxGrammarImpl.functionDefinition)
-      .build());
+    builder.withSquidAstVisitor(new CxxCognitiveComplexityVisitor<Grammar>());
 
     builder.withSquidAstVisitor(new CxxFunctionComplexityVisitor<>(language));
     builder.withSquidAstVisitor(new CxxFunctionSizeVisitor<>(language));

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxCognitiveComplexityVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxCognitiveComplexityVisitorTest.java
@@ -19,10 +19,11 @@
  */
 package org.sonar.cxx.visitors;
 
-import com.sonar.sslr.api.Grammar;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 import org.sonar.cxx.CxxAstScanner;
 import org.sonar.cxx.CxxFileTester;
@@ -33,19 +34,14 @@ import org.sonar.squidbridge.api.SourceFile;
 public class CxxCognitiveComplexityVisitorTest {
 
   private int testFile(String fileName) throws UnsupportedEncodingException, IOException {
-    CxxCognitiveComplexityVisitor<Grammar> visitor = CxxCognitiveComplexityVisitor.<Grammar>builder()
-      .setMetricDef(CxxMetric.COGNITIVE_COMPLEXITY)
-      .build();
-
     CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester(fileName, ".", "");
-    SourceFile sourceFile = CxxAstScanner.scanSingleFile(tester.cxxFile, tester.sensorContext, CxxFileTesterHelper.mockCxxLanguage(), visitor);
+    SourceFile sourceFile = CxxAstScanner.scanSingleFile(tester.cxxFile, tester.sensorContext, CxxFileTesterHelper.mockCxxLanguage());
 
     return (sourceFile.getInt(CxxMetric.COGNITIVE_COMPLEXITY));
   }
 
   @Test
   public void if_statement() throws UnsupportedEncodingException, IOException {
-
     assertThat(testFile("src/test/resources/visitors/if.cc")).isEqualTo(1);
   }
 


### PR DESCRIPTION
* replace custom recursive algorithm with the standard AstVisitor approach

  * no risk of StackOverflowError anymore
  * no need to track the set of visited `AstNode`s
  * decrease the run-time and memory footprint

* code simplification and clean-up
* the new code calcualtes an equal value for the cognitive complexity metric

this change is required for #1494

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1535)
<!-- Reviewable:end -->
