### PR TITLE
implement explanation for cyclomatic complexity checks

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/CxxCyclomaticComplexityCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/CxxCyclomaticComplexityCheck.java
@@ -171,16 +171,16 @@ public abstract class CxxCyclomaticComplexityCheck<G extends Grammar> extends Mu
 
   @Override
   public void visitNode(AstNode astNode) {
+    if (getScopeType().isPresent() && astNode.is(getScopeType().get())) {
+      complexityScopes.addFirst(new ComplexityScope(astNode.getTokenLine()));
+    }
+
     if (astNode.is(CxxComplexityConstants.CyclomaticComplexityAstNodeTypes)) {
       // for nested scopes (e.g. nested classes) the inner classes
       // add complexity to the outer ones
       for (ComplexityScope scope : complexityScopes) {
         scope.addComplexitySource(astNode.getTokenLine(), astNode.getType());
       }
-    }
-
-    if (getScopeType().isPresent() && astNode.is(getScopeType().get())) {
-      complexityScopes.addFirst(new ComplexityScope(astNode.getTokenLine()));
     }
   }
 

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/CxxCyclomaticComplexityCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/CxxCyclomaticComplexityCheck.java
@@ -1,0 +1,211 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2018 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.checks.metrics;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+import org.sonar.cxx.CxxComplexityConstants;
+import org.sonar.cxx.api.CxxKeyword;
+import org.sonar.cxx.api.CxxPunctuator;
+import org.sonar.cxx.parser.CxxGrammarImpl;
+import org.sonar.cxx.utils.CxxReportIssue;
+import org.sonar.cxx.visitors.MultiLocatitionSquidCheck;
+
+import com.sonar.sslr.api.AstNode;
+import com.sonar.sslr.api.AstNodeType;
+import com.sonar.sslr.api.Grammar;
+
+/**
+ * This is an enhanced version of
+ * org.sonar.squidbridge.metrics.ComplexityVisitor, which is used in order to
+ * compute the Cyclomatic Complexity.
+ *
+ * @param <G>
+ */
+public abstract class CxxCyclomaticComplexityCheck<G extends Grammar> extends MultiLocatitionSquidCheck<G> {
+
+  /**
+   * Structure, that tracks all nodes, which increase the code complexity
+   */
+  private class ComplexitySource {
+    private final int line;
+    private final AstNodeType type;
+
+    public ComplexitySource(int line, AstNodeType nodeType) {
+      super();
+      this.line = line;
+      this.type = nodeType;
+    }
+
+    public String getLine() {
+      return Integer.valueOf(line).toString();
+    }
+
+    public String getExplanation() {
+      if (type == CxxGrammarImpl.functionDefinition) {
+        return "+1: function definition";
+      } else if (type == CxxKeyword.IF) {
+        return "+1: if statement";
+      } else if (type == CxxKeyword.FOR) {
+        return "+1: for loop";
+      } else if (type == CxxKeyword.WHILE) {
+        return "+1: while loop";
+      } else if (type == CxxKeyword.CATCH) {
+        return "+1: catch-clause";
+      } else if (type == CxxKeyword.CASE || type == CxxKeyword.DEFAULT) {
+        return "+1: switch label";
+      } else if (type == CxxPunctuator.AND || type == CxxPunctuator.OR) {
+        return "+1: logical operator";
+      } else if (type == CxxPunctuator.QUEST) {
+        return "+1: conditional operator";
+      }
+      return "+1";
+    }
+  }
+
+  /**
+   * Describe a code scope (function definition, class definition, entire file
+   * etc) in terms of complexity sources
+   */
+  private class ComplexityScope {
+    public ComplexityScope(int startingLine) {
+      this.sources = new LinkedList<>();
+      this.complexity = 0;
+      this.startingLine = startingLine;
+    }
+
+    public void addComplexitySource(int line, AstNodeType nodeType) {
+      sources.add(new ComplexitySource(line, nodeType));
+      ++complexity;
+    }
+
+    public List<ComplexitySource> getSources() {
+      return sources;
+    }
+
+    public int getComplexity() {
+      return complexity;
+    }
+
+    public String getStartingLine() {
+      return Integer.valueOf(startingLine).toString();
+    }
+
+    private List<ComplexitySource> sources;
+    private int complexity;
+    private int startingLine;
+  }
+
+  /**
+   * Stack for tracking the nested scopes (e.g. declaration of classes can be
+   * nested). Complexity of the inner scopes is added to the complexity of outer
+   * scopes.
+   */
+  private Deque<ComplexityScope> complexityScopes;
+
+  /**
+   * @return the maximum allowed complexity for this scope
+   */
+  protected abstract int getMaxComplexity();
+
+  /**
+   * @return valid AstNodeType if complexity is calculated for some language
+   *         constructs only (e.g. function definition, class definition etc).
+   *         Return Optional.empty() if the complexity is calculated for entire
+   *         file.
+   */
+  protected abstract Optional<AstNodeType> getScopeType();
+
+  /**
+   * @return the name of analyzed scope: "function", "class", "file" etc
+   */
+  protected abstract String getScopeName();
+
+  @Override
+  public void init() {
+    subscribeTo(CxxComplexityConstants.CyclomaticComplexityAstNodeTypes);
+
+    if (getScopeType().isPresent()) {
+      final AstNodeType additionalNode = getScopeType().get();
+      if (!getAstNodeTypesToVisit().contains(additionalNode)) {
+        subscribeTo(additionalNode);
+      }
+    }
+
+    complexityScopes = new LinkedList<>();
+  }
+
+  @Override
+  public void visitFile(AstNode astNode) {
+    if (!getScopeType().isPresent()) {
+      complexityScopes.addFirst(new ComplexityScope(1));
+    }
+  }
+
+  @Override
+  public void leaveFile(AstNode astNode) {
+    if (!getScopeType().isPresent()) {
+      analyzeScopeComplexity();
+    }
+  }
+
+  @Override
+  public void visitNode(AstNode astNode) {
+    if (astNode.is(CxxComplexityConstants.CyclomaticComplexityAstNodeTypes)) {
+      // for nested scopes (e.g. nested classes) the inner classes
+      // add complexity to the outer ones
+      for (ComplexityScope scope : complexityScopes) {
+        scope.addComplexitySource(astNode.getTokenLine(), astNode.getType());
+      }
+    }
+
+    if (getScopeType().isPresent() && astNode.is(getScopeType().get())) {
+      complexityScopes.addFirst(new ComplexityScope(astNode.getTokenLine()));
+    }
+  }
+
+  @Override
+  public void leaveNode(AstNode astNode) {
+    if (getScopeType().isPresent() && astNode.is(getScopeType().get())) {
+      analyzeScopeComplexity();
+    }
+  }
+
+  private void analyzeScopeComplexity() {
+    ComplexityScope scope = complexityScopes.removeFirst();
+
+    final int maxComplexity = getMaxComplexity();
+    final int currentComplexity = scope.getComplexity();
+    if (scope.getComplexity() > maxComplexity) {
+      final StringBuilder msg = new StringBuilder();
+      msg.append("The Cyclomatic Complexity of this ").append(getScopeName()).append(" is ").append(currentComplexity)
+          .append(" which is greater than ").append(maxComplexity).append(" authorized.");
+
+      final CxxReportIssue issue = new CxxReportIssue(getRuleKey(), null, scope.getStartingLine(), msg.toString());
+      for (ComplexitySource source : scope.getSources()) {
+        issue.addLocation(null, source.getLine(), source.getExplanation());
+      }
+      createMultiLocationViolation(issue);
+    }
+  }
+}

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/FileComplexityCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/FileComplexityCheck.java
@@ -19,15 +19,17 @@
  */
 package org.sonar.cxx.checks.metrics;
 
-import com.sonar.sslr.api.Grammar;
+import java.util.Optional;
+
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
-import org.sonar.cxx.api.CxxMetric;
 import org.sonar.cxx.tag.Tag;
 import org.sonar.squidbridge.annotations.SqaleLinearWithOffsetRemediation;
-import org.sonar.squidbridge.checks.AbstractFileComplexityCheck;
-import org.sonar.squidbridge.measures.MetricDef;
+
+import com.sonar.sslr.api.AstNode;
+import com.sonar.sslr.api.AstNodeType;
+import com.sonar.sslr.api.Grammar;
 
 @Rule(
   key = "FileComplexity",
@@ -39,7 +41,7 @@ import org.sonar.squidbridge.measures.MetricDef;
   coeff = "1min",
   offset = "30min",
   effortToFixDescription = "per complexity point above the threshold")
-public class FileComplexityCheck extends AbstractFileComplexityCheck<Grammar> {
+public class FileComplexityCheck extends CxxCyclomaticComplexityCheck<Grammar> {
 
   private static final int DEFAULT_MAX = 200;
 
@@ -49,18 +51,22 @@ public class FileComplexityCheck extends AbstractFileComplexityCheck<Grammar> {
     defaultValue = "" + DEFAULT_MAX)
   private int max = DEFAULT_MAX;
 
-  public void setMax(int max) {
+  @Override
+  protected Optional<AstNodeType> getScopeType() {
+    return Optional.empty();
+  }
+
+  @Override
+  protected String getScopeName() {
+    return "file";
+  }
+
+  @Override
+  protected int getMaxComplexity() {
+    return max;
+  }
+
+  public void setMaxComplexity(int max) {
     this.max = max;
   }
-
-  @Override
-  public int getMaximumFileComplexity() {
-    return this.max;
-  }
-
-  @Override
-  public MetricDef getComplexityMetric() {
-    return CxxMetric.COMPLEXITY;
-  }
-
 }

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/FunctionCognitiveComplexityCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/FunctionCognitiveComplexityCheck.java
@@ -27,6 +27,8 @@ import org.sonar.check.RuleProperty;
 import org.sonar.cxx.api.CxxMetric;
 import org.sonar.cxx.parser.CxxGrammarImpl;
 import org.sonar.cxx.tag.Tag;
+import org.sonar.cxx.utils.CxxReportIssue;
+import org.sonar.cxx.visitors.MultiLocatitionSquidCheck;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
 import org.sonar.squidbridge.annotations.SqaleLinearWithOffsetRemediation;
 import org.sonar.squidbridge.api.SourceFunction;

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/FunctionComplexityCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/FunctionComplexityCheck.java
@@ -19,19 +19,18 @@
  */
 package org.sonar.cxx.checks.metrics;
 
+import java.util.Optional;
+
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
-import org.sonar.cxx.api.CxxMetric;
 import org.sonar.cxx.parser.CxxGrammarImpl;
-import org.sonar.squidbridge.api.SourceFunction;
-import org.sonar.squidbridge.checks.ChecksHelper;
-import org.sonar.squidbridge.checks.SquidCheck;
-import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Grammar;
+import org.sonar.cxx.tag.Tag;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
 import org.sonar.squidbridge.annotations.SqaleLinearWithOffsetRemediation;
-import org.sonar.cxx.tag.Tag;
+
+import com.sonar.sslr.api.AstNodeType;
+import com.sonar.sslr.api.Grammar;
 
 @Rule(
   key = "FunctionComplexity",
@@ -43,7 +42,9 @@ import org.sonar.cxx.tag.Tag;
   coeff = "1min",
   offset = "10min",
   effortToFixDescription = "per complexity point above the threshold")
-public class FunctionComplexityCheck extends SquidCheck<Grammar> {
+public class FunctionComplexityCheck extends CxxCyclomaticComplexityCheck<Grammar> {
+
+  // TODO MultiLineSquidCheck<Grammar>
 
   private static final int DEFAULT_MAX = 10;
 
@@ -54,25 +55,21 @@ public class FunctionComplexityCheck extends SquidCheck<Grammar> {
   private int max = DEFAULT_MAX;
 
   @Override
-  public void init() {
-    subscribeTo(CxxGrammarImpl.functionDefinition);
+  protected Optional<AstNodeType> getScopeType() {
+    return Optional.of(CxxGrammarImpl.functionDefinition);
   }
 
   @Override
-  public void leaveNode(AstNode node) {
-    SourceFunction sourceFunction = (SourceFunction) getContext().peekSourceCode();
-    int complexity = ChecksHelper.getRecursiveMeasureInt(sourceFunction, CxxMetric.COMPLEXITY);
-    if (complexity > max) {
-      getContext().createLineViolation(this,
-        "The Cyclomatic Complexity of this function is {0,number,integer} which is greater than "
-          + "{1,number,integer} authorized.",
-        node,
-        complexity,
-        max);
-    }
+  protected String getScopeName() {
+    return "function";
   }
 
-  public void setMax(int max) {
+  @Override
+  protected int getMaxComplexity() {
+    return max;
+  }
+
+  public void setMaxComplexity(int max) {
     this.max = max;
   }
 }

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FunctionComplexityCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FunctionComplexityCheckTest.java
@@ -19,31 +19,108 @@
  */
 package org.sonar.cxx.checks.metrics;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.Set;
 
+import org.assertj.core.api.SoftAssertions;
 import org.junit.Test;
 import org.sonar.cxx.CxxAstScanner;
 import org.sonar.cxx.checks.CxxFileTester;
 import org.sonar.cxx.checks.CxxFileTesterHelper;
+import org.sonar.cxx.utils.CxxReportIssue;
+import org.sonar.cxx.utils.CxxReportLocation;
+import org.sonar.cxx.visitors.MultiLocatitionSquidCheck;
 import org.sonar.squidbridge.api.SourceFile;
-import org.sonar.squidbridge.checks.CheckMessagesVerifier;
 
 public class FunctionComplexityCheckTest {
 
   @Test
-  @SuppressWarnings("squid:S2699") // ... verify contains the assertion
   public void check() throws UnsupportedEncodingException, IOException {
     FunctionComplexityCheck check = new FunctionComplexityCheck();
-    check.setMax(5);
+    check.setMaxComplexity(5);
     CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/checks/FunctionComplexity.cc", ".");
     SourceFile file = CxxAstScanner.scanSingleFile(tester.cxxFile, tester.sensorContext, CxxFileTesterHelper.mockCxxLanguage(), check);
 
-    CheckMessagesVerifier.verify(file.getCheckMessages())
-      .next().atLine(13)
-      .next().atLine(33)
-      .next().atLine(51)
-      .next().atLine(72);
+    Set<CxxReportIssue> issues = MultiLocatitionSquidCheck.getMultiLocationCheckMessages(file);
+    assertThat(issues).isNotNull();
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(issues).hasSize(5);
+    softly.assertThat(issues).allSatisfy(issue -> "FunctionComplexity".equals(issue.getRuleId()));
+
+    CxxReportIssue issue0 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("13"))
+        .findFirst().orElseThrow(() -> new AssertionError("No issue at line 13"));
+    softly.assertThat(issue0.getLocations()).containsOnly(
+        new CxxReportLocation(null, "13",
+            "The Cyclomatic Complexity of this function is 7 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "14", "+1: if statement"),
+        new CxxReportLocation(null, "15", "+1: if statement"),
+        new CxxReportLocation(null, "16", "+1: conditional operator"),
+        new CxxReportLocation(null, "18", "+1: conditional operator"),
+        new CxxReportLocation(null, "21", "+1: if statement"),
+        new CxxReportLocation(null, "22", "+1: conditional operator"),
+        new CxxReportLocation(null, "24", "+1: conditional operator"));
+
+    CxxReportIssue issue1 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("33"))
+        .findFirst().orElseThrow(() -> new AssertionError("No issue at line 33"));
+    softly.assertThat(issue1.getLocations()).containsOnly(
+        new CxxReportLocation(null, "33",
+            "The Cyclomatic Complexity of this function is 7 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "34", "+1: if statement"),
+        new CxxReportLocation(null, "35", "+1: if statement"),
+        new CxxReportLocation(null, "36", "+1: conditional operator"),
+        new CxxReportLocation(null, "38", "+1: conditional operator"),
+        new CxxReportLocation(null, "41", "+1: if statement"),
+        new CxxReportLocation(null, "42", "+1: conditional operator"),
+        new CxxReportLocation(null, "44", "+1: conditional operator"));
+
+    CxxReportIssue issue2 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("51"))
+        .findFirst().orElseThrow(() -> new AssertionError("No issue at line 51"));
+    softly.assertThat(issue2.getLocations()).containsOnly(
+        new CxxReportLocation(null, "51",
+            "The Cyclomatic Complexity of this function is 7 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "52", "+1: if statement"),
+        new CxxReportLocation(null, "53", "+1: if statement"),
+        new CxxReportLocation(null, "54", "+1: conditional operator"),
+        new CxxReportLocation(null, "56", "+1: conditional operator"),
+        new CxxReportLocation(null, "59", "+1: if statement"),
+        new CxxReportLocation(null, "60", "+1: conditional operator"),
+        new CxxReportLocation(null, "62", "+1: conditional operator"));
+
+    CxxReportIssue issue3 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("72"))
+        .findFirst().orElseThrow(() -> new AssertionError("No issue at line 72"));
+    softly.assertThat(issue3.getLocations()).containsOnly(
+        new CxxReportLocation(null, "72",
+            "The Cyclomatic Complexity of this function is 7 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "73", "+1: if statement"),
+        new CxxReportLocation(null, "74", "+1: if statement"),
+        new CxxReportLocation(null, "75", "+1: conditional operator"),
+        new CxxReportLocation(null, "77", "+1: conditional operator"),
+        new CxxReportLocation(null, "80", "+1: if statement"),
+        new CxxReportLocation(null, "81", "+1: conditional operator"),
+        new CxxReportLocation(null, "83", "+1: conditional operator"));
+
+    CxxReportIssue issue4 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("89"))
+        .findFirst().orElseThrow(() -> new AssertionError("No issue at line 89"));
+    softly.assertThat(issue4.getLocations()).containsOnly(
+        new CxxReportLocation(null, "89",
+            "The Cyclomatic Complexity of this function is 13 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "91", "+1: if statement"),
+        new CxxReportLocation(null, "91", "+1: logical operator"),
+        new CxxReportLocation(null, "91", "+1: logical operator"),
+        new CxxReportLocation(null, "94", "+1: catch-clause"),
+        new CxxReportLocation(null, "96", "+1: catch-clause"),
+        new CxxReportLocation(null, "98", "+1: catch-clause"),
+        new CxxReportLocation(null, "100", "+1: catch-clause"),
+        new CxxReportLocation(null, "102", "+1: catch-clause"),
+        new CxxReportLocation(null, "104", "+1: catch-clause"),
+        new CxxReportLocation(null, "106", "+1: catch-clause"),
+        new CxxReportLocation(null, "107", "+1: while loop"),
+        new CxxReportLocation(null, "108", "+1: conditional operator"),
+        new CxxReportLocation(null, "110", "+1: conditional operator"));
+    softly.assertAll();
   }
 
 }

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FunctionComplexityCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FunctionComplexityCheckTest.java
@@ -54,7 +54,8 @@ public class FunctionComplexityCheckTest {
         .findFirst().orElseThrow(() -> new AssertionError("No issue at line 13"));
     softly.assertThat(issue0.getLocations()).containsOnly(
         new CxxReportLocation(null, "13",
-            "The Cyclomatic Complexity of this function is 7 which is greater than 5 authorized."),
+            "The Cyclomatic Complexity of this function is 8 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "13", "+1: function definition"),
         new CxxReportLocation(null, "14", "+1: if statement"),
         new CxxReportLocation(null, "15", "+1: if statement"),
         new CxxReportLocation(null, "16", "+1: conditional operator"),
@@ -67,7 +68,8 @@ public class FunctionComplexityCheckTest {
         .findFirst().orElseThrow(() -> new AssertionError("No issue at line 33"));
     softly.assertThat(issue1.getLocations()).containsOnly(
         new CxxReportLocation(null, "33",
-            "The Cyclomatic Complexity of this function is 7 which is greater than 5 authorized."),
+            "The Cyclomatic Complexity of this function is 8 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "33", "+1: function definition"),
         new CxxReportLocation(null, "34", "+1: if statement"),
         new CxxReportLocation(null, "35", "+1: if statement"),
         new CxxReportLocation(null, "36", "+1: conditional operator"),
@@ -80,7 +82,8 @@ public class FunctionComplexityCheckTest {
         .findFirst().orElseThrow(() -> new AssertionError("No issue at line 51"));
     softly.assertThat(issue2.getLocations()).containsOnly(
         new CxxReportLocation(null, "51",
-            "The Cyclomatic Complexity of this function is 7 which is greater than 5 authorized."),
+            "The Cyclomatic Complexity of this function is 8 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "51", "+1: function definition"),
         new CxxReportLocation(null, "52", "+1: if statement"),
         new CxxReportLocation(null, "53", "+1: if statement"),
         new CxxReportLocation(null, "54", "+1: conditional operator"),
@@ -93,7 +96,8 @@ public class FunctionComplexityCheckTest {
         .findFirst().orElseThrow(() -> new AssertionError("No issue at line 72"));
     softly.assertThat(issue3.getLocations()).containsOnly(
         new CxxReportLocation(null, "72",
-            "The Cyclomatic Complexity of this function is 7 which is greater than 5 authorized."),
+            "The Cyclomatic Complexity of this function is 8 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "72", "+1: function definition"),
         new CxxReportLocation(null, "73", "+1: if statement"),
         new CxxReportLocation(null, "74", "+1: if statement"),
         new CxxReportLocation(null, "75", "+1: conditional operator"),
@@ -106,7 +110,8 @@ public class FunctionComplexityCheckTest {
         .findFirst().orElseThrow(() -> new AssertionError("No issue at line 89"));
     softly.assertThat(issue4.getLocations()).containsOnly(
         new CxxReportLocation(null, "89",
-            "The Cyclomatic Complexity of this function is 13 which is greater than 5 authorized."),
+            "The Cyclomatic Complexity of this function is 14 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "89", "+1: function definition"),
         new CxxReportLocation(null, "91", "+1: if statement"),
         new CxxReportLocation(null, "91", "+1: logical operator"),
         new CxxReportLocation(null, "91", "+1: logical operator"),

--- a/cxx-checks/src/test/resources/checks/ClassComplexity.cc
+++ b/cxx-checks/src/test/resources/checks/ClassComplexity.cc
@@ -8,6 +8,16 @@ public:
 
 class MyClass2 {
 public:
+   // nested class adds complexity to the outer one
+   class SimpleNestedClass {
+   public:
+      SimpleNestedClass() {
+      }
+      int Method0(int a, int b) {
+         return 0;
+      }
+   };
+
    MyClass2() {};
    int Method1(int a, int b) {
       return 0;
@@ -26,5 +36,32 @@ public:
             return a+b ? 7 : 8;
          }
       }
+   }
+};
+
+class MyClass3 {
+public:
+   // nested class adds complexity to the outer one
+   class ComplexNestedClass {
+   public:
+      ComplexNestedClass() {
+      }
+      int Method0(int in) {
+         switch (in) {
+         case 0:
+            return 1;
+         default:
+            return 2;
+         }
+      }
+      int Method1() {
+         for (int i = 0; i < 10; ++i) {
+            if (i != 0 && i % 2 == 0 && i % 3 == 0) {
+               return i;
+            }
+         }
+      }
+   };
+   void Method1() {
    }
 };

--- a/cxx-checks/src/test/resources/checks/FunctionComplexity.cc
+++ b/cxx-checks/src/test/resources/checks/FunctionComplexity.cc
@@ -85,3 +85,28 @@ public:
       }
    }
 };
+
+std::string func_with_trycatch(int i) {
+   try {
+      if ((i % 2 == 0 && i % 3 == 0) || (i % 6 == 0)) {
+         return std::to_string(i);
+      }
+   } catch (const std::logic_error& e) {
+      return "std::logic_error";
+   } catch (const std::bad_cast& e) {
+      return std::string { "std::bad_cast" };
+   } catch (const std::invalid_argument& e) {
+      return std::string { "std::invalid_argument" };
+   } catch (const std::length_error& e) {
+      return std::string { "std::length_error" };
+   } catch (const std::out_of_range& e) {
+      return std::string { "std::out_of_range" };
+   } catch (const std::exception& e) {
+      return std::string("std::exception");
+   } catch (...) {
+      while (i >= 0) {
+         return (i % 3 == 0) ? "unknown exception" : "unexpected exception";
+      }
+      return (i % 2 == 0) ? "exotic exception" : "strange exception";
+   }
+}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensor.java
@@ -30,7 +30,7 @@ import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.CxxMetricsFactory;
 import org.sonar.cxx.sensors.utils.CxxIssuesReportSensor;
-import org.sonar.cxx.sensors.utils.CxxReportIssue;
+import org.sonar.cxx.utils.CxxReportIssue;
 
 import com.dd.plist.NSArray;
 import com.dd.plist.NSDictionary;

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensor.java
@@ -32,7 +32,7 @@ import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.CxxMetricsFactory;
 import org.sonar.cxx.sensors.utils.CxxIssuesReportSensor;
-import org.sonar.cxx.sensors.utils.CxxReportIssue;
+import org.sonar.cxx.utils.CxxReportIssue;
 
 /**
  * Sensor for clang-tidy

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensor.java
@@ -29,7 +29,7 @@ import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.CxxMetricsFactory;
 import org.sonar.cxx.sensors.utils.CxxIssuesReportSensor;
-import org.sonar.cxx.sensors.utils.CxxReportIssue;
+import org.sonar.cxx.utils.CxxReportIssue;
 
 /**
  * compiler for C++ with advanced analysis features (e.g. for VC 2008 team edition or 2010/2012/2013/2015/2017 premium

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CppcheckParserV1.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CppcheckParserV1.java
@@ -26,9 +26,9 @@ import org.codehaus.staxmate.in.SMInputCursor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
-import org.sonar.cxx.sensors.utils.CxxReportIssue;
 import org.sonar.cxx.sensors.utils.EmptyReportException;
 import org.sonar.cxx.sensors.utils.StaxParser;
+import org.sonar.cxx.utils.CxxReportIssue;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CppcheckParserV2.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CppcheckParserV2.java
@@ -30,10 +30,10 @@ import org.codehaus.staxmate.in.SMInputCursor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
-import org.sonar.cxx.sensors.utils.CxxReportIssue;
-import org.sonar.cxx.sensors.utils.CxxReportLocation;
 import org.sonar.cxx.sensors.utils.EmptyReportException;
 import org.sonar.cxx.sensors.utils.StaxParser;
+import org.sonar.cxx.utils.CxxReportIssue;
+import org.sonar.cxx.utils.CxxReportLocation;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/CxxDrMemorySensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/CxxDrMemorySensor.java
@@ -31,7 +31,7 @@ import org.sonar.cxx.CxxMetricsFactory;
 import org.sonar.cxx.sensors.drmemory.DrMemoryParser.DrMemoryError;
 import org.sonar.cxx.sensors.drmemory.DrMemoryParser.DrMemoryError.Location;
 import org.sonar.cxx.sensors.utils.CxxIssuesReportSensor;
-import org.sonar.cxx.sensors.utils.CxxReportIssue;
+import org.sonar.cxx.utils.CxxReportIssue;
 
 /**
  * Dr. Memory is a memory monitoring tool capable of identifying memory-related programming errors such as accesses of

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/other/CxxOtherSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/other/CxxOtherSensor.java
@@ -40,9 +40,9 @@ import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.CxxMetricsFactory;
 import org.sonar.cxx.sensors.utils.CxxIssuesReportSensor;
-import org.sonar.cxx.sensors.utils.CxxReportIssue;
 import org.sonar.cxx.sensors.utils.CxxUtils;
 import org.sonar.cxx.sensors.utils.StaxParser;
+import org.sonar.cxx.utils.CxxReportIssue;
 
 /**
  * Custom Rule Import, all static analysis are supported.

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensor.java
@@ -35,10 +35,10 @@ import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.CxxMetricsFactory;
 import org.sonar.cxx.sensors.utils.CxxIssuesReportSensor;
-import org.sonar.cxx.sensors.utils.CxxReportIssue;
 import org.sonar.cxx.sensors.utils.CxxUtils;
 import org.sonar.cxx.sensors.utils.EmptyReportException;
 import org.sonar.cxx.sensors.utils.StaxParser;
+import org.sonar.cxx.utils.CxxReportIssue;
 
 /**
  * PC-lint is an equivalent to pmd but for C++ The first version of the tool was release 1985 and the tool analyzes

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/rats/CxxRatsSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/rats/CxxRatsSensor.java
@@ -34,8 +34,8 @@ import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.CxxMetricsFactory;
 import org.sonar.cxx.sensors.utils.CxxIssuesReportSensor;
-import org.sonar.cxx.sensors.utils.CxxReportIssue;
 import org.sonar.cxx.sensors.utils.CxxUtils;
+import org.sonar.cxx.utils.CxxReportIssue;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxChecks.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxChecks.java
@@ -76,11 +76,8 @@ public final class CxxChecks {
 
   @Nullable
   public RuleKey ruleKey(SquidAstVisitor<Grammar> check) {
-    RuleKey ruleKey;
-
     for (Checks<SquidAstVisitor<Grammar>> checks : checksByRepository) {
-      ruleKey = checks.ruleKey(check);
-
+      RuleKey ruleKey = checks.ruleKey(check);
       if (ruleKey != null) {
         return ruleKey;
       }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
@@ -39,6 +39,8 @@ import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.CxxMetricsFactory;
+import org.sonar.cxx.utils.CxxReportIssue;
+import org.sonar.cxx.utils.CxxReportLocation;
 
 /**
  * This class is used as base for all sensors which import external reports,

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/valgrind/CxxValgrindSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/valgrind/CxxValgrindSensor.java
@@ -29,7 +29,7 @@ import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.CxxMetricsFactory;
 import org.sonar.cxx.sensors.utils.CxxIssuesReportSensor;
-import org.sonar.cxx.sensors.utils.CxxReportIssue;
+import org.sonar.cxx.utils.CxxReportIssue;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxSensor.java
@@ -30,10 +30,10 @@ import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.CxxMetricsFactory;
 import org.sonar.cxx.sensors.utils.CxxIssuesReportSensor;
-import org.sonar.cxx.sensors.utils.CxxReportIssue;
 import org.sonar.cxx.sensors.utils.CxxUtils;
 import org.sonar.cxx.sensors.utils.EmptyReportException;
 import org.sonar.cxx.sensors.utils.StaxParser;
+import org.sonar.cxx.utils.CxxReportIssue;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/MockCxxCompilerSensor.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/MockCxxCompilerSensor.java
@@ -34,8 +34,8 @@ import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.profiles.RulesProfile;
 import org.sonar.cxx.CxxLanguage;
-import org.sonar.cxx.sensors.utils.CxxReportIssue;
-import org.sonar.cxx.sensors.utils.CxxReportLocation;
+import org.sonar.cxx.utils.CxxReportIssue;
+import org.sonar.cxx.utils.CxxReportLocation;
 
 public class MockCxxCompilerSensor extends CxxCompilerSensor {
 

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxAstScanner.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxAstScanner.java
@@ -23,9 +23,7 @@ import java.util.Collection;
 
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.cxx.api.CxxKeyword;
 import org.sonar.cxx.api.CxxMetric;
-import org.sonar.cxx.api.CxxPunctuator;
 import org.sonar.cxx.parser.CxxGrammarImpl;
 import org.sonar.cxx.parser.CxxParser;
 import org.sonar.cxx.visitors.CxxCharsetAwareVisitor;
@@ -55,7 +53,6 @@ import org.sonar.squidbridge.metrics.CounterVisitor;
 import org.sonar.squidbridge.metrics.LinesVisitor;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.AstNodeType;
 import com.sonar.sslr.api.GenericTokenType;
 import com.sonar.sslr.api.Grammar;
 import com.sonar.sslr.api.Token;
@@ -217,23 +214,9 @@ public final class CxxAstScanner {
       .subscribeTo(CxxGrammarImpl.statement)
       .build());
 
-    AstNodeType[] complexityAstNodeType = new AstNodeType[]{
-      // Entry points
-      CxxGrammarImpl.functionDefinition,
-      CxxKeyword.IF,
-      CxxKeyword.FOR,
-      CxxKeyword.WHILE,
-      CxxKeyword.CATCH,
-      CxxKeyword.CASE,
-      CxxKeyword.DEFAULT,
-      CxxPunctuator.AND,
-      CxxPunctuator.OR,
-      CxxPunctuator.QUEST
-    };
-
     builder.withSquidAstVisitor(ComplexityVisitor.<Grammar>builder()
       .setMetricDef(CxxMetric.COMPLEXITY)
-      .subscribeTo(complexityAstNodeType)
+      .subscribeTo(CxxComplexityConstants.CyclomaticComplexityAstNodeTypes)
       .build());
 
     builder.withSquidAstVisitor(new CxxCognitiveComplexityVisitor<Grammar>());

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxComplexityConstants.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxComplexityConstants.java
@@ -1,0 +1,55 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2018 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx;
+
+import org.sonar.cxx.api.CxxKeyword;
+import org.sonar.cxx.api.CxxPunctuator;
+import org.sonar.cxx.parser.CxxGrammarImpl;
+
+import com.sonar.sslr.api.AstNodeType;
+
+public class CxxComplexityConstants {
+
+  private CxxComplexityConstants() {
+    /* utility class */
+  }
+
+  /**
+   * From original SonarQube documentation: <blockquote>The complexity is
+   * measured by the number of if, while, do, for, ?:, catch, switch, case
+   * statements, and operators && and || (plus one) in the body of a
+   * constructor, method, static initializer, or instance initializer.
+   * </blockquote>
+   *
+   * @see CyclomaticComplexityExclusionAstNodeTypes
+   */
+  public static final AstNodeType[] CyclomaticComplexityAstNodeTypes = new AstNodeType[] {
+      CxxGrammarImpl.functionDefinition,
+      CxxKeyword.IF,
+      CxxKeyword.FOR,
+      CxxKeyword.WHILE,
+      CxxKeyword.CATCH,
+      CxxKeyword.CASE,
+      CxxKeyword.DEFAULT,
+      CxxPunctuator.AND,
+      CxxPunctuator.OR,
+      CxxPunctuator.QUEST };
+
+}

--- a/cxx-squid/src/main/java/org/sonar/cxx/utils/CxxReportIssue.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/utils/CxxReportIssue.java
@@ -17,47 +17,50 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.cxx.sensors.utils;
+package org.sonar.cxx.utils;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
- * Each issues in SonarQube might have multiple locations; Encapsulate its
- * properties in this structure
+ * Issue with one or multiple locations
  */
-public class CxxReportLocation {
-  private final String file;
-  private final String line;
-  private final String info;
+public class CxxReportIssue {
+  private final String ruleId;
+  private final List<CxxReportLocation> locations;
 
-  public CxxReportLocation(@Nullable String file, @Nullable String line, String info) {
+  public CxxReportIssue(String ruleId, @Nullable String file, @Nullable String line, String info) {
     super();
-    this.file = file;
-    this.line = line;
-    this.info = info;
+    this.ruleId = ruleId;
+    this.locations = new ArrayList<>();
+    addLocation(file, line, info);
   }
 
-  public String getFile() {
-    return file;
+  public final void addLocation(@Nullable String file, @Nullable String line, String info) {
+    locations.add(new CxxReportLocation(file, line, info));
   }
 
-  public String getLine() {
-    return line;
+  public String getRuleId() {
+    return ruleId;
   }
 
-  public String getInfo() {
-    return info;
+  public List<CxxReportLocation> getLocations() {
+    return Collections.unmodifiableList(locations);
   }
 
   @Override
   public String toString() {
-    return "CxxReportLocation [file=" + file + ", line=" + line + ", info=" + info + "]";
+    String locationsToString = locations.stream().map(Object::toString).collect(Collectors.joining(", "));
+    return "CxxReportIssue [ruleId=" + ruleId + ", locations=" + locationsToString + "]";
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(file, info, line);
+    return Objects.hash(locations, ruleId);
   }
 
   @Override
@@ -71,7 +74,7 @@ public class CxxReportLocation {
     if (getClass() != obj.getClass()) {
       return false;
     }
-    CxxReportLocation other = (CxxReportLocation) obj;
-    return Objects.equals(file, other.file) && Objects.equals(info, other.info) && Objects.equals(line, other.line);
+    CxxReportIssue other = (CxxReportIssue) obj;
+    return Objects.equals(locations, other.locations) && Objects.equals(ruleId, other.ruleId);
   }
 }

--- a/cxx-squid/src/main/java/org/sonar/cxx/utils/CxxReportLocation.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/utils/CxxReportLocation.java
@@ -17,50 +17,47 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.cxx.sensors.utils;
+package org.sonar.cxx.utils;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
- * Issue with one or multiple locations
+ * Each issues in SonarQube might have multiple locations; Encapsulate its
+ * properties in this structure
  */
-public class CxxReportIssue {
-  private final String ruleId;
-  private final List<CxxReportLocation> locations;
+public class CxxReportLocation {
+  private final String file;
+  private final String line;
+  private final String info;
 
-  public CxxReportIssue(String ruleId, @Nullable String file, @Nullable String line, String info) {
+  public CxxReportLocation(@Nullable String file, @Nullable String line, String info) {
     super();
-    this.ruleId = ruleId;
-    this.locations = new ArrayList<>();
-    addLocation(file, line, info);
+    this.file = file;
+    this.line = line;
+    this.info = info;
   }
 
-  public final void addLocation(@Nullable String file, @Nullable String line, String info) {
-    locations.add(new CxxReportLocation(file, line, info));
+  public String getFile() {
+    return file;
   }
 
-  public String getRuleId() {
-    return ruleId;
+  public String getLine() {
+    return line;
   }
 
-  public List<CxxReportLocation> getLocations() {
-    return Collections.unmodifiableList(locations);
+  public String getInfo() {
+    return info;
   }
 
   @Override
   public String toString() {
-    String locationsToString = locations.stream().map(Object::toString).collect(Collectors.joining(", "));
-    return "CxxReportIssue [ruleId=" + ruleId + ", locations=" + locationsToString + "]";
+    return "CxxReportLocation [file=" + file + ", line=" + line + ", info=" + info + "]";
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(locations, ruleId);
+    return Objects.hash(file, info, line);
   }
 
   @Override
@@ -74,7 +71,7 @@ public class CxxReportIssue {
     if (getClass() != obj.getClass()) {
       return false;
     }
-    CxxReportIssue other = (CxxReportIssue) obj;
-    return Objects.equals(locations, other.locations) && Objects.equals(ruleId, other.ruleId);
+    CxxReportLocation other = (CxxReportLocation) obj;
+    return Objects.equals(file, other.file) && Objects.equals(info, other.info) && Objects.equals(line, other.line);
   }
 }

--- a/cxx-squid/src/main/java/org/sonar/cxx/utils/package-info.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/utils/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2018 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+@ParametersAreNonnullByDefault
+package org.sonar.cxx.utils;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
@@ -20,7 +20,6 @@
 package org.sonar.cxx.visitors;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.AstVisitor;
 import com.sonar.sslr.api.GenericTokenType;
 import com.sonar.sslr.api.Grammar;
 import com.sonar.sslr.api.Token;

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/MultiLocatitionSquidCheck.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/MultiLocatitionSquidCheck.java
@@ -1,0 +1,138 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2018 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.visitors;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.sonar.api.utils.AnnotationUtils;
+import org.sonar.cxx.utils.CxxReportIssue;
+import org.sonar.squidbridge.SquidAstVisitorContext;
+import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.SquidCheck;
+import org.sonar.squidbridge.measures.CalculatedMetricFormula;
+import org.sonar.squidbridge.measures.MetricDef;
+
+import com.sonar.sslr.api.Grammar;
+
+/**
+ * Derivation of {@link SquidCheck}, which can create issues with multiple
+ * locations (1 primary location, arbitrary number of secondary locations
+ *
+ * See also org.sonar.squidbridge.SquidAstVisitorContext.createLineViolation
+ *
+ * @param <G>
+ */
+public class MultiLocatitionSquidCheck<G extends Grammar> extends SquidCheck<G> {
+
+  private static enum DataKey implements MetricDef {
+    FILE_VIOLATIONS_WITH_MULTIPLE_LOCATIONS;
+
+    @Override
+    public String getName() {
+      return FILE_VIOLATIONS_WITH_MULTIPLE_LOCATIONS.getName();
+    }
+
+    @Override
+    public boolean isCalculatedMetric() {
+      return false;
+    }
+
+    @Override
+    public boolean aggregateIfThereIsAlreadyAValue() {
+      return false;
+    }
+
+    @Override
+    public boolean isThereAggregationFormula() {
+      return false;
+    }
+
+    @Override
+    public CalculatedMetricFormula getCalculatedMetricFormula() {
+      return null;
+    }
+  }
+
+  /**
+   * @return the rule key of this check visitor
+   * @see org.sonar.check.Rule
+   */
+  protected String getRuleKey() {
+    org.sonar.check.Rule ruleAnnotation = AnnotationUtils.getAnnotation(this, org.sonar.check.Rule.class);
+    if (ruleAnnotation != null && ruleAnnotation.key() != null) {
+      return ruleAnnotation.key();
+    }
+    throw new IllegalStateException("Check must be annotated with @Rule( key = <key> )");
+  }
+
+  private SourceFile getSourceFile() {
+    final SquidAstVisitorContext<G> c = getContext();
+    if (c.peekSourceCode() instanceof SourceFile) {
+      return (SourceFile) c.peekSourceCode();
+    } else if (c.peekSourceCode().getParent(SourceFile.class) != null) {
+      return c.peekSourceCode().getParent(SourceFile.class);
+    } else {
+      throw new IllegalStateException("Unable to get SourceFile on source code '"
+          + (c.peekSourceCode() == null ? "[NULL]" : c.peekSourceCode().getKey()) + "'");
+    }
+  }
+
+  /**
+   * Add the given message to the current SourceFile object
+   * @see SquidAstVisitorContext<G extends Grammar>.createLineViolation() for simple violations
+   */
+  protected void createMultiLocationViolation(CxxReportIssue message) {
+    SourceFile sourceFile = getSourceFile();
+    Set<CxxReportIssue> messages = getMultiLocationCheckMessages(sourceFile);
+    if (messages == null) {
+      messages = new HashSet<>();
+    }
+    messages.add(message);
+    setMultiLocationViolation(sourceFile, messages);
+  }
+
+  /**
+   * @return set of multi-location issues, raised on the given file; might be
+   *         <code>null</code>
+   * @see SourceFile.getCheckMessages() for simple violations
+   */
+  @SuppressWarnings("unchecked")
+  public static Set<CxxReportIssue> getMultiLocationCheckMessages(SourceFile sourceFile) {
+    return (Set<CxxReportIssue>) sourceFile.getData(DataKey.FILE_VIOLATIONS_WITH_MULTIPLE_LOCATIONS);
+  }
+
+  /**
+   * @return true if the given file has mult-location issues
+   * @see SourceFile.hasCheckMessages() for simple violations
+   */
+  public static boolean hasMultiLocationCheckMessages(SourceFile sourceFile) {
+    Set<CxxReportIssue> issues = getMultiLocationCheckMessages(sourceFile);
+    return issues != null && !issues.isEmpty();
+  }
+
+  private static void setMultiLocationViolation(SourceFile sourceFile, Set<CxxReportIssue> messages) {
+    sourceFile.addData(DataKey.FILE_VIOLATIONS_WITH_MULTIPLE_LOCATIONS, messages);
+  }
+
+  public static void eraseMultilineCheckMessages(SourceFile sourceFile) {
+    setMultiLocationViolation(sourceFile, null);
+  }
+}

--- a/cxx-squid/src/test/java/org/sonar/cxx/utils/CxxReportIssueTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/utils/CxxReportIssueTest.java
@@ -17,7 +17,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.cxx.sensors.utils;
+package org.sonar.cxx.utils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;

--- a/cxx-squid/src/test/java/org/sonar/cxx/utils/package-info.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/utils/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2018 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+@ParametersAreNonnullByDefault
+package org.sonar.cxx.utils;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
1. implement multi-location messages for squidsensor
* move CxxReportIssue and CxxReportLocation from
  cxx-sensors to cxx-squid in order to satisfy dependencies

2. introduce CxxCyclomaticComplexityCheck
* this class is used for all scoped cyclomatic complexity checks
* implement
  * ClassComplexityCheck (rule cxx:ClassComplexity)
  * FileComplexityCheck (rule cxx:FileComplexity)
  * FunctionComplexityCheck (rule cxx:FunctionComplexity)

* they respect the scopes (important for nested classes)
* they provide detailed information about complexity sources

This change addresses #1494:

* cyclomatic complexity checks (done)
* cognitive complexity checks (todo)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1537)
<!-- Reviewable:end -->
