### PR TITLE
exclude macro expansions from complexity metrics/checks

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/CxxCyclomaticComplexityCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/CxxCyclomaticComplexityCheck.java
@@ -97,6 +97,10 @@ public abstract class CxxCyclomaticComplexityCheck<G extends Grammar> extends Mu
 
   @Override
   public void visitNode(AstNode astNode) {
+    if (astNode.getToken().isGeneratedCode()) {
+      return;
+    }
+
     final Optional<AstNodeType> scopeType = getScopeType();
     if (scopeType.isPresent() && astNode.is(scopeType.get())) {
       complexityScopes.addFirst(new CxxComplexityScope(astNode.getTokenLine()));
@@ -113,6 +117,10 @@ public abstract class CxxCyclomaticComplexityCheck<G extends Grammar> extends Mu
 
   @Override
   public void leaveNode(AstNode astNode) {
+    if (astNode.getToken().isGeneratedCode()) {
+      return;
+    }
+
     final Optional<AstNodeType> scopeType = getScopeType();
     if (scopeType.isPresent() && astNode.is(scopeType.get())) {
       analyzeScopeComplexity();

--- a/cxx-checks/src/test/resources/checks/FunctionCognitiveComplexity.cc
+++ b/cxx-checks/src/test/resources/checks/FunctionCognitiveComplexity.cc
@@ -110,3 +110,31 @@ std::string func_with_trycatch(int i) {
       return (i % 2 == 0) ? "exotic exception" : "strange exception";
    }
 }
+
+#define IMPLEMENTATION()                                                      \
+   try {                                                                      \
+      if ((i % 2 == 0 && i % 3 == 0) || (i % 6 == 0)) {                       \
+         return std::to_string(i);                                            \
+      }                                                                       \
+   } catch (const std::logic_error& e) {                                      \
+      return "std::logic_error";                                              \
+   } catch (const std::bad_cast& e) {                                         \
+      return std::string { "std::bad_cast" };                                 \
+   } catch (const std::invalid_argument& e) {                                 \
+      return std::string { "std::invalid_argument" };                         \
+   } catch (const std::length_error& e) {                                     \
+      return std::string { "std::length_error" };                             \
+   } catch (const std::out_of_range& e) {                                     \
+      return std::string { "std::out_of_range" };                             \
+   } catch (const std::exception& e) {                                        \
+      return std::string("std::exception");                                   \
+   } catch (...) {                                                            \
+      while (i >= 0) {                                                        \
+         return (i % 3 == 0) ? "unknown exception" : "unexpected exception";  \
+      }                                                                       \
+      return (i % 2 == 0) ? "exotic exception" : "strange exception";         \
+   }                                                                          \
+
+std::string func_with_macro(int i) {
+   IMPLEMENTATION()
+}

--- a/cxx-checks/src/test/resources/checks/FunctionComplexity.cc
+++ b/cxx-checks/src/test/resources/checks/FunctionComplexity.cc
@@ -110,3 +110,31 @@ std::string func_with_trycatch(int i) {
       return (i % 2 == 0) ? "exotic exception" : "strange exception";
    }
 }
+
+#define IMPLEMENTATION()                                                      \
+   try {                                                                      \
+      if ((i % 2 == 0 && i % 3 == 0) || (i % 6 == 0)) {                       \
+         return std::to_string(i);                                            \
+      }                                                                       \
+   } catch (const std::logic_error& e) {                                      \
+      return "std::logic_error";                                              \
+   } catch (const std::bad_cast& e) {                                         \
+      return std::string { "std::bad_cast" };                                 \
+   } catch (const std::invalid_argument& e) {                                 \
+      return std::string { "std::invalid_argument" };                         \
+   } catch (const std::length_error& e) {                                     \
+      return std::string { "std::length_error" };                             \
+   } catch (const std::out_of_range& e) {                                     \
+      return std::string { "std::out_of_range" };                             \
+   } catch (const std::exception& e) {                                        \
+      return std::string("std::exception");                                   \
+   } catch (...) {                                                            \
+      while (i >= 0) {                                                        \
+         return (i % 3 == 0) ? "unknown exception" : "unexpected exception";  \
+      }                                                                       \
+      return (i % 2 == 0) ? "exotic exception" : "strange exception";         \
+   }                                                                          \
+
+std::string func_with_macro(int i) {
+   IMPLEMENTATION()
+}

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxAstScanner.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxAstScanner.java
@@ -28,6 +28,7 @@ import org.sonar.cxx.parser.CxxGrammarImpl;
 import org.sonar.cxx.parser.CxxParser;
 import org.sonar.cxx.visitors.CxxCharsetAwareVisitor;
 import org.sonar.cxx.visitors.CxxCognitiveComplexityVisitor;
+import org.sonar.cxx.visitors.CxxCyclomaticComplexityVisitor;
 import org.sonar.cxx.visitors.CxxFileVisitor;
 import org.sonar.cxx.visitors.CxxFunctionComplexityVisitor;
 import org.sonar.cxx.visitors.CxxFunctionSizeVisitor;
@@ -214,10 +215,10 @@ public final class CxxAstScanner {
       .subscribeTo(CxxGrammarImpl.statement)
       .build());
 
-    builder.withSquidAstVisitor(ComplexityVisitor.<Grammar>builder()
+    builder.withSquidAstVisitor(new CxxCyclomaticComplexityVisitor(ComplexityVisitor.<Grammar>builder()
       .setMetricDef(CxxMetric.COMPLEXITY)
       .subscribeTo(CxxComplexityConstants.CyclomaticComplexityAstNodeTypes)
-      .build());
+      .build()));
 
     builder.withSquidAstVisitor(new CxxCognitiveComplexityVisitor<Grammar>());
 

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -835,6 +835,16 @@ public class CxxPreprocessor extends Preprocessor {
     } finally {
       getMacros().enable(macroName);
     }
+
+    // make sure that all expanded Tokens are marked as generated
+    // it will prevent them from being involved into NCLOC / complexity /
+    // highlighting
+    for (Token token : tokens) {
+      if (!token.isGeneratedCode()) {
+        token = Token.builder(token).setGeneratedCode(true).build();
+      }
+    }
+
     return tokens;
   }
 

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxCognitiveComplexityVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxCognitiveComplexityVisitor.java
@@ -100,6 +100,10 @@ public class CxxCognitiveComplexityVisitor<G extends Grammar> extends MultiLocat
 
   @Override
   public void visitNode(AstNode node) {
+    if (node.getToken().isGeneratedCode()) {
+      return;
+    }
+
     if (node.is(CxxGrammarImpl.functionDefinition)) {
       complexityScopes.addFirst(new CxxComplexityScope(node.getTokenLine()));
     }
@@ -123,6 +127,10 @@ public class CxxCognitiveComplexityVisitor<G extends Grammar> extends MultiLocat
 
   @Override
   public void leaveNode(AstNode node) {
+    if (node.getToken().isGeneratedCode()) {
+      return;
+    }
+
     if (node.is(CxxGrammarImpl.functionDefinition)) {
       analyzeComplexity(complexityScopes.removeFirst());
     }

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxCyclomaticComplexityVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxCyclomaticComplexityVisitor.java
@@ -1,0 +1,104 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2018 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.visitors;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.sonar.squidbridge.SquidAstVisitor;
+import org.sonar.squidbridge.SquidAstVisitorContext;
+import org.sonar.squidbridge.metrics.ComplexityVisitor;
+
+import com.sonar.sslr.api.AstNode;
+import com.sonar.sslr.api.AstNodeType;
+import com.sonar.sslr.api.Grammar;
+import com.sonar.sslr.api.Token;
+
+/**
+ * Decorator for {@link org.sonar.squidbridge.metrics.ComplexityVisitor} in
+ * order to prevent visiting of generated {@link com.sonar.sslr.api.AstNode}s
+ *
+ * Inheritance is not possible, since the class
+ * {@link org.sonar.squidbridge.metrics.ComplexityVisitor} is marked as final
+ *
+ * @param <G>
+ */
+public class CxxCyclomaticComplexityVisitor<G extends Grammar> extends SquidAstVisitor<G> {
+
+  private ComplexityVisitor<G> visitor;
+
+  public CxxCyclomaticComplexityVisitor(ComplexityVisitor<G> visitor) {
+    this.visitor = visitor;
+  }
+
+  @Override
+  public void visitNode(AstNode astNode) {
+    final Token token = astNode.getToken();
+    if (token != null && token.isGeneratedCode()) {
+      return;
+    }
+    visitor.visitNode(astNode);
+  }
+
+  @Override
+  public void leaveNode(AstNode astNode) {
+    final Token token = astNode.getToken();
+    if (token != null && token.isGeneratedCode()) {
+      return;
+    }
+    visitor.leaveNode(astNode);
+  }
+
+  @Override
+  public void init() {
+    visitor.init();
+  }
+
+  @Override
+  public void setContext(SquidAstVisitorContext<G> context) {
+    visitor.setContext(context);
+  }
+
+  @Override
+  public SquidAstVisitorContext<G> getContext() {
+    return visitor.getContext();
+  }
+
+  @Override
+  public List<AstNodeType> getAstNodeTypesToVisit() {
+    return visitor.getAstNodeTypesToVisit();
+  }
+
+  @Override
+  public void visitFile(@Nullable AstNode astNode) {
+    visitor.visitFile(astNode);
+  }
+
+  @Override
+  public void leaveFile(@Nullable AstNode astNode) {
+    visitor.leaveFile(astNode);
+  }
+
+  @Override
+  public void destroy() {
+    visitor.destroy();
+  }
+}

--- a/cxx-squid/src/test/java/org/sonar/cxx/CxxAstScannerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/CxxAstScannerTest.java
@@ -106,6 +106,13 @@ public class CxxAstScannerTest {
   }
 
   @Test
+  public void complexity_macro() throws UnsupportedEncodingException, IOException {
+    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/metrics/complexity_macro.cc", ".", "");
+    SourceFile file = CxxAstScanner.scanSingleFile(tester.cxxFile, tester.sensorContext, CxxFileTesterHelper.mockCxxLanguage());
+    assertThat(file.getInt(CxxMetric.COMPLEXITY)).isEqualTo(1);
+  }
+
+  @Test
   public void error_recovery_declaration() throws UnsupportedEncodingException, IOException {
     CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/parser/bad/error_recovery_declaration.cc", ".", "");
     SourceFile file = CxxAstScanner.scanSingleFile(tester.cxxFile, tester.sensorContext, CxxFileTesterHelper.mockCxxLanguage());

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxCognitiveComplexityVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxCognitiveComplexityVisitorTest.java
@@ -146,6 +146,11 @@ public class CxxCognitiveComplexityVisitorTest {
   }
 
   @Test
+  public void add_version_macro() throws UnsupportedEncodingException, IOException {
+    assertThat(testFile("src/test/resources/visitors/add_version_macro.cc")).isEqualTo(1);
+  }
+
+  @Test
   public void to_regexp() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/to_regexp.cc")).isEqualTo(20);
   }

--- a/cxx-squid/src/test/resources/metrics/complexity_macro.cc
+++ b/cxx-squid/src/test/resources/metrics/complexity_macro.cc
@@ -1,0 +1,39 @@
+# include <iostream>
+# include <exception>
+
+using namespace std;
+
+// same as complexity.cc, but the whole implementation is extracted to the macro
+
+#define IMPLEMENTATION()           \
+    if(true)                       \
+        ;                          \
+                                   \
+    if(true && false)              \
+        ;                          \
+                                   \
+    if(true || false)              \
+        ;                          \
+                                   \
+    for(;;);                       \
+                                   \
+    while(true);                   \
+                                   \
+    try{                           \
+    }                              \
+    catch(std::exception e) {}     \
+    catch(...) {}                  \
+                                   \
+    true ? 1 : 0;                  \
+                                   \
+    int i = 3;                     \
+    switch(i){                     \
+    case 2: break;                 \
+    case 3: break;                 \
+    default: break;                \
+    }                              \
+
+
+int main(){                       // +1
+   IMPLEMENTATION()               // macro was expanded but generated code was not considered as complexity source
+}

--- a/cxx-squid/src/test/resources/visitors/add_version_macro.cc
+++ b/cxx-squid/src/test/resources/visitors/add_version_macro.cc
@@ -1,0 +1,55 @@
+// Example from https://www.sonarsource.com/docs/CognitiveComplexity.pdf version 1.2 page 16
+// same as add_version.cc, but the whole implementation is extracted to macro
+
+#define IMPLEMENTATION()                                                                    \
+   TransactionIndex ti = _persistit.getTransactionIndex();                                  \
+   while (true) {                                                                           \
+      try {                                                                                 \
+         if (frst != null) {                                                                \
+            if (frst.getVersion() > entry.getVersion()) {                                   \
+               RollbackException();                                                         \
+            }                                                                               \
+            if (txn.isActive()) {                                                           \
+               for (Entry e = frst;                                                         \
+                    e != nullptr;                                                           \
+                    e = e.getPrevious()) {                                                  \
+                  long version = e.getVersion();                                            \
+                  long depends = ti.wwDependency(version, txn.getTransactionStatus(), 0);   \
+                  if (depends == TIMED_OUT) {                                               \
+                     WWRetryException(version);                                             \
+                  }                                                                         \
+                  if (depends != 0                                                          \
+                      && depends != ABORTED) {                                              \
+                     RollbackException();                                                   \
+                  }                                                                         \
+               }                                                                            \
+            }                                                                               \
+            entry.setPrevious(frst);                                                        \
+            frst = entry;                                                                   \
+         }                                                                                  \
+      } catch (WRetryException re) {                                                        \
+         try {                                                                              \
+            long depends = _persistit.getTransactionIndex()                                 \
+                                     .wwDependency(re.getVersionHandle(),                   \
+                                                   txn.getTransactionStatus(),              \
+                                                   SharedResource.DEFAULT_MAX_WAIT_TIME);   \
+            if (depends != 0                                                                \
+                && depends != ABORTED) {                                                    \
+               RollbackException();                                                         \
+            }                                                                               \
+         } catch (InterruptedException ie) {                                                \
+            PersistitInterruptedException(ie);                                              \
+         }                                                                                  \
+      } catch (InterruptedException ie) {                                                   \
+         PersistitInterruptedException(ie);                                                 \
+      }                                                                                     \
+   }                                                                                        \
+
+
+void addVersion(Entry entry, Transaction txn)
+{
+   IMPLEMENTATION()                          // macro was expanded but generated code was not considered as complexity source
+   if ("1" < entry.getVersion()) {           // +1
+      RollbackException();
+   }
+}


### PR DESCRIPTION
* partial solution for #1547

MOTIVATION:

* #1494 made visible the fact, that preprocessor affects the complexity
metric. E.g. if function uses macros, the underlying (hidden) complexity
of theses macros increases the complexity of the function. This is wrong
because of many reasons:

1. Cognitive complexity:
Macros do not increase the cognitive complexity of the source code. To
the reader they are similar to the function invocations.
Example ASSERT_XX/EXPECT_XX macros of GTest.

2. Cyclomatic complexity:
Similar logic might be applied to the cyclomatic complexity: macro expansions
are similar to the function calls (which become inlined). In this case
the cyclomatic complexity of the caller should not be increased.
[Cyclomatic] complexity of the callee must be calculated separately.

3. Preprocessor doesn't distinguish between the macros, which
were declared inside of the analyzed project or were included from the
external header. Obviously the external source code (e.g. again very
complex GTest macros) should not affect the complexity of someone's
custom SonarQube project.

SOLUTION:

In general it's impossible to build a valid C/C++ AST without
performing of preprocessor step. The original source code might
be syntactically incorrect (e.g. if macros are used to "invent" some
domain specific language out of C/C++). All metrics of sonar-cxx
are however AST-based. (This is a very questionably decision
e.g. because #if/#ifdef etc might affect the resulting complexity or [NC]LOC
in dramatic way). So we cannot skip preprocessor step entirely and/or
perform metrics calculation/checks on the non-preprocessed code.

Sonar SSLR has a possibility to mark some tokens as generated.
This property (`Token::isGeneratedCode()`) is for example used
in order to ignore generated while
* [NC]LOC counting (see `AbstractLineLengthCheck<>`)
* CDP analysis (see `CxxCpdVisitor`) or
* Highlighting (see `CxxHighlighterVisitor`)

This patch ensures, that
* all `AstNode`s, which were created while macro expansion are marked as
generated
* all complexity related visitors ignore generated `AstNode`s

RESULT:

PRO:
1. The complexity of "callers" is not affected by macro anymore.
   This fact makes the complexity check look logical again.

CON:
1. the complexity of "callees" is not calculated at all. This
is correct in case of external macros, but wrong w.r.t. to the
project intern macros. Possible solution: preprocessor must try
to extract the function-like macro declaration into some special AST-subtree.
Afterwards complexity metrics/check will be able to calculate/check
macros as separate language construct.

By the way: it must be analyzed if and how macros affect other metrics.
For example LOC etc.

2. This patch might change the complexity related metrics. Depending
on how many macros were used in the analyzed project, the reduction
can be radical.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1552)
<!-- Reviewable:end -->
