### PR TITLE
implement explanation for cognitive complexity check

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/CxxCyclomaticComplexityCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/CxxCyclomaticComplexityCheck.java
@@ -21,14 +21,12 @@ package org.sonar.cxx.checks.metrics;
 
 import java.util.Deque;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Optional;
 
 import org.sonar.cxx.CxxComplexityConstants;
-import org.sonar.cxx.api.CxxKeyword;
-import org.sonar.cxx.api.CxxPunctuator;
-import org.sonar.cxx.parser.CxxGrammarImpl;
 import org.sonar.cxx.utils.CxxReportIssue;
+import org.sonar.cxx.visitors.CxxComplexityScope;
+import org.sonar.cxx.visitors.CxxComplexitySource;
 import org.sonar.cxx.visitors.MultiLocatitionSquidCheck;
 
 import com.sonar.sslr.api.AstNode;
@@ -45,83 +43,11 @@ import com.sonar.sslr.api.Grammar;
 public abstract class CxxCyclomaticComplexityCheck<G extends Grammar> extends MultiLocatitionSquidCheck<G> {
 
   /**
-   * Structure, that tracks all nodes, which increase the code complexity
-   */
-  private class ComplexitySource {
-    private final int line;
-    private final AstNodeType type;
-
-    public ComplexitySource(int line, AstNodeType nodeType) {
-      super();
-      this.line = line;
-      this.type = nodeType;
-    }
-
-    public String getLine() {
-      return Integer.valueOf(line).toString();
-    }
-
-    public String getExplanation() {
-      if (type == CxxGrammarImpl.functionDefinition) {
-        return "+1: function definition";
-      } else if (type == CxxKeyword.IF) {
-        return "+1: if statement";
-      } else if (type == CxxKeyword.FOR) {
-        return "+1: for loop";
-      } else if (type == CxxKeyword.WHILE) {
-        return "+1: while loop";
-      } else if (type == CxxKeyword.CATCH) {
-        return "+1: catch-clause";
-      } else if (type == CxxKeyword.CASE || type == CxxKeyword.DEFAULT) {
-        return "+1: switch label";
-      } else if (type == CxxPunctuator.AND || type == CxxPunctuator.OR) {
-        return "+1: logical operator";
-      } else if (type == CxxPunctuator.QUEST) {
-        return "+1: conditional operator";
-      }
-      return "+1";
-    }
-  }
-
-  /**
-   * Describe a code scope (function definition, class definition, entire file
-   * etc) in terms of complexity sources
-   */
-  private class ComplexityScope {
-    public ComplexityScope(int startingLine) {
-      this.sources = new LinkedList<>();
-      this.complexity = 0;
-      this.startingLine = startingLine;
-    }
-
-    public void addComplexitySource(int line, AstNodeType nodeType) {
-      sources.add(new ComplexitySource(line, nodeType));
-      ++complexity;
-    }
-
-    public List<ComplexitySource> getSources() {
-      return sources;
-    }
-
-    public int getComplexity() {
-      return complexity;
-    }
-
-    public String getStartingLine() {
-      return Integer.valueOf(startingLine).toString();
-    }
-
-    private List<ComplexitySource> sources;
-    private int complexity;
-    private int startingLine;
-  }
-
-  /**
    * Stack for tracking the nested scopes (e.g. declaration of classes can be
    * nested). Complexity of the inner scopes is added to the complexity of outer
    * scopes.
    */
-  private Deque<ComplexityScope> complexityScopes;
+  private Deque<CxxComplexityScope> complexityScopes;
 
   /**
    * @return the maximum allowed complexity for this scope
@@ -144,9 +70,9 @@ public abstract class CxxCyclomaticComplexityCheck<G extends Grammar> extends Mu
   @Override
   public void init() {
     subscribeTo(CxxComplexityConstants.CyclomaticComplexityAstNodeTypes);
-
-    if (getScopeType().isPresent()) {
-      final AstNodeType additionalNode = getScopeType().get();
+    final Optional<AstNodeType> scopeType = getScopeType();
+    if (scopeType.isPresent()) {
+      final AstNodeType additionalNode = scopeType.get();
       if (!getAstNodeTypesToVisit().contains(additionalNode)) {
         subscribeTo(additionalNode);
       }
@@ -158,7 +84,7 @@ public abstract class CxxCyclomaticComplexityCheck<G extends Grammar> extends Mu
   @Override
   public void visitFile(AstNode astNode) {
     if (!getScopeType().isPresent()) {
-      complexityScopes.addFirst(new ComplexityScope(1));
+      complexityScopes.addFirst(new CxxComplexityScope(1));
     }
   }
 
@@ -171,14 +97,15 @@ public abstract class CxxCyclomaticComplexityCheck<G extends Grammar> extends Mu
 
   @Override
   public void visitNode(AstNode astNode) {
-    if (getScopeType().isPresent() && astNode.is(getScopeType().get())) {
-      complexityScopes.addFirst(new ComplexityScope(astNode.getTokenLine()));
+    final Optional<AstNodeType> scopeType = getScopeType();
+    if (scopeType.isPresent() && astNode.is(scopeType.get())) {
+      complexityScopes.addFirst(new CxxComplexityScope(astNode.getTokenLine()));
     }
 
     if (astNode.is(CxxComplexityConstants.CyclomaticComplexityAstNodeTypes)) {
       // for nested scopes (e.g. nested classes) the inner classes
       // add complexity to the outer ones
-      for (ComplexityScope scope : complexityScopes) {
+      for (CxxComplexityScope scope : complexityScopes) {
         scope.addComplexitySource(astNode.getTokenLine(), astNode.getType());
       }
     }
@@ -186,13 +113,14 @@ public abstract class CxxCyclomaticComplexityCheck<G extends Grammar> extends Mu
 
   @Override
   public void leaveNode(AstNode astNode) {
-    if (getScopeType().isPresent() && astNode.is(getScopeType().get())) {
+    final Optional<AstNodeType> scopeType = getScopeType();
+    if (scopeType.isPresent() && astNode.is(scopeType.get())) {
       analyzeScopeComplexity();
     }
   }
 
   private void analyzeScopeComplexity() {
-    ComplexityScope scope = complexityScopes.removeFirst();
+    CxxComplexityScope scope = complexityScopes.removeFirst();
 
     final int maxComplexity = getMaxComplexity();
     final int currentComplexity = scope.getComplexity();
@@ -202,7 +130,7 @@ public abstract class CxxCyclomaticComplexityCheck<G extends Grammar> extends Mu
           .append(" which is greater than ").append(maxComplexity).append(" authorized.");
 
       final CxxReportIssue issue = new CxxReportIssue(getRuleKey(), null, scope.getStartingLine(), msg.toString());
-      for (ComplexitySource source : scope.getSources()) {
+      for (CxxComplexitySource source : scope.getSources()) {
         issue.addLocation(null, source.getLine(), source.getExplanation());
       }
       createMultiLocationViolation(issue);

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/FunctionCognitiveComplexityCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/FunctionCognitiveComplexityCheck.java
@@ -19,21 +19,18 @@
  */
 package org.sonar.cxx.checks.metrics;
 
-import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Grammar;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
-import org.sonar.cxx.api.CxxMetric;
-import org.sonar.cxx.parser.CxxGrammarImpl;
 import org.sonar.cxx.tag.Tag;
 import org.sonar.cxx.utils.CxxReportIssue;
-import org.sonar.cxx.visitors.MultiLocatitionSquidCheck;
+import org.sonar.cxx.visitors.CxxCognitiveComplexityVisitor;
+import org.sonar.cxx.visitors.CxxComplexityScope;
+import org.sonar.cxx.visitors.CxxComplexitySource;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
 import org.sonar.squidbridge.annotations.SqaleLinearWithOffsetRemediation;
-import org.sonar.squidbridge.api.SourceFunction;
-import org.sonar.squidbridge.checks.ChecksHelper;
-import org.sonar.squidbridge.checks.SquidCheck;
+
+import com.sonar.sslr.api.Grammar;
 
 @Rule(
   key = "FunctionCognitiveComplexity",
@@ -45,7 +42,7 @@ import org.sonar.squidbridge.checks.SquidCheck;
   coeff = "1min",
   offset = "5min",
   effortToFixDescription = "per complexity point above the threshold")
-public class FunctionCognitiveComplexityCheck extends SquidCheck<Grammar> {
+public class FunctionCognitiveComplexityCheck extends CxxCognitiveComplexityVisitor<Grammar> {
 
   private static final int DEFAULT_MAX = 15;
 
@@ -56,25 +53,21 @@ public class FunctionCognitiveComplexityCheck extends SquidCheck<Grammar> {
   private int max = DEFAULT_MAX;
 
   @Override
-  public void init() {
-    subscribeTo(CxxGrammarImpl.functionDefinition);
-  }
+  protected void analyzeComplexity(CxxComplexityScope scope) {
+    if (scope.getComplexity() > max) {
+      final StringBuilder msg = new StringBuilder();
+      msg.append("The Cognitive Complexity of this function is ").append(scope.getComplexity())
+          .append(" which is greater than ").append(max).append(" authorized.");
 
-  @Override
-  public void leaveNode(AstNode node) {
-    SourceFunction sourceFunction = (SourceFunction) getContext().peekSourceCode();
-    int complexity = ChecksHelper.getRecursiveMeasureInt(sourceFunction, CxxMetric.COGNITIVE_COMPLEXITY);
-    if (complexity > max) {
-      getContext().createLineViolation(this,
-        "The Cognitive Complexity of this function is {0,number,integer} which is greater than "
-          + "{1,number,integer} authorized.",
-        node,
-        complexity,
-        max);
+      final CxxReportIssue issue = new CxxReportIssue(getRuleKey(), null, scope.getStartingLine(), msg.toString());
+      for (CxxComplexitySource source : scope.getSources()) {
+        issue.addLocation(null, source.getLine(), source.getExplanation());
+      }
+      createMultiLocationViolation(issue);
     }
   }
 
-  public void setMax(int max) {
+  public void setMaxComplexity(int max) {
     this.max = max;
   }
 }

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FunctionCognitiveComplexityCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FunctionCognitiveComplexityCheckTest.java
@@ -19,31 +19,115 @@
  */
 package org.sonar.cxx.checks.metrics;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.Set;
 
+import org.assertj.core.api.SoftAssertions;
 import org.junit.Test;
 import org.sonar.cxx.CxxAstScanner;
 import org.sonar.cxx.checks.CxxFileTester;
 import org.sonar.cxx.checks.CxxFileTesterHelper;
+import org.sonar.cxx.utils.CxxReportIssue;
+import org.sonar.cxx.utils.CxxReportLocation;
+import org.sonar.cxx.visitors.MultiLocatitionSquidCheck;
 import org.sonar.squidbridge.api.SourceFile;
-import org.sonar.squidbridge.checks.CheckMessagesVerifier;
 
 public class FunctionCognitiveComplexityCheckTest {
 
   @Test
-  @SuppressWarnings("squid:S2699") // ... verify contains the assertion
   public void check() throws UnsupportedEncodingException, IOException {
     FunctionCognitiveComplexityCheck check = new FunctionCognitiveComplexityCheck();
-    check.setMax(18);
+    check.setMaxComplexity(5);
     CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/checks/FunctionCognitiveComplexity.cc", ".");
     SourceFile file = CxxAstScanner.scanSingleFile(tester.cxxFile, tester.sensorContext, CxxFileTesterHelper.mockCxxLanguage(), check);
+    Set<CxxReportIssue> issues = MultiLocatitionSquidCheck.getMultiLocationCheckMessages(file);
+    assertThat(issues).isNotNull();
 
-    CheckMessagesVerifier.verify(file.getCheckMessages())
-      .next().atLine(13)
-      .next().atLine(33)
-      .next().atLine(51)
-      .next().atLine(72);
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(issues).hasSize(5);
+    softly.assertThat(issues).allSatisfy(issue -> "FunctionCognitiveComplexity".equals(issue.getRuleId()));
+
+    CxxReportIssue issue0 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("13"))
+        .findFirst().orElseThrow(() -> new AssertionError("No issue at line 13"));
+    softly.assertThat(issue0.getLocations()).containsOnly(
+        new CxxReportLocation(null, "13", "The Cognitive Complexity of this function is 20 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "14", "+1: if statement"),
+        new CxxReportLocation(null, "15", "+2: if statement (incl 1 for nesting)"),
+        new CxxReportLocation(null, "16", "+3: conditional operator (incl 2 for nesting)"),
+        new CxxReportLocation(null, "17", "+1: else statement"),
+        new CxxReportLocation(null, "18", "+3: conditional operator (incl 2 for nesting)"),
+        new CxxReportLocation(null, "20", "+1: else statement"),
+        new CxxReportLocation(null, "21", "+2: if statement (incl 1 for nesting)"),
+        new CxxReportLocation(null, "22", "+3: conditional operator (incl 2 for nesting)"),
+        new CxxReportLocation(null, "23", "+1: else statement"),
+        new CxxReportLocation(null, "24", "+3: conditional operator (incl 2 for nesting)"));
+
+    CxxReportIssue issue1 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("33"))
+        .findFirst().orElseThrow(() -> new AssertionError("No issue at line 33"));
+    softly.assertThat(issue1.getLocations()).containsOnly(
+        new CxxReportLocation(null, "33", "The Cognitive Complexity of this function is 20 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "34", "+1: if statement"),
+        new CxxReportLocation(null, "35", "+2: if statement (incl 1 for nesting)"),
+        new CxxReportLocation(null, "36", "+3: conditional operator (incl 2 for nesting)"),
+        new CxxReportLocation(null, "37", "+1: else statement"),
+        new CxxReportLocation(null, "38", "+3: conditional operator (incl 2 for nesting)"),
+        new CxxReportLocation(null, "40", "+1: else statement"),
+        new CxxReportLocation(null, "41", "+2: if statement (incl 1 for nesting)"),
+        new CxxReportLocation(null, "42", "+3: conditional operator (incl 2 for nesting)"),
+        new CxxReportLocation(null, "43", "+1: else statement"),
+        new CxxReportLocation(null, "44", "+3: conditional operator (incl 2 for nesting)"));
+
+    CxxReportIssue issue2 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("51"))
+        .findFirst().orElseThrow(() -> new AssertionError("No issue at line 51"));
+    softly.assertThat(issue2.getLocations()).containsOnly(
+        new CxxReportLocation(null, "51", "The Cognitive Complexity of this function is 20 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "52", "+1: if statement"),
+        new CxxReportLocation(null, "53", "+2: if statement (incl 1 for nesting)"),
+        new CxxReportLocation(null, "54", "+3: conditional operator (incl 2 for nesting)"),
+        new CxxReportLocation(null, "55", "+1: else statement"),
+        new CxxReportLocation(null, "56", "+3: conditional operator (incl 2 for nesting)"),
+        new CxxReportLocation(null, "58", "+1: else statement"),
+        new CxxReportLocation(null, "59", "+2: if statement (incl 1 for nesting)"),
+        new CxxReportLocation(null, "60", "+3: conditional operator (incl 2 for nesting)"),
+        new CxxReportLocation(null, "61", "+1: else statement"),
+        new CxxReportLocation(null, "62", "+3: conditional operator (incl 2 for nesting)"));
+
+    CxxReportIssue issue3 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("72"))
+        .findFirst().orElseThrow(() -> new AssertionError("No issue at line 72"));
+    softly.assertThat(issue3.getLocations()).containsOnly(
+        new CxxReportLocation(null, "72", "The Cognitive Complexity of this function is 20 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "73", "+1: if statement"),
+        new CxxReportLocation(null, "74", "+2: if statement (incl 1 for nesting)"),
+        new CxxReportLocation(null, "75", "+3: conditional operator (incl 2 for nesting)"),
+        new CxxReportLocation(null, "76", "+1: else statement"),
+        new CxxReportLocation(null, "77", "+3: conditional operator (incl 2 for nesting)"),
+        new CxxReportLocation(null, "79", "+1: else statement"),
+        new CxxReportLocation(null, "80", "+2: if statement (incl 1 for nesting)"),
+        new CxxReportLocation(null, "81", "+3: conditional operator (incl 2 for nesting)"),
+        new CxxReportLocation(null, "82", "+1: else statement"),
+        new CxxReportLocation(null, "83", "+3: conditional operator (incl 2 for nesting)"));
+
+    CxxReportIssue issue4 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("89"))
+        .findFirst().orElseThrow(() -> new AssertionError("No issue at line 89"));
+    softly.assertThat(issue4.getLocations()).containsOnly(
+        new CxxReportLocation(null, "89", "The Cognitive Complexity of this function is 17 which is greater than 5 authorized."),
+        new CxxReportLocation(null, "91", "+1: if statement"),
+        new CxxReportLocation(null, "91", "+1: logical operator"),
+        new CxxReportLocation(null, "91", "+1: logical operator"),
+        new CxxReportLocation(null, "94", "+1: catch-clause"),
+        new CxxReportLocation(null, "96", "+1: catch-clause"),
+        new CxxReportLocation(null, "98", "+1: catch-clause"),
+        new CxxReportLocation(null, "100", "+1: catch-clause"),
+        new CxxReportLocation(null, "102", "+1: catch-clause"),
+        new CxxReportLocation(null, "104", "+1: catch-clause"),
+        new CxxReportLocation(null, "106", "+1: catch-clause"),
+        new CxxReportLocation(null, "107", "+2: iteration statement (incl 1 for nesting)"),
+        new CxxReportLocation(null, "108", "+3: conditional operator (incl 2 for nesting)"),
+        new CxxReportLocation(null, "110", "+2: conditional operator (incl 1 for nesting)"));
+    softly.assertAll();
   }
 
 }

--- a/cxx-checks/src/test/resources/checks/FunctionCognitiveComplexity.cc
+++ b/cxx-checks/src/test/resources/checks/FunctionCognitiveComplexity.cc
@@ -85,3 +85,28 @@ public:
         }
     }
 };
+
+std::string func_with_trycatch(int i) {
+   try {
+      if ((i % 2 == 0 && i % 3 == 0) || (i % 6 == 0)) {
+         return std::to_string(i);
+      }
+   } catch (const std::logic_error& e) {
+      return "std::logic_error";
+   } catch (const std::bad_cast& e) {
+      return std::string { "std::bad_cast" };
+   } catch (const std::invalid_argument& e) {
+      return std::string { "std::invalid_argument" };
+   } catch (const std::length_error& e) {
+      return std::string { "std::length_error" };
+   } catch (const std::out_of_range& e) {
+      return std::string { "std::out_of_range" };
+   } catch (const std::exception& e) {
+      return std::string("std::exception");
+   } catch (...) {
+      while (i >= 0) {
+         return (i % 3 == 0) ? "unknown exception" : "unexpected exception";
+      }
+      return (i % 2 == 0) ? "exotic exception" : "strange exception";
+   }
+}

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxCognitiveComplexityVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxCognitiveComplexityVisitor.java
@@ -22,20 +22,22 @@ package org.sonar.cxx.visitors;
 import static com.sonar.sslr.api.GenericTokenType.IDENTIFIER;
 
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.Set;
 
 import org.sonar.cxx.api.CxxKeyword;
 import org.sonar.cxx.api.CxxMetric;
 import org.sonar.cxx.api.CxxPunctuator;
 import org.sonar.cxx.parser.CxxGrammarImpl;
-import org.sonar.squidbridge.SquidAstVisitor;
+import org.sonar.squidbridge.api.SourceCode;
 
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.AstNodeType;
 import com.sonar.sslr.api.Grammar;
 
-public final class CxxCognitiveComplexityVisitor<G extends Grammar> extends SquidAstVisitor<G> {
+public class CxxCognitiveComplexityVisitor<G extends Grammar> extends MultiLocatitionSquidCheck<G> {
 
   private static final AstNodeType[] DESCENDANT_TYPES = new AstNodeType[] {
       CxxGrammarImpl.handler,
@@ -72,11 +74,9 @@ public final class CxxCognitiveComplexityVisitor<G extends Grammar> extends Squi
       CxxGrammarImpl.selectionStatement,
       CxxPunctuator.QUEST };
 
-  private CxxMetric metric;
-  private int nesting;
-  private boolean inFunctionDefinitionScope;
+  private Deque<CxxComplexityScope> complexityScopes;
 
-  static final Set<AstNodeType> SUBSCRIPTION_NODES = new HashSet<>();
+  private static final Set<AstNodeType> SUBSCRIPTION_NODES = new HashSet<>();
   static {
     SUBSCRIPTION_NODES.add(CxxGrammarImpl.functionDefinition);
     SUBSCRIPTION_NODES.addAll(Arrays.asList(DESCENDANT_TYPES));
@@ -85,10 +85,9 @@ public final class CxxCognitiveComplexityVisitor<G extends Grammar> extends Squi
     SUBSCRIPTION_NODES.addAll(Arrays.asList(NESTING_INCREMENTS_TYPES));
   }
 
-  public CxxCognitiveComplexityVisitor() {
-    this.metric = CxxMetric.COGNITIVE_COMPLEXITY;
-    nesting = 0;
-    inFunctionDefinitionScope = false;
+  protected void analyzeComplexity(CxxComplexityScope scope) {
+    SourceCode code = getContext().peekSourceCode();
+    code.setMeasure(CxxMetric.COGNITIVE_COMPLEXITY, scope.getComplexity());
   }
 
   @Override
@@ -96,43 +95,46 @@ public final class CxxCognitiveComplexityVisitor<G extends Grammar> extends Squi
     for (AstNodeType astNodeType : SUBSCRIPTION_NODES) {
       subscribeTo(astNodeType);
     }
+    complexityScopes = new LinkedList<>();
   }
 
   @Override
   public void visitNode(AstNode node) {
     if (node.is(CxxGrammarImpl.functionDefinition)) {
-      inFunctionDefinitionScope = true;
+      complexityScopes.addFirst(new CxxComplexityScope(node.getTokenLine()));
     }
 
-    if (!inFunctionDefinitionScope || isElseIf(node)) {
+    if (complexityScopes.isEmpty() || isElseIf(node)) {
       return;
     }
 
-    if (node.is(INCREMENT_TYPES)) {
-      getContext().peekSourceCode().add(metric, 1);
-    }
-
     if (node.is(NESTING_INCREMENTS_TYPES)) {
-      getContext().peekSourceCode().add(metric, nesting);
+      complexityScopes.getFirst().addComplexitySourceWithNesting(node.getTokenLine(), node.getType());
+    } else if (node.is(INCREMENT_TYPES)) {
+      complexityScopes.getFirst().addComplexitySource(node.getTokenLine(), node.getType());
     }
 
     if (node.is(NESTING_LEVEL_TYPES)) {
-      ++nesting;
+      for (CxxComplexityScope scope : complexityScopes) {
+        scope.increaseNesting();
+      }
     }
   }
 
   @Override
   public void leaveNode(AstNode node) {
     if (node.is(CxxGrammarImpl.functionDefinition)) {
-      inFunctionDefinitionScope = false;
+      analyzeComplexity(complexityScopes.removeFirst());
     }
 
-    if (!inFunctionDefinitionScope || isElseIf(node)) {
+    if (complexityScopes.isEmpty() || isElseIf(node)) {
       return;
     }
 
     if (node.is(NESTING_LEVEL_TYPES)) {
-      --nesting;
+      for (CxxComplexityScope scope : complexityScopes) {
+        scope.decreaseNesting();
+      }
     }
   }
 

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxComplexityScope.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxComplexityScope.java
@@ -1,0 +1,75 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2018 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package org.sonar.cxx.visitors;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import com.sonar.sslr.api.AstNodeType;
+
+/**
+ * Describe a code scope (function definition, class definition, entire file
+ * etc) in terms of complexity sources
+ */
+public class CxxComplexityScope {
+  public CxxComplexityScope(int startingLine) {
+    this.sources = new LinkedList<>();
+    this.complexity = 0;
+    this.nesting = 0;
+    this.startingLine = startingLine;
+  }
+
+  public void addComplexitySource(int line, AstNodeType nodeType) {
+    sources.add(new CxxComplexitySource(line, nodeType, 0));
+    ++complexity;
+  }
+
+  public void addComplexitySourceWithNesting(int line, AstNodeType nodeType) {
+    sources.add(new CxxComplexitySource(line, nodeType, nesting));
+    complexity += (1 + nesting);
+  }
+
+  public List<CxxComplexitySource> getSources() {
+    return Collections.unmodifiableList(sources);
+  }
+
+  public int getComplexity() {
+    return complexity;
+  }
+
+  public String getStartingLine() {
+    return Integer.valueOf(startingLine).toString();
+  }
+
+  public void increaseNesting() {
+    ++nesting;
+  }
+
+  public void decreaseNesting() {
+    --nesting;
+  }
+
+  private List<CxxComplexitySource> sources;
+  private int complexity;
+  private int nesting;
+  private int startingLine;
+}

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxComplexitySource.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxComplexitySource.java
@@ -1,0 +1,83 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2018 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.visitors;
+
+import org.sonar.cxx.api.CxxKeyword;
+import org.sonar.cxx.api.CxxPunctuator;
+import org.sonar.cxx.parser.CxxGrammarImpl;
+
+import com.sonar.sslr.api.AstNodeType;
+
+/**
+ * Structure, that tracks all nodes, which increase the code complexity
+ */
+public class CxxComplexitySource {
+  public CxxComplexitySource(int line, AstNodeType nodeType, int nesting) {
+    super();
+    this.line = line;
+    this.type = nodeType;
+    this.nesting = nesting;
+  }
+
+  public String getLine() {
+    return Integer.valueOf(line).toString();
+  }
+
+  private String getNodeDescripton() {
+    if (type == CxxGrammarImpl.functionDefinition) {
+      return "function definition";
+    } else if (type == CxxKeyword.IF || type == CxxGrammarImpl.selectionStatement) {
+      return "if statement";
+    } else if (type == CxxKeyword.ELSE) {
+      return "else statement";
+    } else if (type == CxxKeyword.FOR) {
+      return "for loop";
+    } else if (type == CxxKeyword.WHILE) {
+      return "while loop";
+    } else if (type == CxxGrammarImpl.iterationStatement) {
+      return "iteration statement";
+    } else if (type == CxxKeyword.CATCH || type == CxxGrammarImpl.handler) {
+      return "catch-clause";
+    } else if (type == CxxKeyword.CASE || type == CxxKeyword.DEFAULT) {
+      return "switch label";
+    } else if (type == CxxKeyword.GOTO) {
+      return "goto statement";
+    } else if (type == CxxPunctuator.AND || type == CxxPunctuator.OR || type == CxxGrammarImpl.logicalAndExpression
+        || type == CxxGrammarImpl.logicalOrExpression) {
+      return "logical operator";
+    } else if (type == CxxPunctuator.QUEST) {
+      return "conditional operator";
+    }
+    return "";
+  }
+
+  public String getExplanation() {
+    if (nesting == 0) {
+      return "+1: " + getNodeDescripton();
+    } else {
+      return new StringBuilder().append("+").append(1 + nesting).append(": ").append(getNodeDescripton())
+          .append(" (incl ").append(nesting).append(" for nesting)").toString();
+    }
+  }
+
+  private final int line;
+  private final AstNodeType type;
+  private final int nesting;
+}


### PR DESCRIPTION
* `FunctionCognitiveComplexityCheck` (rule `cxx:FunctionCognitiveComplexity`) collects the details of the too complex function (cognitive complexity) and shows the single complexity summands as secondary locations
* the project/file metric "cognitive complexity" produces the same value as before
* this change is built on basis of #1537 and fixes some quality flows introduced in this PU

closes #1494

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1546)
<!-- Reviewable:end -->
