### PR TITLE
Clang tidy rule generation

### DIFF
--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -8,12 +8,23 @@
 <rule>
   <key>boost-use-to-string</key>
   <name>boost-use-to-string</name>
-  <description><![CDATA[<p>
-    This check finds conversion from integer type like ``int`` to ``std::string`` or
-    ``std::wstring`` using ``boost::lexical_cast``, and replace it with calls to
-    ``std::to_string`` and ``std::to_wstring``.</p>
-        <h2>References</h2>
-        <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/boost-use-to-string.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - boost-use-to-string</p>
+</div>
+<h1 id="boost-use-to-string">boost-use-to-string</h1>
+<p>This check finds conversion from integer type like <code>int</code> to <code>std::string</code> or <code>std::wstring</code> using <code>boost::lexical_cast</code>, and replace it with calls to <code>std::to_string</code> and <code>std::to_wstring</code>.</p>
+<p>It doesn't replace conversion from floating points despite the <code>to_string</code> overloads, because it would change the behaviour.</p>
+<blockquote>
+<pre class="sourceCode c++"><code>auto str = boost::lexical_cast&lt;std::string&gt;(42);
+auto wstr = boost::lexical_cast&lt;std::wstring&gt;(2137LL);
+
+// Will be changed to
+auto str = std::to_string(42);
+auto wstr = std::to_wstring(2137LL);</code></pre>
+</blockquote>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/boost-use-to-string.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>cert</tag>
   <severity>MINOR</severity>
@@ -22,13 +33,15 @@
 <rule>
   <key>cert-dcl50-cpp</key>
   <name>cert-dcl50-cpp</name>
-  <description><![CDATA[<p>
-This check flags all function definitions (but not declarations) of C-style
-variadic functions.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl50-cpp.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cert-dcl50-cpp</p>
+</div>
+<h1 id="cert-dcl50-cpp">cert-dcl50-cpp</h1>
+<p>This check flags all function definitions (but not declarations) of C-style variadic functions.</p>
+<p>This check corresponds to the CERT C++ Coding Standard rule <a href="">DCL50-CPP. Do not define a C-style variadic function &lt;https://www.securecoding.cert.org/confluence/display/cplusplus/DCL50-CPP.+Do+not+define+a+C-style+variadic+function&gt;</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl50-cpp.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>cert</tag>
   <severity>MINOR</severity>
@@ -37,15 +50,15 @@ variadic functions.
 <rule>
   <key>cert-env33-c</key>
   <name>cert-env33-c</name>
-  <description><![CDATA[<p>
-This check flags calls to ``system()``, ``popen()``, and ``_popen()``, which
-execute a command processor. It does not flag calls to ``system()`` with a null
-pointer argument, as such a call checks for the presence of a command processor
-but does not actually attempt to execute a command.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-env33-c.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cert-env33-c</p>
+</div>
+<h1 id="cert-env33-c">cert-env33-c</h1>
+<p>This check flags calls to <code>system()</code>, <code>popen()</code>, and <code>_popen()</code>, which execute a command processor. It does not flag calls to <code>system()</code> with a null pointer argument, as such a call checks for the presence of a command processor but does not actually attempt to execute a command.</p>
+<p>This check corresponds to the CERT C Coding Standard rule <a href="">ENV33-C. Do not call system() &lt;https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=2130132&gt;</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-env33-c.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>cert</tag>
   <severity>MINOR</severity>
@@ -54,15 +67,27 @@ but does not actually attempt to execute a command.
 <rule>
   <key>cert-err34-c</key>
   <name>cert-err34-c</name>
-  <description><![CDATA[<p>
-This check flags calls to string-to-number conversion functions that do not
-verify the validity of the conversion, such as ``atoi()`` or ``scanf()``. It
-does not flag calls to ``strtol()``, or other, related conversion functions that
-do perform better error checking.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cert-err34-c</p>
+</div>
+<h1 id="cert-err34-c">cert-err34-c</h1>
+<p>This check flags calls to string-to-number conversion functions that do not verify the validity of the conversion, such as <code>atoi()</code> or <code>scanf()</code>. It does not flag calls to <code>strtol()</code>, or other, related conversion functions that do perform better error checking.</p>
+<pre class="sourceCode c"><code>#include &lt;stdlib.h&gt;
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err34-c.html" target="_blank">clang.llvm.org</a></p>
+void func(const char *buff) {
+  int si;
+
+  if (buff) {
+    si = atoi(buff); /* &#39;atoi&#39; used to convert a string to an integer, but function will
+                         not report conversion errors; consider using &#39;strtol&#39; instead. */
+  } else {
+    /* Handle error */
+  }
+}</code></pre>
+<p>This check corresponds to the CERT C Coding Standard rule <a href="">ERR34-C. Detect errors when converting a string to a number &lt;https://www.securecoding.cert.org/confluence/display/c/ERR34-C.+Detect+errors+when+converting+a+string+to+a+number&gt;</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err34-c.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>cert</tag>
   <severity>MINOR</severity>
@@ -71,12 +96,15 @@ do perform better error checking.
 <rule>
   <key>cert-err52-cpp</key>
   <name>cert-err52-cpp</name>
-  <description><![CDATA[<p>
-This check flags all call expressions involving ``setjmp()`` and ``longjmp()``.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err52-cpp.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cert-err52-cpp</p>
+</div>
+<h1 id="cert-err52-cpp">cert-err52-cpp</h1>
+<p>This check flags all call expressions involving <code>setjmp()</code> and <code>longjmp()</code>.</p>
+<p>This check corresponds to the CERT C++ Coding Standard rule <a href="">ERR52-CPP. Do not use setjmp() or longjmp() &lt;https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=1834&gt;</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err52-cpp.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>cert</tag>
   <severity>MINOR</severity>
@@ -85,12 +113,15 @@ This check flags all call expressions involving ``setjmp()`` and ``longjmp()``.
 <rule>
   <key>cert-err58-cpp</key>
   <name>cert-err58-cpp</name>
-  <description><![CDATA[<p>
-This check flags all ``static`` or ``thread_local`` variable declarations where the constructor for the object may throw an exception.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err58-cpp.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cert-err58-cpp</p>
+</div>
+<h1 id="cert-err58-cpp">cert-err58-cpp</h1>
+<p>This check flags all <code>static</code> or <code>thread_local</code> variable declarations where the initializer for the object may throw an exception.</p>
+<p>This check corresponds to the CERT C++ Coding Standard rule <a href="">ERR58-CPP. Handle all exceptions thrown before main() begins executing &lt;https://www.securecoding.cert.org/confluence/display/cplusplus/ERR58-CPP.+Handle+all+exceptions+thrown+before+main%28%29+begins+executing&gt;</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err58-cpp.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>cert</tag>
   <severity>MINOR</severity>
@@ -99,12 +130,15 @@ This check flags all ``static`` or ``thread_local`` variable declarations where 
 <rule>
   <key>cert-err60-cpp</key>
   <name>cert-err60-cpp</name>
-  <description><![CDATA[<p>
-This check flags all throw expressions where the exception object is not nothrow copy constructible.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err60-cpp.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cert-err60-cpp</p>
+</div>
+<h1 id="cert-err60-cpp">cert-err60-cpp</h1>
+<p>This check flags all throw expressions where the exception object is not nothrow copy constructible.</p>
+<p>This check corresponds to the CERT C++ Coding Standard rule <a href="">ERR60-CPP. Exception objects must be nothrow copy constructible &lt;https://www.securecoding.cert.org/confluence/display/cplusplus/ERR60-CPP.+Exception+objects+must+be+nothrow+copy+constructible&gt;</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err60-cpp.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>cert</tag>
   <severity>MINOR</severity>
@@ -113,12 +147,15 @@ This check flags all throw expressions where the exception object is not nothrow
 <rule>
   <key>cert-flp30-c</key>
   <name>cert-flp30-c</name>
-  <description><![CDATA[<p>
-This check flags ``for`` loops where the induction expression has a floating-point type.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-flp30-c.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cert-flp30-c</p>
+</div>
+<h1 id="cert-flp30-c">cert-flp30-c</h1>
+<p>This check flags <code>for</code> loops where the induction expression has a floating-point type.</p>
+<p>This check corresponds to the CERT C Coding Standard rule <a href="">FLP30-C. Do not use floating-point variables as loop counters &lt;https://www.securecoding.cert.org/confluence/display/c/FLP30-C.+Do+not+use+floating-point+variables+as+loop+counters&gt;</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-flp30-c.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>cert</tag>
   <severity>MINOR</severity>
@@ -127,14 +164,16 @@ This check flags ``for`` loops where the induction expression has a floating-poi
 <rule>
   <key>cppcoreguidelines-interfaces-global-init</key>
   <name>cppcoreguidelines-interfaces-global-init</name>
-  <description><![CDATA[<p>
-This check flags initializers of globals that access extern objects,
-and therefore can lead to order-of-initialization problems.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-interfaces-global-init.html" target="_blank">clang.llvm.org</a></p>
-    <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-global-init" target="_blank">github</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cppcoreguidelines-interfaces-global-init</p>
+</div>
+<h1 id="cppcoreguidelines-interfaces-global-init">cppcoreguidelines-interfaces-global-init</h1>
+<p>This check flags initializers of globals that access extern objects, and therefore can lead to order-of-initialization problems.</p>
+<p>This rule is part of the &quot;Interfaces&quot; profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-global-init" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-global-init</a></p>
+<p>Note that currently this does not flag calls to non-constexpr functions, and therefore globals could still be accessed from functions themselves.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-interfaces-global-init.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>bad-practice</tag>
   <tag>suspicious</tag>
@@ -144,15 +183,38 @@ and therefore can lead to order-of-initialization problems.
 <rule>
   <key>cppcoreguidelines-no-malloc</key>
   <name>cppcoreguidelines-no-malloc</name>
-  <description><![CDATA[<p>
-This check handles C-Style memory management using malloc(), realloc(), calloc() and free(). 
-It warns about its use and tries to suggest the use of an appropriate RAII object. 
-Furthermore, it can be configured to check against a user-specified list of functions that are used for memory management (e.g. posix_memalign()). 
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cppcoreguidelines-no-malloc</p>
+</div>
+<h1 id="cppcoreguidelines-no-malloc">cppcoreguidelines-no-malloc</h1>
+<p>This check handles C-Style memory management using <code>malloc()</code>, <code>realloc()</code>, <code>calloc()</code> and <code>free()</code>. It warns about its use and tries to suggest the use of an appropriate RAII object. Furthermore, it can be configured to check against a user-specified list of functions that are used for memory management (e.g. <code>posix_memalign()</code>). See <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-mallocfree">C++ Core Guidelines</a>.</p>
+<p>There is no attempt made to provide fix-it hints, since manual resource management isn't easily transformed automatically into RAII.</p>
+<pre class="sourceCode c++"><code>// Warns each of the following lines.
+// Containers like std::vector or std::string should be used.
+char* some_string = (char*) malloc(sizeof(char) * 20);
+char* some_string = (char*) realloc(sizeof(char) * 30);
+free(some_string);
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-no-malloc.html" target="_blank">clang.llvm.org</a></p>
-    <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-mallocfree" target="_blank">github</a></p>
+int* int_array = (int*) calloc(30, sizeof(int));
+
+// Rather use a smartpointer or stack variable.
+struct some_struct* s = (struct some_struct*) malloc(sizeof(struct some_struct));</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>Allocations</p>
+<p>Semicolon-separated list of fully qualified names of memory allocation functions. Defaults to <code>::malloc;::calloc</code>.</p>
+</div>
+<div class="option">
+<p>Deallocations</p>
+<p>Semicolon-separated list of fully qualified names of memory allocation functions. Defaults to <code>::free</code>.</p>
+</div>
+<div class="option">
+<p>Reallocations</p>
+<p>Semicolon-separated list of fully qualified names of memory allocation functions. Defaults to <code>::realloc</code>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-no-malloc.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>bad-practice</tag>
   <tag>suspicious</tag>
@@ -162,13 +224,16 @@ Furthermore, it can be configured to check against a user-specified list of func
 <rule>
   <key>cppcoreguidelines-pro-bounds-array-to-pointer-decay</key>
   <name>cppcoreguidelines-pro-bounds-array-to-pointer-decay</name>
-  <description><![CDATA[<p>
-This check flags all array to pointer decays.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-bounds-array-to-pointer-decay.html" target="_blank">clang.llvm.org</a></p>
-    <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-decay" target="_blank">github</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cppcoreguidelines-pro-bounds-array-to-pointer-decay</p>
+</div>
+<h1 id="cppcoreguidelines-pro-bounds-array-to-pointer-decay">cppcoreguidelines-pro-bounds-array-to-pointer-decay</h1>
+<p>This check flags all array to pointer decays.</p>
+<p>Pointers should not be used as arrays. <code>span&lt;T&gt;</code> is a bounds-checked, safe alternative to using pointers to access arrays.</p>
+<p>This rule is part of the &quot;Bounds safety&quot; profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-decay" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-decay</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-bounds-array-to-pointer-decay.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>bad-practice</tag>
   <tag>suspicious</tag>
@@ -178,16 +243,24 @@ This check flags all array to pointer decays.
 <rule>
   <key>cppcoreguidelines-pro-bounds-constant-array-index</key>
   <name>cppcoreguidelines-pro-bounds-constant-array-index</name>
-  <description><![CDATA[<p>
-This check flags all array subscript expressions on static arrays and
-``std::arrays`` that either do not have a constant integer expression index or
-are out of bounds (for ``std::array``). For out-of-bounds checking of static
-arrays, see the clang-diagnostic-array-bounds check.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-bounds-constant-array-index.html" target="_blank">clang.llvm.org</a></p>
-    <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-arrayindex" target="_blank">github</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cppcoreguidelines-pro-bounds-constant-array-index</p>
+</div>
+<h1 id="cppcoreguidelines-pro-bounds-constant-array-index">cppcoreguidelines-pro-bounds-constant-array-index</h1>
+<p>This check flags all array subscript expressions on static arrays and <code>std::arrays</code> that either do not have a constant integer expression index or are out of bounds (for <code>std::array</code>). For out-of-bounds checking of static arrays, see the <span class="title-ref">-Warray-bounds</span> Clang diagnostic.</p>
+<p>This rule is part of the &quot;Bounds safety&quot; profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-arrayindex" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-arrayindex</a>.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>GslHeader</p>
+<p>The check can generate fixes after this option has been set to the name of the include file that contains <code>gsl::at()</code>, e.g. <span class="title-ref">&quot;gsl/gsl.h&quot;</span>.</p>
+</div>
+<div class="option">
+<p>IncludeStyle</p>
+<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-bounds-constant-array-index.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -195,14 +268,16 @@ arrays, see the clang-diagnostic-array-bounds check.
 <rule>
   <key>cppcoreguidelines-pro-bounds-pointer-arithmetic</key>
   <name>cppcoreguidelines-pro-bounds-pointer-arithmetic</name>
-  <description><![CDATA[<p>
-This check flags all usage of pointer arithmetic, because it could lead to an
-invalid pointer. Subtraction of two pointers is not flagged by this check.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-bounds-pointer-arithmetic.html" target="_blank">clang.llvm.org</a></p>
-    <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-arithmetic" target="_blank">github</a></p>    
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cppcoreguidelines-pro-bounds-pointer-arithmetic</p>
+</div>
+<h1 id="cppcoreguidelines-pro-bounds-pointer-arithmetic">cppcoreguidelines-pro-bounds-pointer-arithmetic</h1>
+<p>This check flags all usage of pointer arithmetic, because it could lead to an invalid pointer. Subtraction of two pointers is not flagged by this check.</p>
+<p>Pointers should only refer to single objects, and pointer arithmetic is fragile and easy to get wrong. <code>span&lt;T&gt;</code> is a bounds-checked, safe type for accessing arrays of data.</p>
+<p>This rule is part of the &quot;Bounds safety&quot; profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-arithmetic" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-arithmetic</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-bounds-pointer-arithmetic.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -210,13 +285,16 @@ invalid pointer. Subtraction of two pointers is not flagged by this check.
 <rule>
   <key>cppcoreguidelines-pro-type-const-cast</key>
   <name>cppcoreguidelines-pro-type-const-cast</name>
-  <description><![CDATA[<p>
-This check flags all uses of ``const_cast`` in C++ code.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-bounds-pointer-arithmetic.html" target="_blank">clang.llvm.org</a></p>
-    <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-constcast" target="_blank">github</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cppcoreguidelines-pro-type-const-cast</p>
+</div>
+<h1 id="cppcoreguidelines-pro-type-const-cast">cppcoreguidelines-pro-type-const-cast</h1>
+<p>This check flags all uses of <code>const_cast</code> in C++ code.</p>
+<p>Modifying a variable that was declared const is undefined behavior, even with <code>const_cast</code>.</p>
+<p>This rule is part of the &quot;Type safety&quot; profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-constcast" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-constcast</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-const-cast.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -224,14 +302,16 @@ This check flags all uses of ``const_cast`` in C++ code.
 <rule>
   <key>cppcoreguidelines-pro-type-cstyle-cast</key>
   <name>cppcoreguidelines-pro-type-cstyle-cast</name>
-  <description><![CDATA[<p>
-This check flags all use of C-style casts that perform a ``static_cast``
-downcast, ``const_cast``, or ``reinterpret_cast``.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-cstyle-cast.html" target="_blank">clang.llvm.org</a></p>
-    <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-cstylecast" target="_blank">github</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cppcoreguidelines-pro-type-cstyle-cast</p>
+</div>
+<h1 id="cppcoreguidelines-pro-type-cstyle-cast">cppcoreguidelines-pro-type-cstyle-cast</h1>
+<p>This check flags all use of C-style casts that perform a <code>static_cast</code> downcast, <code>const_cast</code>, or <code>reinterpret_cast</code>.</p>
+<p>Use of these casts can violate type safety and cause the program to access a variable that is actually of type X to be accessed as if it were of an unrelated type Z. Note that a C-style <code>(T)expression</code> cast means to perform the first of the following that is possible: a <code>const_cast</code>, a <code>static_cast</code>, a <code>static_cast</code> followed by a <code>const_cast</code>, a <code>reinterpret_cast</code>, or a <code>reinterpret_cast</code> followed by a <code>const_cast</code>. This rule bans <code>(T)expression</code> only when used to perform an unsafe cast.</p>
+<p>This rule is part of the &quot;Type safety&quot; profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-cstylecast" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-cstylecast</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-cstyle-cast.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -239,18 +319,23 @@ downcast, ``const_cast``, or ``reinterpret_cast``.
 <rule>
   <key>cppcoreguidelines-pro-type-member-init</key>
   <name>cppcoreguidelines-pro-type-member-init</name>
-  <description><![CDATA[<p>
-The check flags user-defined constructor definitions that do not
-initialize all fields that would be left in an undefined state by
-default construction, e.g. builtins, pointers and record types without
-user-provided default constructors containing at least one such
-type. If these fields aren't initialized, the constructor will leave
-some of the memory in an undefined state.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-member-init.html" target="_blank">clang.llvm.org</a></p>
-    <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-memberinit" target="_blank">github</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cppcoreguidelines-pro-type-member-init</p>
+</div>
+<h1 id="cppcoreguidelines-pro-type-member-init">cppcoreguidelines-pro-type-member-init</h1>
+<p>The check flags user-defined constructor definitions that do not initialize all fields that would be left in an undefined state by default construction, e.g. builtins, pointers and record types without user-provided default constructors containing at least one such type. If these fields aren't initialized, the constructor will leave some of the memory in an undefined state.</p>
+<p>For C++11 it suggests fixes to add in-class field initializers. For older versions it inserts the field initializers into the constructor initializer list. It will also initialize any direct base classes that need to be zeroed in the constructor initializer list.</p>
+<p>The check takes assignment of fields in the constructor body into account but generates false positives for fields initialized in methods invoked in the constructor body.</p>
+<p>The check also flags variables with automatic storage duration that have record types without a user-provided constructor and are not initialized. The suggested fix is to zero initialize the variable via <code>{}</code> for C++11 and beyond or <code>= {}</code> for older language versions.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreArrays</p>
+<p>If set to non-zero, the check will not warn about array members that are not zero-initialized during construction. For performance critical code, it may be important to not initialize fixed-size array members. Default is <span class="title-ref">0</span>.</p>
+</div>
+<p>This rule is part of the &quot;Type safety&quot; profile of the C++ Core Guidelines, corresponding to rule Type.6. See <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-memberinit" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-memberinit</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-member-init.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -258,13 +343,16 @@ some of the memory in an undefined state.
 <rule>
   <key>cppcoreguidelines-pro-type-reinterpret-cast</key>
   <name>cppcoreguidelines-pro-type-reinterpret-cast</name>
-  <description><![CDATA[<p>
-This check flags all uses of ``reinterpret_cast`` in C++ code.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-reinterpret-cast.html" target="_blank">clang.llvm.org</a></p>
-    <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-reinterpretcast" target="_blank">github</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cppcoreguidelines-pro-type-reinterpret-cast</p>
+</div>
+<h1 id="cppcoreguidelines-pro-type-reinterpret-cast">cppcoreguidelines-pro-type-reinterpret-cast</h1>
+<p>This check flags all uses of <code>reinterpret_cast</code> in C++ code.</p>
+<p>Use of these casts can violate type safety and cause the program to access a variable that is actually of type <code>X</code> to be accessed as if it were of an unrelated type <code>Z</code>.</p>
+<p>This rule is part of the &quot;Type safety&quot; profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-reinterpretcast" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-reinterpretcast</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-reinterpret-cast.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -272,15 +360,16 @@ This check flags all uses of ``reinterpret_cast`` in C++ code.
 <rule>
   <key>cppcoreguidelines-pro-type-static-cast-downcast</key>
   <name>cppcoreguidelines-pro-type-static-cast-downcast</name>
-  <description><![CDATA[<p>
-This check flags all usages of ``static_cast``, where a base class is casted to
-a derived class. In those cases, a fixit is provided to convert the cast to a
-``dynamic_cast``.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-static-cast-downcast.html" target="_blank">clang.llvm.org</a></p>
-    <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-downcast" target="_blank">github</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cppcoreguidelines-pro-type-static-cast-downcast</p>
+</div>
+<h1 id="cppcoreguidelines-pro-type-static-cast-downcast">cppcoreguidelines-pro-type-static-cast-downcast</h1>
+<p>This check flags all usages of <code>static_cast</code>, where a base class is casted to a derived class. In those cases, a fix-it is provided to convert the cast to a <code>dynamic_cast</code>.</p>
+<p>Use of these casts can violate type safety and cause the program to access a variable that is actually of type <code>X</code> to be accessed as if it were of an unrelated type <code>Z</code>.</p>
+<p>This rule is part of the &quot;Type safety&quot; profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-downcast" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-downcast</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-static-cast-downcast.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -288,14 +377,16 @@ a derived class. In those cases, a fixit is provided to convert the cast to a
 <rule>
   <key>cppcoreguidelines-pro-type-union-access</key>
   <name>cppcoreguidelines-pro-type-union-access</name>
-  <description><![CDATA[<p>
-This check flags all access to members of unions. Passing unions as a whole is
-not flagged.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-union-access.html" target="_blank">clang.llvm.org</a></p>
-    <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-unions" target="_blank">github</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cppcoreguidelines-pro-type-union-access</p>
+</div>
+<h1 id="cppcoreguidelines-pro-type-union-access">cppcoreguidelines-pro-type-union-access</h1>
+<p>This check flags all access to members of unions. Passing unions as a whole is not flagged.</p>
+<p>Reading from a union member assumes that member was the last one written, and writing to a union member assumes another member with a nontrivial destructor had its destructor called. This is fragile because it cannot generally be enforced to be safe in the language and so relies on programmer discipline to get it right.</p>
+<p>This rule is part of the &quot;Type safety&quot; profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-unions" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-unions</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-union-access.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -303,13 +394,17 @@ not flagged.
 <rule>
   <key>cppcoreguidelines-pro-type-vararg</key>
   <name>cppcoreguidelines-pro-type-vararg</name>
-  <description><![CDATA[<p>
-This check flags all calls to c-style vararg functions and all use of ``va_arg``.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-vararg.html" target="_blank">clang.llvm.org</a></p>
-    <p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-varargs" target="_blank">github</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - cppcoreguidelines-pro-type-vararg</p>
+</div>
+<h1 id="cppcoreguidelines-pro-type-vararg">cppcoreguidelines-pro-type-vararg</h1>
+<p>This check flags all calls to c-style vararg functions and all use of <code>va_arg</code>.</p>
+<p>To allow for SFINAE use of vararg functions, a call is not flagged if a literal 0 is passed as the only vararg argument.</p>
+<p>Passing to varargs assumes the correct type will be read. This is fragile because it cannot generally be enforced to be safe in the language and so relies on programmer discipline to get it right.</p>
+<p>This rule is part of the &quot;Type safety&quot; profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-varargs" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-varargs</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-vararg.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -317,12 +412,16 @@ This check flags all calls to c-style vararg functions and all use of ``va_arg``
 <rule>
   <key>google-build-explicit-make-pair</key>
   <name>google-build-explicit-make-pair</name>
-  <description><![CDATA[<p>
-Check that ``make_pair``'s template arguments are deduced.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-build-explicit-make-pair.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - google-build-explicit-make-pair</p>
+</div>
+<h1 id="google-build-explicit-make-pair">google-build-explicit-make-pair</h1>
+<p>Check that <code>make_pair</code>'s template arguments are deduced.</p>
+<p>G++ 4.6 in C++11 mode fails badly if <code>make_pair</code>'s template arguments are specified explicitly, and such use isn't intended in any case.</p>
+<p>Corresponding cpplint.py check name: <span class="title-ref">build/explicit_make_pair</span>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-build-explicit-make-pair.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>bad-practice</tag>
   <tag>cpplint-style</tag>
@@ -332,12 +431,22 @@ Check that ``make_pair``'s template arguments are deduced.
 <rule>
   <key>google-build-namespaces</key>
   <name>google-build-namespaces</name>
-  <description><![CDATA[<p>
-Finds anonymous namespaces in headers.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-build-namespaces.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - google-build-namespaces</p>
+</div>
+<h1 id="google-build-namespaces">google-build-namespaces</h1>
+<p><span class="title-ref">cert-dcl59-cpp</span> redirects here as an alias for this check. <span class="title-ref">fuchsia-header-anon-namespaces</span> redirects here as an alias for this check.</p>
+<p>Finds anonymous namespaces in headers.</p>
+<p><a href="https://google.github.io/styleguide/cppguide.html#Namespaces" class="uri">https://google.github.io/styleguide/cppguide.html#Namespaces</a></p>
+<p>Corresponding cpplint.py check name: <span class="title-ref">build/namespaces</span>.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>HeaderFileExtensions</p>
+<p>A comma-separated list of filename extensions of header files (the filename extensions should not include &quot;.&quot; prefix). Default is &quot;h,hh,hpp,hxx&quot;. For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. e.g., &quot;h,hh,hpp,hxx,&quot; (note the trailing comma).</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-build-namespaces.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
    <tag>cpplint-style</tag>
    <tag>bad-practice</tag>
@@ -347,12 +456,21 @@ Finds anonymous namespaces in headers.
 <rule>
   <key>google-build-using-namespace</key>
   <name>google-build-using-namespace</name>
-  <description><![CDATA[<p>
-Finds ``using namespace`` directives.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-build-using-namespace.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - google-build-using-namespace</p>
+</div>
+<h1 id="google-build-using-namespace">google-build-using-namespace</h1>
+<p>Finds <code>using namespace</code> directives.</p>
+<p>The check implements the following rule of the <a href="https://google.github.io/styleguide/cppguide.html#Namespaces">Google C++ Style Guide</a>:</p>
+<blockquote>
+<p>You may not use a using-directive to make all names from a namespace available.</p>
+<pre class="sourceCode c++"><code>// Forbidden -- This pollutes the namespace.
+using namespace foo;</code></pre>
+</blockquote>
+<p>Corresponding cpplint.py check name: <span class="title-ref">build/namespaces</span>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-build-using-namespace.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -360,12 +478,15 @@ Finds ``using namespace`` directives.
 <rule>
   <key>google-default-arguments</key>
   <name>google-default-arguments</name>
-  <description><![CDATA[<p>
-Checks that default arguments are not given for virtual methods.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-build-using-namespace.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - google-default-arguments</p>
+</div>
+<h1 id="google-default-arguments">google-default-arguments</h1>
+<p>Checks that default arguments are not given for virtual methods.</p>
+<p>See <a href="https://google.github.io/styleguide/cppguide.html#Default_Arguments" class="uri">https://google.github.io/styleguide/cppguide.html#Default_Arguments</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-default-arguments.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
    <tag>cpplint-style</tag>
    <tag>bad-practice</tag>
@@ -375,12 +496,40 @@ Checks that default arguments are not given for virtual methods.
 <rule>
   <key>google-explicit-constructor</key>
   <name>google-explicit-constructor</name>
-  <description><![CDATA[<p>
-Checks that all single-argument constructors are explicit.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - google-explicit-constructor</p>
+</div>
+<h1 id="google-explicit-constructor">google-explicit-constructor</h1>
+<p>Checks that constructors callable with a single argument and conversion operators are marked explicit to avoid the risk of unintentional implicit conversions.</p>
+<p>Consider this example:</p>
+<pre class="sourceCode c++"><code>struct S {
+  int x;
+  operator bool() const { return true; }
+};
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-explicit-constructor.html" target="_blank">clang.llvm.org</a></p>
+bool f() {
+  S a{1};
+  S b{2};
+  return a == b;
+}</code></pre>
+<p>The function will return <code>true</code>, since the objects are implicitly converted to <code>bool</code> before comparison, which is unlikely to be the intent.</p>
+<p>The check will suggest inserting <code>explicit</code> before the constructor or conversion operator declaration. However, copy and move constructors should not be explicit, as well as constructors taking a single <code>initializer_list</code> argument.</p>
+<p>This code:</p>
+<pre class="sourceCode c++"><code>struct S {
+  S(int a);
+  explicit S(const S&amp;);
+  operator bool() const;
+  ...</code></pre>
+<p>will become</p>
+<pre class="sourceCode c++"><code>struct S {
+  explicit S(int a);
+  S(const S&amp;);
+  explicit operator bool() const;
+  ...</code></pre>
+<p>See <a href="https://google.github.io/styleguide/cppguide.html#Explicit_Constructors" class="uri">https://google.github.io/styleguide/cppguide.html#Explicit_Constructors</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-explicit-constructor.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
    <tag>cpplint-style</tag>
    <tag>bad-practice</tag>
@@ -390,13 +539,20 @@ Checks that all single-argument constructors are explicit.
 <rule>
   <key>google-global-names-in-headers</key>
   <name>google-global-names-in-headers</name>
-  <description><![CDATA[<p>
-Flag global namespace pollution in header files.
-Right now it only triggers on ``using`` declarations and directives.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-global-names-in-headers.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - google-global-names-in-headers</p>
+</div>
+<h1 id="google-global-names-in-headers">google-global-names-in-headers</h1>
+<p>Flag global namespace pollution in header files. Right now it only triggers on <code>using</code> declarations and directives.</p>
+<p>The relevant style guide section is <a href="https://google.github.io/styleguide/cppguide.html#Namespaces" class="uri">https://google.github.io/styleguide/cppguide.html#Namespaces</a>.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>HeaderFileExtensions</p>
+<p>A comma-separated list of filename extensions of header files (the filename extensions should not contain &quot;.&quot; prefix). Default is &quot;h&quot;. For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. e.g., &quot;h,hh,hpp,hxx,&quot; (note the trailing comma).</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-global-names-in-headers.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
    <tag>cpplint-style</tag>
    <tag>bad-practice</tag>
@@ -406,12 +562,17 @@ Right now it only triggers on ``using`` declarations and directives.
 <rule>
   <key>google-readability-casting</key>
   <name>google-readability-casting</name>
-  <description><![CDATA[<p>
-Finds usages of C-style casts.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-readability-casting.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - google-readability-casting</p>
+</div>
+<h1 id="google-readability-casting">google-readability-casting</h1>
+<p>Finds usages of C-style casts.</p>
+<p><a href="https://google.github.io/styleguide/cppguide.html#Casting" class="uri">https://google.github.io/styleguide/cppguide.html#Casting</a></p>
+<p>Corresponding cpplint.py check name: <span class="title-ref">readability/casting</span>.</p>
+<p>This check is similar to <span class="title-ref">-Wold-style-cast</span>, but it suggests automated fixes in some cases. The reported locations should not be different from the ones generated by <span class="title-ref">-Wold-style-cast</span>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-readability-casting.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
    <tag>cpplint-style</tag>
   <severity>MINOR</severity>
@@ -420,12 +581,17 @@ Finds usages of C-style casts.
 <rule>
   <key>google-readability-namespace-comments</key>
   <name>google-readability-namespace-comments</name>
-  <description><![CDATA[<p>
-Checks that long namespaces have a closing comment.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - google-readability-namespace-comments</p>
+</div>
+<div class="meta">
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-readability-namespace-comments.html" target="_blank">clang.llvm.org</a></p>
+</div>
+<h1 id="google-readability-namespace-comments">google-readability-namespace-comments</h1>
+<p>The google-readability-namespace-comments check is an alias, please see <a href="llvm-namespace-comment.html">llvm-namespace-comment</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-readability-namespace-comments.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
    <tag>cpplint-style</tag>
    <tag>bad-practice</tag>
@@ -450,12 +616,16 @@ Find and remove redundant calls to smart pointer's ``.get()`` method.
 <rule>
   <key>google-readability-todo</key>
   <name>google-readability-todo</name>
-  <description><![CDATA[<p>
-Finds TODO comments without a username or bug number.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-readability-todo.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - google-readability-todo</p>
+</div>
+<h1 id="google-readability-todo">google-readability-todo</h1>
+<p>Finds TODO comments without a username or bug number.</p>
+<p>The relevant style guide section is <a href="https://google.github.io/styleguide/cppguide.html#TODO_Comments" class="uri">https://google.github.io/styleguide/cppguide.html#TODO_Comments</a>.</p>
+<p>Corresponding cpplint.py check: <span class="title-ref">readability/todo</span></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-readability-todo.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
    <tag>cpplint-style</tag>
    <tag>bad-practice</tag>
@@ -465,13 +635,29 @@ Finds TODO comments without a username or bug number.
 <rule>
   <key>google-runtime-int</key>
   <name>google-runtime-int</name>
-  <description><![CDATA[<p>
-Finds uses of ``short``, ``long`` and ``long long`` and suggest replacing them
-with ``u?intXX(_t)?``.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-runtime-int.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - google-runtime-int</p>
+</div>
+<h1 id="google-runtime-int">google-runtime-int</h1>
+<p>Finds uses of <code>short</code>, <code>long</code> and <code>long long</code> and suggest replacing them with <code>u?intXX(_t)?</code>.</p>
+<p>The corresponding style guide rule: <a href="https://google.github.io/styleguide/cppguide.html#Integer_Types" class="uri">https://google.github.io/styleguide/cppguide.html#Integer_Types</a>.</p>
+<p>Correspondig cpplint.py check: <span class="title-ref">runtime/int</span>.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>UnsignedTypePrefix</p>
+<p>A string specifying the unsigned type prefix. Default is <span class="title-ref">uint</span>.</p>
+</div>
+<div class="option">
+<p>SignedTypePrefix</p>
+<p>A string specifying the signed type prefix. Default is <span class="title-ref">int</span>.</p>
+</div>
+<div class="option">
+<p>TypeSuffix</p>
+<p>A string specifying the type suffix. Default is an empty string.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-runtime-int.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
    <tag>cpplint-style</tag>
    <tag>bad-practice</tag>
@@ -511,12 +697,16 @@ Finds calls to ``memset`` with a literal zero in the length argument.
 <rule>
   <key>google-runtime-operator</key>
   <name>google-runtime-operator</name>
-  <description><![CDATA[<p>
-Finds overloads of unary ``operator &``.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-runtime-operator.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - google-runtime-operator</p>
+</div>
+<h1 id="google-runtime-operator">google-runtime-operator</h1>
+<p>Finds overloads of unary <code>operator &amp;</code>.</p>
+<p><a href="https://google.github.io/styleguide/cppguide.html#Operator_Overloading" class="uri">https://google.github.io/styleguide/cppguide.html#Operator_Overloading</a></p>
+<p>Corresponding cpplint.py check name: <span class="title-ref">runtime/operator</span>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-runtime-operator.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>bad-practice</tag>
    <tag>cpplint-style</tag>
@@ -526,12 +716,20 @@ Finds overloads of unary ``operator &``.
 <rule>
   <key>google-runtime-references</key>
   <name>google-runtime-references</name>
-  <description><![CDATA[<p>
-Checks the usage of non-constant references in function parameters.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-runtime-references.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - google-runtime-references</p>
+</div>
+<h1 id="google-runtime-references">google-runtime-references</h1>
+<p>Checks the usage of non-constant references in function parameters.</p>
+<p>The corresponding style guide rule: <a href="https://google.github.io/styleguide/cppguide.html#Reference_Arguments" class="uri">https://google.github.io/styleguide/cppguide.html#Reference_Arguments</a></p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>WhiteListTypes</p>
+<p>A semicolon-separated list of names of whitelist types. Default is empty.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-runtime-references.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
    <tag>cpplint-style</tag>
    <tag>bad-practice</tag>
@@ -541,12 +739,19 @@ Checks the usage of non-constant references in function parameters.
 <rule>
   <key>llvm-header-guard</key>
   <name>llvm-header-guard</name>
-  <description><![CDATA[<p>
-Finds and fixes header guards that do not adhere to LLVM style.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-header-guard.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - llvm-header-guard</p>
+</div>
+<h1 id="llvm-header-guard">llvm-header-guard</h1>
+<p>Finds and fixes header guards that do not adhere to LLVM style.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>HeaderFileExtensions</p>
+<p>A comma-separated list of filename extensions of header files (the filename extensions should not include &quot;.&quot; prefix). Default is &quot;h,hh,hpp,hxx&quot;. For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. e.g., &quot;h,hh,hpp,hxx,&quot; (note the trailing comma).</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-header-guard.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>llvm-style</tag>
   <tag>bad-practice</tag>
@@ -556,12 +761,15 @@ Finds and fixes header guards that do not adhere to LLVM style.
 <rule>
   <key>llvm-include-order</key>
   <name>llvm-include-order</name>
-  <description><![CDATA[<p>
-Checks the correct order of ``#includes`` according to LLVM style.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-include-order.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - llvm-include-order</p>
+</div>
+<h1 id="llvm-include-order">llvm-include-order</h1>
+<p>Checks the correct order of <code>#includes</code>.</p>
+<p>See <a href="http://llvm.org/docs/CodingStandards.html#include-style" class="uri">http://llvm.org/docs/CodingStandards.html#include-style</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-include-order.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>llvm-style</tag>
   <tag>bad-practice</tag>
@@ -571,12 +779,35 @@ Checks the correct order of ``#includes`` according to LLVM style.
 <rule>
   <key>llvm-namespace-comment</key>
   <name>llvm-namespace-comment</name>
-  <description><![CDATA[<p>
-Checks that long namespaces have a closing comment.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - llvm-namespace-comment</p>
+</div>
+<h1 id="llvm-namespace-comment">llvm-namespace-comment</h1>
+<p><span class="title-ref">google-readability-namespace-comments</span> redirects here as an alias for this check.</p>
+<p>Checks that long namespaces have a closing comment.</p>
+<p><a href="http://llvm.org/docs/CodingStandards.html#namespace-indentation" class="uri">http://llvm.org/docs/CodingStandards.html#namespace-indentation</a></p>
+<p><a href="https://google.github.io/styleguide/cppguide.html#Namespaces" class="uri">https://google.github.io/styleguide/cppguide.html#Namespaces</a></p>
+<pre class="sourceCode c++"><code>namespace n1 {
+void f();
+}
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-namespace-comment.html" target="_blank">clang.llvm.org</a></p>
+// becomes
+
+namespace n1 {
+void f();
+}  // namespace n1</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>ShortNamespaceLines</p>
+<p>Requires the closing brace of the namespace definition to be followed by a closing comment if the body of the namespace has more than <span class="title-ref">ShortNamespaceLines</span> lines of code. The value is an unsigned integer that defaults to <span class="title-ref">1U</span>.</p>
+</div>
+<div class="option">
+<p>SpacesBeforeComments</p>
+<p>An unsigned integer specifying the number of spaces before the comment closing a namespace definition. Default is <span class="title-ref">1U</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-namespace-comment.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>llvm-style</tag>
   <tag>bad-practice</tag>
@@ -586,13 +817,19 @@ Checks that long namespaces have a closing comment.
 <rule>
   <key>llvm-twine-local</key>
   <name>llvm-twine-local</name>
-  <description><![CDATA[<p>
-Looks for local ``Twine`` variables which are prone to use after frees and
-should be generally avoided.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - llvm-twine-local</p>
+</div>
+<h1 id="llvm-twine-local">llvm-twine-local</h1>
+<p>Looks for local <code>Twine</code> variables which are prone to use after frees and should be generally avoided.</p>
+<pre class="sourceCode c++"><code>static Twine Moo = Twine(&quot;bark&quot;) + &quot;bah&quot;;
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-twine-local.html" target="_blank">clang.llvm.org</a></p>
+// becomes
+
+static std::string Moo = (Twine(&quot;bark&quot;) + &quot;bah&quot;).str();</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-twine-local.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <tag>llvm-style</tag>
   <severity>MINOR</severity>
@@ -657,14 +894,96 @@ values, where the temporary is destroyed soon after the handle is created.
 <rule>
   <key>misc-definitions-in-headers</key>
   <name>misc-definitions-in-headers</name>
-  <description><![CDATA[<p>
-Finds non-extern non-inline function and variable definitions in header files,
-which can lead to potential ODR violations in case these headers are included
-from multiple translation units.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - misc-definitions-in-headers</p>
+</div>
+<h1 id="misc-definitions-in-headers">misc-definitions-in-headers</h1>
+<p>Finds non-extern non-inline function and variable definitions in header files, which can lead to potential ODR violations in case these headers are included from multiple translation units.</p>
+<pre class="sourceCode c++"><code>// Foo.h
+int a = 1; // Warning: variable definition.
+extern int d; // OK: extern variable.
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-definitions-in-headers.html" target="_blank">clang.llvm.org</a></p>
+namespace N {
+  int e = 2; // Warning: variable definition.
+}
+
+// Warning: variable definition.
+const char* str = &quot;foo&quot;;
+
+// OK: internal linkage variable definitions are ignored for now.
+// Although these might also cause ODR violations, we can be less certain and
+// should try to keep the false-positive rate down.
+static int b = 1;
+const int c = 1;
+const char* const str2 = &quot;foo&quot;;
+constexpr int k = 1;
+
+// Warning: function definition.
+int g() {
+  return 1;
+}
+
+// OK: inline function definition is allowed to be defined multiple times.
+inline int e() {
+  return 1;
+}
+
+class A {
+public:
+  int f1() { return 1; } // OK: implicitly inline member function definition is allowed.
+  int f2();
+
+  static int d;
+};
+
+// Warning: not an inline member function definition.
+int A::f2() { return 1; }
+
+// OK: class static data member declaration is allowed.
+int A::d = 1;
+
+// OK: function template is allowed.
+template&lt;typename T&gt;
+T f3() {
+  T a = 1;
+  return a;
+}
+
+// Warning: full specialization of a function template is not allowed.
+template &lt;&gt;
+int f3() {
+  int a = 1;
+  return a;
+}
+
+template &lt;typename T&gt;
+struct B {
+  void f1();
+};
+
+// OK: member function definition of a class template is allowed.
+template &lt;typename T&gt;
+void B&lt;T&gt;::f1() {}
+
+class CE {
+  constexpr static int i = 5; // OK: inline variable definition.
+};
+
+inline int i = 5; // OK: inline variable definition.
+
+constexpr int f10() { return 0; } // OK: constexpr function implies inline.</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>HeaderFileExtensions</p>
+<p>A comma-separated list of filename extensions of header files (the filename extensions should not include &quot;.&quot; prefix). Default is &quot;h,hh,hpp,hxx&quot;. For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. e.g., &quot;h,hh,hpp,hxx,&quot; (note the trailing comma).</p>
+</div>
+<div class="option">
+<p>UseHeaderFileExtension</p>
+<p>When non-zero, the check will use the file extension to distinguish header files. Default is <span class="title-ref">1</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-definitions-in-headers.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -767,15 +1086,18 @@ Checks for repeated argument with side effects in macros.
 <rule>
   <key>misc-misplaced-const</key>
   <name>misc-misplaced-const</name>
-  <description><![CDATA[<p>
-This check diagnoses when a ``const`` qualifier is applied to a ``typedef`` to a
-pointer type rather than to the pointee, because such constructs are often
-misleading to developers because the ``const`` applies to the pointer rather
-than the pointee.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-misplaced-const.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - misc-misplaced-const</p>
+</div>
+<h1 id="misc-misplaced-const">misc-misplaced-const</h1>
+<p>This check diagnoses when a <code>const</code> qualifier is applied to a <code>typedef</code> to a pointer type rather than to the pointee, because such constructs are often misleading to developers because the <code>const</code> applies to the pointer rather than the pointee.</p>
+<p>For instance, in the following code, the resulting type is <code>int *</code> <code>const</code> rather than <code>const int *</code>:</p>
+<pre class="sourceCode c++"><code>typedef int *int_ptr;
+void f(const int_ptr ptr);</code></pre>
+<p>The check does not diagnose when the underlying <code>typedef</code> type is a pointer to a <code>const</code> type or a function pointer type. This is because the <code>const</code> qualifier is less likely to be mistaken because it would be redundant (or disallowed) on the underlying pointee type.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-misplaced-const.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -844,14 +1166,17 @@ Only the first statement of the macro will be inside the conditional and the oth
 <rule>
   <key>misc-new-delete-overloads</key>
   <name>misc-new-delete-overloads</name>
-  <description><![CDATA[<p>
-The check flags overloaded operator ``new()`` and operator ``delete()`` functions that do not have a corresponding free store
-function defined within the same scope. For instance, the check will flag a class implementation of a non-placement operator ``new()``
-when the class does not also define a non-placement operator ``delete()`` function as well.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-new-delete-overloads.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - misc-new-delete-overloads</p>
+</div>
+<h1 id="misc-new-delete-overloads">misc-new-delete-overloads</h1>
+<p><span class="title-ref">cert-dcl54-cpp</span> redirects here as an alias for this check.</p>
+<p>The check flags overloaded operator <code>new()</code> and operator <code>delete()</code> functions that do not have a corresponding free store function defined within the same scope. For instance, the check will flag a class implementation of a non-placement operator <code>new()</code> when the class does not also define a non-placement operator <code>delete()</code> function as well.</p>
+<p>The check does not flag implicitly-defined operators, deleted or private operators, or placement operators.</p>
+<p>This check corresponds to CERT C++ Coding Standard rule <a href="">DCL54-CPP. Overload allocation and deallocation functions as a pair in the same scope &lt;https://www.securecoding.cert.org/confluence/display/cplusplus/DCL54-CPP.+Overload+allocation+and+deallocation+functions+as+a+pair+in+the+same+scope&gt;</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-new-delete-overloads.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MAJOR</severity>
   <type>BUG</type>
@@ -874,12 +1199,16 @@ evaluates to ``false`` (but is not a ``false`` literal itself).
 <rule>
   <key>misc-non-copyable-objects</key>
   <name>misc-non-copyable-objects</name>
-  <description><![CDATA[<p>
-The check flags dereferences and non-pointer declarations of objects that are not meant to be passed by value, such as C FILE objects or POSIX ``pthread_mutex_t`` objects.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-non-copyable-objects.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - misc-non-copyable-objects</p>
+</div>
+<h1 id="misc-non-copyable-objects">misc-non-copyable-objects</h1>
+<p><span class="title-ref">cert-fio38-c</span> redirects here as an alias for this check.</p>
+<p>The check flags dereferences and non-pointer declarations of objects that are not meant to be passed by value, such as C FILE objects or POSIX <code>pthread_mutex_t</code> objects.</p>
+<p>This check corresponds to CERT C++ Coding Standard rule <a href="">FIO38-C. Do not copy a FILE object &lt;https://www.securecoding.cert.org/confluence/display/c/FIO38-C.+Do+not+copy+a+FILE+object&gt;</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-non-copyable-objects.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -902,12 +1231,26 @@ object is compare to an object with integral type.
 <rule>
   <key>misc-redundant-expression</key>
   <name>misc-redundant-expression</name>
-  <description><![CDATA[<p>
-Detect redundant expressions which are typically errors due to copy-paste.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-redundant-expression.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - misc-redundant-expression</p>
+</div>
+<h1 id="misc-redundant-expression">misc-redundant-expression</h1>
+<p>Detect redundant expressions which are typically errors due to copy-paste.</p>
+<p>Depending on the operator expressions may be</p>
+<ul>
+<li>redundant,</li>
+<li>always <code>true</code>,</li>
+<li>always <code>false</code>,</li>
+<li>always a constant (zero or one).</li>
+</ul>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>((x+1) | (x+1))             // (x+1) is redundant
+(p-&gt;x == p-&gt;x)              // always true
+(p-&gt;x &lt; p-&gt;x)               // always false
+(speed - speed + 1 == 12)   // speed - speed is always zero</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-redundant-expression.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -942,12 +1285,16 @@ The check finds usages of ``sizeof`` expressions which are most likely errors.
 <rule>
   <key>misc-static-assert</key>
   <name>misc-static-assert</name>
-  <description><![CDATA[<p>
-Replaces ``assert()`` with ``static_assert()`` if the condition is evaluatable at compile time.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-static-assert.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - misc-static-assert</p>
+</div>
+<h1 id="misc-static-assert">misc-static-assert</h1>
+<p><span class="title-ref">cert-dcl03-c</span> redirects here as an alias for this check.</p>
+<p>Replaces <code>assert()</code> with <code>static_assert()</code> if the condition is evaluatable at compile time.</p>
+<p>The condition of <code>static_assert()</code> is evaluated at compile time which is safer and more efficient.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-static-assert.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1057,12 +1404,31 @@ Finds potentially swapped arguments by looking at implicit conversions.
 <rule>
   <key>misc-throw-by-value-catch-by-reference</key>
   <name>misc-throw-by-value-catch-by-reference</name>
-  <description><![CDATA[<p>
-Finds violations of the rule "Throw by value, catch by reference" presented for example in "C++ Coding Standards" by H. Sutter and A. Alexandrescu.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-throw-by-value-catch-by-reference.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - misc-throw-by-value-catch-by-reference</p>
+</div>
+<h1 id="misc-throw-by-value-catch-by-reference">misc-throw-by-value-catch-by-reference</h1>
+<p>&quot;cert-err09-cpp&quot; redirects here as an alias for this check. &quot;cert-err61-cpp&quot; redirects here as an alias for this check.</p>
+<p>Finds violations of the rule &quot;Throw by value, catch by reference&quot; presented for example in &quot;C++ Coding Standards&quot; by H. Sutter and A. Alexandrescu.</p>
+<dl>
+<dt>Exceptions:</dt>
+<dd><ul>
+<li>Throwing string literals will not be flagged despite being a pointer. They are not susceptible to slicing and the usage of string literals is idomatic.</li>
+<li>Catching character pointers (<code>char</code>, <code>wchar_t</code>, unicode character types) will not be flagged to allow catching sting literals.</li>
+<li>Moved named values will not be flagged as not throwing an anonymous temporary. In this case we can be sure that the user knows that the object can't be accessed outside catch blocks handling the error.</li>
+<li>Throwing function parameters will not be flagged as not throwing an anonymous temporary. This allows helper functions for throwing.</li>
+<li>Re-throwing caught exception variables will not be flragged as not throwing an anonymous temporary. Although this can usually be done by just writing <code>throw;</code> it happens often enough in real code.</li>
+</ul>
+</dd>
+</dl>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>CheckThrowTemporaries</p>
+<p>Triggers detection of violations of the rule <a href="">Throw anonymous temporaries &lt;https://www.securecoding.cert.org/confluence/display/cplusplus/ERR09-CPP.+Throw+anonymous+temporaries&gt;</a>. Default is <span class="title-ref">1</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-throw-by-value-catch-by-reference.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1070,13 +1436,22 @@ Finds violations of the rule "Throw by value, catch by reference" presented for 
 <rule>
   <key>misc-unconventional-assign-operator</key>
   <name>misc-unconventional-assign-operator</name>
-  <description><![CDATA[<p>
-Finds declarations of assign operators with the wrong return and/or argument
-types and definitions with good return type but wrong ``return`` statements.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-unconventional-assign-operator.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - misc-unconventional-assign-operator</p>
+</div>
+<h1 id="misc-unconventional-assign-operator">misc-unconventional-assign-operator</h1>
+<p>Finds declarations of assign operators with the wrong return and/or argument types and definitions with good return type but wrong <code>return</code> statements.</p>
+<blockquote>
+<ul>
+<li>The return type must be <code>Class&amp;</code>.</li>
+<li>Works with move-assign and assign by value.</li>
+<li>Private and deleted operators are ignored.</li>
+<li>The operator must always return <code>*this</code>.</li>
+</ul>
+</blockquote>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-unconventional-assign-operator.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1098,12 +1473,18 @@ function call to another constructor of the same class.
 <rule>
   <key>misc-uniqueptr-reset-release</key>
   <name>misc-uniqueptr-reset-release</name>
-  <description><![CDATA[<p>
-Find and replace ``unique_ptr::reset(release())`` with ``std::move()``.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-uniqueptr-reset-release.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - misc-uniqueptr-reset-release</p>
+</div>
+<h1 id="misc-uniqueptr-reset-release">misc-uniqueptr-reset-release</h1>
+<p>Find and replace <code>unique_ptr::reset(release())</code> with <code>std::move()</code>.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>std::unique_ptr&lt;Foo&gt; x, y;
+x.reset(y.release()); -&gt; x = std::move(y);</code></pre>
+<p>If <code>y</code> is already rvalue, <code>std::move()</code> is not added. <code>x</code> and <code>y</code> can also be <code>std::unique_ptr&lt;Foo&gt;*</code>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-uniqueptr-reset-release.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1111,12 +1492,14 @@ Find and replace ``unique_ptr::reset(release())`` with ``std::move()``.
 <rule>
   <key>misc-unused-alias-decls</key>
   <name>misc-unused-alias-decls</name>
-  <description><![CDATA[<p>
-Finds unused namespace alias declarations.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-unused-alias-decls.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - misc-unused-alias-decls</p>
+</div>
+<h1 id="misc-unused-alias-decls">misc-unused-alias-decls</h1>
+<p>Finds unused namespace alias declarations.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-unused-alias-decls.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1124,12 +1507,32 @@ Finds unused namespace alias declarations.
 <rule>
   <key>misc-unused-parameters</key>
   <name>misc-unused-parameters</name>
-  <description><![CDATA[<p>
-Finds unused parameters.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - misc-unused-parameters</p>
+</div>
+<h1 id="misc-unused-parameters">misc-unused-parameters</h1>
+<p>Finds unused function parameters. Unused parameters may signify a bug in the code (e.g. when a different parameter is used instead). The suggested fixes either comment parameter name out or remove the parameter completely, if all callers of the function are in the same translation unit and can be updated.</p>
+<p>The check is similar to the <span class="title-ref">-Wunused-parameter</span> compiler diagnostic and can be used to prepare a codebase to enabling of that diagnostic. By default the check is more permissive (see <code class="interpreted-text" data-role="option">StrictMode</code>).</p>
+<pre class="sourceCode c++"><code>void a(int i) { /*some code that doesn&#39;t use `i`*/ }
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-unused-parameters.html" target="_blank">clang.llvm.org</a></p>
+// becomes
+
+void a(int  /*i*/) { /*some code that doesn&#39;t use `i`*/ }</code></pre>
+<pre class="sourceCode c++"><code>static void staticFunctionA(int i);
+static void staticFunctionA(int i) { /*some code that doesn&#39;t use `i`*/ }
+
+// becomes
+
+static void staticFunctionA()
+static void staticFunctionA() { /*some code that doesn&#39;t use `i`*/ }</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>StrictMode</p>
+<p>When zero (default value), the check will ignore trivially unused parameters, i.e. when the corresponding function has an empty body (and in case of constructors - no constructor initializers). When the function body is empty, an unused parameter is unlikely to be unnoticed by a human reader, and there's basically no place for a bug to hide.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-unused-parameters.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1150,12 +1553,17 @@ Finds temporaries that look like RAII objects.
 <rule>
   <key>misc-unused-using-decls</key>
   <name>misc-unused-using-decls</name>
-  <description><![CDATA[<p>
-Finds unused ``using`` declarations.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-unused-using-decls.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - misc-unused-using-decls</p>
+</div>
+<h1 id="misc-unused-using-decls">misc-unused-using-decls</h1>
+<p>Finds unused <code>using</code> declarations.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>namespace n { class C; }
+using n::C;  // Never actually used.</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-unused-using-decls.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1177,13 +1585,28 @@ signiture is the same) to a virtual function from a base class.
 <rule>
   <key>modernize-avoid-bind</key>
   <name>modernize-avoid-bind</name>
-  <description><![CDATA[<p>
-The check finds uses of ``std::bind`` and replaces simple uses with lambdas.
-Lambdas will use value-capture where required.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-avoid-bind.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-avoid-bind</p>
+</div>
+<h1 id="modernize-avoid-bind">modernize-avoid-bind</h1>
+<p>The check finds uses of <code>std::bind</code> and replaces simple uses with lambdas. Lambdas will use value-capture where required.</p>
+<p>Right now it only handles free functions, not member functions.</p>
+<p>Given:</p>
+<pre class="sourceCode c++"><code>int add(int x, int y) { return x + y; }</code></pre>
+<p>Then:</p>
+<pre class="sourceCode c++"><code>void f() {
+  int x = 2;
+  auto clj = std::bind(add, x, _1);
+}</code></pre>
+<p>is replaced by:</p>
+<pre class="sourceCode c++"><code>void f() {
+  int x = 2;
+  auto clj = [=](auto &amp;&amp; arg1) { return add(x, arg1); };
+}</code></pre>
+<p><code>std::bind</code> can be hard to read and can result in larger object files and binaries due to type information that will not be produced by equivalent lambdas.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-avoid-bind.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1191,14 +1614,48 @@ Lambdas will use value-capture where required.
 <rule>
   <key>modernize-deprecated-headers</key>
   <name>modernize-deprecated-headers</name>
-  <description><![CDATA[<p>
-Some headers from C library were deprecated in C++ and are no longer welcome in
-C++ codebases. For more details refer to the C++ 14 Standard [depr.c.headers]
-section.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-deprecated-headers.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-deprecated-headers</p>
+</div>
+<h1 id="modernize-deprecated-headers">modernize-deprecated-headers</h1>
+<p>Some headers from C library were deprecated in C++ and are no longer welcome in C++ codebases. Some have no effect in C++. For more details refer to the C++ 14 Standard [depr.c.headers] section.</p>
+<p>This check replaces C standard library headers with their C++ alternatives and removes redundant ones.</p>
+<p>Improtant note: the Standard doesn't guarantee that the C++ headers declare all the same functions in the global namespace. The check in its current form can break the code that uses library symbols from the global namespace.</p>
+<ul>
+<li><span class="title-ref">&lt;assert.h&gt;</span></li>
+<li><span class="title-ref">&lt;complex.h&gt;</span></li>
+<li><span class="title-ref">&lt;ctype.h&gt;</span></li>
+<li><span class="title-ref">&lt;errno.h&gt;</span></li>
+<li><span class="title-ref">&lt;fenv.h&gt;</span> // deprecated since C++11</li>
+<li><span class="title-ref">&lt;float.h&gt;</span></li>
+<li><span class="title-ref">&lt;inttypes.h&gt;</span></li>
+<li><span class="title-ref">&lt;limits.h&gt;</span></li>
+<li><span class="title-ref">&lt;locale.h&gt;</span></li>
+<li><span class="title-ref">&lt;math.h&gt;</span></li>
+<li><span class="title-ref">&lt;setjmp.h&gt;</span></li>
+<li><span class="title-ref">&lt;signal.h&gt;</span></li>
+<li><span class="title-ref">&lt;stdarg.h&gt;</span></li>
+<li><span class="title-ref">&lt;stddef.h&gt;</span></li>
+<li><span class="title-ref">&lt;stdint.h&gt;</span></li>
+<li><span class="title-ref">&lt;stdio.h&gt;</span></li>
+<li><span class="title-ref">&lt;stdlib.h&gt;</span></li>
+<li><span class="title-ref">&lt;string.h&gt;</span></li>
+<li><span class="title-ref">&lt;tgmath.h&gt;</span> // deprecated since C++11</li>
+<li><span class="title-ref">&lt;time.h&gt;</span></li>
+<li><span class="title-ref">&lt;uchar.h&gt;</span> // deprecated since C++11</li>
+<li><span class="title-ref">&lt;wchar.h&gt;</span></li>
+<li><span class="title-ref">&lt;wctype.h&gt;</span></li>
+</ul>
+<p>If the specified standard is older than C++11 the check will only replace headers deprecated before C++11, otherwise -- every header that appeared in the previous list.</p>
+<p>These headers don't have effect in C++:</p>
+<ul>
+<li><span class="title-ref">&lt;iso646.h&gt;</span></li>
+<li><span class="title-ref">&lt;stdalign.h&gt;</span></li>
+<li><span class="title-ref">&lt;stdbool.h&gt;</span></li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-deprecated-headers.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1206,13 +1663,152 @@ section.
 <rule>
   <key>modernize-loop-convert</key>
   <name>modernize-loop-convert</name>
-  <description><![CDATA[<p>
-This check converts ``for(...; ...; ...)`` loops to use the new range-based
-loops in C++11.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-loop-convert</p>
+</div>
+<h1 id="modernize-loop-convert">modernize-loop-convert</h1>
+<p>This check converts <code>for(...; ...; ...)</code> loops to use the new range-based loops in C++11.</p>
+<p>Three kinds of loops can be converted:</p>
+<ul>
+<li>Loops over statically allocated arrays.</li>
+<li>Loops over containers, using iterators.</li>
+<li>Loops over array-like containers, using <code>operator[]</code> and <code>at()</code>.</li>
+</ul>
+<h2 id="minconfidence-option">MinConfidence option</h2>
+<h3 id="risky">risky</h3>
+<p>In loops where the container expression is more complex than just a reference to a declared expression (a variable, function, enum, etc.), and some part of it appears elsewhere in the loop, we lower our confidence in the transformation due to the increased risk of changing semantics. Transformations for these loops are marked as <span class="title-ref">risky</span>, and thus will only be converted if the minimum required confidence level is set to <span class="title-ref">risky</span>.</p>
+<pre class="sourceCode c++"><code>int arr[10][20];
+int l = 5;
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-loop-convert.html" target="_blank">clang.llvm.org</a></p>
+for (int j = 0; j &lt; 20; ++j)
+  int k = arr[l][j] + l; // using l outside arr[l] is considered risky
+
+for (int i = 0; i &lt; obj.getVector().size(); ++i)
+  obj.foo(10); // using &#39;obj&#39; is considered risky</code></pre>
+<p>See <code class="interpreted-text" data-role="ref">Range-based loops evaluate end() only once&lt;IncorrectRiskyTransformation&gt;</code> for an example of an incorrect transformation when the minimum required confidence level is set to <span class="title-ref">risky</span>.</p>
+<h3 id="reasonable-default">reasonable (Default)</h3>
+<p>If a loop calls <code>.end()</code> or <code>.size()</code> after each iteration, the transformation for that loop is marked as <span class="title-ref">reasonable</span>, and thus will be converted if the required confidence level is set to <span class="title-ref">reasonable</span> (default) or lower.</p>
+<pre class="sourceCode c++"><code>// using size() is considered reasonable
+for (int i = 0; i &lt; container.size(); ++i)
+  cout &lt;&lt; container[i];</code></pre>
+<h3 id="safe">safe</h3>
+<p>Any other loops that do not match the above criteria to be marked as <span class="title-ref">risky</span> or <span class="title-ref">reasonable</span> are marked <span class="title-ref">safe</span>, and thus will be converted if the required confidence level is set to <span class="title-ref">safe</span> or lower.</p>
+<pre class="sourceCode c++"><code>int arr[] = {1,2,3};
+
+for (int i = 0; i &lt; 3; ++i)
+  cout &lt;&lt; arr[i];</code></pre>
+<h2 id="example">Example</h2>
+<p>Original:</p>
+<pre class="sourceCode c++"><code>const int N = 5;
+int arr[] = {1,2,3,4,5};
+vector&lt;int&gt; v;
+v.push_back(1);
+v.push_back(2);
+v.push_back(3);
+
+// safe conversion
+for (int i = 0; i &lt; N; ++i)
+  cout &lt;&lt; arr[i];
+
+// reasonable conversion
+for (vector&lt;int&gt;::iterator it = v.begin(); it != v.end(); ++it)
+  cout &lt;&lt; *it;
+
+// reasonable conversion
+for (int i = 0; i &lt; v.size(); ++i)
+  cout &lt;&lt; v[i];</code></pre>
+<p>After applying the check with minimum confidence level set to <span class="title-ref">reasonable</span> (default):</p>
+<pre class="sourceCode c++"><code>const int N = 5;
+int arr[] = {1,2,3,4,5};
+vector&lt;int&gt; v;
+v.push_back(1);
+v.push_back(2);
+v.push_back(3);
+
+// safe conversion
+for (auto &amp; elem : arr)
+  cout &lt;&lt; elem;
+
+// reasonable conversion
+for (auto &amp; elem : v)
+  cout &lt;&lt; elem;
+
+// reasonable conversion
+for (auto &amp; elem : v)
+  cout &lt;&lt; elem;</code></pre>
+<h2 id="limitations">Limitations</h2>
+<p>There are certain situations where the tool may erroneously perform transformations that remove information and change semantics. Users of the tool should be aware of the behaviour and limitations of the check outlined by the cases below.</p>
+<h3 id="comments-inside-loop-headers">Comments inside loop headers</h3>
+<p>Comments inside the original loop header are ignored and deleted when transformed.</p>
+<pre class="sourceCode c++"><code>for (int i = 0; i &lt; N; /* This will be deleted */ ++i) { }</code></pre>
+<h3 id="range-based-loops-evaluate-end-only-once">Range-based loops evaluate end() only once</h3>
+<p>The C++11 range-based for loop calls <code>.end()</code> only once during the initialization of the loop. If in the original loop <code>.end()</code> is called after each iteration the semantics of the transformed loop may differ.</p>
+<pre class="sourceCode c++"><code>// The following is semantically equivalent to the C++11 range-based for loop,
+// therefore the semantics of the header will not change.
+for (iterator it = container.begin(), e = container.end(); it != e; ++it) { }
+
+// Instead of calling .end() after each iteration, this loop will be
+// transformed to call .end() only once during the initialization of the loop,
+// which may affect semantics.
+for (iterator it = container.begin(); it != container.end(); ++it) { }</code></pre>
+<div id="IncorrectRiskyTransformation">
+<p>As explained above, calling member functions of the container in the body of the loop is considered <span class="title-ref">risky</span>. If the called member function modifies the container the semantics of the converted loop will differ due to <code>.end()</code> being called only once.</p>
+</div>
+<pre class="sourceCode c++"><code>bool flag = false;
+for (vector&lt;T&gt;::iterator it = vec.begin(); it != vec.end(); ++it) {
+  // Add a copy of the first element to the end of the vector.
+  if (!flag) {
+    // This line makes this transformation &#39;risky&#39;.
+    vec.push_back(*it);
+    flag = true;
+  }
+  cout &lt;&lt; *it;
+}</code></pre>
+<p>The original code above prints out the contents of the container including the newly added element while the converted loop, shown below, will only print the original contents and not the newly added element.</p>
+<pre class="sourceCode c++"><code>bool flag = false;
+for (auto &amp; elem : vec) {
+  // Add a copy of the first element to the end of the vector.
+  if (!flag) {
+    // This line makes this transformation &#39;risky&#39;
+    vec.push_back(elem);
+    flag = true;
+  }
+  cout &lt;&lt; elem;
+}</code></pre>
+<p>Semantics will also be affected if <code>.end()</code> has side effects. For example, in the case where calls to <code>.end()</code> are logged the semantics will change in the transformed loop if <code>.end()</code> was originally called after each iteration.</p>
+<pre class="sourceCode c++"><code>iterator end() {
+  num_of_end_calls++;
+  return container.end();
+}</code></pre>
+<h3 id="overloaded-operator--with-side-effects">Overloaded operator-&gt;() with side effects</h3>
+<p>Similarly, if <code>operator-&gt;()</code> was overloaded to have side effects, such as logging, the semantics will change. If the iterator's <code>operator-&gt;()</code> was used in the original loop it will be replaced with <code>&lt;container element&gt;.&lt;member&gt;</code> instead due to the implicit dereference as part of the range-based for loop. Therefore any side effect of the overloaded <code>operator-&gt;()</code> will no longer be performed.</p>
+<pre class="sourceCode c++"><code>for (iterator it = c.begin(); it != c.end(); ++it) {
+  it-&gt;func(); // Using operator-&gt;()
+}
+// Will be transformed to:
+for (auto &amp; elem : c) {
+  elem.func(); // No longer using operator-&gt;()
+}</code></pre>
+<h3 id="pointers-and-references-to-containers">Pointers and references to containers</h3>
+<p>While most of the check's risk analysis is dedicated to determining whether the iterator or container was modified within the loop, it is possible to circumvent the analysis by accessing and modifying the container through a pointer or reference.</p>
+<p>If the container were directly used instead of using the pointer or reference the following transformation would have only been applied at the <span class="title-ref">risky</span> level since calling a member function of the container is considered <span class="title-ref">risky</span>. The check cannot identify expressions associated with the container that are different than the one used in the loop header, therefore the transformation below ends up being performed at the <span class="title-ref">safe</span> level.</p>
+<pre class="sourceCode c++"><code>vector&lt;int&gt; vec;
+
+vector&lt;int&gt; *ptr = &amp;vec;
+vector&lt;int&gt; &amp;ref = vec;
+
+for (vector&lt;int&gt;::iterator it = vec.begin(), e = vec.end(); it != e; ++it) {
+  if (!flag) {
+    // Accessing and modifying the container is considered risky, but the risk
+    // level is not raised here.
+    ptr-&gt;push_back(*it);
+    ref.push_back(*it);
+    flag = true;
+  }
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-loop-convert.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1220,14 +1816,42 @@ loops in C++11.
 <rule>
   <key>modernize-make-shared</key>
   <name>modernize-make-shared</name>
-  <description><![CDATA[<p>
-This check finds the creation of ``std::shared_ptr`` objects by explicitly
-calling the constructor and a ``new`` expression, and replaces it with a call
-to ``std::make_shared``.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-make-shared</p>
+</div>
+<h1 id="modernize-make-shared">modernize-make-shared</h1>
+<p>This check finds the creation of <code>std::shared_ptr</code> objects by explicitly calling the constructor and a <code>new</code> expression, and replaces it with a call to <code>std::make_shared</code>.</p>
+<pre class="sourceCode c++"><code>auto my_ptr = std::shared_ptr&lt;MyPair&gt;(new MyPair(1, 2));
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-make-shared.html" target="_blank">clang.llvm.org</a></p>
+// becomes
+
+auto my_ptr = std::make_shared&lt;MyPair&gt;(1, 2);</code></pre>
+<p>This check also finds calls to <code>std::shared_ptr::reset()</code> with a <code>new</code> expression, and replaces it with a call to <code>std::make_shared</code>.</p>
+<pre class="sourceCode c++"><code>my_ptr.reset(new MyPair(1, 2));
+
+// becomes
+
+my_ptr = std::make_shared&lt;MyPair&gt;(1, 2);</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>MakeSmartPtrFunction</p>
+<p>A string specifying the name of make-shared-ptr function. Default is <span class="title-ref">std::make_shared</span>.</p>
+</div>
+<div class="option">
+<p>MakeSmartPtrFunctionHeader</p>
+<p>A string specifying the corresponding header of make-shared-ptr function. Default is <span class="title-ref">memory</span>.</p>
+</div>
+<div class="option">
+<p>IncludeStyle</p>
+<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
+</div>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>If set to non-zero, the check will not give warnings inside macros. Default is <span class="title-ref">1</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-make-shared.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1235,14 +1859,42 @@ to ``std::make_shared``.
 <rule>
   <key>modernize-make-unique</key>
   <name>modernize-make-unique</name>
-  <description><![CDATA[<p>
-This check finds the creation of ``std::unique_ptr`` objects by explicitly
-calling the constructor and a ``new`` expression, and replaces it with a call
-to ``std::make_unique``, introduced in C++14.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-make-unique</p>
+</div>
+<h1 id="modernize-make-unique">modernize-make-unique</h1>
+<p>This check finds the creation of <code>std::unique_ptr</code> objects by explicitly calling the constructor and a <code>new</code> expression, and replaces it with a call to <code>std::make_unique</code>, introduced in C++14.</p>
+<pre class="sourceCode c++"><code>auto my_ptr = std::unique_ptr&lt;MyPair&gt;(new MyPair(1, 2));
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-make-unique.html" target="_blank">clang.llvm.org</a></p>
+// becomes
+
+auto my_ptr = std::make_unique&lt;MyPair&gt;(1, 2);</code></pre>
+<p>This check also finds calls to <code>std::unique_ptr::reset()</code> with a <code>new</code> expression, and replaces it with a call to <code>std::make_unique</code>.</p>
+<pre class="sourceCode c++"><code>my_ptr.reset(new MyPair(1, 2));
+
+// becomes
+
+my_ptr = std::make_unique&lt;MyPair&gt;(1, 2);</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>MakeSmartPtrFunction</p>
+<p>A string specifying the name of make-unique-ptr function. Default is <span class="title-ref">std::make_unique</span>.</p>
+</div>
+<div class="option">
+<p>MakeSmartPtrFunctionHeader</p>
+<p>A string specifying the corresponding header of make-unique-ptr function. Default is <span class="title-ref">memory</span>.</p>
+</div>
+<div class="option">
+<p>IncludeStyle</p>
+<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
+</div>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>If set to non-zero, the check will not give warnings inside macros. Default is <span class="title-ref">1</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-make-unique.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1250,16 +1902,142 @@ to ``std::make_unique``, introduced in C++14.
 <rule>
   <key>modernize-pass-by-value</key>
   <name>modernize-pass-by-value</name>
-  <description><![CDATA[<p>
-With move semantics added to the language and the standard library updated with
-move constructors added for many types it is now interesting to take an
-argument directly by value, instead of by const-reference, and then copy. This
-check allows the compiler to take care of choosing the best way to construct
-the copy.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-pass-by-value</p>
+</div>
+<h1 id="modernize-pass-by-value">modernize-pass-by-value</h1>
+<p>With move semantics added to the language and the standard library updated with move constructors added for many types it is now interesting to take an argument directly by value, instead of by const-reference, and then copy. This check allows the compiler to take care of choosing the best way to construct the copy.</p>
+<p>The transformation is usually beneficial when the calling code passes an <em>rvalue</em> and assumes the move construction is a cheap operation. This short example illustrates how the construction of the value happens:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>void foo(std::string s);
+std::string get_str();
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-pass-by-value.html" target="_blank">clang.llvm.org</a></p>
+void f(const std::string &amp;str) {
+  foo(str);       // lvalue  -&gt; copy construction
+  foo(get_str()); // prvalue -&gt; move construction
+}</code></pre>
+</blockquote>
+<div class="note">
+<div class="admonition-title">
+<p>Note</p>
+</div>
+<p>Currently, only constructors are transformed to make use of pass-by-value. Contributions that handle other situations are welcome!</p>
+</div>
+<h2 id="pass-by-value-in-constructors">Pass-by-value in constructors</h2>
+<p>Replaces the uses of const-references constructor parameters that are copied into class fields. The parameter is then moved with <span class="title-ref">std::move()</span>.</p>
+<p>Since <code>std::move()</code> is a library function declared in <span class="title-ref">&lt;utility&gt;</span> it may be necessary to add this include. The check will add the include directive when necessary.</p>
+<blockquote>
+<pre class="sourceCode c++"><code>#include &lt;string&gt;
+
+class Foo {
+public:</code></pre>
+<blockquote>
+<ul>
+<li>Foo(const std::string &amp;Copied, const std::string &amp;ReadOnly)</li>
+<li>: Copied(Copied), ReadOnly(ReadOnly)</li>
+<li>Foo(std::string Copied, const std::string &amp;ReadOnly)</li>
+</ul>
+<dl>
+<dt>+ : Copied(std::move(Copied)), ReadOnly(ReadOnly)</dt>
+<dd><p>{}</p>
+</dd>
+<dt>private:</dt>
+<dd><p>std::string Copied; const std::string &amp;ReadOnly;</p>
+</dd>
+</dl>
+<blockquote>
+<p>};</p>
+<p>std::string get_cwd();</p>
+<dl>
+<dt>void f(const std::string &amp;Path) {</dt>
+<dd><p>// The parameter corresponding to 'get_cwd()' is move-constructed. By // using pass-by-value in the Foo constructor we managed to avoid a // copy-construction. Foo foo(get_cwd(), Path);</p>
+</dd>
+</dl>
+<p>}</p>
+</blockquote>
+</blockquote>
+</blockquote>
+<p>If the parameter is used more than once no transformation is performed since moved objects have an undefined state. It means the following code will be left untouched:</p>
+<pre class="sourceCode c++"><code>#include &lt;string&gt;
+
+void pass(const std::string &amp;S);
+
+struct Foo {
+  Foo(const std::string &amp;S) : Str(S) {
+    pass(S);
+  }
+
+  std::string Str;
+};</code></pre>
+<h3 id="known-limitations">Known limitations</h3>
+<p>A situation where the generated code can be wrong is when the object referenced is modified before the assignment in the init-list through a &quot;hidden&quot; reference.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>std::string s(&quot;foo&quot;);
+
+struct Base {
+  Base() {
+    s = &quot;bar&quot;;
+  }
+};
+
+struct Derived : Base {</code></pre>
+<blockquote>
+<ul>
+<li>Derived(const std::string &amp;S) : Field(S)</li>
+</ul>
+<dl>
+<dt>+ Derived(std::string S) : Field(std::move(S))</dt>
+<dd><p>{ }</p>
+<p>std::string Field;</p>
+</dd>
+</dl>
+<blockquote>
+<p>};</p>
+<p>void f() {</p>
+</blockquote>
+<ul>
+<li>Derived d(s); // d.Field holds &quot;bar&quot;</li>
+</ul>
+<dl>
+<dt>+ Derived d(s); // d.Field holds &quot;foo&quot;</dt>
+<dd><p>}</p>
+</dd>
+</dl>
+</blockquote>
+<h3 id="note-about-delayed-template-parsing">Note about delayed template parsing</h3>
+<p>When delayed template parsing is enabled, constructors part of templated contexts; templated constructors, constructors in class templates, constructors of inner classes of template classes, etc., are not transformed. Delayed template parsing is enabled by default on Windows as a Microsoft extension: <a href="http://clang.llvm.org/docs/UsersManual.html#microsoft-extensions">Clang Compiler User’s Manual - Microsoft extensions</a>.</p>
+<p>Delayed template parsing can be enabled using the <span class="title-ref">-fdelayed-template-parsing</span> flag and disabled using <span class="title-ref">-fno-delayed-template-parsing</span>.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>template &lt;typename T&gt; class C {
+  std::string S;
+
+public:</code></pre>
+<blockquote>
+<p>= // using -fdelayed-template-parsing (default on Windows) = C(const std::string &amp;S) : S(S) {}</p>
+<ul>
+<li>// using -fno-delayed-template-parsing (default on non-Windows systems)</li>
+</ul>
+<dl>
+<dt>+ C(std::string S) : S(std::move(S)) {}</dt>
+<dd><p>};</p>
+</dd>
+</dl>
+</blockquote>
+<div class="seealso">
+<p>For more information about the pass-by-value idiom, read: <a href="">Want Speed? Pass by Value</a>.</p>
+</div>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IncludeStyle</p>
+<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
+</div>
+<div class="option">
+<p>ValuesOnly</p>
+<p>When non-zero, the check only warns about copied parameters that are already passed by value. Default is <span class="title-ref">0</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-pass-by-value.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1267,13 +2045,35 @@ the copy.
 <rule>
   <key>modernize-raw-string-literal</key>
   <name>modernize-raw-string-literal</name>
-  <description><![CDATA[<p>
-This check selectively replaces string literals containing escaped characters
-with raw string literals.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-raw-string-literal.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-raw-string-literal</p>
+</div>
+<h1 id="modernize-raw-string-literal">modernize-raw-string-literal</h1>
+<p>This check selectively replaces string literals containing escaped characters with raw string literals.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>const char *const Quotes{&quot;embedded \&quot;quotes\&quot;&quot;};
+const char *const Paragraph{&quot;Line one.\nLine two.\nLine three.\n&quot;};
+const char *const SingleLine{&quot;Single line.\n&quot;};
+const char *const TrailingSpace{&quot;Look here -&gt; \n&quot;};
+const char *const Tab{&quot;One\tTwo\n&quot;};
+const char *const Bell{&quot;Hello!\a  And welcome!&quot;};
+const char *const Path{&quot;C:\\Program Files\\Vendor\\Application.exe&quot;};
+const char *const RegEx{&quot;\\w\\([a-z]\\)&quot;};</code></pre>
+<p>becomes</p>
+<pre class="sourceCode c++"><code>const char *const Quotes{R&quot;(embedded &quot;quotes&quot;)&quot;};
+const char *const Paragraph{&quot;Line one.\nLine two.\nLine three.\n&quot;};
+const char *const SingleLine{&quot;Single line.\n&quot;};
+const char *const TrailingSpace{&quot;Look here -&gt; \n&quot;};
+const char *const Tab{&quot;One\tTwo\n&quot;};
+const char *const Bell{&quot;Hello!\a  And welcome!&quot;};
+const char *const Path{R&quot;(C:\Program Files\Vendor\Application.exe)&quot;};
+const char *const RegEx{R&quot;(\w\([a-z]\))&quot;};</code></pre>
+<p>The presence of any of the following escapes can cause the string to be converted to a raw string literal: <code>\\</code>, <code>\'</code>, <code>\&quot;</code>, <code>\?</code>, and octal or hexadecimal escapes for printable ASCII characters.</p>
+<p>A string literal containing only escaped newlines is a common way of writing lines of text output. Introducing physical newlines with raw string literals in this case is likely to impede readability. These string literals are left unchanged.</p>
+<p>An escaped horizontal tab, form feed, or vertical tab prevents the string literal from being converted. The presence of a horizontal tab, form feed or vertical tab in source code is not visually obvious.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-raw-string-literal.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1281,12 +2081,52 @@ with raw string literals.
 <rule>
   <key>modernize-redundant-void-arg</key>
   <name>modernize-redundant-void-arg</name>
-  <description><![CDATA[<p>
-Find and remove redundant ``void`` argument lists.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-redundant-void-arg.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-redundant-void-arg</p>
+</div>
+<h1 id="modernize-redundant-void-arg">modernize-redundant-void-arg</h1>
+<p>Find and remove redundant <code>void</code> argument lists.</p>
+<dl>
+<dt>Examples:</dt>
+<dd><table>
+<thead>
+<tr class="header">
+<th>Initial code</th>
+<th>Code with applied fixes</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><code>int f(void);</code></td>
+<td><code>int f();</code></td>
+</tr>
+<tr class="even">
+<td><code>int (*f(void))(void);</code></td>
+<td><code>int (*f())();</code></td>
+</tr>
+<tr class="odd">
+<td><code>typedef int (*f_t(void))(void);</code></td>
+<td><code>typedef int (*f_t())();</code></td>
+</tr>
+<tr class="even">
+<td><code>void (C::*p)(void);</code></td>
+<td><code>void (C::*p)();</code></td>
+</tr>
+<tr class="odd">
+<td><code>C::C(void) {}</code></td>
+<td><code>C::C() {}</code></td>
+</tr>
+<tr class="even">
+<td><code>C::~C(void) {}</code></td>
+<td><code>C::~C() {}</code></td>
+</tr>
+</tbody>
+</table>
+</dd>
+</dl>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-redundant-void-arg.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1294,15 +2134,56 @@ Find and remove redundant ``void`` argument lists.
 <rule>
   <key>modernize-replace-auto-ptr</key>
   <name>modernize-replace-auto-ptr</name>
-  <description><![CDATA[<p>
-This check replaces the uses of the deprecated class ``std::auto_ptr`` by
-``std::unique_ptr`` (introduced in C++11). The transfer of ownership, done
-by the copy-constructor and the assignment operator, is changed to match
-``std::unique_ptr`` usage by using explicit calls to ``std::move()``.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-replace-auto-ptr</p>
+</div>
+<h1 id="modernize-replace-auto-ptr">modernize-replace-auto-ptr</h1>
+<p>This check replaces the uses of the deprecated class <code>std::auto_ptr</code> by <code>std::unique_ptr</code> (introduced in C++11). The transfer of ownership, done by the copy-constructor and the assignment operator, is changed to match <code>std::unique_ptr</code> usage by using explicit calls to <code>std::move()</code>.</p>
+<p>Migration example:</p>
+<pre class="sourceCode c++"><code>-void take_ownership_fn(std::auto_ptr&lt;int&gt; int_ptr);
++void take_ownership_fn(std::unique_ptr&lt;int&gt; int_ptr);
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-replace-auto-ptr.html" target="_blank">clang.llvm.org</a></p>
+ void f(int x) {
+-  std::auto_ptr&lt;int&gt; a(new int(x));
+-  std::auto_ptr&lt;int&gt; b;
++  std::unique_ptr&lt;int&gt; a(new int(x));
++  std::unique_ptr&lt;int&gt; b;
+
+-  b = a;
+-  take_ownership_fn(b);
++  b = std::move(a);
++  take_ownership_fn(std::move(b));
+ }</code></pre>
+<p>Since <code>std::move()</code> is a library function declared in <code>&lt;utility&gt;</code> it may be necessary to add this include. The check will add the include directive when necessary.</p>
+<h2 id="known-limitations">Known Limitations</h2>
+<ul>
+<li>If headers modification is not activated or if a header is not allowed to be changed this check will produce broken code (compilation error), where the headers' code will stay unchanged while the code using them will be changed.</li>
+<li><p>Client code that declares a reference to an <code>std::auto_ptr</code> coming from code that can't be migrated (such as a header coming from a 3<sup>rd</sup> party library) will produce a compilation error after migration. This is because the type of the reference will be changed to <code>std::unique_ptr</code> but the type returned by the library won't change, binding a reference to <code>std::unique_ptr</code> from an <code>std::auto_ptr</code>. This pattern doesn't make much sense and usually <code>std::auto_ptr</code> are stored by value (otherwise what is the point in using them instead of a reference or a pointer?).</p>
+<pre class="sourceCode c++"><code>// &lt;3rd-party header...&gt;
+std::auto_ptr&lt;int&gt; get_value();
+const std::auto_ptr&lt;int&gt; &amp; get_ref();
+
+// &lt;calling code (with migration)...&gt;</code></pre>
+<blockquote>
+<p>-std::auto_ptr&lt;int&gt; a(get_value()); +std::unique_ptr&lt;int&gt; a(get_value()); // ok, unique_ptr constructed from auto_ptr</p>
+<p>-const std::auto_ptr&lt;int&gt; &amp; p = get_ptr(); +const std::unique_ptr&lt;int&gt; &amp; p = get_ptr(); // won't compile</p>
+</blockquote></li>
+<li><p>Non-instantiated templates aren't modified.</p>
+<pre class="sourceCode c++"><code>template &lt;typename X&gt;
+void f() {
+    std::auto_ptr&lt;X&gt; p;
+}
+
+// only &#39;f&lt;int&gt;()&#39; (or similar) will trigger the replacement.</code></pre></li>
+</ul>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IncludeStyle</p>
+<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-replace-auto-ptr.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1310,13 +2191,15 @@ by the copy-constructor and the assignment operator, is changed to match
 <rule>
   <key>modernize-shrink-to-fit</key>
   <name>modernize-shrink-to-fit</name>
-  <description><![CDATA[<p>
-Replace copy and swap tricks on shrinkable containers with the
-``shrink_to_fit()`` method call.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-shrink-to-fit.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-shrink-to-fit</p>
+</div>
+<h1 id="modernize-shrink-to-fit">modernize-shrink-to-fit</h1>
+<p>Replace copy and swap tricks on shrinkable containers with the <code>shrink_to_fit()</code> method call.</p>
+<p>The <code>shrink_to_fit()</code> method is more readable and more effective than the copy and swap trick to reduce the capacity of a shrinkable container. Note that, the <code>shrink_to_fit()</code> method is only available in C++11 and up.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-shrink-to-fit.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1324,13 +2207,161 @@ Replace copy and swap tricks on shrinkable containers with the
 <rule>
   <key>modernize-use-auto</key>
   <name>modernize-use-auto</name>
-  <description><![CDATA[<p>
-This check is responsible for using the ``auto`` type specifier for variable
-declarations to *improve code readability and maintainability*.  For example:
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-use-auto</p>
+</div>
+<h1 id="modernize-use-auto">modernize-use-auto</h1>
+<p>This check is responsible for using the <code>auto</code> type specifier for variable declarations to <em>improve code readability and maintainability</em>. For example:</p>
+<pre class="sourceCode c++"><code>std::vector&lt;int&gt;::iterator I = my_container.begin();
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-auto.html" target="_blank">clang.llvm.org</a></p>
+// transforms to:
+
+auto I = my_container.begin();</code></pre>
+<p>The <code>auto</code> type specifier will only be introduced in situations where the variable type matches the type of the initializer expression. In other words <code>auto</code> should deduce the same type that was originally spelled in the source. However, not every situation should be transformed:</p>
+<pre class="sourceCode c++"><code>int val = 42;
+InfoStruct &amp;I = SomeObject.getInfo();
+
+// Should not become:
+
+auto val = 42;
+auto &amp;I = SomeObject.getInfo();</code></pre>
+<p>In this example using <code>auto</code> for builtins doesn't improve readability. In other situations it makes the code less self-documenting impairing readability and maintainability. As a result, <code>auto</code> is used only introduced in specific situations described below.</p>
+<h2 id="iterators">Iterators</h2>
+<p>Iterator type specifiers tend to be long and used frequently, especially in loop constructs. Since the functions generating iterators have a common format, the type specifier can be replaced without obscuring the meaning of code while improving readability and maintainability.</p>
+<pre class="sourceCode c++"><code>for (std::vector&lt;int&gt;::iterator I = my_container.begin(),
+                                E = my_container.end();
+     I != E; ++I) {
+}
+
+// becomes
+
+for (auto I = my_container.begin(), E = my_container.end(); I != E; ++I) {
+}</code></pre>
+<p>The check will only replace iterator type-specifiers when all of the following conditions are satisfied:</p>
+<ul>
+<li>The iterator is for one of the standard container in <code>std</code> namespace:
+<ul>
+<li><code>array</code></li>
+<li><code>deque</code></li>
+<li><code>forward_list</code></li>
+<li><code>list</code></li>
+<li><code>vector</code></li>
+<li><code>map</code></li>
+<li><code>multimap</code></li>
+<li><code>set</code></li>
+<li><code>multiset</code></li>
+<li><code>unordered_map</code></li>
+<li><code>unordered_multimap</code></li>
+<li><code>unordered_set</code></li>
+<li><code>unordered_multiset</code></li>
+<li><code>queue</code></li>
+<li><code>priority_queue</code></li>
+<li><code>stack</code></li>
+</ul></li>
+<li>The iterator is one of the possible iterator types for standard containers:
+<ul>
+<li><code>iterator</code></li>
+<li><code>reverse_iterator</code></li>
+<li><code>const_iterator</code></li>
+<li><code>const_reverse_iterator</code></li>
+</ul></li>
+<li>In addition to using iterator types directly, typedefs or other ways of referring to those types are also allowed. However, implementation-specific types for which a type like <code>std::vector&lt;int&gt;::iterator</code> is itself a typedef will not be transformed. Consider the following examples:</li>
+</ul>
+<pre class="sourceCode c++"><code>// The following direct uses of iterator types will be transformed.
+std::vector&lt;int&gt;::iterator I = MyVec.begin();
+{
+  using namespace std;
+  list&lt;int&gt;::iterator I = MyList.begin();
+}
+
+// The type specifier for J would transform to auto since it&#39;s a typedef
+// to a standard iterator type.
+typedef std::map&lt;int, std::string&gt;::const_iterator map_iterator;
+map_iterator J = MyMap.begin();
+
+// The following implementation-specific iterator type for which
+// std::vector&lt;int&gt;::iterator could be a typedef would not be transformed.
+__gnu_cxx::__normal_iterator&lt;int*, std::vector&gt; K = MyVec.begin();</code></pre>
+<ul>
+<li>The initializer for the variable being declared is not a braced initializer list. Otherwise, use of <code>auto</code> would cause the type of the variable to be deduced as <code>std::initializer_list</code>.</li>
+</ul>
+<h2 id="new-expressions">New expressions</h2>
+<p>Frequently, when a pointer is declared and initialized with <code>new</code>, the pointee type is written twice: in the declaration type and in the <code>new</code> expression. In this cases, the declaration type can be replaced with <code>auto</code> improving readability and maintainability.</p>
+<pre class="sourceCode c++"><code>TypeName *my_pointer = new TypeName(my_param);
+
+// becomes
+
+auto *my_pointer = new TypeName(my_param);</code></pre>
+<p>The check will also replace the declaration type in multiple declarations, if the following conditions are satisfied:</p>
+<ul>
+<li>All declared variables have the same type (i.e. all of them are pointers to the same type).</li>
+<li>All declared variables are initialized with a <code>new</code> expression.</li>
+<li>The types of all the new expressions are the same than the pointee of the declaration type.</li>
+</ul>
+<pre class="sourceCode c++"><code>TypeName *my_first_pointer = new TypeName, *my_second_pointer = new TypeName;
+
+// becomes
+
+auto *my_first_pointer = new TypeName, *my_second_pointer = new TypeName;</code></pre>
+<h2 id="cast-expressions">Cast expressions</h2>
+<p>Frequently, when a variable is declared and initialized with a cast, the variable type is written twice: in the declaration type and in the cast expression. In this cases, the declaration type can be replaced with <code>auto</code> improving readability and maintainability.</p>
+<pre class="sourceCode c++"><code>TypeName *my_pointer = static_cast&lt;TypeName&gt;(my_param);
+
+// becomes
+
+auto *my_pointer = static_cast&lt;TypeName&gt;(my_param);</code></pre>
+<p>The check handles <code>static_cast</code>, <code>dynamic_cast</code>, <code>const_cast</code>, <code>reinterpret_cast</code>, functional casts, C-style casts and function templates that behave as casts, such as <code>llvm::dyn_cast</code>, <code>boost::lexical_cast</code> and <code>gsl::narrow_cast</code>. Calls to function templates are considered to behave as casts if the first template argument is explicit and is a type, and the function returns that type, or a pointer or reference to it.</p>
+<h2 id="known-limitations">Known Limitations</h2>
+<ul>
+<li>If the initializer is an explicit conversion constructor, the check will not replace the type specifier even though it would be safe to do so.</li>
+<li>User-defined iterators are not handled at this time.</li>
+</ul>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>MinTypeNameLength</p>
+<p>If the option is set to non-zero (default <span class="title-ref">5</span>), the check will ignore type names having a length less than the option value. The option affects expressions only, not iterators. Spaces between multi-lexeme type names (<code>long int</code>) are considered as one. If <code>RemoveStars</code> option (see below) is set to non-zero, then <code>*s</code> in the type are also counted as a part of the type name.</p>
+</div>
+<pre class="sourceCode c++"><code>// MinTypeNameLength = 0, RemoveStars=0
+
+int a = static_cast&lt;int&gt;(foo());            // ---&gt; auto a = ...
+// length(bool *) = 4
+bool *b = new bool;                         // ---&gt; auto *b = ...
+unsigned c = static_cast&lt;unsigned&gt;(foo());  // ---&gt; auto c = ...
+
+// MinTypeNameLength = 5, RemoveStars=0
+
+int a = static_cast&lt;int&gt;(foo());                 // ---&gt; int  a = ...
+bool b = static_cast&lt;bool&gt;(foo());               // ---&gt; bool b = ...
+bool *pb = static_cast&lt;bool*&gt;(foo());            // ---&gt; bool *pb = ...
+unsigned c = static_cast&lt;unsigned&gt;(foo());       // ---&gt; auto c = ...
+// length(long &lt;on-or-more-spaces&gt; int) = 8
+long int d = static_cast&lt;long int&gt;(foo());       // ---&gt; auto d = ...
+
+// MinTypeNameLength = 5, RemoveStars=1
+
+int a = static_cast&lt;int&gt;(foo());                 // ---&gt; int  a = ...
+// length(int * * ) = 5
+int **pa = static_cast&lt;int**&gt;(foo());            // ---&gt; auto pa = ...
+bool b = static_cast&lt;bool&gt;(foo());               // ---&gt; bool b = ...
+bool *pb = static_cast&lt;bool*&gt;(foo());            // ---&gt; auto pb = ...
+unsigned c = static_cast&lt;unsigned&gt;(foo());       // ---&gt; auto c = ...
+long int d = static_cast&lt;long int&gt;(foo());       // ---&gt; auto d = ...</code></pre>
+<div class="option">
+<p>RemoveStars</p>
+<p>If the option is set to non-zero (default is <span class="title-ref">0</span>), the check will remove stars from the non-typedef pointer types when replacing type names with <code>auto</code>. Otherwise, the check will leave stars. For example:</p>
+</div>
+<pre class="sourceCode c++"><code>TypeName *my_first_pointer = new TypeName, *my_second_pointer = new TypeName;
+
+// RemoveStars = 0
+
+auto *my_first_pointer = new TypeName, *my_second_pointer = new TypeName;
+
+// RemoveStars = 1
+
+auto my_first_pointer = new TypeName, my_second_pointer = new TypeName;</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-auto.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1338,12 +2369,30 @@ declarations to *improve code readability and maintainability*.  For example:
 <rule>
   <key>modernize-use-bool-literals</key>
   <name>modernize-use-bool-literals</name>
-  <description><![CDATA[<p>
-Finds integer literals which are cast to ``bool``.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-use-bool-literals</p>
+</div>
+<h1 id="modernize-use-bool-literals">modernize-use-bool-literals</h1>
+<p>Finds integer literals which are cast to <code>bool</code>.</p>
+<pre class="sourceCode c++"><code>bool p = 1;
+bool f = static_cast&lt;bool&gt;(1);
+std::ios_base::sync_with_stdio(0);
+bool x = p ? 1 : 0;
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-bool-literals.html" target="_blank">clang.llvm.org</a></p>
+// transforms to
+
+bool p = true;
+bool f = true;
+std::ios_base::sync_with_stdio(false);
+bool x = p ? true : false;</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>If set to non-zero, the check will not give warnings inside macros. Default is <span class="title-ref">1</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-bool-literals.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1351,15 +2400,22 @@ Finds integer literals which are cast to ``bool``.
 <rule>
   <key>modernize-use-default</key>
   <name>modernize-use-default</name>
-  <description><![CDATA[<p>
-This check replaces default bodies of special member functions with ``=
-default;``.  The explicitly defaulted function declarations enable more
-opportunities in optimization, because the compiler might treat explicitly
-defaulted functions as trivial.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<dl>
+<dt>orphan</dt>
+<dd>
+</dd>
+</dl>
+<div class="title">
+<p>clang-tidy - modernize-use-default</p>
+</div>
+<div class="meta">
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-default.html" target="_blank">clang.llvm.org</a></p>
+</div>
+<h1 id="modernize-use-default">modernize-use-default</h1>
+<p>This check has been renamed to <a href="modernize-use-equals-default.html">modernize-use-equals-default</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-default.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1367,19 +2423,86 @@ defaulted functions as trivial.
 <rule>
   <key>modernize-use-emplace</key>
   <name>modernize-use-emplace</name>
-  <description><![CDATA[<p>
-The check flags insertions to an STL-style container done by calling the
-``push_back`` method with an explicitly-constructed temporary of the container
-element type. In this case, the corresponding ``emplace_back`` method
-results in less verbose and potentially more efficient code.
-Right now the check doesn't support ``push_front`` and ``insert``.
-It also doesn't support ``insert`` functions for associative containers
-because replacing ``insert`` with ``emplace`` may result in
-`speed regression, but it might get support with some addition flag in the future.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-use-emplace</p>
+</div>
+<h1 id="modernize-use-emplace">modernize-use-emplace</h1>
+<p>The check flags insertions to an STL-style container done by calling the <code>push_back</code> method with an explicitly-constructed temporary of the container element type. In this case, the corresponding <code>emplace_back</code> method results in less verbose and potentially more efficient code. Right now the check doesn't support <code>push_front</code> and <code>insert</code>. It also doesn't support <code>insert</code> functions for associative containers because replacing <code>insert</code> with <code>emplace</code> may result in <a href="http://htmlpreview.github.io/?https://github.com/HowardHinnant/papers/blob/master/insert_vs_emplace.html">speed regression</a>, but it might get support with some addition flag in the future.</p>
+<p>By default only <code>std::vector</code>, <code>std::deque</code>, <code>std::list</code> are considered. This list can be modified using the <code class="interpreted-text" data-role="option">ContainersWithPushBack</code> option.</p>
+<p>Before:</p>
+<pre class="sourceCode c++"><code>std::vector&lt;MyClass&gt; v;
+v.push_back(MyClass(21, 37));
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html" target="_blank">clang.llvm.org</a></p>
+std::vector&lt;std::pair&lt;int, int&gt;&gt; w;
+
+w.push_back(std::pair&lt;int, int&gt;(21, 37));
+w.push_back(std::make_pair(21L, 37L));</code></pre>
+<p>After:</p>
+<pre class="sourceCode c++"><code>std::vector&lt;MyClass&gt; v;
+v.emplace_back(21, 37);
+
+std::vector&lt;std::pair&lt;int, int&gt;&gt; w;
+w.emplace_back(21, 37);
+w.emplace_back(21L, 37L);</code></pre>
+<p>By default, the check is able to remove unnecessary <code>std::make_pair</code> and <code>std::make_tuple</code> calls from <code>push_back</code> calls on containers of <code>std::pair</code> and <code>std::tuple</code>. Custom tuple-like types can be modified by the <code class="interpreted-text" data-role="option">TupleTypes</code> option; custom make functions can be modified by the <code class="interpreted-text" data-role="option">TupleMakeFunctions</code> option.</p>
+<p>The other situation is when we pass arguments that will be converted to a type inside a container.</p>
+<p>Before:</p>
+<pre class="sourceCode c++"><code>std::vector&lt;boost::optional&lt;std::string&gt; &gt; v;
+v.push_back(&quot;abc&quot;);</code></pre>
+<p>After:</p>
+<pre class="sourceCode c++"><code>std::vector&lt;boost::optional&lt;std::string&gt; &gt; v;
+v.emplace_back(&quot;abc&quot;);</code></pre>
+<p>In some cases the transformation would be valid, but the code wouldn't be exception safe. In this case the calls of <code>push_back</code> won't be replaced.</p>
+<pre class="sourceCode c++"><code>std::vector&lt;std::unique_ptr&lt;int&gt;&gt; v;
+v.push_back(std::unique_ptr&lt;int&gt;(new int(0)));
+auto *ptr = new int(1);
+v.push_back(std::unique_ptr&lt;int&gt;(ptr));</code></pre>
+<p>This is because replacing it with <code>emplace_back</code> could cause a leak of this pointer if <code>emplace_back</code> would throw exception before emplacement (e.g. not enough memory to add a new element).</p>
+<p>For more info read item 42 - &quot;Consider emplacement instead of insertion.&quot; of Scott Meyers &quot;Effective Modern C++&quot;.</p>
+<p>The default smart pointers that are considered are <code>std::unique_ptr</code>, <code>std::shared_ptr</code>, <code>std::auto_ptr</code>. To specify other smart pointers or other classes use the <code class="interpreted-text" data-role="option">SmartPointers</code> option.</p>
+<p>Check also doesn't fire if any argument of the constructor call would be:</p>
+<blockquote>
+<ul>
+<li>a bit-field (bit-fields can't bind to rvalue/universal reference)</li>
+<li>a <code>new</code> expression (to avoid leak)</li>
+<li>if the argument would be converted via derived-to-base cast.</li>
+</ul>
+</blockquote>
+<p>This check requires C++11 or higher to run.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>ContainersWithPushBack</p>
+<p>Semicolon-separated list of class names of custom containers that support <code>push_back</code>.</p>
+</div>
+<div class="option">
+<p>IgnoreImplicitConstructors</p>
+<p>When non-zero, the check will ignore implicitly constructed arguments of <code>push_back</code>, e.g.</p>
+<pre class="sourceCode c++"><code>std::vector&lt;std::string&gt; v;
+v.push_back(&quot;a&quot;); // Ignored when IgnoreImplicitConstructors is ``1``.</code></pre>
+<p>Default is <code>0</code>.</p>
+</div>
+<div class="option">
+<p>SmartPointers</p>
+<p>Semicolon-separated list of class names of custom smart pointers.</p>
+</div>
+<div class="option">
+<p>TupleTypes</p>
+<p>Semicolon-separated list of <code>std::tuple</code>-like class names.</p>
+</div>
+<div class="option">
+<p>TupleMakeFunctions</p>
+<p>Semicolon-separated list of <code>std::make_tuple</code>-like function names. Those function calls will be removed from <code>push_back</code> calls and turned into <code>emplace_back</code>.</p>
+</div>
+<h3 id="example">Example</h3>
+<pre class="sourceCode c++"><code>std::vector&lt;MyTuple&lt;int, bool, char&gt;&gt; x;
+x.push_back(MakeMyTuple(1, false, &#39;x&#39;));</code></pre>
+<p>transforms to:</p>
+<pre class="sourceCode c++"><code>std::vector&lt;MyTuple&lt;int, bool, char&gt;&gt; x;
+x.emplace_back(1, false, &#39;x&#39;);</code></pre>
+<p>when <code class="interpreted-text" data-role="option">TupleTypes</code> is set to <code>MyTuple</code> and <code class="interpreted-text" data-role="option">TupleMakeFunctions</code> is set to <code>MakeMyTuple</code>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1387,13 +2510,50 @@ because replacing ``insert`` with ``emplace`` may result in
 <rule>
   <key>modernize-use-nullptr</key>
   <name>modernize-use-nullptr</name>
-  <description><![CDATA[<p>
-The check converts the usage of null pointer constants (eg. ``NULL``, ``0``)
-to use the new C++11 ``nullptr`` keyword.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-use-nullptr</p>
+</div>
+<h1 id="modernize-use-nullptr">modernize-use-nullptr</h1>
+<p>The check converts the usage of null pointer constants (eg. <code>NULL</code>, <code>0</code>) to use the new C++11 <code>nullptr</code> keyword.</p>
+<h2 id="example">Example</h2>
+<pre class="sourceCode c++"><code>void assignment() {
+  char *a = NULL;
+  char *b = 0;
+  char c = 0;
+}
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-nullptr.html" target="_blank">clang.llvm.org</a></p>
+int *ret_ptr() {
+  return 0;
+}</code></pre>
+<p>transforms to:</p>
+<pre class="sourceCode c++"><code>void assignment() {
+  char *a = nullptr;
+  char *b = nullptr;
+  char c = 0;
+}
+
+int *ret_ptr() {
+  return nullptr;
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>NullMacros</p>
+<p>Comma-separated list of macro names that will be transformed along with <code>NULL</code>. By default this check will only replace the <code>NULL</code> macro and will skip any similar user-defined macros.</p>
+</div>
+<h3 id="example-1">Example</h3>
+<pre class="sourceCode c++"><code>#define MY_NULL (void*)0
+void assignment() {
+  void *p = MY_NULL;
+}</code></pre>
+<p>transforms to:</p>
+<pre class="sourceCode c++"><code>#define MY_NULL NULL
+void assignment() {
+  int *p = nullptr;
+}</code></pre>
+<p>if the <code class="interpreted-text" data-role="option">NullMacros</code> option is set to <code>MY_NULL</code>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-nullptr.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1401,12 +2561,14 @@ to use the new C++11 ``nullptr`` keyword.
 <rule>
   <key>modernize-use-override</key>
   <name>modernize-use-override</name>
-  <description><![CDATA[<p>
-Use C++11's ``override`` and remove ``virtual`` where applicable.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-override.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-use-override</p>
+</div>
+<h1 id="modernize-use-override">modernize-use-override</h1>
+<p>Use C++11's <code>override</code> and remove <code>virtual</code> where applicable.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-override.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1414,12 +2576,30 @@ Use C++11's ``override`` and remove ``virtual`` where applicable.
 <rule>
   <key>modernize-use-using</key>
   <name>modernize-use-using</name>
-  <description><![CDATA[<p>
-Use C++11's ``using`` instead of ``typedef``.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - modernize-use-using</p>
+</div>
+<h1 id="modernize-use-using">modernize-use-using</h1>
+<p>The check converts the usage of <code>typedef</code> with <code>using</code> keyword.</p>
+<p>Before:</p>
+<pre class="sourceCode c++"><code>typedef int variable;
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-using.html" target="_blank">clang.llvm.org</a></p>
+class Class{};
+typedef void (Class::* MyPtrType)() const;</code></pre>
+<p>After:</p>
+<pre class="sourceCode c++"><code>using variable = int;
+
+class Class{};
+using MyPtrType = void (Class::*)() const;</code></pre>
+<p>This check requires using C++11 or higher to run.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>If set to non-zero, the check will not give warnings inside macros. Default is <span class="title-ref">1</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-using.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1427,14 +2607,25 @@ Use C++11's ``using`` instead of ``typedef``.
 <rule>
   <key>performance-faster-string-find</key>
   <name>performance-faster-string-find</name>
-  <description><![CDATA[<p>
-Optimize calls to ``std::string::find()`` and friends when the needle passed is
-a single character string literal.
-The character literal overload is more efficient.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - performance-faster-string-find</p>
+</div>
+<h1 id="performance-faster-string-find">performance-faster-string-find</h1>
+<p>Optimize calls to <code>std::string::find()</code> and friends when the needle passed is a single character string literal. The character literal overload is more efficient.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>str.find(&quot;A&quot;);
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-faster-string-find.html" target="_blank">clang.llvm.org</a></p>
+// becomes
+
+str.find(&#39;A&#39;);</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>StringLikeClasses</p>
+<p>Semicolon-separated list of names of string-like classes. By default only <code>std::basic_string</code> is considered. The list of methods to consired is fixed.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-faster-string-find.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1442,13 +2633,25 @@ The character literal overload is more efficient.
 <rule>
   <key>performance-for-range-copy</key>
   <name>performance-for-range-copy</name>
-  <description><![CDATA[<p>
-Finds C++11 for ranges where the loop variable is copied in each iteration but
-it would suffice to obtain it by const reference.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-for-range-copy.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - performance-for-range-copy</p>
+</div>
+<h1 id="performance-for-range-copy">performance-for-range-copy</h1>
+<p>Finds C++11 for ranges where the loop variable is copied in each iteration but it would suffice to obtain it by const reference.</p>
+<p>The check is only applied to loop variables of types that are expensive to copy which means they are not trivially copyable or have a non-trivial copy constructor or destructor.</p>
+<p>To ensure that it is safe to replace the copy with a const reference the following heuristic is employed:</p>
+<ol type="1">
+<li>The loop variable is const qualified.</li>
+<li>The loop variable is not const, but only const methods or operators are invoked on it, or it is used as const reference or value argument in constructors or function calls.</li>
+</ol>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>WarnOnAllAutoCopies</p>
+<p>When non-zero, warns on any use of <span class="title-ref">auto</span> as the type of the range-based for loop variable. Default is <span class="title-ref">0</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-for-range-copy.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1456,16 +2659,22 @@ it would suffice to obtain it by const reference.
 <rule>
   <key>performance-implicit-cast-in-loop</key>
   <name>performance-implicit-cast-in-loop</name>
-  <description><![CDATA[<p>
-This warning appears in a range-based loop with a loop variable of const ref
-type where the type of the variable does not match the one returned by the
-iterator.
-This means that an implicit cast has been added, which can for example result in
-expensive deep copies.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<dl>
+<dt>orphan</dt>
+<dd>
+</dd>
+</dl>
+<div class="title">
+<p>clang-tidy - performance-implicit-cast-in-loop</p>
+</div>
+<div class="meta">
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-implicit-cast-in-loop.html" target="_blank">clang.llvm.org</a></p>
+</div>
+<h1 id="performance-implicit-cast-in-loop">performance-implicit-cast-in-loop</h1>
+<p>This check has been renamed to <a href="">performance-implicit-conversion-in-loop &lt;performance-implicit-conversion-in-loop.html&gt;</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-implicit-cast-in-loop.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1473,14 +2682,34 @@ expensive deep copies.
 <rule>
   <key>performance-unnecessary-copy-initialization</key>
   <name>performance-unnecessary-copy-initialization</name>
-  <description><![CDATA[<p>
-Finds local variable declarations that are initialized using the copy
-constructor of a non-trivially-copyable type but it would suffice to obtain a
-const reference.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - performance-unnecessary-copy-initialization</p>
+</div>
+<h1 id="performance-unnecessary-copy-initialization">performance-unnecessary-copy-initialization</h1>
+<p>Finds local variable declarations that are initialized using the copy constructor of a non-trivially-copyable type but it would suffice to obtain a const reference.</p>
+<p>The check is only applied if it is safe to replace the copy by a const reference. This is the case when the variable is const qualified or when it is only used as a const, i.e. only const methods or operators are invoked on it, or it is used as const reference or value argument in constructors or function calls.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>const string&amp; constReference();
+void Function() {
+  // The warning will suggest making this a const reference.
+  const string UnnecessaryCopy = constReference();
+}
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-copy-initialization.html" target="_blank">clang.llvm.org</a></p>
+struct Foo {
+  const string&amp; name() const;
+};
+void Function(const Foo&amp; foo) {
+  // The warning will suggest making this a const reference.
+  string UnnecessaryCopy1 = foo.name();
+  UnnecessaryCopy1.find(&quot;bar&quot;);
+
+  // The warning will suggest making this a const reference.
+  string UnnecessaryCopy2 = UnnecessaryCopy1;
+  UnnecessaryCopy2.find(&quot;bar&quot;);
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-copy-initialization.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1488,13 +2717,46 @@ const reference.
 <rule>
   <key>performance-unnecessary-value-param</key>
   <name>performance-unnecessary-value-param</name>
-  <description><![CDATA[<p>
-Flags value parameter declarations of expensive to copy types that are copied
-for each invocation but it would suffice to pass them by const reference.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - performance-unnecessary-value-param</p>
+</div>
+<h1 id="performance-unnecessary-value-param">performance-unnecessary-value-param</h1>
+<p>Flags value parameter declarations of expensive to copy types that are copied for each invocation but it would suffice to pass them by const reference.</p>
+<p>The check is only applied to parameters of types that are expensive to copy which means they are not trivially copyable or have a non-trivial copy constructor or destructor.</p>
+<p>To ensure that it is safe to replace the value parameter with a const reference the following heuristic is employed:</p>
+<ol type="1">
+<li>the parameter is const qualified;</li>
+<li>the parameter is not const, but only const methods or operators are invoked on it, or it is used as const reference or value argument in constructors or function calls.</li>
+</ol>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>void f(const string Value) {
+  // The warning will suggest making Value a reference.
+}
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-value-param.html" target="_blank">clang.llvm.org</a></p>
+void g(ExpensiveToCopy Value) {
+  // The warning will suggest making Value a const reference.
+  Value.ConstMethd();
+  ExpensiveToCopy Copy(Value);
+}</code></pre>
+<p>If the parameter is not const, only copied or assigned once and has a non-trivial move-constructor or move-assignment operator respectively the check will suggest to move it.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>void setValue(string Value) {
+  Field = Value;
+}</code></pre>
+<p>Will become:</p>
+<pre class="sourceCode c++"><code>#include &lt;utility&gt;
+
+void setValue(string Value) {
+  Field = std::move(Value);
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IncludeStyle</p>
+<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-value-param.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1502,24 +2764,45 @@ for each invocation but it would suffice to pass them by const reference.
 <rule>
   <key>readability-avoid-const-params-in-decls</key>
   <name>readability-avoid-const-params-in-decls</name>
-  <description><![CDATA[<p>
-Checks whether a function declaration has parameters that are top level const.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-avoid-const-params-in-decls.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-avoid-const-params-in-decls</p>
+</div>
+<h1 id="readability-avoid-const-params-in-decls">readability-avoid-const-params-in-decls</h1>
+<p>Checks whether a function declaration has parameters that are top level <code>const</code>.</p>
+<p><code>const</code> values in declarations do not affect the signature of a function, so they should not be put there.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>void f(const string);   // Bad: const is top level.
+void f(const string&amp;);  // Good: const is not top level.</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-avoid-const-params-in-decls.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
 </rule>
 <rule>
   <key>readability-braces-around-statements</key>
   <name>readability-braces-around-statements</name>
-  <description><![CDATA[<p>
-Checks that bodies of ``if`` statements and loops (``for``, ``do while``, and ``while``) are inside braces.
-this check.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-braces-around-statements.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-braces-around-statements</p>
+</div>
+<h1 id="readability-braces-around-statements">readability-braces-around-statements</h1>
+<p><span class="title-ref">google-readability-braces-around-statements</span> redirects here as an alias for this check.</p>
+<p>Checks that bodies of <code>if</code> statements and loops (<code>for</code>, <code>do while</code>, and <code>while</code>) are inside braces.</p>
+<p>Before:</p>
+<pre class="sourceCode c++"><code>if (condition)
+  statement;</code></pre>
+<p>After:</p>
+<pre class="sourceCode c++"><code>if (condition) {
+  statement;
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>ShortStatementLines</p>
+<p>Defines the minimal number of lines that the statement should have in order to trigger this check.</p>
+<p>The number of lines is counted from the end of condition or initial keyword (<code>do</code>/<code>else</code>) until the last line of the inner statement. Default value <span class="title-ref">0</span> means that braces will be added to all statements (not having them already).</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-braces-around-statements.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1527,25 +2810,44 @@ this check.
 <rule>
   <key>readability-container-size-empty</key>
   <name>readability-container-size-empty</name>
-  <description><![CDATA[<p>
-Checks whether a call to the ``size()`` method can be replaced with a call to
-``empty()``.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-container-size-empty.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-container-size-empty</p>
+</div>
+<h1 id="readability-container-size-empty">readability-container-size-empty</h1>
+<p>Checks whether a call to the <code>size()</code> method can be replaced with a call to <code>empty()</code>.</p>
+<p>The emptiness of a container should be checked using the <code>empty()</code> method instead of the <code>size()</code> method. It is not guaranteed that <code>size()</code> is a constant-time function, and it is generally more efficient and also shows clearer intent to use <code>empty()</code>. Furthermore some containers may implement the <code>empty()</code> method but not implement the <code>size()</code> method. Using <code>empty()</code> whenever possible makes it easier to switch to another container in the future.</p>
+<p>The check issues warning if a container has <code>size()</code> and <code>empty()</code> methods matching following signatures:</p>
+<pre class="sourceCode c++"><code>size_type size() const;
+bool empty() const;</code></pre>
+<p><span class="title-ref">size_type</span> can be any kind of integer type.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-container-size-empty.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
 </rule>
 <rule>
   <key>readability-deleted-default</key>
   <name>readability-deleted-default</name>
-  <description><![CDATA[<p>
-Checks that constructors and assignment operators marked as ``= default`` are
-not actually deleted by the compiler.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-deleted-default</p>
+</div>
+<h1 id="readability-deleted-default">readability-deleted-default</h1>
+<p>Checks that constructors and assignment operators marked as <code>= default</code> are not actually deleted by the compiler.</p>
+<pre class="sourceCode c++"><code>class Example {
+public:
+  // This constructor is deleted because I is missing a default value.
+  Example() = default;
+  // This is fine.
+  Example(const Example&amp; Other) = default;
+  // This operator is deleted because I cannot be assigned (it is const).
+  Example&amp; operator=(const Example&amp; Other) = default;
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-deleted-default.html" target="_blank">clang.llvm.org</a></p>
+private:
+  const int I;
+};</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-deleted-default.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1553,12 +2855,56 @@ not actually deleted by the compiler.
 <rule>
   <key>readability-else-after-return</key>
   <name>readability-else-after-return</name>
-  <description><![CDATA[<p>
-Flags the usages of ``else`` after ``return``.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-else-after-return</p>
+</div>
+<h1 id="readability-else-after-return">readability-else-after-return</h1>
+<p><a href="http://llvm.org/docs/CodingStandards.html">LLVM Coding Standards</a> advises to reduce indentation where possible and where it makes understanding code easier. Early exit is one of the suggested enforcements of that. Please do not use <code>else</code> or <code>else if</code> after something that interrupts control flow - like <code>return</code>, <code>break</code>, <code>continue</code>, <code>throw</code>.</p>
+<p>The following piece of code illustrates how the check works. This piece of code:</p>
+<pre class="sourceCode c++"><code>void foo(int Value) {
+  int Local = 0;
+  for (int i = 0; i &lt; 42; i++) {
+    if (Value == 1) {
+      return;
+    } else {
+      Local++;
+    }
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-else-after-return.html" target="_blank">clang.llvm.org</a></p>
+    if (Value == 2)
+      continue;
+    else
+      Local++;
+
+    if (Value == 3) {
+      throw 42;
+    } else {
+      Local++;
+    }
+  }
+}</code></pre>
+<p>Would be transformed into:</p>
+<pre class="sourceCode c++"><code>void foo(int Value) {
+  int Local = 0;
+  for (int i = 0; i &lt; 42; i++) {
+    if (Value == 1) {
+      return;
+    }
+    Local++;
+
+    if (Value == 2)
+      continue;
+    Local++;
+
+    if (Value == 3) {
+      throw 42;
+    }
+    Local++;
+  }
+}</code></pre>
+<p>This check helps to enforce this <a href="">LLVM Coding Standards recommendation &lt;http://llvm.org/docs/CodingStandards.html#don-t-use-else-after-a-return&gt;</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-else-after-return.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1566,12 +2912,40 @@ Flags the usages of ``else`` after ``return``.
 <rule>
   <key>readability-function-size</key>
   <name>readability-function-size</name>
-  <description><![CDATA[<p>
-Checks for large functions based on various metrics.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-function-size.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-function-size</p>
+</div>
+<h1 id="readability-function-size">readability-function-size</h1>
+<p><span class="title-ref">google-readability-function-size</span> redirects here as an alias for this check.</p>
+<p>Checks for large functions based on various metrics.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>LineThreshold</p>
+<p>Flag functions exceeding this number of lines. The default is <span class="title-ref">-1</span> (ignore the number of lines).</p>
+</div>
+<div class="option">
+<p>StatementThreshold</p>
+<p>Flag functions exceeding this number of statements. This may differ significantly from the number of lines for macro-heavy code. The default is <span class="title-ref">800</span>.</p>
+</div>
+<div class="option">
+<p>BranchThreshold</p>
+<p>Flag functions exceeding this number of control statements. The default is <span class="title-ref">-1</span> (ignore the number of branches).</p>
+</div>
+<div class="option">
+<p>ParameterThreshold</p>
+<p>Flag functions that exceed a specified number of parameters. The default is <span class="title-ref">-1</span> (ignore the number of parameters).</p>
+</div>
+<div class="option">
+<p>NestingThreshold</p>
+<p>Flag compound statements which create next nesting level after <span class="title-ref">NestingThreshold</span>. This may differ significantly from the expected value for macro-heavy code. The default is <span class="title-ref">-1</span> (ignore the nesting level).</p>
+</div>
+<div class="option">
+<p>VariableThreshold</p>
+<p>Flag functions exceeding this number of variables declared in the body. The default is <span class="title-ref">-1</span> (ignore the number of variables). Please note that function parameters and variables declared in lambdas, GNU Statement Expressions, and nested class inline functions are not counted.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-function-size.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1579,12 +2953,17 @@ Checks for large functions based on various metrics.
 <rule>
   <key>readability-identifier-naming</key>
   <name>readability-identifier-naming</name>
-  <description><![CDATA[<p>
-Checks for identifiers naming style mismatch.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-identifier-naming.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-identifier-naming</p>
+</div>
+<h1 id="readability-identifier-naming">readability-identifier-naming</h1>
+<p>Checks for identifiers naming style mismatch.</p>
+<p>This check will try to enforce coding guidelines on the identifiers naming. It supports <span class="title-ref">lower_case</span>, <span class="title-ref">UPPER_CASE</span>, <span class="title-ref">camelBack</span> and <span class="title-ref">CamelCase</span> casing and tries to convert from one to another if a mismatch is detected.</p>
+<p>It also supports a fixed prefix and suffix that will be prepended or appended to the identifiers, regardless of the casing.</p>
+<p>Many configuration options are available, in order to be able to create different rules for different kind of identifier. In general, the rules are falling back to a more generic rule if the specific case is not configured.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-identifier-naming.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1592,15 +2971,22 @@ Checks for identifiers naming style mismatch.
 <rule>
   <key>readability-implicit-bool-cast</key>
   <name>readability-implicit-bool-cast</name>
-  <description><![CDATA[<p>
-This check can be used to find implicit conversions between built-in types and
-booleans. Depending on use case, it may simply help with readability of the code,
-or in some cases, point to potential bugs which remain unnoticed due to implicit
-conversions.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<dl>
+<dt>orphan</dt>
+<dd>
+</dd>
+</dl>
+<div class="title">
+<p>clang-tidy - readability-implicit-bool-cast</p>
+</div>
+<div class="meta">
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-implicit-bool-cast.html" target="_blank">clang.llvm.org</a></p>
+</div>
+<h1 id="readability-implicit-bool-cast">readability-implicit-bool-cast</h1>
+<p>This check has been renamed to <a href="">readability-implicit-bool-conversion &lt;readability-implicit-bool-conversion.html&gt;</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-implicit-bool-cast.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1608,12 +2994,41 @@ conversions.
 <rule>
   <key>readability-inconsistent-declaration-parameter-name</key>
   <name>readability-inconsistent-declaration-parameter-name</name>
-  <description><![CDATA[<p>
-Find function declarations which differ in parameter names.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-inconsistent-declaration-parameter-name</p>
+</div>
+<h1 id="readability-inconsistent-declaration-parameter-name">readability-inconsistent-declaration-parameter-name</h1>
+<p>Find function declarations which differ in parameter names.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>// in foo.hpp:
+void foo(int a, int b, int c);
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-inconsistent-declaration-parameter-name.html" target="_blank">clang.llvm.org</a></p>
+// in foo.cpp:
+void foo(int d, int e, int f); // warning</code></pre>
+<p>This check should help to enforce consistency in large projects, where it often happens that a definition of function is refactored, changing the parameter names, but its declaration in header file is not updated. With this check, we can easily find and correct such inconsistencies, keeping declaration and definition always in sync.</p>
+<p>Unnamed parameters are allowed and are not taken into account when comparing function declarations, for example:</p>
+<pre class="sourceCode c++"><code>void foo(int a);
+void foo(int); // no warning</code></pre>
+<p>One name is also allowed to be a case-insensitive prefix/suffix of the other:</p>
+<pre class="sourceCode c++"><code>void foo(int count);
+void foo(int count_input) { // no warning
+  int count = adjustCount(count_input);
+}</code></pre>
+<p>To help with refactoring, in some cases fix-it hints are generated to align parameter names to a single naming convention. This works with the assumption that the function definition is the most up-to-date version, as it directly references parameter names in its body. Example:</p>
+<pre class="sourceCode c++"><code>void foo(int a); // warning and fix-it hint (replace &quot;a&quot; to &quot;b&quot;)
+int foo(int b) { return b + 2; } // definition with use of &quot;b&quot;</code></pre>
+<p>In the case of multiple redeclarations or function template specializations, a warning is issued for every redeclaration or specialization inconsistent with the definition or the first declaration seen in a translation unit.</p>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>If this option is set to non-zero (default is <span class="title-ref">1</span>), the check will not warn about names declared inside macros.</p>
+</div>
+<div class="option">
+<p>Strict</p>
+<p>If this option is set to non-zero (default is <span class="title-ref">0</span>), then names must match exactly (or be absent).</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-inconsistent-declaration-parameter-name.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1621,12 +3036,18 @@ Find function declarations which differ in parameter names.
 <rule>
   <key>readability-named-parameter</key>
   <name>readability-named-parameter</name>
-  <description><![CDATA[<p>
-Find functions with unnamed arguments.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-named-parameter.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-named-parameter</p>
+</div>
+<h1 id="readability-named-parameter">readability-named-parameter</h1>
+<p>Find functions with unnamed arguments.</p>
+<p>The check implements the following rule originating in the Google C++ Style Guide:</p>
+<p><a href="https://google.github.io/styleguide/cppguide.html#Function_Declarations_and_Definitions" class="uri">https://google.github.io/styleguide/cppguide.html#Function_Declarations_and_Definitions</a></p>
+<p>All parameters should be named, with identical names in the declaration and implementation.</p>
+<p>Corresponding cpplint.py check name: <span class="title-ref">readability/function</span>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-named-parameter.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1634,14 +3055,38 @@ Find functions with unnamed arguments.
 <rule>
   <key>readability-redundant-control-flow</key>
   <name>readability-redundant-control-flow</name>
-  <description><![CDATA[<p>
-This check looks for procedures (functions returning no value) with ``return``
-statements at the end of the function.  Such ``return`` statements are
-redundant.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-control-flow.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-redundant-control-flow</p>
+</div>
+<h1 id="readability-redundant-control-flow">readability-redundant-control-flow</h1>
+<p>This check looks for procedures (functions returning no value) with <code>return</code> statements at the end of the function. Such <code>return</code> statements are redundant.</p>
+<p>Loop statements (<code>for</code>, <code>while</code>, <code>do while</code>) are checked for redundant <code>continue</code> statements at the end of the loop body.</p>
+<p>Examples:</p>
+<p>The following function <span class="title-ref">f</span> contains a redundant <code>return</code> statement:</p>
+<pre class="sourceCode c++"><code>extern void g();
+void f() {
+  g();
+  return;
+}</code></pre>
+<p>becomes</p>
+<pre class="sourceCode c++"><code>extern void g();
+void f() {
+  g();
+}</code></pre>
+<p>The following function <span class="title-ref">k</span> contains a redundant <code>continue</code> statement:</p>
+<pre class="sourceCode c++"><code>void k() {
+  for (int i = 0; i &lt; 10; ++i) {
+    continue;
+  }
+}</code></pre>
+<p>becomes</p>
+<pre class="sourceCode c++"><code>void k() {
+  for (int i = 0; i &lt; 10; ++i) {
+  }
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-control-flow.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1649,12 +3094,19 @@ redundant.
 <rule>
   <key>readability-redundant-smartptr-get</key>
   <name>readability-redundant-smartptr-get</name>
-  <description><![CDATA[<p>
-Find redundant calls to smart pointer's ``.get()`` method.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-smartptr-get.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-redundant-smartptr-get</p>
+</div>
+<h1 id="readability-redundant-smartptr-get">readability-redundant-smartptr-get</h1>
+<p>Find and remove redundant calls to smart pointer's <code>.get()</code> method.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>ptr.get()-&gt;Foo()  ==&gt;  ptr-&gt;Foo()
+*ptr.get()  ==&gt;  *ptr
+*ptr-&gt;get()  ==&gt;  **ptr
+if (ptr.get() == nullptr) ... =&gt; if (ptr == nullptr) ...</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-smartptr-get.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1662,12 +3114,14 @@ Find redundant calls to smart pointer's ``.get()`` method.
 <rule>
   <key>readability-redundant-string-cstr</key>
   <name>readability-redundant-string-cstr</name>
-  <description><![CDATA[<p>
-Finds unnecessary calls to ``std::string::c_str()``.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-string-cstr.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-redundant-string-cstr</p>
+</div>
+<h1 id="readability-redundant-string-cstr">readability-redundant-string-cstr</h1>
+<p>Finds unnecessary calls to <code>std::string::c_str()</code> and <code>std::string::data()</code>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-string-cstr.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1675,12 +3129,23 @@ Finds unnecessary calls to ``std::string::c_str()``.
 <rule>
   <key>readability-redundant-string-init</key>
   <name>readability-redundant-string-init</name>
-  <description><![CDATA[<p>
-Finds unnecessary string initializations.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-redundant-string-init</p>
+</div>
+<h1 id="readability-redundant-string-init">readability-redundant-string-init</h1>
+<p>Finds unnecessary string initializations.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>// Initializing string with empty string literal is unnecessary.
+std::string a = &quot;&quot;;
+std::string b(&quot;&quot;);
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-string-init.html" target="_blank">clang.llvm.org</a></p>
+// becomes
+
+std::string a;
+std::string b;</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-string-init.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1688,13 +3153,155 @@ Finds unnecessary string initializations.
 <rule>
   <key>readability-simplify-boolean-expr</key>
   <name>readability-simplify-boolean-expr</name>
-  <description><![CDATA[<p>
-Looks for boolean expressions involving boolean constants and simplifies
-them to use the appropriate boolean expression directly.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-string-init.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-simplify-boolean-expr</p>
+</div>
+<h1 id="readability-simplify-boolean-expr">readability-simplify-boolean-expr</h1>
+<p>Looks for boolean expressions involving boolean constants and simplifies them to use the appropriate boolean expression directly.</p>
+<p>Examples:</p>
+<table>
+<thead>
+<tr class="header">
+<th>Initial expression</th>
+<th>Result</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><code>if (b == true)</code></td>
+<td><blockquote>
+<p><code>if (b)</code></p>
+</blockquote></td>
+</tr>
+<tr class="even">
+<td><code>if (b == false)</code></td>
+<td><blockquote>
+<p><code>if (!b)</code></p>
+</blockquote></td>
+</tr>
+<tr class="odd">
+<td><code>if (b &amp;&amp; true)</code></td>
+<td><blockquote>
+<p><code>if (b)</code></p>
+</blockquote></td>
+</tr>
+<tr class="even">
+<td><code>if (b &amp;&amp; false)</code></td>
+<td><blockquote>
+<p><code>if (false)</code></p>
+</blockquote></td>
+</tr>
+<tr class="odd">
+<td><code>if (b || true)</code></td>
+<td><blockquote>
+<p><code>if (true)</code></p>
+</blockquote></td>
+</tr>
+<tr class="even">
+<td><code>if (b || false)</code></td>
+<td><blockquote>
+<p><code>if (b)</code></p>
+</blockquote></td>
+</tr>
+<tr class="odd">
+<td><code>e ? true : false</code></td>
+<td><blockquote>
+<p><code>e</code></p>
+</blockquote></td>
+</tr>
+<tr class="even">
+<td><code>e ? false : true</code></td>
+<td><blockquote>
+<p><code>!e</code></p>
+</blockquote></td>
+</tr>
+<tr class="odd">
+<td><code>if (true) t(); else f();</code></td>
+<td><blockquote>
+<p><code>t();</code></p>
+</blockquote></td>
+</tr>
+<tr class="even">
+<td><code>if (false) t(); else f();</code></td>
+<td><blockquote>
+<p><code>f();</code></p>
+</blockquote></td>
+</tr>
+<tr class="odd">
+<td><code>if (e) return true; else return false;</code></td>
+<td><blockquote>
+<p><code>return e;</code></p>
+</blockquote></td>
+</tr>
+<tr class="even">
+<td><code>if (e) return false; else return true;</code></td>
+<td><blockquote>
+<p><code>return !e;</code></p>
+</blockquote></td>
+</tr>
+<tr class="odd">
+<td><code>if (e) b = true; else b = false;</code></td>
+<td><blockquote>
+<p><code>b = e;</code></p>
+</blockquote></td>
+</tr>
+<tr class="even">
+<td><code>if (e) b = false; else b = true;</code></td>
+<td><blockquote>
+<p><code>b = !e;</code></p>
+</blockquote></td>
+</tr>
+<tr class="odd">
+<td><code>if (e) return true; return false;</code></td>
+<td><blockquote>
+<p><code>return e;</code></p>
+</blockquote></td>
+</tr>
+<tr class="even">
+<td><code>if (e) return false; return true;</code></td>
+<td><blockquote>
+<p><code>return !e;</code></p>
+</blockquote></td>
+</tr>
+</tbody>
+</table>
+<dl>
+<dt>The resulting expression <code>e</code> is modified as follows:</dt>
+<dd><ol type="1">
+<li>Unnecessary parentheses around the expression are removed.</li>
+<li>Negated applications of <code>!</code> are eliminated.</li>
+<li>Negated applications of comparison operators are changed to use the opposite condition.</li>
+<li>Implicit conversions of pointers, including pointers to members, to <code>bool</code> are replaced with explicit comparisons to <code>nullptr</code> in C++11 or <code>NULL</code> in C++98/03.</li>
+<li>Implicit casts to <code>bool</code> are replaced with explicit casts to <code>bool</code>.</li>
+<li>Object expressions with <code>explicit operator bool</code> conversion operators are replaced with explicit casts to <code>bool</code>.</li>
+<li>Implicit conversions of integral types to <code>bool</code> are replaced with explicit comparisons to <code>0</code>.</li>
+</ol>
+</dd>
+<dt>Examples:</dt>
+<dd><ol type="1">
+<li>The ternary assignment <code>bool b = (i &lt; 0) ? true : false;</code> has redundant parentheses and becomes <code>bool b = i &lt; 0;</code>.</li>
+<li>The conditional return <code>if (!b) return false; return true;</code> has an implied double negation and becomes <code>return b;</code>.</li>
+<li><p>The conditional return <code>if (i &lt; 0) return false; return true;</code> becomes <code>return i &gt;= 0;</code>.</p>
+<p>The conditional return <code>if (i != 0) return false; return true;</code> becomes <code>return i == 0;</code>.</p></li>
+<li><p>The conditional return <code>if (p) return true; return false;</code> has an implicit conversion of a pointer to <code>bool</code> and becomes <code>return p != nullptr;</code>.</p>
+<p>The ternary assignment <code>bool b = (i &amp; 1) ? true : false;</code> has an implicit conversion of <code>i &amp; 1</code> to <code>bool</code> and becomes <code>bool b = (i &amp; 1) != 0;</code>.</p></li>
+<li>The conditional return <code>if (i &amp; 1) return true; else return false;</code> has an implicit conversion of an integer quantity <code>i &amp; 1</code> to <code>bool</code> and becomes <code>return (i &amp; 1) != 0;</code></li>
+<li>Given <code>struct X { explicit operator bool(); };</code>, and an instance <code>x</code> of <code>struct X</code>, the conditional return <code>if (x) return true; return false;</code> becomes <code>return static_cast&lt;bool&gt;(x);</code></li>
+</ol>
+</dd>
+</dl>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>ChainedConditionalReturn</p>
+<p>If non-zero, conditional boolean return statements at the end of an <code>if/else if</code> chain will be transformed. Default is <span class="title-ref">0</span>.</p>
+</div>
+<div class="option">
+<p>ChainedConditionalAssignment</p>
+<p>If non-zero, conditional boolean assignments at the end of an <code>if/else if</code> chain will be transformed. Default is <span class="title-ref">0</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-simplify-boolean-expr.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1702,12 +3309,20 @@ them to use the appropriate boolean expression directly.
 <rule>
   <key>readability-static-definition-in-anonymous-namespace</key>
   <name>readability-static-definition-in-anonymous-namespace</name>
-  <description><![CDATA[<p>
-Finds static function and variable definitions in anonymous namespace.
-  </p>
-    <h2>References</h2>
-
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-static-definition-in-anonymous-namespace.html" target="_blank">clang.llvm.org</a></p>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-static-definition-in-anonymous-namespace</p>
+</div>
+<h1 id="readability-static-definition-in-anonymous-namespace">readability-static-definition-in-anonymous-namespace</h1>
+<p>Finds static function and variable definitions in anonymous namespace.</p>
+<p>In this case, <code>static</code> is redundant, because anonymous namespace limits the visibility of definitions to a single translation unit.</p>
+<pre class="sourceCode c++"><code>namespace {
+  static int a = 1; // Warning.
+  static const b = 1; // Warning.
+}</code></pre>
+<p>The check will apply a fix by removing the redundant <code>static</code> qualifier.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-static-definition-in-anonymous-namespace.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -1715,13 +3330,21 @@ Finds static function and variable definitions in anonymous namespace.
 <rule>
   <key>readability-uniqueptr-delete-release</key>
   <name>readability-uniqueptr-delete-release</name>
-  <description><![CDATA[<p>
-Replace ``delete &lt;unique_ptr&gt;.release()`` with ``&lt;unique_ptr&gt; = nullptr``.
-The latter is shorter, simpler and does not require use of raw pointer APIs.
-  </p>
-    <h2>References</h2>
+  <description><![CDATA[
+<div class="title">
+<p>clang-tidy - readability-uniqueptr-delete-release</p>
+</div>
+<h1 id="readability-uniqueptr-delete-release">readability-uniqueptr-delete-release</h1>
+<p>Replace <code>delete &lt;unique_ptr&gt;.release()</code> with <code>&lt;unique_ptr&gt; = nullptr</code>. The latter is shorter, simpler and does not require use of raw pointer APIs.</p>
+<pre class="sourceCode c++"><code>std::unique_ptr&lt;int&gt; P;
+delete P.release();
 
-    <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-uniqueptr-delete-release.html" target="_blank">clang.llvm.org</a></p>
+// becomes
+
+std::unique_ptr&lt;int&gt; P;
+P = nullptr;</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-uniqueptr-delete-release.html" target="_blank">clang.llvm.org</a></p>
 ]]></description>
   <severity>MINOR</severity>
   <type>CODE_SMELL</type>
@@ -2104,4 +3727,4532 @@ Check for null pointers being passed as arguments to C string functions
   <type>BUG</type>
   <tag>bug</tag>
 </rule>
+<rule>
+  <key>abseil-duration-division</key>
+  <name>abseil-duration-division</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - abseil-duration-division</p>
+</div>
+<h1 id="abseil-duration-division">abseil-duration-division</h1>
+<p><code>absl::Duration</code> arithmetic works like it does with integers. That means that division of two <code>absl::Duration</code> objects returns an <code>int64</code> with any fractional component truncated toward 0. See <a href="https://github.com/abseil/abseil-cpp/blob/29ff6d4860070bf8fcbd39c8805d0c32d56628a3/absl/time/time.h#L137">this link</a> for more information on arithmetic with <code>absl::Duration</code>.</p>
+<p>For example:</p>
+<pre class="sourceCode c++"><code>absl::Duration d = absl::Seconds(3.5);
+int64 sec1 = d / absl::Seconds(1);     // Truncates toward 0.
+int64 sec2 = absl::ToInt64Seconds(d);  // Equivalent to division.
+assert(sec1 == 3 &amp;&amp; sec2 == 3);
+
+double dsec = d / absl::Seconds(1);  // WRONG: Still truncates toward 0.
+assert(dsec == 3.0);</code></pre>
+<p>If you want floating-point division, you should use either the <code>absl::FDivDuration()</code> function, or one of the unit conversion functions such as <code>absl::ToDoubleSeconds()</code>. For example:</p>
+<pre class="sourceCode c++"><code>absl::Duration d = absl::Seconds(3.5);
+double dsec1 = absl::FDivDuration(d, absl::Seconds(1));  // GOOD: No truncation.
+double dsec2 = absl::ToDoubleSeconds(d);                 // GOOD: No truncation.
+assert(dsec1 == 3.5 &amp;&amp; dsec2 == 3.5);</code></pre>
+<p>This check looks for uses of <code>absl::Duration</code> division that is done in a floating-point context, and recommends the use of a function that returns a floating-point value.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-duration-division.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>abseil-faster-strsplit-delimiter</key>
+  <name>abseil-faster-strsplit-delimiter</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - abseil-faster-strsplit-delimiter</p>
+</div>
+<h1 id="abseil-faster-strsplit-delimiter">abseil-faster-strsplit-delimiter</h1>
+<p>Finds instances of <code>absl::StrSplit()</code> or <code>absl::MaxSplits()</code> where the delimiter is a single character string literal and replaces with a character. The check will offer a suggestion to change the string literal into a character. It will also catch code using <code>absl::ByAnyChar()</code> for just a single character and will transform that into a single character as well.</p>
+<p>These changes will give the same result, but using characters rather than single character string literals is more efficient and readable.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>// Original - the argument is a string literal.
+for (auto piece : absl::StrSplit(str, &quot;B&quot;)) {
+
+// Suggested - the argument is a character, which causes the more efficient
+// overload of absl::StrSplit() to be used.
+for (auto piece : absl::StrSplit(str, &#39;B&#39;)) {
+
+
+// Original - the argument is a string literal inside absl::ByAnyChar call.
+for (auto piece : absl::StrSplit(str, absl::ByAnyChar(&quot;B&quot;))) {
+
+// Suggested - the argument is a character, which causes the more efficient
+// overload of absl::StrSplit() to be used and we do not need absl::ByAnyChar
+// anymore.
+for (auto piece : absl::StrSplit(str, &#39;B&#39;)) {
+
+
+// Original - the argument is a string literal inside absl::MaxSplits call.
+for (auto piece : absl::StrSplit(str, absl::MaxSplits(&quot;B&quot;, 1))) {
+
+// Suggested - the argument is a character, which causes the more efficient
+// overload of absl::StrSplit() to be used.
+for (auto piece : absl::StrSplit(str, absl::MaxSplits(&#39;B&#39;, 1))) {</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-faster-strsplit-delimiter.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>abseil-no-internal-dependencies</key>
+  <name>abseil-no-internal-dependencies</name>
+  <description><![CDATA[
+      <p>subl.. title:: clang-tidy - abseil-no-internal-dependencies</p>
+<h1 id="abseil-no-internal-dependencies">abseil-no-internal-dependencies</h1>
+<p>Warns if code using Abseil depends on internal details. If something is in a namespace that includes the word “internal”, code is not allowed to depend upon it beaucse it’s an implementation detail. They cannot friend it, include it, you mention it or refer to it in any way. Doing so violates Abseil's compatibility guidelines and may result in breakage. See <a href="https://abseil.io/about/compatibility" class="uri">https://abseil.io/about/compatibility</a> for more information.</p>
+<p>The following cases will result in warnings:</p>
+<pre class="sourceCode c++"><code>absl::strings_internal::foo();
+// warning triggered on this line
+class foo {
+  friend struct absl::container_internal::faa;
+  // warning triggered on this line
+};
+absl::memory_internal::MakeUniqueResult();
+// warning triggered on this line</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-no-internal-dependencies.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>abseil-no-namespace</key>
+  <name>abseil-no-namespace</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - abseil-no-namespace</p>
+</div>
+<h1 id="abseil-no-namespace">abseil-no-namespace</h1>
+<p>Ensures code does not open <code>namespace absl</code> as that violates Abseil's compatibility guidelines. Code should not open <code>namespace absl</code> as that conflicts with Abseil's compatibility guidelines and may result in breakage.</p>
+<p>Any code that uses:</p>
+<pre class="sourceCode c++"><code>namespace absl {
+ ...
+}</code></pre>
+<p>will be prompted with a warning.</p>
+<p>See <a href="">the full Abseil compatibility guidelines &lt;https:// abseil.io/about/compatibility&gt;</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-no-namespace.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>abseil-redundant-strcat-calls</key>
+  <name>abseil-redundant-strcat-calls</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - abseil-redundant-strcat-calls</p>
+</div>
+<h1 id="abseil-redundant-strcat-calls">abseil-redundant-strcat-calls</h1>
+<p>Suggests removal of unnecessary calls to <code>absl::StrCat</code> when the result is being passed to another call to <code>absl::StrCat</code> or <code>absl::StrAppend</code>.</p>
+<p>The extra calls cause unnecessary temporary strings to be constructed. Removing them makes the code smaller and faster.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>std::string s = absl::StrCat(&quot;A&quot;, absl::StrCat(&quot;B&quot;, absl::StrCat(&quot;C&quot;, &quot;D&quot;)));
+//before
+
+std::string s = absl::StrCat(&quot;A&quot;, &quot;B&quot;, &quot;C&quot;, &quot;D&quot;);
+//after
+
+absl::StrAppend(&amp;s, absl::StrCat(&quot;E&quot;, &quot;F&quot;, &quot;G&quot;));
+//before
+
+absl::StrAppend(&amp;s, &quot;E&quot;, &quot;F&quot;, &quot;G&quot;);
+//after</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-redundant-strcat-calls.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>abseil-str-cat-append</key>
+  <name>abseil-str-cat-append</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - abseil-str-cat-append</p>
+</div>
+<h1 id="abseil-str-cat-append">abseil-str-cat-append</h1>
+<p>Flags uses of <code>absl::StrCat()</code> to append to a <code>std::string</code>. Suggests <code>absl::StrAppend()</code> should be used instead.</p>
+<p>The extra calls cause unnecessary temporary strings to be constructed. Removing them makes the code smaller and faster.</p>
+<pre class="sourceCode c++"><code>a = absl::StrCat(a, b); // Use absl::StrAppend(&amp;a, b) instead.</code></pre>
+<p>Does not diagnose cases where <code>abls::StrCat()</code> is used as a template argument for a functor.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-str-cat-append.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>abseil-string-find-startswith</key>
+  <name>abseil-string-find-startswith</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - abseil-string-find-startswith</p>
+</div>
+<h1 id="abseil-string-find-startswith">abseil-string-find-startswith</h1>
+<p>Checks whether a <code>std::string::find()</code> result is compared with 0, and suggests replacing with <code>absl::StartsWith()</code>. This is both a readability and performance issue.</p>
+<pre class="sourceCode c++"><code>string s = &quot;...&quot;;
+if (s.find(&quot;Hello World&quot;) == 0) { /* do something */ }</code></pre>
+<p>becomes</p>
+<pre class="sourceCode c++"><code>string s = &quot;...&quot;;
+if (absl::StartsWith(s, &quot;Hello World&quot;)) { /* do something */ }</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>StringLikeClasses</p>
+<p>Semicolon-separated list of names of string-like classes. By default only <code>std::basic_string</code> is considered. The list of methods to considered is fixed.</p>
+</div>
+<div class="option">
+<p>IncludeStyle</p>
+<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
+</div>
+<div class="option">
+<p>AbseilStringsMatchHeader</p>
+<p>The location of Abseil's <code>strings/match.h</code>. Defaults to <code>absl/strings/match.h</code>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-string-find-startswith.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>android-cloexec-accept</key>
+  <name>android-cloexec-accept</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - android-cloexec-accept</p>
+</div>
+<h1 id="android-cloexec-accept">android-cloexec-accept</h1>
+<p>The usage of <code>accept()</code> is not recommended, it's better to use <code>accept4()</code>. Without this flag, an opened sensitive file descriptor would remain open across a fork+exec to a lower-privileged SELinux domain.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>accept(sockfd, addr, addrlen);
+
+// becomes
+
+accept4(sockfd, addr, addrlen, SOCK_CLOEXEC);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-accept.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>android-cloexec-accept4</key>
+  <name>android-cloexec-accept4</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - android-cloexec-accept4</p>
+</div>
+<h1 id="android-cloexec-accept4">android-cloexec-accept4</h1>
+<p><code>accept4()</code> should include <code>SOCK_CLOEXEC</code> in its type argument to avoid the file descriptor leakage. Without this flag, an opened sensitive file would remain open across a fork+exec to a lower-privileged SELinux domain.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>accept4(sockfd, addr, addrlen, SOCK_NONBLOCK);
+
+// becomes
+
+accept4(sockfd, addr, addrlen, SOCK_NONBLOCK | SOCK_CLOEXEC);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-accept4.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>android-cloexec-creat</key>
+  <name>android-cloexec-creat</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - android-cloexec-creat</p>
+</div>
+<h1 id="android-cloexec-creat">android-cloexec-creat</h1>
+<p>The usage of <code>creat()</code> is not recommended, it's better to use <code>open()</code>.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>int fd = creat(path, mode);
+
+// becomes
+
+int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, mode);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-creat.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>android-cloexec-dup</key>
+  <name>android-cloexec-dup</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - android-cloexec-dup</p>
+</div>
+<h1 id="android-cloexec-dup">android-cloexec-dup</h1>
+<p>The usage of <code>dup()</code> is not recommended, it's better to use <code>fcntl()</code>, which can set the close-on-exec flag. Otherwise, an opened sensitive file would remain open across a fork+exec to a lower-privileged SELinux domain.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>int fd = dup(oldfd);
+
+// becomes
+
+int fd = fcntl(oldfd, F_DUPFD_CLOEXEC);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-dup.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>android-cloexec-epoll-create</key>
+  <name>android-cloexec-epoll-create</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - android-cloexec-epoll-create</p>
+</div>
+<h1 id="android-cloexec-epoll-create">android-cloexec-epoll-create</h1>
+<p>The usage of <code>epoll_create()</code> is not recommended, it's better to use <code>epoll_create1()</code>, which allows close-on-exec.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>epoll_create(size);
+
+// becomes
+
+epoll_create1(EPOLL_CLOEXEC);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-epoll-create.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>android-cloexec-epoll-create1</key>
+  <name>android-cloexec-epoll-create1</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - android-cloexec-epoll-create1</p>
+</div>
+<h1 id="android-cloexec-epoll-create1">android-cloexec-epoll-create1</h1>
+<p><code>epoll_create1()</code> should include <code>EPOLL_CLOEXEC</code> in its type argument to avoid the file descriptor leakage. Without this flag, an opened sensitive file would remain open across a fork+exec to a lower-privileged SELinux domain.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>epoll_create1(0);
+
+// becomes
+
+epoll_create1(EPOLL_CLOEXEC);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-epoll-create1.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>android-cloexec-fopen</key>
+  <name>android-cloexec-fopen</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - android-cloexec-fopen</p>
+</div>
+<h1 id="android-cloexec-fopen">android-cloexec-fopen</h1>
+<p><code>fopen()</code> should include <code>e</code> in their mode string; so <code>re</code> would be valid. This is equivalent to having set <code>FD_CLOEXEC on</code> that descriptor.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>fopen(&quot;fn&quot;, &quot;r&quot;);
+
+// becomes
+
+fopen(&quot;fn&quot;, &quot;re&quot;);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-fopen.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>android-cloexec-inotify-init</key>
+  <name>android-cloexec-inotify-init</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - android-cloexec-inotify-init</p>
+</div>
+<h1 id="android-cloexec-inotify-init">android-cloexec-inotify-init</h1>
+<p>The usage of <code>inotify_init()</code> is not recommended, it's better to use <code>inotify_init1()</code>.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>inotify_init();
+
+// becomes
+
+inotify_init1(IN_CLOEXEC);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-inotify-init.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>android-cloexec-inotify-init1</key>
+  <name>android-cloexec-inotify-init1</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - android-cloexec-inotify-init1</p>
+</div>
+<h1 id="android-cloexec-inotify-init1">android-cloexec-inotify-init1</h1>
+<p><code>inotify_init1()</code> should include <code>IN_CLOEXEC</code> in its type argument to avoid the file descriptor leakage. Without this flag, an opened sensitive file would remain open across a fork+exec to a lower-privileged SELinux domain.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>inotify_init1(IN_NONBLOCK);
+
+// becomes
+
+inotify_init1(IN_NONBLOCK | IN_CLOEXEC);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-inotify-init1.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>android-cloexec-memfd-create</key>
+  <name>android-cloexec-memfd-create</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - android-cloexec-memfd-create</p>
+</div>
+<h1 id="android-cloexec-memfd-create">android-cloexec-memfd-create</h1>
+<p><code>memfd_create()</code> should include <code>MFD_CLOEXEC</code> in its type argument to avoid the file descriptor leakage. Without this flag, an opened sensitive file would remain open across a fork+exec to a lower-privileged SELinux domain.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>memfd_create(name, MFD_ALLOW_SEALING);
+
+// becomes
+
+memfd_create(name, MFD_ALLOW_SEALING | MFD_CLOEXEC);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-memfd-create.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>android-cloexec-open</key>
+  <name>android-cloexec-open</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - android-cloexec-open</p>
+</div>
+<h1 id="android-cloexec-open">android-cloexec-open</h1>
+<p>A common source of security bugs is code that opens a file without using the <code>O_CLOEXEC</code> flag. Without that flag, an opened sensitive file would remain open across a fork+exec to a lower-privileged SELinux domain, leaking that sensitive data. Open-like functions including <code>open()</code>, <code>openat()</code>, and <code>open64()</code> should include <code>O_CLOEXEC</code> in their flags argument.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>open(&quot;filename&quot;, O_RDWR);
+open64(&quot;filename&quot;, O_RDWR);
+openat(0, &quot;filename&quot;, O_RDWR);
+
+// becomes
+
+open(&quot;filename&quot;, O_RDWR | O_CLOEXEC);
+open64(&quot;filename&quot;, O_RDWR | O_CLOEXEC);
+openat(0, &quot;filename&quot;, O_RDWR | O_CLOEXEC);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-open.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>android-cloexec-socket</key>
+  <name>android-cloexec-socket</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - android-cloexec-socket</p>
+</div>
+<h1 id="android-cloexec-socket">android-cloexec-socket</h1>
+<p><code>socket()</code> should include <code>SOCK_CLOEXEC</code> in its type argument to avoid the file descriptor leakage. Without this flag, an opened sensitive file would remain open across a fork+exec to a lower-privileged SELinux domain.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>socket(domain, type, SOCK_STREAM);
+
+// becomes
+
+socket(domain, type, SOCK_STREAM | SOCK_CLOEXEC);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-socket.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>android-comparison-in-temp-failure-retry</key>
+  <name>android-comparison-in-temp-failure-retry</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - android-comparison-in-temp-failure-retry</p>
+</div>
+<h1 id="android-comparison-in-temp-failure-retry">android-comparison-in-temp-failure-retry</h1>
+<p>Diagnoses comparisons that appear to be incorrectly placed in the argument to the <code>TEMP_FAILURE_RETRY</code> macro. Having such a use is incorrect in the vast majority of cases, and will often silently defeat the purpose of the <code>TEMP_FAILURE_RETRY</code> macro.</p>
+<p>For context, <code>TEMP_FAILURE_RETRY</code> is <a href="">a convenience macro &lt;https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html&gt;</a> provided by both glibc and Bionic. Its purpose is to repeatedly run a syscall until it either succeeds, or fails for reasons other than being interrupted.</p>
+<p>Example buggy usage looks like:</p>
+<pre class="sourceCode c"><code>char cs[1];
+while (TEMP_FAILURE_RETRY(read(STDIN_FILENO, cs, sizeof(cs)) != 0)) {
+  // Do something with cs.
+}</code></pre>
+<p>Because TEMP_FAILURE_RETRY will check for whether the result <em>of the comparison</em> is <code>-1</code>, and retry if so.</p>
+<p>If you encounter this, the fix is simple: lift the comparison out of the <code>TEMP_FAILURE_RETRY</code> argument, like so:</p>
+<pre class="sourceCode c"><code>char cs[1];
+while (TEMP_FAILURE_RETRY(read(STDIN_FILENO, cs, sizeof(cs))) != 0) {
+  // Do something with cs.
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-comparison-in-temp-failure-retry.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-argument-comment</key>
+  <name>bugprone-argument-comment</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-argument-comment</p>
+</div>
+<h1 id="bugprone-argument-comment">bugprone-argument-comment</h1>
+<p>Checks that argument comments match parameter names.</p>
+<p>The check understands argument comments in the form <code>/*parameter_name=*/</code> that are placed right before the argument.</p>
+<pre class="sourceCode c++"><code>void f(bool foo);
+
+...
+
+f(/*bar=*/true);
+// warning: argument name &#39;bar&#39; in comment does not match parameter name &#39;foo&#39;</code></pre>
+<p>The check tries to detect typos and suggest automated fixes for them.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>StrictMode</p>
+<p>When zero (default value), the check will ignore leading and trailing underscores and case when comparing names -- otherwise they are taken into account.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-argument-comment.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-assert-side-effect</key>
+  <name>bugprone-assert-side-effect</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-assert-side-effect</p>
+</div>
+<h1 id="bugprone-assert-side-effect">bugprone-assert-side-effect</h1>
+<p>Finds <code>assert()</code> with side effect.</p>
+<p>The condition of <code>assert()</code> is evaluated only in debug builds so a condition with side effect can cause different behavior in debug / release builds.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>AssertMacros</p>
+<p>A comma-separated list of the names of assert macros to be checked.</p>
+</div>
+<div class="option">
+<p>CheckFunctionCalls</p>
+<p>Whether to treat non-const member and non-member functions as they produce side effects. Disabled by default because it can increase the number of false positive warnings.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-assert-side-effect.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-bool-pointer-implicit-conversion</key>
+  <name>bugprone-bool-pointer-implicit-conversion</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-bool-pointer-implicit-conversion</p>
+</div>
+<h1 id="bugprone-bool-pointer-implicit-conversion">bugprone-bool-pointer-implicit-conversion</h1>
+<p>Checks for conditions based on implicit conversion from a <code>bool</code> pointer to <code>bool</code>.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>bool *p;
+if (p) {
+  // Never used in a pointer-specific way.
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-bool-pointer-implicit-conversion.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-copy-constructor-init</key>
+  <name>bugprone-copy-constructor-init</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-copy-constructor-init</p>
+</div>
+<h1 id="bugprone-copy-constructor-init">bugprone-copy-constructor-init</h1>
+<p>Finds copy constructors where the constructor doesn't call the copy constructor of the base class.</p>
+<pre class="sourceCode c++"><code>class Copyable {
+public:
+  Copyable() = default;
+  Copyable(const Copyable &amp;) = default;
+};
+class X2 : public Copyable {
+  X2(const X2 &amp;other) {} // Copyable(other) is missing
+};</code></pre>
+<p>Also finds copy constructors where the constructor of the base class don't have parameter.</p>
+<pre class="sourceCode c++"><code>class X4 : public Copyable {
+  X4(const X4 &amp;other) : Copyable() {} // other is missing
+};</code></pre>
+<p>The check also suggests a fix-its in some cases.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-copy-constructor-init.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-dangling-handle</key>
+  <name>bugprone-dangling-handle</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-dangling-handle</p>
+</div>
+<h1 id="bugprone-dangling-handle">bugprone-dangling-handle</h1>
+<p>Detect dangling references in value handles like <code>std::experimental::string_view</code>. These dangling references can be a result of constructing handles from temporary values, where the temporary is destroyed soon after the handle is created.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>string_view View = string();  // View will dangle.
+string A;
+View = A + &quot;A&quot;;  // still dangle.
+
+vector&lt;string_view&gt; V;
+V.push_back(string());  // V[0] is dangling.
+V.resize(3, string());  // V[1] and V[2] will also dangle.
+
+string_view f() {
+  // All these return values will dangle.
+  return string();
+  string S;
+  return S;
+  char Array[10]{};
+  return Array;
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>HandleClasses</p>
+<p>A semicolon-separated list of class names that should be treated as handles. By default only <code>std::experimental::basic_string_view</code> is considered.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-dangling-handle.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-exception-escape</key>
+  <name>bugprone-exception-escape</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-exception-escape</p>
+</div>
+<h1 id="bugprone-exception-escape">bugprone-exception-escape</h1>
+<p>Finds functions which may throw an exception directly or indirectly, but they should not. The functions which should not throw exceptions are the following: * Destructors * Move constructors * Move assignment operators * The <code>main()</code> functions * <code>swap()</code> functions * Functions marked with <code>throw()</code> or <code>noexcept</code> * Other functions given as option</p>
+<p>A destructor throwing an exception may result in undefined behavior, resource leaks or unexpected termination of the program. Throwing move constructor or move assignment also may result in undefined behavior or resource leak. The <code>swap()</code> operations expected to be non throwing most of the cases and they are always possible to implement in a non throwing way. Non throwing <code>swap()</code> operations are also used to create move operations. A throwing <code>main()</code> function also results in unexpected termination.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>FunctionsThatShouldNotThrow</p>
+<p>Comma separated list containing function names which should not throw. An example value for this parameter can be <code>WinMain</code> which adds function <code>WinMain()</code> in the Windows API to the list of the funcions which should not throw. Default value is an empty string.</p>
+</div>
+<div class="option">
+<p>IgnoredExceptions</p>
+<p>Comma separated list containing type names which are not counted as thrown exceptions in the check. Default value is an empty string.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-exception-escape.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-fold-init-type</key>
+  <name>bugprone-fold-init-type</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-fold-init-type</p>
+</div>
+<h1 id="bugprone-fold-init-type">bugprone-fold-init-type</h1>
+<p>The check flags type mismatches in <a href="https://en.wikipedia.org/wiki/Fold_(higher-order_function)">folds</a> like <code>std::accumulate</code> that might result in loss of precision. <code>std::accumulate</code> folds an input range into an initial value using the type of the latter, with <code>operator+</code> by default. This can cause loss of precision through:</p>
+<ul>
+<li>Truncation: The following code uses a floating point range and an int initial value, so trucation wil happen at every application of <code>operator+</code> and the result will be <span class="title-ref">0</span>, which might not be what the user expected.</li>
+</ul>
+<pre class="sourceCode c++"><code>auto a = {0.5f, 0.5f, 0.5f, 0.5f};
+return std::accumulate(std::begin(a), std::end(a), 0);</code></pre>
+<ul>
+<li>Overflow: The following code also returns <span class="title-ref">0</span>.</li>
+</ul>
+<pre class="sourceCode c++"><code>auto a = {65536LL * 65536 * 65536};
+return std::accumulate(std::begin(a), std::end(a), 0);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-fold-init-type.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-forward-declaration-namespace</key>
+  <name>bugprone-forward-declaration-namespace</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-forward-declaration-namespace</p>
+</div>
+<h1 id="bugprone-forward-declaration-namespace">bugprone-forward-declaration-namespace</h1>
+<p>Checks if an unused forward declaration is in a wrong namespace.</p>
+<p>The check inspects all unused forward declarations and checks if there is any declaration/definition with the same name existing, which could indicate that the forward declaration is in a potentially wrong namespace.</p>
+<pre class="sourceCode c++"><code>namespace na { struct A; }
+namespace nb { struct A {}; }
+nb::A a;
+// warning : no definition found for &#39;A&#39;, but a definition with the same name
+// &#39;A&#39; found in another namespace &#39;nb::&#39;</code></pre>
+<p>This check can only generate warnings, but it can't suggest a fix at this point.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-forward-declaration-namespace.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-forwarding-reference-overload</key>
+  <name>bugprone-forwarding-reference-overload</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-forwarding-reference-overload</p>
+</div>
+<h1 id="bugprone-forwarding-reference-overload">bugprone-forwarding-reference-overload</h1>
+<p>The check looks for perfect forwarding constructors that can hide copy or move constructors. If a non const lvalue reference is passed to the constructor, the forwarding reference parameter will be a better match than the const reference parameter of the copy constructor, so the perfect forwarding constructor will be called, which can be confusing. For detailed description of this issue see: Scott Meyers, Effective Modern C++, Item 26.</p>
+<p>Consider the following example:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>class Person {
+public:
+  // C1: perfect forwarding ctor
+  template&lt;typename T&gt;
+  explicit Person(T&amp;&amp; n) {}
+
+  // C2: perfect forwarding ctor with parameter default value
+  template&lt;typename T&gt;
+  explicit Person(T&amp;&amp; n, int x = 1) {}
+
+  // C3: perfect forwarding ctor guarded with enable_if
+  template&lt;typename T, typename X = enable_if_t&lt;is_special&lt;T&gt;,void&gt;&gt;
+  explicit Person(T&amp;&amp; n) {}
+
+  // (possibly compiler generated) copy ctor
+  Person(const Person&amp; rhs);
+};</code></pre>
+</blockquote>
+<p>The check warns for constructors C1 and C2, because those can hide copy and move constructors. We suppress warnings if the copy and the move constructors are both disabled (deleted or private), because there is nothing the perfect forwarding constructor could hide in this case. We also suppress warnings for constructors like C3 that are guarded with an enable_if, assuming the programmer was aware of the possible hiding.</p>
+<h2 id="background">Background</h2>
+<p>For deciding whether a constructor is guarded with enable_if, we consider the default values of the type parameters and the types of the constructor parameters. If any part of these types is std::enable_if or std::enable_if_t, we assume the constructor is guarded.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-forwarding-reference-overload.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-inaccurate-erase</key>
+  <name>bugprone-inaccurate-erase</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-inaccurate-erase</p>
+</div>
+<h1 id="bugprone-inaccurate-erase">bugprone-inaccurate-erase</h1>
+<p>Checks for inaccurate use of the <code>erase()</code> method.</p>
+<p>Algorithms like <code>remove()</code> do not actually remove any element from the container but return an iterator to the first redundant element at the end of the container. These redundant elements must be removed using the <code>erase()</code> method. This check warns when not all of the elements will be removed due to using an inappropriate overload.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-inaccurate-erase.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-incorrect-roundings</key>
+  <name>bugprone-incorrect-roundings</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-incorrect-roundings</p>
+</div>
+<h1 id="bugprone-incorrect-roundings">bugprone-incorrect-roundings</h1>
+<p>Checks the usage of patterns known to produce incorrect rounding. Programmers often use:</p>
+<pre><code>(int)(double_expression + 0.5)</code></pre>
+<p>to round the double expression to an integer. The problem with this:</p>
+<ol type="1">
+<li>It is unnecessarily slow.</li>
+<li>It is incorrect. The number 0.499999975 (smallest representable float number below 0.5) rounds to 1.0. Even worse behavior for negative numbers where both -0.5f and -1.4f both round to 0.0.</li>
+</ol>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-incorrect-roundings.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-integer-division</key>
+  <name>bugprone-integer-division</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-integer-division</p>
+</div>
+<h1 id="bugprone-integer-division">bugprone-integer-division</h1>
+<p>Finds cases where integer division in a floating point context is likely to cause unintended loss of precision.</p>
+<p>No reports are made if divisions are part of the following expressions:</p>
+<ul>
+<li>operands of operators expecting integral or bool types,</li>
+<li>call expressions of integral or bool types, and</li>
+<li>explicit cast expressions to integral or bool types,</li>
+</ul>
+<p>as these are interpreted as signs of deliberateness from the programmer.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>float floatFunc(float);
+int intFunc(int);
+double d;
+int i = 42;
+
+// Warn, floating-point values expected.
+d = 32 * 8 / (2 + i);
+d = 8 * floatFunc(1 + 7 / 2);
+d = i / (1 &lt;&lt; 4);
+
+// OK, no integer division.
+d = 32 * 8.0 / (2 + i);
+d = 8 * floatFunc(1 + 7.0 / 2);
+d = (double)i / (1 &lt;&lt; 4);
+
+// OK, there are signs of deliberateness.
+d = 1 &lt;&lt; (i / 2);
+d = 9 + intFunc(6 * i / 32);
+d = (int)(i / 32) - 8;</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-integer-division.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-lambda-function-name</key>
+  <name>bugprone-lambda-function-name</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-lambda-function-name</p>
+</div>
+<h1 id="bugprone-lambda-function-name">bugprone-lambda-function-name</h1>
+<p>Checks for attempts to get the name of a function from within a lambda expression. The name of a lambda is always something like <code>operator()</code>, which is almost never what was intended.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>void FancyFunction() {
+  [] { printf(&quot;Called from %s\n&quot;, __func__); }();
+  [] { printf(&quot;Now called from %s\n&quot;, __FUNCTION__); }();
+}</code></pre>
+<p>Output:</p>
+<pre><code>Called from operator()
+Now called from operator()</code></pre>
+<p>Likely intended output:</p>
+<pre><code>Called from FancyFunction
+Now called from FancyFunction</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-lambda-function-name.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-macro-parentheses</key>
+  <name>bugprone-macro-parentheses</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-macro-parentheses</p>
+</div>
+<h1 id="bugprone-macro-parentheses">bugprone-macro-parentheses</h1>
+<p>Finds macros that can have unexpected behaviour due to missing parentheses.</p>
+<p>Macros are expanded by the preprocessor as-is. As a result, there can be unexpected behaviour; operators may be evaluated in unexpected order and unary operators may become binary operators, etc.</p>
+<p>When the replacement list has an expression, it is recommended to surround it with parentheses. This ensures that the macro result is evaluated completely before it is used.</p>
+<p>It is also recommended to surround macro arguments in the replacement list with parentheses. This ensures that the argument value is calculated properly.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-macro-parentheses.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-macro-repeated-side-effects</key>
+  <name>bugprone-macro-repeated-side-effects</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-macro-repeated-side-effects</p>
+</div>
+<h1 id="bugprone-macro-repeated-side-effects">bugprone-macro-repeated-side-effects</h1>
+<p>Checks for repeated argument with side effects in macros.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-macro-repeated-side-effects.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-misplaced-operator-in-strlen-in-alloc</key>
+  <name>bugprone-misplaced-operator-in-strlen-in-alloc</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-misplaced-operator-in-strlen-in-alloc</p>
+</div>
+<h1 id="bugprone-misplaced-operator-in-strlen-in-alloc">bugprone-misplaced-operator-in-strlen-in-alloc</h1>
+<p>Finds cases where <code>1</code> is added to the string in the argument to <code>strlen()</code>, <code>strnlen()</code>, <code>strnlen_s()</code>, <code>wcslen()</code>, <code>wcsnlen()</code>, and <code>wcsnlen_s()</code> instead of the result and the value is used as an argument to a memory allocation function (<code>malloc()</code>, <code>calloc()</code>, <code>realloc()</code>, <code>alloca()</code>) or the <code>new[]</code> operator in <span class="title-ref">C++</span>. The check detects error cases even if one of these functions (except the <code>new[]</code> operator) is called by a constant function pointer. Cases where <code>1</code> is added both to the parameter and the result of the <code>strlen()</code>-like function are ignored, as are cases where the whole addition is surrounded by extra parentheses.</p>
+<p><span class="title-ref">C</span> example code:</p>
+<pre class="sourceCode c"><code>void bad_malloc(char *str) {
+  char *c = (char*) malloc(strlen(str + 1));
+}</code></pre>
+<p>The suggested fix is to add <code>1</code> to the return value of <code>strlen()</code> and not to its argument. In the example above the fix would be</p>
+<pre class="sourceCode c"><code>char *c = (char*) malloc(strlen(str) + 1);</code></pre>
+<p><span class="title-ref">C++</span> example code:</p>
+<pre class="sourceCode c++"><code>void bad_new(char *str) {
+  char *c = new char[strlen(str + 1)];
+}</code></pre>
+<p>As in the <span class="title-ref">C</span> code with the <code>malloc()</code> function, the suggested fix is to add <code>1</code> to the return value of <code>strlen()</code> and not to its argument. In the example above the fix would be</p>
+<pre class="sourceCode c++"><code>char *c = new char[strlen(str) + 1];</code></pre>
+<p>Example for silencing the diagnostic:</p>
+<pre class="sourceCode c"><code>void bad_malloc(char *str) {
+  char *c = (char*) malloc(strlen((str + 1)));
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-misplaced-operator-in-strlen-in-alloc.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-misplaced-widening-cast</key>
+  <name>bugprone-misplaced-widening-cast</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-misplaced-widening-cast</p>
+</div>
+<h1 id="bugprone-misplaced-widening-cast">bugprone-misplaced-widening-cast</h1>
+<p>This check will warn when there is a cast of a calculation result to a bigger type. If the intention of the cast is to avoid loss of precision then the cast is misplaced, and there can be loss of precision. Otherwise the cast is ineffective.</p>
+<p>Example code:</p>
+<pre class="sourceCode c++"><code>long f(int x) {
+    return (long)(x * 1000);
+}</code></pre>
+<p>The result <code>x * 1000</code> is first calculated using <code>int</code> precision. If the result exceeds <code>int</code> precision there is loss of precision. Then the result is casted to <code>long</code>.</p>
+<p>If there is no loss of precision then the cast can be removed or you can explicitly cast to <code>int</code> instead.</p>
+<p>If you want to avoid loss of precision then put the cast in a proper location, for instance:</p>
+<pre class="sourceCode c++"><code>long f(int x) {
+    return (long)x * 1000;
+}</code></pre>
+<h2 id="implicit-casts">Implicit casts</h2>
+<p>Forgetting to place the cast at all is at least as dangerous and at least as common as misplacing it. If <code class="interpreted-text" data-role="option">CheckImplicitCasts</code> is enabled the check also detects these cases, for instance:</p>
+<pre class="sourceCode c++"><code>long f(int x) {
+    return x * 1000;
+}</code></pre>
+<h2 id="floating-point">Floating point</h2>
+<p>Currently warnings are only written for integer conversion. No warning is written for this code:</p>
+<pre class="sourceCode c++"><code>double f(float x) {
+    return (double)(x * 10.0f);
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>CheckImplicitCasts</p>
+<p>If non-zero, enables detection of implicit casts. Default is non-zero.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-misplaced-widening-cast.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-move-forwarding-reference</key>
+  <name>bugprone-move-forwarding-reference</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-move-forwarding-reference</p>
+</div>
+<h1 id="bugprone-move-forwarding-reference">bugprone-move-forwarding-reference</h1>
+<p>Warns if <code>std::move</code> is called on a forwarding reference, for example:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>template &lt;typename T&gt;
+void foo(T&amp;&amp; t) {
+  bar(std::move(t));
+}</code></pre>
+</blockquote>
+<p><a href="">Forwarding references &lt;http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4164.pdf&gt;</a> should typically be passed to <code>std::forward</code> instead of <code>std::move</code>, and this is the fix that will be suggested.</p>
+<p>(A forwarding reference is an rvalue reference of a type that is a deduced function template argument.)</p>
+<p>In this example, the suggested fix would be</p>
+<blockquote>
+<pre class="sourceCode c++"><code>bar(std::forward&lt;T&gt;(t));</code></pre>
+</blockquote>
+<h2 id="background">Background</h2>
+<p>Code like the example above is sometimes written with the expectation that <code>T&amp;&amp;</code> will always end up being an rvalue reference, no matter what type is deduced for <code>T</code>, and that it is therefore not possible to pass an lvalue to <code>foo()</code>. However, this is not true. Consider this example:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>std::string s = &quot;Hello, world&quot;;
+foo(s);</code></pre>
+</blockquote>
+<p>This code compiles and, after the call to <code>foo()</code>, <code>s</code> is left in an indeterminate state because it has been moved from. This may be surprising to the caller of <code>foo()</code> because no <code>std::move</code> was used when calling <code>foo()</code>.</p>
+<p>The reason for this behavior lies in the special rule for template argument deduction on function templates like <code>foo()</code> -- i.e. on function templates that take an rvalue reference argument of a type that is a deduced function template argument. (See section [temp.deduct.call]/3 in the C++11 standard.)</p>
+<p>If <code>foo()</code> is called on an lvalue (as in the example above), then <code>T</code> is deduced to be an lvalue reference. In the example, <code>T</code> is deduced to be <code>std::string &amp;</code>. The type of the argument <code>t</code> therefore becomes <code>std::string&amp; &amp;&amp;</code>; by the reference collapsing rules, this collapses to <code>std::string&amp;</code>.</p>
+<p>This means that the <code>foo(s)</code> call passes <code>s</code> as an lvalue reference, and <code>foo()</code> ends up moving <code>s</code> and thereby placing it into an indeterminate state.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-move-forwarding-reference.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-multiple-statement-macro</key>
+  <name>bugprone-multiple-statement-macro</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-multiple-statement-macro</p>
+</div>
+<h1 id="bugprone-multiple-statement-macro">bugprone-multiple-statement-macro</h1>
+<p>Detect multiple statement macros that are used in unbraced conditionals. Only the first statement of the macro will be inside the conditional and the other ones will be executed unconditionally.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>#define INCREMENT_TWO(x, y) (x)++; (y)++
+if (do_increment)
+  INCREMENT_TWO(a, b);  // (b)++ will be executed unconditionally.</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-multiple-statement-macro.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-parent-virtual-call</key>
+  <name>bugprone-parent-virtual-call</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-parent-virtual-call</p>
+</div>
+<h1 id="bugprone-parent-virtual-call">bugprone-parent-virtual-call</h1>
+<p>Detects and fixes calls to grand-...parent virtual methods instead of calls to overridden parent's virtual methods.</p>
+<pre class="sourceCode c++"><code>class A {
+  int virtual foo() {...}
+};
+
+class B: public A {
+  int foo() override {...}
+};
+
+class C: public B {
+  int foo() override { A::foo(); }
+//                     ^^^^^^^^
+// warning: qualified name A::foo refers to a member overridden in subclass; did you mean &#39;B&#39;?  [bugprone-parent-virtual-call]
+};</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-parent-virtual-call.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-sizeof-container</key>
+  <name>bugprone-sizeof-container</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-sizeof-container</p>
+</div>
+<h1 id="bugprone-sizeof-container">bugprone-sizeof-container</h1>
+<p>The check finds usages of <code>sizeof</code> on expressions of STL container types. Most likely the user wanted to use <code>.size()</code> instead.</p>
+<p>All class/struct types declared in namespace <code>std::</code> having a const <code>size()</code> method are considered containers, with the exception of <code>std::bitset</code> and <code>std::array</code>.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>std::string s;
+int a = 47 + sizeof(s); // warning: sizeof() doesn&#39;t return the size of the container. Did you mean .size()?
+
+int b = sizeof(std::string); // no warning, probably intended.
+
+std::string array_of_strings[10];
+int c = sizeof(array_of_strings) / sizeof(array_of_strings[0]); // no warning, definitely intended.
+
+std::array&lt;int, 3&gt; std_array;
+int d = sizeof(std_array); // no warning, probably intended.</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-sizeof-container.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-sizeof-expression</key>
+  <name>bugprone-sizeof-expression</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-sizeof-expression</p>
+</div>
+<h1 id="bugprone-sizeof-expression">bugprone-sizeof-expression</h1>
+<p>The check finds usages of <code>sizeof</code> expressions which are most likely errors.</p>
+<p>The <code>sizeof</code> operator yields the size (in bytes) of its operand, which may be an expression or the parenthesized name of a type. Misuse of this operator may be leading to errors and possible software vulnerabilities.</p>
+<h2 id="suspicious-usage-of-sizeofk">Suspicious usage of 'sizeof(K)'</h2>
+<p>A common mistake is to query the <code>sizeof</code> of an integer literal. This is equivalent to query the size of its type (probably <code>int</code>). The intent of the programmer was probably to simply get the integer and not its size.</p>
+<pre class="sourceCode c++"><code>#define BUFLEN 42
+char buf[BUFLEN];
+memset(buf, 0, sizeof(BUFLEN));  // sizeof(42) ==&gt; sizeof(int)</code></pre>
+<h2 id="suspicious-usage-of-sizeofexpr">Suspicious usage of 'sizeof(expr)'</h2>
+<p>In cases, where there is an enum or integer to represent a type, a common mistake is to query the <code>sizeof</code> on the integer or enum that represents the type that should be used by <code>sizeof</code>. This results in the size of the integer and not of the type the integer represents:</p>
+<pre class="sourceCode c++"><code>enum data_type {
+  FLOAT_TYPE,
+  DOUBLE_TYPE
+};
+
+struct data {
+  data_type type;
+  void* buffer;
+  data_type get_type() {
+    return type;
+  }
+};
+
+void f(data d, int numElements) {
+  // should be sizeof(float) or sizeof(double), depending on d.get_type()
+  int numBytes = numElements * sizeof(d.get_type());
+  ...
+}</code></pre>
+<h2 id="suspicious-usage-of-sizeofthis">Suspicious usage of 'sizeof(this)'</h2>
+<p>The <code>this</code> keyword is evaluated to a pointer to an object of a given type. The expression <code>sizeof(this)</code> is returning the size of a pointer. The programmer most likely wanted the size of the object and not the size of the pointer.</p>
+<pre class="sourceCode c++"><code>class Point {
+  [...]
+  size_t size() { return sizeof(this); }  // should probably be sizeof(*this)
+  [...]
+};</code></pre>
+<h2 id="suspicious-usage-of-sizeofchar">Suspicious usage of 'sizeof(char*)'</h2>
+<p>There is a subtle difference between declaring a string literal with <code>char* A = &quot;&quot;</code> and <code>char A[] = &quot;&quot;</code>. The first case has the type <code>char*</code> instead of the aggregate type <code>char[]</code>. Using <code>sizeof</code> on an object declared with <code>char*</code> type is returning the size of a pointer instead of the number of characters (bytes) in the string literal.</p>
+<pre class="sourceCode c++"><code>const char* kMessage = &quot;Hello World!&quot;;      // const char kMessage[] = &quot;...&quot;;
+void getMessage(char* buf) {
+  memcpy(buf, kMessage, sizeof(kMessage));  // sizeof(char*)
+}</code></pre>
+<h2 id="suspicious-usage-of-sizeofa">Suspicious usage of 'sizeof(A*)'</h2>
+<p>A common mistake is to compute the size of a pointer instead of its pointee. These cases may occur because of explicit cast or implicit conversion.</p>
+<pre class="sourceCode c++"><code>int A[10];
+memset(A, 0, sizeof(A + 0));
+
+struct Point point;
+memset(point, 0, sizeof(&amp;point));</code></pre>
+<h2 id="suspicious-usage-of-sizeof...sizeof...">Suspicious usage of 'sizeof(...)/sizeof(...)'</h2>
+<p>Dividing <code>sizeof</code> expressions is typically used to retrieve the number of elements of an aggregate. This check warns on incompatible or suspicious cases.</p>
+<p>In the following example, the entity has 10-bytes and is incompatible with the type <code>int</code> which has 4 bytes.</p>
+<pre class="sourceCode c++"><code>char buf[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };  // sizeof(buf) =&gt; 10
+void getMessage(char* dst) {
+  memcpy(dst, buf, sizeof(buf) / sizeof(int));  // sizeof(int) =&gt; 4  [incompatible sizes]
+}</code></pre>
+<p>In the following example, the expression <code>sizeof(Values)</code> is returning the size of <code>char*</code>. One can easily be fooled by its declaration, but in parameter declaration the size '10' is ignored and the function is receiving a <code>char*</code>.</p>
+<pre class="sourceCode c++"><code>char OrderedValues[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+return CompareArray(char Values[10]) {
+  return memcmp(OrderedValues, Values, sizeof(Values)) == 0;  // sizeof(Values) ==&gt; sizeof(char*) [implicit cast to char*]
+}</code></pre>
+<h2 id="suspicious-sizeof-by-sizeof-expression">Suspicious 'sizeof' by 'sizeof' expression</h2>
+<p>Multiplying <code>sizeof</code> expressions typically makes no sense and is probably a logic error. In the following example, the programmer used <code>*</code> instead of <code>/</code>.</p>
+<pre class="sourceCode c++"><code>const char kMessage[] = &quot;Hello World!&quot;;
+void getMessage(char* buf) {
+  memcpy(buf, kMessage, sizeof(kMessage) * sizeof(char));  //  sizeof(kMessage) / sizeof(char)
+}</code></pre>
+<p>This check may trigger on code using the arraysize macro. The following code is working correctly but should be simplified by using only the <code>sizeof</code> operator.</p>
+<pre class="sourceCode c++"><code>extern Object objects[100];
+void InitializeObjects() {
+  memset(objects, 0, arraysize(objects) * sizeof(Object));  // sizeof(objects)
+}</code></pre>
+<h2 id="suspicious-usage-of-sizeofsizeof...">Suspicious usage of 'sizeof(sizeof(...))'</h2>
+<p>Getting the <code>sizeof</code> of a <code>sizeof</code> makes no sense and is typically an error hidden through macros.</p>
+<pre class="sourceCode c++"><code>#define INT_SZ sizeof(int)
+int buf[] = { 42 };
+void getInt(int* dst) {
+  memcpy(dst, buf, sizeof(INT_SZ));  // sizeof(sizeof(int)) is suspicious.
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>WarnOnSizeOfConstant</p>
+<p>When non-zero, the check will warn on an expression like <code>sizeof(CONSTANT)</code>. Default is <span class="title-ref">1</span>.</p>
+</div>
+<div class="option">
+<p>WarnOnSizeOfIntegerExpression</p>
+<p>When non-zero, the check will warn on an expression like <code>sizeof(expr)</code> where the expression results in an integer. Default is <span class="title-ref">0</span>.</p>
+</div>
+<div class="option">
+<p>WarnOnSizeOfThis</p>
+<p>When non-zero, the check will warn on an expression like <code>sizeof(this)</code>. Default is <span class="title-ref">1</span>.</p>
+</div>
+<div class="option">
+<p>WarnOnSizeOfCompareToConstant</p>
+<p>When non-zero, the check will warn on an expression like <code>sizeof(epxr) &lt;= k</code> for a suspicious constant <span class="title-ref">k</span> while <span class="title-ref">k</span> is <span class="title-ref">0</span> or greater than <span class="title-ref">0x8000</span>. Default is <span class="title-ref">1</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-sizeof-expression.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-string-constructor</key>
+  <name>bugprone-string-constructor</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-string-constructor</p>
+</div>
+<h1 id="bugprone-string-constructor">bugprone-string-constructor</h1>
+<p>Finds string constructors that are suspicious and probably errors.</p>
+<p>A common mistake is to swap parameters to the 'fill' string-constructor.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>std::string str(&#39;x&#39;, 50); // should be str(50, &#39;x&#39;)</code></pre>
+<p>Calling the string-literal constructor with a length bigger than the literal is suspicious and adds extra random characters to the string.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>std::string(&quot;test&quot;, 200);   // Will include random characters after &quot;test&quot;.</code></pre>
+<p>Creating an empty string from constructors with parameters is considered suspicious. The programmer should use the empty constructor instead.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>std::string(&quot;test&quot;, 0);   // Creation of an empty string.</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>WarnOnLargeLength</p>
+<p>When non-zero, the check will warn on a string with a length greater than <span class="title-ref">LargeLengthThreshold</span>. Default is <span class="title-ref">1</span>.</p>
+</div>
+<div class="option">
+<p>LargeLengthThreshold</p>
+<p>An integer specifying the large length threshold. Default is <span class="title-ref">0x800000</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-string-constructor.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-string-integer-assignment</key>
+  <name>bugprone-string-integer-assignment</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-string-integer-assignment</p>
+</div>
+<h1 id="bugprone-string-integer-assignment">bugprone-string-integer-assignment</h1>
+<p>The check finds assignments of an integer to <code>std::basic_string&lt;CharT&gt;</code> (<code>std::string</code>, <code>std::wstring</code>, etc.). The source of the problem is the following assignment operator of <code>std::basic_string&lt;CharT&gt;</code>:</p>
+<pre class="sourceCode c++"><code>basic_string&amp; operator=( CharT ch );</code></pre>
+<p>Numeric types can be implicitly casted to character types.</p>
+<pre class="sourceCode c++"><code>std::string s;
+int x = 5965;
+s = 6;
+s = x;</code></pre>
+<p>Use the appropriate conversion functions or character literals.</p>
+<pre class="sourceCode c++"><code>std::string s;
+int x = 5965;
+s = &#39;6&#39;;
+s = std::to_string(x);</code></pre>
+<p>In order to suppress false positives, use an explicit cast.</p>
+<pre class="sourceCode c++"><code>std::string s;
+s = static_cast&lt;char&gt;(6);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-string-integer-assignment.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-string-literal-with-embedded-nul</key>
+  <name>bugprone-string-literal-with-embedded-nul</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-string-literal-with-embedded-nul</p>
+</div>
+<h1 id="bugprone-string-literal-with-embedded-nul">bugprone-string-literal-with-embedded-nul</h1>
+<p>Finds occurrences of string literal with embedded NUL character and validates their usage.</p>
+<h2 id="invalid-escaping">Invalid escaping</h2>
+<p>Special characters can be escaped within a string literal by using their hexadecimal encoding like <code>\x42</code>. A common mistake is to escape them like this <code>\0x42</code> where the <code>\0</code> stands for the NUL character.</p>
+<pre class="sourceCode c++"><code>const char* Example[] = &quot;Invalid character: \0x12 should be \x12&quot;;
+const char* Bytes[] = &quot;\x03\0x02\0x01\0x00\0xFF\0xFF\0xFF&quot;;</code></pre>
+<h2 id="truncated-literal">Truncated literal</h2>
+<p>String-like classes can manipulate strings with embedded NUL as they are keeping track of the bytes and the length. This is not the case for a <code>char*</code> (NUL-terminated) string.</p>
+<p>A common mistake is to pass a string-literal with embedded NUL to a string constructor expecting a NUL-terminated string. The bytes after the first NUL character are truncated.</p>
+<pre class="sourceCode c++"><code>std::string str(&quot;abc\0def&quot;);  // &quot;def&quot; is truncated
+str += &quot;\0&quot;;                  // This statement is doing nothing
+if (str == &quot;\0abc&quot;) return;   // This expression is always true</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-string-literal-with-embedded-nul.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-suspicious-enum-usage</key>
+  <name>bugprone-suspicious-enum-usage</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-suspicious-enum-usage</p>
+</div>
+<h1 id="bugprone-suspicious-enum-usage">bugprone-suspicious-enum-usage</h1>
+<p>The checker detects various cases when an enum is probably misused (as a bitmask ).</p>
+<ol type="1">
+<li>When &quot;ADD&quot; or &quot;bitwise OR&quot; is used between two enum which come from different types and these types value ranges are not disjoint.</li>
+</ol>
+<p>The following cases will be investigated only using <code class="interpreted-text" data-role="option">StrictMode</code>. We regard the enum as a (suspicious) bitmask if the three conditions below are true at the same time:</p>
+<ul>
+<li>at most half of the elements of the enum are non pow-of-2 numbers (because of short enumerations)</li>
+<li>there is another non pow-of-2 number than the enum constant representing all choices (the result &quot;bitwise OR&quot; operation of all enum elements)</li>
+<li>enum type variable/enumconstant is used as an argument of a <span class="title-ref">+</span> or &quot;bitwise OR &quot; operator</li>
+</ul>
+<p>So whenever the non pow-of-2 element is used as a bitmask element we diagnose a misuse and give a warning.</p>
+<ol start="2" type="1">
+<li>Investigating the right hand side of <span class="title-ref">+=</span> and <span class="title-ref">|=</span> operator.</li>
+<li>Check only the enum value side of a <span class="title-ref">|</span> and <span class="title-ref">+</span> operator if one of them is not enum val.</li>
+<li>Check both side of <span class="title-ref">|</span> or <span class="title-ref">+</span> operator where the enum values are from the same enum type.</li>
+</ol>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>enum { A, B, C };
+enum { D, E, F = 5 };
+enum { G = 10, H = 11, I = 12 };
+
+unsigned flag;
+flag =
+    A |
+    H; // OK, disjoint value intervalls in the enum types -&gt;probably good use.
+flag = B | F; // Warning, have common values so they are probably misused.
+
+// Case 2:
+enum Bitmask {
+  A = 0,
+  B = 1,
+  C = 2,
+  D = 4,
+  E = 8,
+  F = 16,
+  G = 31 // OK, real bitmask.
+};
+
+enum Almostbitmask {
+  AA = 0,
+  BB = 1,
+  CC = 2,
+  DD = 4,
+  EE = 8,
+  FF = 16,
+  GG // Problem, forgot to initialize.
+};
+
+unsigned flag = 0;
+flag |= E; // OK.
+flag |=
+    EE; // Warning at the decl, and note that it was used here as a bitmask.</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>StrictMode</p>
+<p>Default value: 0. When non-null the suspicious bitmask usage will be investigated additionally to the different enum usage check.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-enum-usage.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-suspicious-memset-usage</key>
+  <name>bugprone-suspicious-memset-usage</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-suspicious-memset-usage</p>
+</div>
+<h1 id="bugprone-suspicious-memset-usage">bugprone-suspicious-memset-usage</h1>
+<p>This check finds <code>memset()</code> calls with potential mistakes in their arguments. Considering the function as <code>void* memset(void* destination, int fill_value, size_t byte_count)</code>, the following cases are covered:</p>
+<p><strong>Case 1: Fill value is a character ``'0'``</strong></p>
+<p>Filling up a memory area with ASCII code 48 characters is not customary, possibly integer zeroes were intended instead. The check offers a replacement of <code>'0'</code> with <code>0</code>. Memsetting character pointers with <code>'0'</code> is allowed.</p>
+<p><strong>Case 2: Fill value is truncated</strong></p>
+<p>Memset converts <code>fill_value</code> to <code>unsigned char</code> before using it. If <code>fill_value</code> is out of unsigned character range, it gets truncated and memory will not contain the desired pattern.</p>
+<p><strong>Case 3: Byte count is zero</strong></p>
+<p>Calling memset with a literal zero in its <code>byte_count</code> argument is likely to be unintended and swapped with <code>fill_value</code>. The check offers to swap these two arguments.</p>
+<p>Corresponding cpplint.py check name: <code>runtime/memset</code>.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>void foo() {
+  int i[5] = {1, 2, 3, 4, 5};
+  int *ip = i;
+  char c = &#39;1&#39;;
+  char *cp = &amp;c;
+  int v = 0;
+
+  // Case 1
+  memset(ip, &#39;0&#39;, 1); // suspicious
+  memset(cp, &#39;0&#39;, 1); // OK
+
+  // Case 2
+  memset(ip, 0xabcd, 1); // fill value gets truncated
+  memset(ip, 0x00, 1);   // OK
+
+  // Case 3
+  memset(ip, sizeof(int), v); // zero length, potentially swapped
+  memset(ip, 0, 1);           // OK
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-memset-usage.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-suspicious-missing-comma</key>
+  <name>bugprone-suspicious-missing-comma</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-suspicious-missing-comma</p>
+</div>
+<h1 id="bugprone-suspicious-missing-comma">bugprone-suspicious-missing-comma</h1>
+<p>String literals placed side-by-side are concatenated at translation phase 6 (after the preprocessor). This feature is used to represent long string literal on multiple lines.</p>
+<p>For instance, the following declarations are equivalent:</p>
+<pre class="sourceCode c++"><code>const char* A[] = &quot;This is a test&quot;;
+const char* B[] = &quot;This&quot; &quot; is a &quot;    &quot;test&quot;;</code></pre>
+<p>A common mistake done by programmers is to forget a comma between two string literals in an array initializer list.</p>
+<pre class="sourceCode c++"><code>const char* Test[] = {
+  &quot;line 1&quot;,
+  &quot;line 2&quot;     // Missing comma!
+  &quot;line 3&quot;,
+  &quot;line 4&quot;,
+  &quot;line 5&quot;
+};</code></pre>
+<p>The array contains the string &quot;line 2line3&quot; at offset 1 (i.e. Test[1]). Clang won't generate warnings at compile time.</p>
+<p>This check may warn incorrectly on cases like:</p>
+<pre class="sourceCode c++"><code>const char* SupportedFormat[] = {
+  &quot;Error %s&quot;,
+  &quot;Code &quot; PRIu64,   // May warn here.
+  &quot;Warning %s&quot;,
+};</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>SizeThreshold</p>
+<p>An unsigned integer specifying the minimum size of a string literal to be considered by the check. Default is <span class="title-ref">5U</span>.</p>
+</div>
+<div class="option">
+<p>RatioThreshold</p>
+<p>A string specifying the maximum threshold ratio [0, 1.0] of suspicious string literals to be considered. Default is <span class="title-ref">&quot;.2&quot;</span>.</p>
+</div>
+<div class="option">
+<p>MaxConcatenatedTokens</p>
+<p>An unsigned integer specifying the maximum number of concatenated tokens. Default is <span class="title-ref">5U</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-missing-comma.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-suspicious-semicolon</key>
+  <name>bugprone-suspicious-semicolon</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-suspicious-semicolon</p>
+</div>
+<h1 id="bugprone-suspicious-semicolon">bugprone-suspicious-semicolon</h1>
+<p>Finds most instances of stray semicolons that unexpectedly alter the meaning of the code. More specifically, it looks for <code>if</code>, <code>while</code>, <code>for</code> and <code>for-range</code> statements whose body is a single semicolon, and then analyzes the context of the code (e.g. indentation) in an attempt to determine whether that is intentional.</p>
+<blockquote>
+<pre class="sourceCode c++"><code>if (x &lt; y);
+{
+  x++;
+}</code></pre>
+</blockquote>
+<p>Here the body of the <code>if</code> statement consists of only the semicolon at the end of the first line, and <span class="title-ref">x</span> will be incremented regardless of the condition.</p>
+<blockquote>
+<pre class="sourceCode c++"><code>while ((line = readLine(file)) != NULL);
+  processLine(line);</code></pre>
+</blockquote>
+<p>As a result of this code, <span class="title-ref">processLine()</span> will only be called once, when the <code>while</code> loop with the empty body exits with <span class="title-ref">line == NULL</span>. The indentation of the code indicates the intention of the programmer.</p>
+<blockquote>
+<pre class="sourceCode c++"><code>if (x &gt;= y);
+x -= y;</code></pre>
+</blockquote>
+<p>While the indentation does not imply any nesting, there is simply no valid reason to have an <span class="title-ref">if</span> statement with an empty body (but it can make sense for a loop). So this check issues a warning for the code above.</p>
+<p>To solve the issue remove the stray semicolon or in case the empty body is intentional, reflect this using code indentation or put the semicolon in a new line. For example:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>while (readWhitespace());
+  Token t = readNextToken();</code></pre>
+</blockquote>
+<p>Here the second line is indented in a way that suggests that it is meant to be the body of the <span class="title-ref">while</span> loop - whose body is in fact empty, because of the semicolon at the end of the first line.</p>
+<p>Either remove the indentation from the second line:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>while (readWhitespace());
+Token t = readNextToken();</code></pre>
+</blockquote>
+<p>... or move the semicolon from the end of the first line to a new line:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>while (readWhitespace())
+  ;
+
+  Token t = readNextToken();</code></pre>
+</blockquote>
+<p>In this case the check will assume that you know what you are doing, and will not raise a warning.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-semicolon.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-suspicious-string-compare</key>
+  <name>bugprone-suspicious-string-compare</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-suspicious-string-compare</p>
+</div>
+<h1 id="bugprone-suspicious-string-compare">bugprone-suspicious-string-compare</h1>
+<p>Find suspicious usage of runtime string comparison functions. This check is valid in C and C++.</p>
+<p>Checks for calls with implicit comparator and proposed to explicitly add it.</p>
+<pre class="sourceCode c++"><code>if (strcmp(...))       // Implicitly compare to zero
+if (!strcmp(...))      // Won&#39;t warn
+if (strcmp(...) != 0)  // Won&#39;t warn</code></pre>
+<p>Checks that compare function results (i,e, <code>strcmp</code>) are compared to valid constant. The resulting value is</p>
+<pre class="sourceCode "><code>&lt;  0    when lower than,
+&gt;  0    when greater than,
+== 0    when equals.</code></pre>
+<p>A common mistake is to compare the result to <span class="title-ref">1</span> or <span class="title-ref">-1</span>.</p>
+<pre class="sourceCode c++"><code>if (strcmp(...) == -1)  // Incorrect usage of the returned value.</code></pre>
+<p>Additionally, the check warns if the results value is implicitly cast to a <em>suspicious</em> non-integer type. It's happening when the returned value is used in a wrong context.</p>
+<pre class="sourceCode c++"><code>if (strcmp(...) &lt; 0.)  // Incorrect usage of the returned value.</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>WarnOnImplicitComparison</p>
+<p>When non-zero, the check will warn on implicit comparison. <span class="title-ref">1</span> by default.</p>
+</div>
+<div class="option">
+<p>WarnOnLogicalNotComparison</p>
+<p>When non-zero, the check will warn on logical not comparison. <span class="title-ref">0</span> by default.</p>
+</div>
+<div class="option">
+<p>StringCompareLikeFunctions</p>
+<p>A string specifying the comma-separated names of the extra string comparison functions. Default is an empty string. The check will detect the following string comparison functions: <span class="title-ref">__builtin_memcmp</span>, <span class="title-ref">__builtin_strcasecmp</span>, <span class="title-ref">__builtin_strcmp</span>, <span class="title-ref">__builtin_strncasecmp</span>, <span class="title-ref">__builtin_strncmp</span>, <span class="title-ref">_mbscmp</span>, <span class="title-ref">_mbscmp_l</span>, <span class="title-ref">_mbsicmp</span>, <span class="title-ref">_mbsicmp_l</span>, <span class="title-ref">_mbsnbcmp</span>, <span class="title-ref">_mbsnbcmp_l</span>, <span class="title-ref">_mbsnbicmp</span>, <span class="title-ref">_mbsnbicmp_l</span>, <span class="title-ref">_mbsncmp</span>, <span class="title-ref">_mbsncmp_l</span>, <span class="title-ref">_mbsnicmp</span>, <span class="title-ref">_mbsnicmp_l</span>, <span class="title-ref">_memicmp</span>, <span class="title-ref">_memicmp_l</span>, <span class="title-ref">_stricmp</span>, <span class="title-ref">_stricmp_l</span>, <span class="title-ref">_strnicmp</span>, <span class="title-ref">_strnicmp_l</span>, <span class="title-ref">_wcsicmp</span>, <span class="title-ref">_wcsicmp_l</span>, <span class="title-ref">_wcsnicmp</span>, <span class="title-ref">_wcsnicmp_l</span>, <span class="title-ref">lstrcmp</span>, <span class="title-ref">lstrcmpi</span>, <span class="title-ref">memcmp</span>, <span class="title-ref">memicmp</span>, <span class="title-ref">strcasecmp</span>, <span class="title-ref">strcmp</span>, <span class="title-ref">strcmpi</span>, <span class="title-ref">stricmp</span>, <span class="title-ref">strncasecmp</span>, <span class="title-ref">strncmp</span>, <span class="title-ref">strnicmp</span>, <span class="title-ref">wcscasecmp</span>, <span class="title-ref">wcscmp</span>, <span class="title-ref">wcsicmp</span>, <span class="title-ref">wcsncmp</span>, <span class="title-ref">wcsnicmp</span>, <span class="title-ref">wmemcmp</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-string-compare.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-swapped-arguments</key>
+  <name>bugprone-swapped-arguments</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-swapped-arguments</p>
+</div>
+<h1 id="bugprone-swapped-arguments">bugprone-swapped-arguments</h1>
+<p>Finds potentially swapped arguments by looking at implicit conversions.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-swapped-arguments.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-terminating-continue</key>
+  <name>bugprone-terminating-continue</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-terminating-continue</p>
+</div>
+<h1 id="bugprone-terminating-continue">bugprone-terminating-continue</h1>
+<p>Detects <span class="title-ref">do while</span> loops with a condition always evaluating to false that have a <span class="title-ref">continue</span> statement, as this <span class="title-ref">continue</span> terminates the loop effectively.</p>
+<pre class="sourceCode c++"><code>void f() {
+do {
+  // some code
+  continue; // terminating continue
+  // some other code
+} while(false);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-terminating-continue.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-throw-keyword-missing</key>
+  <name>bugprone-throw-keyword-missing</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-throw-keyword-missing</p>
+</div>
+<h1 id="bugprone-throw-keyword-missing">bugprone-throw-keyword-missing</h1>
+<p>Warns about a potentially missing <code>throw</code> keyword. If a temporary object is created, but the object's type derives from (or is the same as) a class that has 'EXCEPTION', 'Exception' or 'exception' in its name, we can assume that the programmer's intention was to throw that object.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>void f(int i) {
+  if (i &lt; 0) {
+    // Exception is created but is not thrown.
+    std::runtime_error(&quot;Unexpected argument&quot;);
+  }
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-throw-keyword-missing.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-undefined-memory-manipulation</key>
+  <name>bugprone-undefined-memory-manipulation</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-undefined-memory-manipulation</p>
+</div>
+<h1 id="bugprone-undefined-memory-manipulation">bugprone-undefined-memory-manipulation</h1>
+<p>Finds calls of memory manipulation functions <code>memset()</code>, <code>memcpy()</code> and <code>memmove()</code> on not TriviallyCopyable objects resulting in undefined behavior.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-undefined-memory-manipulation.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-undelegated-constructor</key>
+  <name>bugprone-undelegated-constructor</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-undelegated-constructor</p>
+</div>
+<h1 id="bugprone-undelegated-constructor">bugprone-undelegated-constructor</h1>
+<p>Finds creation of temporary objects in constructors that look like a function call to another constructor of the same class.</p>
+<p>The user most likely meant to use a delegating constructor or base class initializer.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-undelegated-constructor.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-unused-raii</key>
+  <name>bugprone-unused-raii</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-unused-raii</p>
+</div>
+<h1 id="bugprone-unused-raii">bugprone-unused-raii</h1>
+<p>Finds temporaries that look like RAII objects.</p>
+<p>The canonical example for this is a scoped lock.</p>
+<pre class="sourceCode c++"><code>{
+  scoped_lock(&amp;global_mutex);
+  critical_section();
+}</code></pre>
+<p>The destructor of the scoped_lock is called before the <code>critical_section</code> is entered, leaving it unprotected.</p>
+<p>We apply a number of heuristics to reduce the false positive count of this check:</p>
+<ul>
+<li>Ignore code expanded from macros. Testing frameworks make heavy use of this.</li>
+<li>Ignore types with trivial destructors. They are very unlikely to be RAII objects and there's no difference when they are deleted.</li>
+<li>Ignore objects at the end of a compound statement (doesn't change behavior).</li>
+<li>Ignore objects returned from a call.</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-unused-raii.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-unused-return-value</key>
+  <name>bugprone-unused-return-value</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-unused-return-value</p>
+</div>
+<h1 id="bugprone-unused-return-value">bugprone-unused-return-value</h1>
+<p>Warns on unused function return values. The checked funtions can be configured.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>CheckedFunctions</p>
+<p>Semicolon-separated list of functions to check. Defaults to <code>::std::async;::std::launder;::std::remove;::std::remove_if;::std::unique;::std::unique_ptr::release;::std::basic_string::empty;::std::vector::empty</code>. This means that the calls to following functions are checked by default:</p>
+<ul>
+<li><code>std::async()</code>. Not using the return value makes the call synchronous.</li>
+<li><code>std::launder()</code>. Not using the return value usually means that the function interface was misunderstood by the programmer. Only the returned pointer is &quot;laundered&quot;, not the argument.</li>
+<li><code>std::remove()</code>, <code>std::remove_if()</code> and <code>std::unique()</code>. The returned iterator indicates the boundary between elements to keep and elements to be removed. Not using the return value means that the information about which elements to remove is lost.</li>
+<li><code>std::unique_ptr::release()</code>. Not using the return value can lead to resource leaks if the same pointer isn't stored anywhere else. Often, ignoring the <code>release()</code> return value indicates that the programmer confused the function with <code>reset()</code>.</li>
+<li><code>std::basic_string::empty()</code> and <code>std::vector::empty()</code>. Not using the return value often indicates that the programmer confused the function with <code>clear()</code>.</li>
+</ul>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-unused-return-value.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-use-after-move</key>
+  <name>bugprone-use-after-move</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-use-after-move</p>
+</div>
+<h1 id="bugprone-use-after-move">bugprone-use-after-move</h1>
+<p>Warns if an object is used after it has been moved, for example:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>std::string str = &quot;Hello, world!\n&quot;;
+std::vector&lt;std::string&gt; messages;
+messages.emplace_back(std::move(str));
+std::cout &lt;&lt; str;</code></pre>
+</blockquote>
+<p>The last line will trigger a warning that <code>str</code> is used after it has been moved.</p>
+<p>The check does not trigger a warning if the object is reinitialized after the move and before the use. For example, no warning will be output for this code:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>messages.emplace_back(std::move(str));
+str = &quot;Greetings, stranger!\n&quot;;
+std::cout &lt;&lt; str;</code></pre>
+</blockquote>
+<p>The check takes control flow into account. A warning is only emitted if the use can be reached from the move. This means that the following code does not produce a warning:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>if (condition) {
+  messages.emplace_back(std::move(str));
+} else {
+  std::cout &lt;&lt; str;
+}</code></pre>
+</blockquote>
+<p>On the other hand, the following code does produce a warning:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>for (int i = 0; i &lt; 10; ++i) {
+  std::cout &lt;&lt; str;
+  messages.emplace_back(std::move(str));
+}</code></pre>
+</blockquote>
+<p>(The use-after-move happens on the second iteration of the loop.)</p>
+<p>In some cases, the check may not be able to detect that two branches are mutually exclusive. For example (assuming that <code>i</code> is an int):</p>
+<blockquote>
+<pre class="sourceCode c++"><code>if (i == 1) {
+  messages.emplace_back(std::move(str));
+}
+if (i == 2) {
+  std::cout &lt;&lt; str;
+}</code></pre>
+</blockquote>
+<p>In this case, the check will erroneously produce a warning, even though it is not possible for both the move and the use to be executed.</p>
+<p>An erroneous warning can be silenced by reinitializing the object after the move:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>if (i == 1) {
+  messages.emplace_back(std::move(str));
+  str = &quot;&quot;;
+}
+if (i == 2) {
+  std::cout &lt;&lt; str;
+}</code></pre>
+</blockquote>
+<p>Subsections below explain more precisely what exactly the check considers to be a move, use, and reinitialization.</p>
+<h2 id="unsequenced-moves-uses-and-reinitializations">Unsequenced moves, uses, and reinitializations</h2>
+<p>In many cases, C++ does not make any guarantees about the order in which sub-expressions of a statement are evaluated. This means that in code like the following, it is not guaranteed whether the use will happen before or after the move:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>void f(int i, std::vector&lt;int&gt; v);
+std::vector&lt;int&gt; v = { 1, 2, 3 };
+f(v[1], std::move(v));</code></pre>
+</blockquote>
+<p>In this kind of situation, the check will note that the use and move are unsequenced.</p>
+<p>The check will also take sequencing rules into account when reinitializations occur in the same statement as moves or uses. A reinitialization is only considered to reinitialize a variable if it is guaranteed to be evaluated after the move and before the use.</p>
+<h2 id="move">Move</h2>
+<p>The check currently only considers calls of <code>std::move</code> on local variables or function parameters. It does not check moves of member variables or global variables.</p>
+<p>Any call of <code>std::move</code> on a variable is considered to cause a move of that variable, even if the result of <code>std::move</code> is not passed to an rvalue reference parameter.</p>
+<p>This means that the check will flag a use-after-move even on a type that does not define a move constructor or move assignment operator. This is intentional. Developers may use <code>std::move</code> on such a type in the expectation that the type will add move semantics in the future. If such a <code>std::move</code> has the potential to cause a use-after-move, we want to warn about it even if the type does not implement move semantics yet.</p>
+<p>Furthermore, if the result of <code>std::move</code> <em>is</em> passed to an rvalue reference parameter, this will always be considered to cause a move, even if the function that consumes this parameter does not move from it, or if it does so only conditionally. For example, in the following situation, the check will assume that a move always takes place:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>std::vector&lt;std::string&gt; messages;
+void f(std::string &amp;&amp;str) {
+  // Only remember the message if it isn&#39;t empty.
+  if (!str.empty()) {
+    messages.emplace_back(std::move(str));
+  }
+}
+std::string str = &quot;&quot;;
+f(std::move(str));</code></pre>
+</blockquote>
+<p>The check will assume that the last line causes a move, even though, in this particular case, it does not. Again, this is intentional.</p>
+<p>When analyzing the order in which moves, uses and reinitializations happen (see section <a href="#unsequenced-moves-uses-and-reinitializations">Unsequenced moves, uses, and reinitializations</a>), the move is assumed to occur in whichever function the result of the <code>std::move</code> is passed to.</p>
+<h2 id="use">Use</h2>
+<p>Any occurrence of the moved variable that is not a reinitialization (see below) is considered to be a use.</p>
+<p>An exception to this are objects of type <code>std::unique_ptr</code>, <code>std::shared_ptr</code> and <code>std::weak_ptr</code>, which have defined move behavior (objects of these classes are guaranteed to be empty after they have been moved from). Therefore, an object of these classes will only be considered to be used if it is dereferenced, i.e. if <code>operator*</code>, <code>operator-&gt;</code> or <code>operator[]</code> (in the case of <code>std::unique_ptr&lt;T []&gt;</code>) is called on it.</p>
+<p>If multiple uses occur after a move, only the first of these is flagged.</p>
+<h2 id="reinitialization">Reinitialization</h2>
+<p>The check considers a variable to be reinitialized in the following cases:</p>
+<blockquote>
+<ul>
+<li>The variable occurs on the left-hand side of an assignment.</li>
+<li>The variable is passed to a function as a non-const pointer or non-const lvalue reference. (It is assumed that the variable may be an out-parameter for the function.)</li>
+<li><code>clear()</code> or <code>assign()</code> is called on the variable and the variable is of one of the standard container types <code>basic_string</code>, <code>vector</code>, <code>deque</code>, <code>forward_list</code>, <code>list</code>, <code>set</code>, <code>map</code>, <code>multiset</code>, <code>multimap</code>, <code>unordered_set</code>, <code>unordered_map</code>, <code>unordered_multiset</code>, <code>unordered_multimap</code>.</li>
+<li><code>reset()</code> is called on the variable and the variable is of type <code>std::unique_ptr</code>, <code>std::shared_ptr</code> or <code>std::weak_ptr</code>.</li>
+<li>A member function marked with the <code>[[clang::reinitializes]]</code> attribute is called on the variable.</li>
+</ul>
+</blockquote>
+<p>If the variable in question is a struct and an individual member variable of that struct is written to, the check does not consider this to be a reinitialization -- even if, eventually, all member variables of the struct are written to. For example:</p>
+<blockquote>
+<pre class="sourceCode c++"><code>struct S {
+  std::string str;
+  int i;
+};
+S s = { &quot;Hello, world!\n&quot;, 42 };
+S s_other = std::move(s);
+s.str = &quot;Lorem ipsum&quot;;
+s.i = 99;</code></pre>
+</blockquote>
+<p>The check will not consider <code>s</code> to be reinitialized after the last line; instead, the line that assigns to <code>s.str</code> will be flagged as a use-after-move. This is intentional as this pattern of reinitializing a struct is error-prone. For example, if an additional member variable is added to <code>S</code>, it is easy to forget to add the reinitialization for this additional member. Instead, it is safer to assign to the entire struct in one go, and this will also avoid the use-after-move warning.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-use-after-move.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>bugprone-virtual-near-miss</key>
+  <name>bugprone-virtual-near-miss</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-virtual-near-miss</p>
+</div>
+<h1 id="bugprone-virtual-near-miss">bugprone-virtual-near-miss</h1>
+<p>Warn if a function is a near miss (ie. the name is very similar and the function signiture is the same) to a virtual function from a base class.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>struct Base {
+  virtual void func();
+};
+
+struct Derived : Base {
+  virtual funk();
+  // warning: &#39;Derived::funk&#39; has a similar name and the same signature as virtual method &#39;Base::func&#39;; did you mean to override it?
+};</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-virtual-near-miss.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cert-dcl03-c</key>
+  <name>cert-dcl03-c</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-dcl03-c</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="cert-dcl03-c">cert-dcl03-c</h1>
+<p>The cert-dcl03-c check is an alias, please see <a href="misc-static-assert.html">misc-static-assert</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl03-c.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cert-dcl21-cpp</key>
+  <name>cert-dcl21-cpp</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-dcl21-cpp</p>
+</div>
+<h1 id="cert-dcl21-cpp">cert-dcl21-cpp</h1>
+<p>This check flags postfix <code>operator++</code> and <code>operator--</code> declarations if the return type is not a const object. This also warns if the return type is a reference type.</p>
+<p>This check corresponds to the CERT C++ Coding Standard recommendation <a href="">DCL21-CPP. Overloaded postfix increment and decrement operators should return a const object &lt;https://www.securecoding.cert.org/confluence/display/cplusplus/DCL21-CPP.+Overloaded+postfix+increment+and+decrement+operators+should+return+a+const+object&gt;</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl21-cpp.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cert-dcl54-cpp</key>
+  <name>cert-dcl54-cpp</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-dcl54-cpp</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="cert-dcl54-cpp">cert-dcl54-cpp</h1>
+<p>The cert-dcl54-cpp check is an alias, please see <a href="misc-new-delete-overloads.html">misc-new-delete-overloads</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl54-cpp.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cert-dcl58-cpp</key>
+  <name>cert-dcl58-cpp</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-dcl58-cpp</p>
+</div>
+<h1 id="cert-dcl58-cpp">cert-dcl58-cpp</h1>
+<p>Modification of the <code>std</code> or <code>posix</code> namespace can result in undefined behavior. This check warns for such modifications.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>namespace std {
+  int x; // May cause undefined behavior.
+}</code></pre>
+<p>This check corresponds to the CERT C++ Coding Standard rule <a href="">DCL58-CPP. Do not modify the standard namespaces &lt;https://www.securecoding.cert.org/confluence/display/cplusplus/DCL58-CPP.+Do+not+modify+the+standard+namespaces&gt;</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl58-cpp.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cert-dcl59-cpp</key>
+  <name>cert-dcl59-cpp</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-dcl59-cpp</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="cert-dcl59-cpp">cert-dcl59-cpp</h1>
+<p>The cert-dcl59-cpp check is an alias, please see <a href="google-build-namespaces.html">google-build-namespaces</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl59-cpp.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cert-err09-cpp</key>
+  <name>cert-err09-cpp</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-err09-cpp</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="cert-err09-cpp">cert-err09-cpp</h1>
+<p>The cert-err09-cpp check is an alias, please see <a href="misc-throw-by-value-catch-by-reference.html">misc-throw-by-value-catch-by-reference</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err09-cpp.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cert-err61-cpp</key>
+  <name>cert-err61-cpp</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-err61-cpp</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="cert-err61-cpp">cert-err61-cpp</h1>
+<p>The cert-err61-cpp check is an alias, please see <a href="misc-throw-by-value-catch-by-reference.html">misc-throw-by-value-catch-by-reference</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err61-cpp.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cert-fio38-c</key>
+  <name>cert-fio38-c</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-fio38-c</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="cert-fio38-c">cert-fio38-c</h1>
+<p>The cert-fio38-c check is an alias, please see <a href="misc-non-copyable-objects.html">misc-non-copyable-objects</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-fio38-c.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cert-msc30-c</key>
+  <name>cert-msc30-c</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-msc30-c</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="cert-msc30-c">cert-msc30-c</h1>
+<p>The cert-msc30-c check is an alias, please see <a href="cert-msc50-cpp.html">cert-msc50-cpp</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-msc30-c.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cert-msc32-c</key>
+  <name>cert-msc32-c</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-msc32-c</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="cert-msc32-c">cert-msc32-c</h1>
+<p>The cert-msc32-c check is an alias, please see <a href="cert-msc51-cpp.html">cert-msc51-cpp</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-msc32-c.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cert-msc50-cpp</key>
+  <name>cert-msc50-cpp</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-msc50-cpp</p>
+</div>
+<h1 id="cert-msc50-cpp">cert-msc50-cpp</h1>
+<p>Pseudorandom number generators use mathematical algorithms to produce a sequence of numbers with good statistical properties, but the numbers produced are not genuinely random. The <code>std::rand()</code> function takes a seed (number), runs a mathematical operation on it and returns the result. By manipulating the seed the result can be predictable. This check warns for the usage of <code>std::rand()</code>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-msc50-cpp.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cert-msc51-cpp</key>
+  <name>cert-msc51-cpp</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-msc51-cpp</p>
+</div>
+<h1 id="cert-msc51-cpp">cert-msc51-cpp</h1>
+<p>This check flags all pseudo-random number engines, engine adaptor instantiations and <code>srand()</code> when initialized or seeded with default argument, constant expression or any user-configurable type. Pseudo-random number engines seeded with a predictable value may cause vulnerabilities e.g. in security protocols. This is a CERT security rule, see <a href="">MSC51-CPP. Ensure your random number generator is properly seeded &lt;https://wiki.sei.cmu.edu/confluence/display/cplusplus/MSC51-CPP.+Ensure+your+random+number+generator+is+properly+seeded&gt;</a> and <a href="">MSC32-C. Properly seed pseudorandom number generators &lt;https://wiki.sei.cmu.edu/confluence/display/c/MSC32-C.+Properly+seed+pseudorandom+number+generators&gt;</a>.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>void foo() {
+  std::mt19937 engine1; // Diagnose, always generate the same sequence
+  std::mt19937 engine2(1); // Diagnose
+  engine1.seed(); // Diagnose
+  engine2.seed(1); // Diagnose
+
+  std::time_t t;
+  engine1.seed(std::time(&amp;t)); // Diagnose, system time might be controlled by user
+
+  int x = atoi(argv[1]);
+  std::mt19937 engine3(x);  // Will not warn
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>DisallowedSeedTypes</p>
+<p>A comma-separated list of the type names which are disallowed. Default values are <code>time_t</code>, <code>std::time_t</code>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-msc51-cpp.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cert-oop11-cpp</key>
+  <name>cert-oop11-cpp</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-oop11-cpp</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="cert-oop11-cpp">cert-oop11-cpp</h1>
+<p>The cert-oop11-cpp check is an alias, please see <a href="performance-move-constructor-init.html">performance-move-constructor-init</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-oop11-cpp.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cppcoreguidelines-avoid-goto</key>
+  <name>cppcoreguidelines-avoid-goto</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cppcoreguidelines-avoid-goto</p>
+</div>
+<h1 id="cppcoreguidelines-avoid-goto">cppcoreguidelines-avoid-goto</h1>
+<p>The usage of <code>goto</code> for control flow is error prone and should be replaced with looping constructs. Only forward jumps in nested loops are accepted.</p>
+<p>This check implements <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es76-avoid-goto">ES.76</a> from the CppCoreGuidelines and <a href="http://www.codingstandard.com/rule/6-3-1-ensure-that-the-labels-for-a-jump-statement-or-a-switch-condition-appear-later-in-the-same-or-an-enclosing-block/">6.3.1 from High Integrity C++</a>.</p>
+<p>For more information on why to avoid programming with <code>goto</code> you can read the famous paper <a href="https://www.cs.utexas.edu/users/EWD/ewd02xx/EWD215.PDF">A Case against the GO TO Statement.</a>.</p>
+<p>The check diagnoses <code>goto</code> for backward jumps in every language mode. These should be replaced with <span class="title-ref">C/C++</span> looping constructs.</p>
+<pre class="sourceCode c++"><code>// Bad, handwritten for loop.
+int i = 0;
+// Jump label for the loop
+loop_start:
+do_some_operation();
+
+if (i &lt; 100) {
+  ++i;
+  goto loop_start;
+}
+
+// Better
+for(int i = 0; i &lt; 100; ++i)
+  do_some_operation();</code></pre>
+<p>Modern C++ needs <code>goto</code> only to jump out of nested loops.</p>
+<pre class="sourceCode c++"><code>for(int i = 0; i &lt; 100; ++i) {
+  for(int j = 0; j &lt; 100; ++j) {
+    if (i * j &gt; 500)
+      goto early_exit;
+  }
+}
+
+early_exit:
+some_operation();</code></pre>
+<p>All other uses of <code>goto</code> are diagnosed in <span class="title-ref">C++</span>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-avoid-goto.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cppcoreguidelines-avoid-magic-numbers</key>
+  <name>cppcoreguidelines-avoid-magic-numbers</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cppcoreguidelines-avoid-magic-numbers</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="cppcoreguidelines-avoid-magic-numbers">cppcoreguidelines-avoid-magic-numbers</h1>
+<p>The cppcoreguidelines-avoid-magic-numbers check is an alias, please see <a href="readability-magic-numbers.html">readability-magic-numbers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-avoid-magic-numbers.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cppcoreguidelines-c-copy-assignment-signature</key>
+  <name>cppcoreguidelines-c-copy-assignment-signature</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cppcoreguidelines-c-copy-assignment-signature</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="cppcoreguidelines-c-copy-assignment-signature">cppcoreguidelines-c-copy-assignment-signature</h1>
+<p>The cppcoreguidelines-c-copy-assignment-signature check is an alias, please see <a href="misc-unconventional-assign-operator.html">misc-unconventional-assign-operator</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-c-copy-assignment-signature.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cppcoreguidelines-narrowing-conversions</key>
+  <name>cppcoreguidelines-narrowing-conversions</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cppcoreguidelines-narrowing-conversions</p>
+</div>
+<h1 id="cppcoreguidelines-narrowing-conversions">cppcoreguidelines-narrowing-conversions</h1>
+<p>Checks for silent narrowing conversions, e.g: <code>int i = 0; i += 0.1;</code>. While the issue is obvious in this former example, it might not be so in the following: <code>void MyClass::f(double d) { int_member_ += d; }</code>.</p>
+<p>This rule is part of the &quot;Expressions and statements&quot; profile of the C++ Core Guidelines, corresponding to rule ES.46. See</p>
+<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Res-narrowing" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Res-narrowing</a>.</p>
+<dl>
+<dt>We enforce only part of the guideline, more specifically, we flag:</dt>
+<dd><ul>
+<li>All floating-point to integer conversions that are not marked by an explicit cast (c-style or <code>static_cast</code>). For example: <code>int i = 0; i += 0.1;</code>, <code>void f(int); f(0.1);</code>,</li>
+<li>All applications of binary operators where the left-hand-side is an integer and the right-hand-size is a floating-point. For example: <code>int i; i+= 0.1;</code>.</li>
+</ul>
+</dd>
+</dl>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-narrowing-conversions.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cppcoreguidelines-owning-memory</key>
+  <name>cppcoreguidelines-owning-memory</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cppcoreguidelines-owning-memory</p>
+</div>
+<h1 id="cppcoreguidelines-owning-memory">cppcoreguidelines-owning-memory</h1>
+<p>This check implements the type-based semantics of <code>gsl::owner&lt;T*&gt;</code>, which allows static analysis on code, that uses raw pointers to handle resources like dynamic memory, but won't introduce RAII concepts.</p>
+<p>The relevant sections in the <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md">C++ Core Guidelines</a> are I.11, C.33, R.3 and GSL.Views The definition of a <code>gsl::owner&lt;T*&gt;</code> is straight forward</p>
+<pre class="sourceCode c++"><code>namespace gsl { template &lt;typename T&gt; owner = T; }</code></pre>
+<p>It is therefore simple to introduce the owner even without using an implementation of the <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#gsl-guideline-support-library">Guideline Support Library</a>.</p>
+<p>All checks are purely type based and not (yet) flow sensitive.</p>
+<p>The following examples will demonstrate the correct and incorrect initializations of owners, assignment is handled the same way. Note that both <code>new</code> and <code>malloc()</code>-like resource functions are considered to produce resources.</p>
+<pre class="sourceCode c++"><code>// Creating an owner with factory functions is checked.
+gsl::owner&lt;int*&gt; function_that_returns_owner() { return gsl::owner&lt;int*&gt;(new int(42)); }
+
+// Dynamic memory must be assigned to an owner
+int* Something = new int(42); // BAD, will be caught
+gsl::owner&lt;int*&gt; Owner = new int(42); // Good
+gsl::owner&lt;int*&gt; Owner = new int[42]; // Good as well
+
+// Returned owner must be assigned to an owner
+int* Something = function_that_returns_owner(); // Bad, factory function
+gsl::owner&lt;int*&gt; Owner = function_that_returns_owner(); // Good, result lands in owner
+
+// Something not a resource or owner should not be assigned to owners
+int Stack = 42;
+gsl::owner&lt;int*&gt; Owned = &amp;Stack; // Bad, not a resource assigned</code></pre>
+<p>In the case of dynamic memory as resource, only <code>gsl::owner&lt;T*&gt;</code> variables are allowed to be deleted.</p>
+<pre class="sourceCode c++"><code>// Example Bad, non-owner as resource handle, will be caught.
+int* NonOwner = new int(42); // First warning here, since new must land in an owner
+delete NonOwner; // Second warning here, since only owners are allowed to be deleted
+
+// Example Good, Ownership correclty stated
+gsl::owner&lt;int*&gt; Owner = new int(42); // Good
+delete Owner; // Good as well, statically enforced, that only owners get deleted</code></pre>
+<p>The check will furthermore ensure, that functions, that expect a <code>gsl::owner&lt;T*&gt;</code> as argument get called with either a <code>gsl::owner&lt;T*&gt;</code> or a newly created resource.</p>
+<pre class="sourceCode c++"><code>void expects_owner(gsl::owner&lt;int*&gt; o) { delete o; }
+
+// Bad Code
+int NonOwner = 42;
+expects_owner(&amp;NonOwner); // Bad, will get caught
+
+// Good Code
+gsl::owner&lt;int*&gt; Owner = new int(42);
+expects_owner(Owner); // Good
+expects_owner(new int(42)); // Good as well, recognized created resource
+
+// Port legacy code for better resource-safety
+gsl::owner&lt;FILE*&gt; File = fopen(&quot;my_file.txt&quot;, &quot;rw+&quot;);
+FILE* BadFile = fopen(&quot;another_file.txt&quot;, &quot;w&quot;); // Bad, warned
+
+// ... use the file
+
+fclose(File); // Ok, File is annotated as &#39;owner&lt;&gt;&#39;
+fclose(BadFile); // BadFile is not an &#39;owner&lt;&gt;&#39;, will be warned</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>LegacyResourceProducers</p>
+<p>Semicolon-separated list of fully qualified names of legacy functions that create resources but cannot introduce <code>gsl::owner&lt;&gt;</code>. Defaults to <code>::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile</code>.</p>
+</div>
+<div class="option">
+<p>LegacyResourceConsumers</p>
+<p>Semicolon-separated list of fully qualified names of legacy functions expecting resource owners as pointer arguments but cannot introduce <code>gsl::owner&lt;&gt;</code>. Defaults to <code>::free;::realloc;::freopen;::fclose</code>.</p>
+</div>
+<h2 id="limitations">Limitations</h2>
+<p>Using <code>gsl::owner&lt;T*&gt;</code> in a typedef or alias is not handled correctly.</p>
+<pre class="sourceCode c++"><code>using heap_int = gsl::owner&lt;int*&gt;;
+heap_int allocated = new int(42); // False positive!</code></pre>
+<p>The <code>gsl::owner&lt;T*&gt;</code> is declared as a templated type alias. In template functions and classes, like in the example below, the information of the type aliases gets lost. Therefore using <code>gsl::owner&lt;T*&gt;</code> in a heavy templated code base might lead to false positives.</p>
+<p>Known code constructs that do not get diagnosed correctly are:</p>
+<ul>
+<li><code>std::exchange</code></li>
+<li><code>std::vector&lt;gsl::owner&lt;T*&gt;&gt;</code></li>
+</ul>
+<pre class="sourceCode c++"><code>// This template function works as expected. Type information doesn&#39;t get lost.
+template &lt;typename T&gt;
+void delete_owner(gsl::owner&lt;T*&gt; owned_object) {
+  delete owned_object; // Everything alright
+}
+
+gsl::owner&lt;int*&gt; function_that_returns_owner() { return gsl::owner&lt;int*&gt;(new int(42)); }
+
+// Type deduction does not work for auto variables. 
+// This is caught by the check and will be noted accordingly.
+auto OwnedObject = function_that_returns_owner(); // Type of OwnedObject will be int*
+
+// Problematic function template that looses the typeinformation on owner
+template &lt;typename T&gt;
+void bad_template_function(T some_object) {
+  // This line will trigger the warning, that a non-owner is assigned to an owner
+  gsl::owner&lt;T*&gt; new_owner = some_object;
+}
+
+// Calling the function with an owner still yields a false positive.
+bad_template_function(gsl::owner&lt;int*&gt;(new int(42)));
+
+
+// The same issue occurs with templated classes like the following.
+template &lt;typename T&gt;
+class OwnedValue {
+public:
+  const T getValue() const { return _val; }
+private:
+  T _val;
+};
+
+// Code, that yields a false positive.
+OwnedValue&lt;gsl::owner&lt;int*&gt;&gt; Owner(new int(42)); // Type deduction yield T -&gt; int * 
+// False positive, getValue returns int* and not gsl::owner&lt;int*&gt;
+gsl::owner&lt;int*&gt; OwnedInt = Owner.getValue(); </code></pre>
+<p>Another limitation of the current implementation is only the type based checking. Suppose you have code like the following:</p>
+<pre class="sourceCode c++"><code>// Two owners with assigned resources
+gsl::owner&lt;int*&gt; Owner1 = new int(42); 
+gsl::owner&lt;int*&gt; Owner2 = new int(42);
+
+Owner2 = Owner1; // Conceptual Leak of initial resource of Owner2!
+Owner1 = nullptr;</code></pre>
+<p>The semantic of a <code>gsl::owner&lt;T*&gt;</code> is mostly like a <code>std::unique_ptr&lt;T&gt;</code>, therefore assignment of two <code>gsl::owner&lt;T*&gt;</code> is considered a move, which requires that the resource <code>Owner2</code> must have been released before the assignment. This kind of condition could be catched in later improvements of this check with flowsensitive analysis. Currently, the <span class="title-ref">Clang Static Analyzer</span> catches this bug for dynamic memory, but not for general types of resources.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-owning-memory.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cppcoreguidelines-slicing</key>
+  <name>cppcoreguidelines-slicing</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cppcoreguidelines-slicing</p>
+</div>
+<h1 id="cppcoreguidelines-slicing">cppcoreguidelines-slicing</h1>
+<p>Flags slicing of member variables or vtable. Slicing happens when copying a derived object into a base object: the members of the derived object (both member variables and virtual member functions) will be discarded. This can be misleading especially for member function slicing, for example:</p>
+<pre class="sourceCode c++"><code>struct B { int a; virtual int f(); };
+struct D : B { int b; int f() override; };
+
+void use(B b) {  // Missing reference, intended?
+  b.f();  // Calls B::f.
+}
+
+D d;
+use(d);  // Slice.</code></pre>
+<p>See the relevant C++ Core Guidelines sections for details: <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es63-dont-slice" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es63-dont-slice</a> <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c145-access-polymorphic-objects-through-pointers-and-references" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c145-access-polymorphic-objects-through-pointers-and-references</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-slicing.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>cppcoreguidelines-special-member-functions</key>
+  <name>cppcoreguidelines-special-member-functions</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - cppcoreguidelines-special-member-functions</p>
+</div>
+<h1 id="cppcoreguidelines-special-member-functions">cppcoreguidelines-special-member-functions</h1>
+<p>The check finds classes where some but not all of the special member functions are defined.</p>
+<p>By default the compiler defines a copy constructor, copy assignment operator, move constructor, move assignment operator and destructor. The default can be suppressed by explicit user-definitions. The relationship between which functions will be suppressed by definitions of other functions is complicated and it is advised that all five are defaulted or explicitly defined.</p>
+<p>Note that defining a function with <code>= delete</code> is considered to be a definition.</p>
+<p>This rule is part of the &quot;Constructors, assignments, and destructors&quot; profile of the C++ Core Guidelines, corresponding to rule C.21. See</p>
+<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all" class="uri">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all</a>.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>AllowSoleDefaultDtor</p>
+<p>When set to <span class="title-ref">1</span> (default is <span class="title-ref">0</span>), this check doesn't flag classes with a sole, explicitly defaulted destructor. An example for such a class is:</p>
+<pre class="sourceCode c++"><code>struct A {
+  virtual ~A() = default;
+};</code></pre>
+</div>
+<div class="option">
+<p>AllowMissingMoveFunctions</p>
+<p>When set to <span class="title-ref">1</span> (default is <span class="title-ref">0</span>), this check doesn't flag classes which define no move operations at all. It still flags classes which define only one of either move constructor or move assignment operator. With this option enabled, the following class won't be flagged:</p>
+<pre class="sourceCode c++"><code>struct A {
+  A(const A&amp;);
+  A&amp; operator=(const A&amp;);
+  ~A();
+}</code></pre>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-special-member-functions.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>fuchsia-default-arguments</key>
+  <name>fuchsia-default-arguments</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - fuchsia-default-arguments</p>
+</div>
+<h1 id="fuchsia-default-arguments">fuchsia-default-arguments</h1>
+<p>Warns if a function or method is declared or called with default arguments.</p>
+<p>For example, the declaration:</p>
+<pre class="sourceCode c++"><code>int foo(int value = 5) { return value; }</code></pre>
+<p>will cause a warning.</p>
+<p>A function call expression that uses a default argument will be diagnosed. Calling it without defaults will not cause a warning:</p>
+<pre class="sourceCode c++"><code>foo();  // warning
+foo(0); // no warning</code></pre>
+<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md" class="uri">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-default-arguments.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>fuchsia-header-anon-namespaces</key>
+  <name>fuchsia-header-anon-namespaces</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - fuchsia-header-anon-namespaces</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="fuchsia-header-anon-namespaces">fuchsia-header-anon-namespaces</h1>
+<p>The fuchsia-header-anon-namespaces check is an alias, please see <a href="google-build-namespaces.html">google-build-namespace</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-header-anon-namespaces.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>fuchsia-multiple-inheritance</key>
+  <name>fuchsia-multiple-inheritance</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - fuchsia-multiple-inheritance</p>
+</div>
+<h1 id="fuchsia-multiple-inheritance">fuchsia-multiple-inheritance</h1>
+<p>Warns if a class inherits from multiple classes that are not pure virtual.</p>
+<p>For example, declaring a class that inherits from multiple concrete classes is disallowed:</p>
+<pre class="sourceCode c++"><code>class Base_A {
+public:
+  virtual int foo() { return 0; }
+};
+
+class Base_B {
+public:
+  virtual int bar() { return 0; }
+};
+
+// Warning
+class Bad_Child1 : public Base_A, Base_B {};</code></pre>
+<p>A class that inherits from a pure virtual is allowed:</p>
+<pre class="sourceCode c++"><code>class Interface_A {
+public:
+  virtual int foo() = 0;
+};
+
+class Interface_B {
+public:
+  virtual int bar() = 0;
+};
+
+// No warning
+class Good_Child1 : public Interface_A, Interface_B {
+  virtual int foo() override { return 0; }
+  virtual int bar() override { return 0; }
+};</code></pre>
+<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md" class="uri">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-multiple-inheritance.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>fuchsia-overloaded-operator</key>
+  <name>fuchsia-overloaded-operator</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - fuchsia-overloaded-operator</p>
+</div>
+<h1 id="fuchsia-overloaded-operator">fuchsia-overloaded-operator</h1>
+<p>Warns if an operator is overloaded, except for the assignment (copy and move) operators.</p>
+<p>For example:</p>
+<pre class="sourceCode c++"><code>int operator+(int);     // Warning
+
+B &amp;operator=(const B &amp;Other);  // No warning
+B &amp;operator=(B &amp;&amp;Other) // No warning</code></pre>
+<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md" class="uri">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-overloaded-operator.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>fuchsia-restrict-system-includes</key>
+  <name>fuchsia-restrict-system-includes</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - fuchsia-restrict-system-includes</p>
+</div>
+<h1 id="fuchsia-restrict-system-includes">fuchsia-restrict-system-includes</h1>
+<p>Checks for allowed system includes and suggests removal of any others.</p>
+<p>It is important to note that running this check with fixes may break code, as the fix removes headers. Fixes are applied to source and header files, but not to system headers.</p>
+<p>For example, given the allowed system includes 'a.h,b*':</p>
+<pre class="sourceCode c++"><code>#include &lt;a.h&gt;
+#include &lt;b.h&gt;
+#include &lt;bar.h&gt;
+#include &lt;c.h&gt;    // Warning, as c.h is not explicitly allowed</code></pre>
+<p>All system includes can be allowed with '*', and all can be disallowed with an empty string ('').</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>Includes</p>
+<p>A string containing a comma separated glob list of allowed include filenames. Similar to the -checks glob list for running clang-tidy itself, the two wildcard characters are '*' and '-', to include and exclude globs, respectively.The default is '*', which allows all includes.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-restrict-system-includes.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>fuchsia-statically-constructed-objects</key>
+  <name>fuchsia-statically-constructed-objects</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - fuchsia-statically-constructed-objects</p>
+</div>
+<h1 id="fuchsia-statically-constructed-objects">fuchsia-statically-constructed-objects</h1>
+<p>Warns if global, non-trivial objects with static storage are constructed, unless the object is statically initialized with a <code>constexpr</code> constructor or has no explicit constructor.</p>
+<p>For example:</p>
+<pre class="sourceCode c++"><code>class A {};
+
+class B {
+public:
+  B(int Val) : Val(Val) {}
+private:
+  int Val;
+};
+
+class C {
+public:
+  C(int Val) : Val(Val) {}
+  constexpr C() : Val(0) {}
+
+private:
+  int Val;
+};
+
+static A a;         // No warning, as there is no explicit constructor
+static C c(0);      // No warning, as constructor is constexpr
+
+static B b(0);      // Warning, as constructor is not constexpr
+static C c2(0, 1);  // Warning, as constructor is not constexpr
+
+static int i;       // No warning, as it is trivial
+
+extern int get_i();
+static C(get_i())   // Warning, as the constructor is dynamically initialized</code></pre>
+<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md" class="uri">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-statically-constructed-objects.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>fuchsia-trailing-return</key>
+  <name>fuchsia-trailing-return</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - fuchsia-trailing-return</p>
+</div>
+<h1 id="fuchsia-trailing-return">fuchsia-trailing-return</h1>
+<p>Functions that have trailing returns are disallowed, except for those using <code>decltype</code> specifiers and lambda with otherwise unutterable return types.</p>
+<p>For example:</p>
+<pre class="sourceCode c++"><code>// No warning
+int add_one(const int arg) { return arg; }
+
+// Warning
+auto get_add_one() -&gt; int (*)(const int) {
+  return add_one;
+}</code></pre>
+<p>Exceptions are made for lambdas and <code>decltype</code> specifiers:</p>
+<pre class="sourceCode c++"><code>// No warning
+auto lambda = [](double x, double y) -&gt; double {return x + y;};
+
+// No warning
+template &lt;typename T1, typename T2&gt;
+auto fn(const T1 &amp;lhs, const T2 &amp;rhs) -&gt; decltype(lhs + rhs) {
+  return lhs + rhs;
+}</code></pre>
+<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md" class="uri">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-trailing-return.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>fuchsia-virtual-inheritance</key>
+  <name>fuchsia-virtual-inheritance</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - fuchsia-virtual-inheritance</p>
+</div>
+<h1 id="fuchsia-virtual-inheritance">fuchsia-virtual-inheritance</h1>
+<p>Warns if classes are defined with virtual inheritance.</p>
+<p>For example, classes should not be defined with virtual inheritance:</p>
+<pre class="sourceCode c++"><code>class B : public virtual A {};   // warning</code></pre>
+<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md" class="uri">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-virtual-inheritance.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>google-objc-avoid-throwing-exception</key>
+  <name>google-objc-avoid-throwing-exception</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - google-objc-avoid-throwing-exception</p>
+</div>
+<h1 id="google-objc-avoid-throwing-exception">google-objc-avoid-throwing-exception</h1>
+<p>Finds uses of throwing exceptions usages in Objective-C files.</p>
+<p>For the same reason as the Google C++ style guide, we prefer not throwing exceptions from Objective-C code.</p>
+<p>The corresponding C++ style guide rule: <a href="https://google.github.io/styleguide/cppguide.html#Exceptions" class="uri">https://google.github.io/styleguide/cppguide.html#Exceptions</a></p>
+<p>Instead, prefer passing in <code>NSError **</code> and return <code>BOOL</code> to indicate success or failure.</p>
+<p>A counterexample:</p>
+<pre class="sourceCode objc"><code>- (void)readFile {
+  if ([self isError]) {
+    @throw [NSException exceptionWithName:...];
+  }
+}</code></pre>
+<p>Instead, returning an error via <code>NSError **</code> is preferred:</p>
+<pre class="sourceCode objc"><code>- (BOOL)readFileWithError:(NSError **)error {
+  if ([self isError]) {
+    *error = [NSError errorWithDomain:...];
+    return NO;
+  }
+  return YES;
+}</code></pre>
+<p>The corresponding style guide rule: <a href="http://google.github.io/styleguide/objcguide.html#avoid-throwing-exceptions" class="uri">http://google.github.io/styleguide/objcguide.html#avoid-throwing-exceptions</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-objc-avoid-throwing-exception.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>google-objc-global-variable-declaration</key>
+  <name>google-objc-global-variable-declaration</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - google-objc-global-variable-declaration</p>
+</div>
+<h1 id="google-objc-global-variable-declaration">google-objc-global-variable-declaration</h1>
+<p>Finds global variable declarations in Objective-C files that do not follow the pattern of variable names in Google's Objective-C Style Guide.</p>
+<p>The corresponding style guide rule: <a href="http://google.github.io/styleguide/objcguide.html#variable-names" class="uri">http://google.github.io/styleguide/objcguide.html#variable-names</a></p>
+<p>All the global variables should follow the pattern of <span class="title-ref">g[A-Z].*</span> (variables) or <span class="title-ref">k[A-Z].*</span> (constants). The check will suggest a variable name that follows the pattern if it can be inferred from the original name.</p>
+<p>For code:</p>
+<pre class="sourceCode objc"><code>static NSString* myString = @&quot;hello&quot;;</code></pre>
+<p>The fix will be:</p>
+<pre class="sourceCode objc"><code>static NSString* gMyString = @&quot;hello&quot;;</code></pre>
+<p>Another example of constant:</p>
+<pre class="sourceCode objc"><code>static NSString* const myConstString = @&quot;hello&quot;;</code></pre>
+<p>The fix will be:</p>
+<pre class="sourceCode objc"><code>static NSString* const kMyConstString = @&quot;hello&quot;;</code></pre>
+<p>However for code that prefixed with non-alphabetical characters like:</p>
+<pre class="sourceCode objc"><code>static NSString* __anotherString = @&quot;world&quot;;</code></pre>
+<p>The check will give a warning message but will not be able to suggest a fix. The user need to fix it on his own.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-objc-global-variable-declaration.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>google-readability-braces-around-statements</key>
+  <name>google-readability-braces-around-statements</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - google-readability-braces-around-statements</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="google-readability-braces-around-statements">google-readability-braces-around-statements</h1>
+<p>The google-readability-braces-around-statements check is an alias, please see <a href="readability-braces-around-statements.html">readability-braces-around-statements</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-readability-braces-around-statements.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>google-readability-function-size</key>
+  <name>google-readability-function-size</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - google-readability-function-size</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="google-readability-function-size">google-readability-function-size</h1>
+<p>The google-readability-function-size check is an alias, please see <a href="readability-function-size.html">readability-function-size</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-readability-function-size.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-avoid-goto</key>
+  <name>hicpp-avoid-goto</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-avoid-goto</p>
+</div>
+<h1 id="hicpp-avoid-goto">hicpp-avoid-goto</h1>
+<p>The <span class="title-ref">hicpp-avoid-goto</span> check is an alias to <a href="cppcoreguidelines-avoid-goto.html">cppcoreguidelines-avoid-goto</a>. Rule <a href="http://www.codingstandard.com/rule/6-3-1-ensure-that-the-labels-for-a-jump-statement-or-a-switch-condition-appear-later-in-the-same-or-an-enclosing-block/">6.3.1 High Integrity C++</a> requires that <code>goto</code> only skips parts of a block and is not used for other reasons.</p>
+<p>Both coding guidelines implement the same exception to the usage of <code>goto</code>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-avoid-goto.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-braces-around-statements</key>
+  <name>hicpp-braces-around-statements</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-braces-around-statements</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-braces-around-statements">hicpp-braces-around-statements</h1>
+<p>The <span class="title-ref">hicpp-braces-around-statements</span> check is an alias, please see <a href="readability-braces-around-statements.html">readability-braces-around-statements</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/6-1-1-enclose-the-body-of-a-selection-or-an-iteration-statement-in-a-compound-statement/">rule 6.1.1</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-braces-around-statements.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-deprecated-headers</key>
+  <name>hicpp-deprecated-headers</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-deprecated-headers</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-deprecated-headers">hicpp-deprecated-headers</h1>
+<p>The <span class="title-ref">hicpp-deprecated-headers</span> check is an alias, please see <a href="modernize-deprecated-headers.html">modernize-deprecated-headers</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/1-3-3-do-not-use-the-c-standard-library-h-headers/">rule 1.3.3</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-deprecated-headers.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-exception-baseclass</key>
+  <name>hicpp-exception-baseclass</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-exception-baseclass</p>
+</div>
+<h1 id="hicpp-exception-baseclass">hicpp-exception-baseclass</h1>
+<p>Ensure that every value that in a <code>throw</code> expression is an instance of <code>std::exception</code>.</p>
+<p>This enforces <a href="http://www.codingstandard.com/section/15-1-throwing-an-exception/">rule 15.1</a> of the High Integrity C++ Coding Standard.</p>
+<pre class="sourceCode c++"><code>class custom_exception {};
+
+void throwing() noexcept(false) {
+  // Problematic throw expressions.
+  throw int(42);
+  throw custom_exception();
+}
+
+class mathematical_error : public std::exception {};
+
+void throwing2() noexcept(false) {
+  // These kind of throws are ok.
+  throw mathematical_error();
+  throw std::runtime_error();
+  throw std::exception();
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-exception-baseclass.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-explicit-conversions</key>
+  <name>hicpp-explicit-conversions</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-explicit-conversions</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-explicit-conversions">hicpp-explicit-conversions</h1>
+<p>This check is an alias for <a href="google-explicit-constructor.html">google-explicit-constructor</a>. Used to enforce parts of <a href="http://www.codingstandard.com/rule/5-4-1-only-use-casting-forms-static_cast-excl-void-dynamic_cast-or-explicit-constructor-call/">rule 5.4.1</a>. This check will enforce that constructors and conversion operators are marked <span class="title-ref">explicit</span>. Other forms of casting checks are implemented in other places. The following checks can be used to check for more forms of casting:</p>
+<ul>
+<li><a href="cppcoreguidelines-pro-type-static-cast-downcast.html">cppcoreguidelines-pro-type-static-cast-downcast</a></li>
+<li><a href="cppcoreguidelines-pro-type-reinterpret-cast.html">cppcoreguidelines-pro-type-reinterpret-cast</a></li>
+<li><a href="cppcoreguidelines-pro-type-const-cast.html">cppcoreguidelines-pro-type-const-cast</a></li>
+<li><a href="cppcoreguidelines-pro-type-cstyle-cast.html">cppcoreguidelines-pro-type-cstyle-cast</a></li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-explicit-conversions.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-function-size</key>
+  <name>hicpp-function-size</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-function-size</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-function-size">hicpp-function-size</h1>
+<p>This check is an alias for <a href="readability-function-size.html">readability-function-size</a>. Useful to enforce multiple sections on function complexity.</p>
+<ul>
+<li><a href="http://www.codingstandard.com/rule/8-2-2-do-not-declare-functions-with-an-excessive-number-of-parameters/">rule 8.2.2</a></li>
+<li><a href="http://www.codingstandard.com/rule/8-3-1-do-not-write-functions-with-an-excessive-mccabe-cyclomatic-complexity/">rule 8.3.1</a></li>
+<li><a href="http://www.codingstandard.com/rule/8-3-2-do-not-write-functions-with-a-high-static-program-path-count/">rule 8.3.2</a></li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-function-size.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-invalid-access-moved</key>
+  <name>hicpp-invalid-access-moved</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-invalid-access-moved</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-invalid-access-moved">hicpp-invalid-access-moved</h1>
+<p>This check is an alias for <a href="bugprone-use-after-move.html">bugprone-use-after-move</a>.</p>
+<p>Implements parts of the <a href="http://www.codingstandard.com/rule/8-4-1-do-not-access-an-invalid-object-or-an-object-with-indeterminate-value/">rule 8.4.1</a> to check if moved-from objects are accessed.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-invalid-access-moved.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-member-init</key>
+  <name>hicpp-member-init</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-member-init</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-member-init">hicpp-member-init</h1>
+<p>This check is an alias for <a href="cppcoreguidelines-pro-type-member-init.html">cppcoreguidelines-pro-type-member-init</a>. Implements the check for <a href="http://www.codingstandard.com/rule/12-4-2-ensure-that-a-constructor-initializes-explicitly-all-base-classes-and-non-static-data-members/">rule 12.4.2</a> to initialize class members in the right order.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-member-init.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-move-const-arg</key>
+  <name>hicpp-move-const-arg</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-move-const-arg</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-move-const-arg">hicpp-move-const-arg</h1>
+<p>The <span class="title-ref">hicpp-move-const-arg</span> check is an alias, please see <a href="performance-move-const-arg.html">performance-move-const-arg</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/17-3-1-do-not-use-stdmove-on-objects-declared-with-const-or-const-type/">rule 17.3.1</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-move-const-arg.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-multiway-paths-covered</key>
+  <name>hicpp-multiway-paths-covered</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-multiway-paths-covered</p>
+</div>
+<h1 id="hicpp-multiway-paths-covered">hicpp-multiway-paths-covered</h1>
+<p>This check discovers situations where code paths are not fully-covered. It furthermore suggests using <code>if</code> instead of <code>switch</code> if the code will be more clear. The <a href="http://www.codingstandard.com/rule/6-1-2-explicitly-cover-all-paths-through-multi-way-selection-statements/">rule 6.1.2</a> and <a href="http://www.codingstandard.com/rule/6-1-4-ensure-that-a-switch-statement-has-at-least-two-case-labels-distinct-from-the-default-label/">rule 6.1.4</a> of the High Integrity C++ Coding Standard are enforced.</p>
+<p><code>if-else if</code> chains that miss a final <code>else</code> branch might lead to unexpected program execution and be the result of a logical error. If the missing <code>else</code> branch is intended you can leave it empty with a clarifying comment. This warning can be noisy on some code bases, so it is disabled by default.</p>
+<pre class="sourceCode c++"><code>void f1() {
+  int i = determineTheNumber();
+
+   if(i &gt; 0) { 
+     // Some Calculation 
+   } else if (i &lt; 0) { 
+     // Precondition violated or something else. 
+   }
+   // ...
+}</code></pre>
+<p>Similar arguments hold for <code>switch</code> statements which do not cover all possible code paths.</p>
+<pre class="sourceCode c++"><code>// The missing default branch might be a logical error. It can be kept empty
+// if there is nothing to do, making it explicit.
+void f2(int i) {
+  switch (i) {
+  case 0: // something
+    break;
+  case 1: // something else
+    break;
+  }
+  // All other numbers?
+}
+
+// Violates this rule as well, but already emits a compiler warning (-Wswitch).
+enum Color { Red, Green, Blue, Yellow };
+void f3(enum Color c) {
+  switch (c) {
+  case Red: // We can&#39;t drive for now.
+    break;
+  case Green:  // We are allowed to drive.
+    break;
+  }
+  // Other cases missing
+}</code></pre>
+<p>The <a href="http://www.codingstandard.com/rule/6-1-4-ensure-that-a-switch-statement-has-at-least-two-case-labels-distinct-from-the-default-label/">rule 6.1.4</a> requires every <code>switch</code> statement to have at least two <code>case</code> labels other than a <span class="title-ref">default</span> label. Otherwise, the <code>switch</code> could be better expressed with an <code>if</code> statement. Degenerated <code>switch</code> statements without any labels are caught as well.</p>
+<pre class="sourceCode c++"><code>// Degenerated switch that could be better written as `if`
+int i = 42;
+switch(i) {
+  case 1: // do something here
+  default: // do somethe else here
+}
+
+// Should rather be the following:
+if (i == 1) { 
+  // do something here 
+}
+else { 
+  // do something here 
+}</code></pre>
+<pre class="sourceCode c++"><code>// A completly degenerated switch will be diagnosed.
+int i = 42;
+switch(i) {}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>WarnOnMissingElse</p>
+<p>Boolean flag that activates a warning for missing <code>else</code> branches. Default is <span class="title-ref">0</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-multiway-paths-covered.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-named-parameter</key>
+  <name>hicpp-named-parameter</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-named-parameter</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-named-parameter">hicpp-named-parameter</h1>
+<p>This check is an alias for <a href="readability-named-parameter.html">readability-named-parameter</a>.</p>
+<p>Implements <a href="http://www.codingstandard.com/rule/8-2-1-make-parameter-names-absent-or-identical-in-all-declarations/">rule 8.2.1</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-named-parameter.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-new-delete-operators</key>
+  <name>hicpp-new-delete-operators</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-new-delete-operators</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-new-delete-operators">hicpp-new-delete-operators</h1>
+<p>This check is an alias for <a href="misc-new-delete-overloads.html">misc-new-delete-overloads</a>. Implements <a href="http://www.codingstandard.com/section/12-3-free-store/">rule 12.3.1</a> to ensure the <span class="title-ref">new</span> and <span class="title-ref">delete</span> operators have the correct signature.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-new-delete-operators.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-no-array-decay</key>
+  <name>hicpp-no-array-decay</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-no-array-decay</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-no-array-decay">hicpp-no-array-decay</h1>
+<p>The <span class="title-ref">hicpp-no-array-decay</span> check is an alias, please see <a href="cppcoreguidelines-pro-bounds-array-to-pointer-decay.html">cppcoreguidelines-pro-bounds-array-to-pointer-decay</a> for more information. It enforces the <a href="http://www.codingstandard.com/section/4-1-array-to-pointer-conversion/">rule 4.1.1</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-no-array-decay.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-no-assembler</key>
+  <name>hicpp-no-assembler</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-no-assembler</p>
+</div>
+<h1 id="hicpp-no-assembler">hicpp-no-assembler</h1>
+<p>Check for assembler statements. No fix is offered.</p>
+<p>Inline assembler is forbidden by the <a href="">High Intergrity C++ Coding Standard &lt;http://www.codingstandard.com/section/7-5-the-asm-declaration/&gt;</a> as it restricts the portability of code.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-no-assembler.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-no-malloc</key>
+  <name>hicpp-no-malloc</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-no-malloc</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-no-malloc">hicpp-no-malloc</h1>
+<p>The <span class="title-ref">hicpp-no-malloc</span> check is an alias, please see <a href="cppcoreguidelines-no-malloc.html">cppcoreguidelines-no-malloc</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/5-3-2-allocate-memory-using-new-and-release-it-using-delete/">rule 5.3.2</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-no-malloc.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-noexcept-move</key>
+  <name>hicpp-noexcept-move</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-noexcept-move</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-noexcept-move">hicpp-noexcept-move</h1>
+<p>This check is an alias for <a href="misc-noexcept-moveconstructor.html">misc-noexcept-moveconstructor</a>. Checks <a href="http://www.codingstandard.com/rule/12-5-4-declare-noexcept-the-move-constructor-and-move-assignment-operator">rule 12.5.4</a> to mark move assignment and move construction <span class="title-ref">noexcept</span>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-noexcept-move.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-signed-bitwise</key>
+  <name>hicpp-signed-bitwise</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-signed-bitwise</p>
+</div>
+<h1 id="hicpp-signed-bitwise">hicpp-signed-bitwise</h1>
+<p>Finds uses of bitwise operations on signed integer types, which may lead to undefined or implementation defined behaviour.</p>
+<p>The according rule is defined in the <a href="http://www.codingstandard.com/section/5-6-shift-operators/">High Integrity C++ Standard, Section 5.6.1</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-signed-bitwise.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-special-member-functions</key>
+  <name>hicpp-special-member-functions</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-special-member-functions</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-special-member-functions">hicpp-special-member-functions</h1>
+<p>This check is an alias for <a href="cppcoreguidelines-special-member-functions.html">cppcoreguidelines-special-member-functions</a>. Checks that special member functions have the correct signature, according to <a href="http://www.codingstandard.com/rule/12-5-7-declare-assignment-operators-with-the-ref-qualifier/">rule 12.5.7</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-special-member-functions.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-static-assert</key>
+  <name>hicpp-static-assert</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-static-assert</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-static-assert">hicpp-static-assert</h1>
+<p>The <span class="title-ref">hicpp-static-assert</span> check is an alias, please see <a href="misc-static-assert.html">misc-static-assert</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/6-1-1-enclose-the-body-of-a-selection-or-an-iteration-statement-in-a-compound-statement/">rule 7.1.10</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-static-assert.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-undelegated-constructor</key>
+  <name>hicpp-undelegated-constructor</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-undelegated-construtor</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-undelegated-constructor">hicpp-undelegated-constructor</h1>
+<p>This check is an alias for <a href="bugprone-undelegated-constructor.html">bugprone-undelegated-constructor</a>. Partially implements <a href="http://www.codingstandard.com/rule/12-4-5-use-delegating-constructors-to-reduce-code-duplication/">rule 12.4.5</a> to find misplaced constructor calls inside a constructor.</p>
+<pre class="sourceCode c++"><code>struct Ctor {
+  Ctor();
+  Ctor(int);
+  Ctor(int, int);
+  Ctor(Ctor *i) {
+    // All Ctor() calls result in a temporary object
+    Ctor(); // did you intend to call a delegated constructor? 
+    Ctor(0); // did you intend to call a delegated constructor?
+    Ctor(1, 2); // did you intend to call a delegated constructor?
+    foo();
+  }
+};</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-undelegated-constructor.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-use-auto</key>
+  <name>hicpp-use-auto</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-use-auto</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-use-auto">hicpp-use-auto</h1>
+<p>The <span class="title-ref">hicpp-use-auto</span> check is an alias, please see <a href="modernize-use-auto.html">modernize-use-auto</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/7-1-8-use-auto-id-expr-when-declaring-a-variable-to-have-the-same-type-as-its-initializer-function-call/">rule 7.1.8</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-use-auto.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-use-emplace</key>
+  <name>hicpp-use-emplace</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-use-emplace</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-use-emplace">hicpp-use-emplace</h1>
+<p>The <span class="title-ref">hicpp-use-emplace</span> check is an alias, please see <a href="modernize-use-emplace.html">modernize-use-emplace</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/17-4-2-use-api-calls-that-construct-objects-in-place/">rule 17.4.2</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-use-emplace.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-use-equals-default</key>
+  <name>hicpp-use-equals-default</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-use-equals-defaults</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-use-equals-default">hicpp-use-equals-default</h1>
+<p>This check is an alias for <a href="modernize-use-equals-default.html">modernize-use-equals-default</a>. Implements <a href="http://www.codingstandard.com/rule/12-5-1-define-explicitly-default-or-delete-implicit-special-member-functions-of-concrete-classes/">rule 12.5.1</a> to explicitly default special member functions.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-use-equals-default.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-use-equals-delete</key>
+  <name>hicpp-use-equals-delete</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-use-equals-delete</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-use-equals-delete">hicpp-use-equals-delete</h1>
+<p>This check is an alias for <a href="modernize-use-equals-delete.html">modernize-use-equals-delete</a>. Implements <a href="http://www.codingstandard.com/rule/12-5-1-define-explicitly-default-or-delete-implicit-special-member-functions-of-concrete-classes/">rule 12.5.1</a> to explicitly default or delete special member functions.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-use-equals-delete.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-use-noexcept</key>
+  <name>hicpp-use-noexcept</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-use-noexcept</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-use-noexcept">hicpp-use-noexcept</h1>
+<p>The <span class="title-ref">hicpp-use-noexcept</span> check is an alias, please see <a href="modernize-use-noexcept.html">modernize-use-noexcept</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/1-3-5-do-not-use-throw-exception-specifications/">rule 1.3.5</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-use-noexcept.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-use-nullptr</key>
+  <name>hicpp-use-nullptr</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-use-nullptr</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-use-nullptr">hicpp-use-nullptr</h1>
+<p>The <span class="title-ref">hicpp-use-nullptr</span> check is an alias, please see <a href="modernize-use-nullptr.html">modernize-use-nullptr</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/2-5-3-use-nullptr-for-the-null-pointer-constant/">rule 2.5.3</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-use-nullptr.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-use-override</key>
+  <name>hicpp-use-override</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-use-override</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-use-override">hicpp-use-override</h1>
+<p>This check is an alias for <a href="modernize-use-override.html">modernize-use-override</a>. Implements <a href="http://www.codingstandard.com/section/10-2-virtual-functions/">rule 10.2.1</a> to declare a virtual function <span class="title-ref">override</span> when overriding.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-use-override.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>hicpp-vararg</key>
+  <name>hicpp-vararg</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - hicpp-vararg</p>
+</div>
+<div class="meta">
+
+</div>
+<h1 id="hicpp-vararg">hicpp-vararg</h1>
+<p>The <span class="title-ref">hicpp-vararg</span> check is an alias, please see <a href="cppcoreguidelines-pro-type-vararg.html">cppcoreguidelines-pro-type-vararg</a> for more information. It enforces the <a href="http://www.codingstandard.com/section/14-1-template-declarations/">rule 14.1.1</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-vararg.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>modernize-replace-random-shuffle</key>
+  <name>modernize-replace-random-shuffle</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - modernize-replace-random-shuffle</p>
+</div>
+<h1 id="modernize-replace-random-shuffle">modernize-replace-random-shuffle</h1>
+<p>This check will find occurrences of <code>std::random_shuffle</code> and replace it with <code>std::shuffle</code>. In C++17 <code>std::random_shuffle</code> will no longer be available and thus we need to replace it.</p>
+<p>Below are two examples of what kind of occurrences will be found and two examples of what it will be replaced with.</p>
+<pre class="sourceCode c++"><code>std::vector&lt;int&gt; v;
+
+// First example
+std::random_shuffle(vec.begin(), vec.end());
+
+// Second example
+std::random_shuffle(vec.begin(), vec.end(), randomFunc);</code></pre>
+<p>Both of these examples will be replaced with:</p>
+<pre class="sourceCode c++"><code>std::shuffle(vec.begin(), vec.end(), std::mt19937(std::random_device()()));</code></pre>
+<p>The second example will also receive a warning that <code>randomFunc</code> is no longer supported in the same way as before so if the user wants the same functionality, the user will need to change the implementation of the <code>randomFunc</code>.</p>
+<p>One thing to be aware of here is that <code>std::random_device</code> is quite expensive to initialize. So if you are using the code in a performance critical place, you probably want to initialize it elsewhere. Another thing is that the seeding quality of the suggested fix is quite poor: <code>std::mt19937</code> has an internal state of 624 32-bit integers, but is only seeded with a single integer. So if you require higher quality randomness, you should consider seeding better, for example:</p>
+<pre class="sourceCode c++"><code>std::shuffle(v.begin(), v.end(), []() {
+  std::mt19937::result_type seeds[std::mt19937::state_size];
+  std::random_device device;
+  std::uniform_int_distribution&lt;typename std::mt19937::result_type&gt; dist;
+  std::generate(std::begin(seeds), std::end(seeds), [&amp;] { return dist(device); });
+  std::seed_seq seq(std::begin(seeds), std::end(seeds));
+  return std::mt19937(seq);
+}());</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-replace-random-shuffle.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>modernize-return-braced-init-list</key>
+  <name>modernize-return-braced-init-list</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - modernize-return-braced-init-list</p>
+</div>
+<h1 id="modernize-return-braced-init-list">modernize-return-braced-init-list</h1>
+<p>Replaces explicit calls to the constructor in a return with a braced initializer list. This way the return type is not needlessly duplicated in the function definition and the return statement.</p>
+<pre class="sourceCode c++"><code>Foo bar() {
+  Baz baz;
+  return Foo(baz);
+}
+
+// transforms to:
+
+Foo bar() {
+  Baz baz;
+  return {baz};
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-return-braced-init-list.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>modernize-unary-static-assert</key>
+  <name>modernize-unary-static-assert</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - modernize-unary-static-assert</p>
+</div>
+<h1 id="modernize-unary-static-assert">modernize-unary-static-assert</h1>
+<p>The check diagnoses any <code>static_assert</code> declaration with an empty string literal and provides a fix-it to replace the declaration with a single-argument <code>static_assert</code> declaration.</p>
+<p>The check is only applicable for C++17 and later code.</p>
+<p>The following code:</p>
+<pre class="sourceCode c++"><code>void f_textless(int a) {
+  static_assert(sizeof(a) &lt;= 10, &quot;&quot;);
+}</code></pre>
+<p>is replaced by:</p>
+<pre class="sourceCode c++"><code>void f_textless(int a) {
+  static_assert(sizeof(a) &lt;= 10);
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-unary-static-assert.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>modernize-use-default-member-init</key>
+  <name>modernize-use-default-member-init</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - modernize-use-default-member-init</p>
+</div>
+<h1 id="modernize-use-default-member-init">modernize-use-default-member-init</h1>
+<p>This check converts a default constructor's member initializers into the new default member initializers in C++11. Other member initializers that match the default member initializer are removed. This can reduce repeated code or allow use of '= default'.</p>
+<pre class="sourceCode c++"><code>struct A {
+  A() : i(5), j(10.0) {}
+  A(int i) : i(i), j(10.0) {}
+  int i;
+  double j;
+};
+
+// becomes
+
+struct A {
+  A() {}
+  A(int i) : i(i) {}
+  int i{5};
+  double j{10.0};
+};</code></pre>
+<div class="note">
+<div class="admonition-title">
+<p>Note</p>
+</div>
+<p>Only converts member initializers for built-in types, enums, and pointers. The <span class="title-ref">readability-redundant-member-init</span> check will remove redundant member initializers for classes.</p>
+</div>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>UseAssignment</p>
+<p>If this option is set to non-zero (default is <span class="title-ref">0</span>), the check will initialise members with an assignment. For example:</p>
+</div>
+<pre class="sourceCode c++"><code>struct A {
+  A() {}
+  A(int i) : i(i) {}
+  int i = 5;
+  double j = 10.0;
+};</code></pre>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>If this option is set to non-zero (default is <span class="title-ref">1</span>), the check will not warn about members declared inside macros.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-default-member-init.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>modernize-use-equals-default</key>
+  <name>modernize-use-equals-default</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - modernize-use-equals-default</p>
+</div>
+<h1 id="modernize-use-equals-default">modernize-use-equals-default</h1>
+<p>This check replaces default bodies of special member functions with <code>= default;</code>. The explicitly defaulted function declarations enable more opportunities in optimization, because the compiler might treat explicitly defaulted functions as trivial.</p>
+<pre class="sourceCode c++"><code>struct A {
+  A() {}
+  ~A();
+};
+A::~A() {}
+
+// becomes
+
+struct A {
+  A() = default;
+  ~A();
+};
+A::~A() = default;</code></pre>
+<div class="note">
+<div class="admonition-title">
+<p>Note</p>
+</div>
+<p>Move-constructor and move-assignment operator are not supported yet.</p>
+</div>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>If set to non-zero, the check will not give warnings inside macros. Default is <span class="title-ref">1</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-equals-default.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>modernize-use-equals-delete</key>
+  <name>modernize-use-equals-delete</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - modernize-use-equals-delete</p>
+</div>
+<h1 id="modernize-use-equals-delete">modernize-use-equals-delete</h1>
+<p>This check marks unimplemented private special member functions with <code>= delete</code>. To avoid false-positives, this check only applies in a translation unit that has all other member functions implemented.</p>
+<pre class="sourceCode c++"><code>struct A {
+private:
+  A(const A&amp;);
+  A&amp; operator=(const A&amp;);
+};
+
+// becomes
+
+struct A {
+private:
+  A(const A&amp;) = delete;
+  A&amp; operator=(const A&amp;) = delete;
+};</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-equals-delete.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>modernize-use-noexcept</key>
+  <name>modernize-use-noexcept</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - modernize-use-noexcept</p>
+</div>
+<h1 id="modernize-use-noexcept">modernize-use-noexcept</h1>
+<p>This check replaces deprecated dynamic exception specifications with the appropriate noexcept specification (introduced in C++11). By default this check will replace <code>throw()</code> with <code>noexcept</code>, and <code>throw(&lt;exception&gt;[,...])</code> or <code>throw(...)</code> with <code>noexcept(false)</code>.</p>
+<h2 id="example">Example</h2>
+<pre class="sourceCode c++"><code>void foo() throw();
+  void bar() throw(int) {}</code></pre>
+<p>transforms to:</p>
+<pre class="sourceCode c++"><code>void foo() noexcept;
+  void bar() noexcept(false) {}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>ReplacementString</p>
+</div>
+<p>Users can use <code class="interpreted-text" data-role="option">ReplacementString</code> to specify a macro to use instead of <code>noexcept</code>. This is useful when maintaining source code that uses custom exception specification marking other than <code>noexcept</code>. Fix-it hints will only be generated for non-throwing specifications.</p>
+<h3 id="example-1">Example</h3>
+<pre class="sourceCode c++"><code>void bar() throw(int);
+void foo() throw();</code></pre>
+<p>transforms to:</p>
+<pre class="sourceCode c++"><code>void bar() throw(int);  // No fix-it generated.
+void foo() NOEXCEPT;</code></pre>
+<p>if the <code class="interpreted-text" data-role="option">ReplacementString</code> option is set to <span class="title-ref">NOEXCEPT</span>.</p>
+<div class="option">
+<p>UseNoexceptFalse</p>
+</div>
+<p>Enabled by default, disabling will generate fix-it hints that remove throwing dynamic exception specs, e.g., <code>throw(&lt;something&gt;)</code>, completely without providing a replacement text, except for destructors and delete operators that are <code>noexcept(true)</code> by default.</p>
+<h3 id="example-2">Example</h3>
+<pre class="sourceCode c++"><code>void foo() throw(int) {}
+
+struct bar {
+  void foobar() throw(int);
+  void operator delete(void *ptr) throw(int);
+  void operator delete[](void *ptr) throw(int);
+  ~bar() throw(int);
+}</code></pre>
+<p>transforms to:</p>
+<pre class="sourceCode c++"><code>void foo() {}
+
+struct bar {
+  void foobar();
+  void operator delete(void *ptr) noexcept(false);
+  void operator delete[](void *ptr) noexcept(false);
+  ~bar() noexcept(false);
+}</code></pre>
+<p>if the <code class="interpreted-text" data-role="option">UseNoexceptFalse</code> option is set to <span class="title-ref">0</span>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-noexcept.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>modernize-use-transparent-functors</key>
+  <name>modernize-use-transparent-functors</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - modernize-use-transparent-functors</p>
+</div>
+<h1 id="modernize-use-transparent-functors">modernize-use-transparent-functors</h1>
+<p>Prefer transparent functors to non-transparent ones. When using transparent functors, the type does not need to be repeated. The code is easier to read, maintain and less prone to errors. It is not possible to introduce unwanted conversions.</p>
+<blockquote>
+<pre class="sourceCode c++"><code>// Non-transparent functor
+std::map&lt;int, std::string, std::greater&lt;int&gt;&gt; s;
+
+// Transparent functor.
+std::map&lt;int, std::string, std::greater&lt;&gt;&gt; s;
+
+// Non-transparent functor
+using MyFunctor = std::less&lt;MyType&gt;;</code></pre>
+</blockquote>
+<p>It is not always a safe transformation though. The following case will be untouched to preserve the semantics.</p>
+<blockquote>
+<pre class="sourceCode c++"><code>// Non-transparent functor
+std::map&lt;const char *, std::string, std::greater&lt;std::string&gt;&gt; s;</code></pre>
+</blockquote>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>SafeMode</p>
+<p>If the option is set to non-zero, the check will not diagnose cases where using a transparent functor cannot be guaranteed to produce identical results as the original code. The default value for this option is <span class="title-ref">0</span>.</p>
+</div>
+<p>This check requires using C++14 or higher to run.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-transparent-functors.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>modernize-use-uncaught-exceptions</key>
+  <name>modernize-use-uncaught-exceptions</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - modernize-use-uncaught-exceptions</p>
+</div>
+<h1 id="modernize-use-uncaught-exceptions">modernize-use-uncaught-exceptions</h1>
+<p>This check will warn on calls to <code>std::uncaught_exception</code> and replace them with calls to <code>std::uncaught_exceptions</code>, since <code>std::uncaught_exception</code> was deprecated in C++17.</p>
+<p>Below are a few examples of what kind of occurrences will be found and what they will be replaced with.</p>
+<pre class="sourceCode c++"><code>#define MACRO1 std::uncaught_exception
+#define MACRO2 std::uncaught_exception
+
+int uncaught_exception() {
+    return 0;
+}
+
+int main() {
+    int res;
+
+  res = uncaught_exception();
+  // No warning, since it is not the deprecated function from namespace std
+
+  res = MACRO2();
+  // Warning, but will not be replaced
+
+  res = std::uncaught_exception();
+  // Warning and replaced
+
+  using std::uncaught_exception;
+  // Warning and replaced
+
+  res = uncaught_exception();
+  // Warning and replaced
+}</code></pre>
+<p>After applying the fixes the code will look like the following:</p>
+<pre class="sourceCode c++"><code>#define MACRO1 std::uncaught_exception
+#define MACRO2 std::uncaught_exception
+
+int uncaught_exception() {
+    return 0;
+}
+
+int main() {
+  int res;
+
+  res = uncaught_exception();
+
+  res = MACRO2();
+
+  res = std::uncaught_exceptions();
+
+  using std::uncaught_exceptions;
+
+  res = uncaught_exceptions();
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-uncaught-exceptions.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>mpi-buffer-deref</key>
+  <name>mpi-buffer-deref</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - mpi-buffer-deref</p>
+</div>
+<h1 id="mpi-buffer-deref">mpi-buffer-deref</h1>
+<p>This check verifies if a buffer passed to an MPI (Message Passing Interface) function is sufficiently dereferenced. Buffers should be passed as a single pointer or array. As MPI function signatures specify <code>void *</code> for their buffer types, insufficiently dereferenced buffers can be passed, like for example as double pointers or multidimensional arrays, without a compiler warning emitted.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>// A double pointer is passed to the MPI function.
+char *buf;
+MPI_Send(&amp;buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+
+// A multidimensional array is passed to the MPI function.
+short buf[1][1];
+MPI_Send(buf, 1, MPI_SHORT, 0, 0, MPI_COMM_WORLD);
+
+// A pointer to an array is passed to the MPI function.
+short *buf[1];
+MPI_Send(buf, 1, MPI_SHORT, 0, 0, MPI_COMM_WORLD);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/mpi-buffer-deref.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>mpi-type-mismatch</key>
+  <name>mpi-type-mismatch</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - mpi-type-mismatch</p>
+</div>
+<h1 id="mpi-type-mismatch">mpi-type-mismatch</h1>
+<p>This check verifies if buffer type and MPI (Message Passing Interface) datatype pairs match for used MPI functions. All MPI datatypes defined by the MPI standard (3.1) are verified by this check. User defined typedefs, custom MPI datatypes and null pointer constants are skipped, in the course of verification.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>// In this case, the buffer type matches MPI datatype.
+char buf;
+MPI_Send(&amp;buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+
+// In the following case, the buffer type does not match MPI datatype.
+int buf;
+MPI_Send(&amp;buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/mpi-type-mismatch.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>objc-avoid-nserror-init</key>
+  <name>objc-avoid-nserror-init</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - objc-avoid-nserror-init</p>
+</div>
+<h1 id="objc-avoid-nserror-init">objc-avoid-nserror-init</h1>
+<p>Finds improper initialization of <code>NSError</code> objects.</p>
+<p>According to Apple developer document, we should always use factory method <code>errorWithDomain:code:userInfo:</code> to create new NSError objects instead of <code>[NSError alloc] init]</code>. Otherwise it will lead to a warning message during runtime.</p>
+<p>The corresponding information about <code>NSError</code> creation: <a href="https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html" class="uri">https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc-avoid-nserror-init.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>objc-avoid-spinlock</key>
+  <name>objc-avoid-spinlock</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - objc-avoid-spinlock</p>
+</div>
+<h1 id="objc-avoid-spinlock">objc-avoid-spinlock</h1>
+<p>Finds usages of <code>OSSpinlock</code>, which is deprecated due to potential livelock problems.</p>
+<p>This check will detect following function invocations:</p>
+<ul>
+<li><code>OSSpinlockLock</code></li>
+<li><code>OSSpinlockTry</code></li>
+<li><code>OSSpinlockUnlock</code></li>
+</ul>
+<p>The corresponding information about the problem of <code>OSSpinlock</code>: <a href="https://blog.postmates.com/why-spinlocks-are-bad-on-ios-b69fc5221058" class="uri">https://blog.postmates.com/why-spinlocks-are-bad-on-ios-b69fc5221058</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc-avoid-spinlock.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>objc-forbidden-subclassing</key>
+  <name>objc-forbidden-subclassing</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - objc-forbidden-subclassing</p>
+</div>
+<h1 id="objc-forbidden-subclassing">objc-forbidden-subclassing</h1>
+<p>Finds Objective-C classes which are subclasses of classes which are not designed to be subclassed.</p>
+<p>By default, includes a list of Objective-C classes which are publicly documented as not supporting subclassing.</p>
+<div class="note">
+<div class="admonition-title">
+<p>Note</p>
+</div>
+<p>Instead of using this check, for code under your control, you should add <code>__attribute__((objc_subclassing_restricted))</code> before your <code>@interface</code> declarations to ensure the compiler prevents others from subclassing your Objective-C classes. See <a href="https://clang.llvm.org/docs/AttributeReference.html#objc-subclassing-restricted" class="uri">https://clang.llvm.org/docs/AttributeReference.html#objc-subclassing-restricted</a></p>
+</div>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>ForbiddenSuperClassNames</p>
+<p>Semicolon-separated list of names of Objective-C classes which do not support subclassing.</p>
+<p>Defaults to <span class="title-ref">ABNewPersonViewController;ABPeoplePickerNavigationController;ABPersonViewController;ABUnknownPersonViewController;NSHashTable;NSMapTable;NSPointerArray;NSPointerFunctions;NSTimer;UIActionSheet;UIAlertView;UIImagePickerController;UITextInputMode;UIWebView</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc-forbidden-subclassing.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>objc-property-declaration</key>
+  <name>objc-property-declaration</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - objc-property-declaration</p>
+</div>
+<h1 id="objc-property-declaration">objc-property-declaration</h1>
+<p>Finds property declarations in Objective-C files that do not follow the pattern of property names in Apple's programming guide. The property name should be in the format of Lower Camel Case.</p>
+<p>For code:</p>
+<pre class="sourceCode objc"><code>@property(nonatomic, assign) int LowerCamelCase;</code></pre>
+<p>The fix will be:</p>
+<pre class="sourceCode objc"><code>@property(nonatomic, assign) int lowerCamelCase;</code></pre>
+<p>The check will only fix 'CamelCase' to 'camelCase'. In some other cases we will only provide warning messages since the property name could be complicated. Users will need to come up with a proper name by their own.</p>
+<p>This check also accepts special acronyms as prefixes or suffixes. Such prefixes or suffixes will suppress the Lower Camel Case check according to the guide: <a href="https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingBasics.html#//apple_ref/doc/uid/20001281-1002931-BBCFHEAB" class="uri">https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingBasics.html#//apple_ref/doc/uid/20001281-1002931-BBCFHEAB</a></p>
+<p>For a full list of well-known acronyms: <a href="https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/APIAbbreviations.html#//apple_ref/doc/uid/20001285-BCIHCGAE" class="uri">https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/APIAbbreviations.html#//apple_ref/doc/uid/20001285-BCIHCGAE</a></p>
+<p>The corresponding style rule: <a href="https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingIvarsAndTypes.html#//apple_ref/doc/uid/20001284-1001757" class="uri">https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingIvarsAndTypes.html#//apple_ref/doc/uid/20001284-1001757</a></p>
+<p>The check will also accept property declared in category with a prefix of lowercase letters followed by a '_' to avoid naming conflict. For example:</p>
+<pre class="sourceCode objc"><code>@property(nonatomic, assign) int abc_lowerCamelCase;</code></pre>
+<p>The corresponding style rule: <a href="https://developer.apple.com/library/content/qa/qa1908/_index.html" class="uri">https://developer.apple.com/library/content/qa/qa1908/_index.html</a></p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>Acronyms</p>
+<p>Semicolon-separated list of custom acronyms that can be used as a prefix or a suffix of property names.</p>
+<p>By default, appends to the list of default acronyms ( <code>IncludeDefaultAcronyms</code> set to <code>1</code>). If <code>IncludeDefaultAcronyms</code> is set to <code>0</code>, instead replaces the default list of acronyms.</p>
+</div>
+<div class="option">
+<p>IncludeDefaultAcronyms</p>
+<p>Integer value (defaults to <code>1</code>) to control whether the default acronyms are included in the list of acronyms.</p>
+<p>If set to <code>1</code>, the value in <code>Acronyms</code> is appended to the default list of acronyms:</p>
+<p><code>[2-9]G;ACL;API;APN;APNS;AR;ARGB;ASCII;AV;BGRA;CA;CDN;CF;CG;CI;CRC;CV;CMYK;DNS;FPS;FTP;GIF;GL;GPS;GUID;HD;HDR;HMAC;HTML;HTTP;HTTPS;HUD;ID;JPG;JS;JSON;LAN;LZW;LTR;MAC;MD;MDNS;MIDI;NS;OS;P2P;PDF;PIN;PNG;POI;PSTN;PTR;QA;QOS;RGB;RGBA;RGBX;RIPEMD;ROM;RPC;RTF;RTL;SC;SDK;SHA;SQL;SSO;TCP;TIFF;TOS;TTS;UI;URI;URL;UUID;VC;VO;VOIP;VPN;VR;W;WAN;X;XML;Y;Z</code>.</p>
+<p>If set to <code>0</code>, the value in <code>Acronyms</code> replaces the default list of acronyms.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc-property-declaration.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>performance-implicit-conversion-in-loop</key>
+  <name>performance-implicit-conversion-in-loop</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - performance-implicit-conversion-in-loop</p>
+</div>
+<h1 id="performance-implicit-conversion-in-loop">performance-implicit-conversion-in-loop</h1>
+<p>This warning appears in a range-based loop with a loop variable of const ref type where the type of the variable does not match the one returned by the iterator. This means that an implicit conversion happens, which can for example result in expensive deep copies.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>map&lt;int, vector&lt;string&gt;&gt; my_map;
+for (const pair&lt;int, vector&lt;string&gt;&gt;&amp; p : my_map) {}
+// The iterator type is in fact pair&lt;const int, vector&lt;string&gt;&gt;, which means
+// that the compiler added a conversion, resulting in a copy of the vectors.</code></pre>
+<p>The easiest solution is usually to use <code>const auto&amp;</code> instead of writing the type manually.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-implicit-conversion-in-loop.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>performance-inefficient-algorithm</key>
+  <name>performance-inefficient-algorithm</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - performance-inefficient-algorithm</p>
+</div>
+<h1 id="performance-inefficient-algorithm">performance-inefficient-algorithm</h1>
+<p>Warns on inefficient use of STL algorithms on associative containers.</p>
+<p>Associative containers implements some of the algorithms as methods which should be preferred to the algorithms in the algorithm header. The methods can take advanatage of the order of the elements.</p>
+<pre class="sourceCode c++"><code>std::set&lt;int&gt; s;
+auto it = std::find(s.begin(), s.end(), 43);
+
+// becomes
+
+auto it = s.find(43);</code></pre>
+<pre class="sourceCode c++"><code>std::set&lt;int&gt; s;
+auto c = std::count(s.begin(), s.end(), 43);
+
+// becomes
+
+auto c = s.count(43);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-inefficient-algorithm.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>performance-inefficient-string-concatenation</key>
+  <name>performance-inefficient-string-concatenation</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - performance-inefficient-string-concatenation</p>
+</div>
+<h1 id="performance-inefficient-string-concatenation">performance-inefficient-string-concatenation</h1>
+<p>This check warns about the performance overhead arising from concatenating strings using the <code>operator+</code>, for instance:</p>
+<pre class="sourceCode c++"><code>std::string a(&quot;Foo&quot;), b(&quot;Bar&quot;);
+a = a + b;</code></pre>
+<p>Instead of this structure you should use <code>operator+=</code> or <code>std::string</code>'s (<code>std::basic_string</code>) class member function <code>append()</code>. For instance:</p>
+<pre class="sourceCode c++"><code>std::string a(&quot;Foo&quot;), b(&quot;Baz&quot;);
+for (int i = 0; i &lt; 20000; ++i) {
+    a = a + &quot;Bar&quot; + b;
+}</code></pre>
+<p>Could be rewritten in a greatly more efficient way like:</p>
+<pre class="sourceCode c++"><code>std::string a(&quot;Foo&quot;), b(&quot;Baz&quot;);
+for (int i = 0; i &lt; 20000; ++i) {
+    a.append(&quot;Bar&quot;).append(b);
+}</code></pre>
+<p>And this can be rewritten too:</p>
+<pre class="sourceCode c++"><code>void f(const std::string&amp;) {}
+std::string a(&quot;Foo&quot;), b(&quot;Baz&quot;);
+void g() {
+    f(a + &quot;Bar&quot; + b);
+}</code></pre>
+<p>In a slightly more efficient way like:</p>
+<pre class="sourceCode c++"><code>void f(const std::string&amp;) {}
+std::string a(&quot;Foo&quot;), b(&quot;Baz&quot;);
+void g() {
+    f(std::string(a).append(&quot;Bar&quot;).append(b));
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>StrictMode</p>
+<p>When zero, the check will only check the string usage in <code>while</code>, <code>for</code> and <code>for-range</code> statements. Default is <span class="title-ref">0</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-inefficient-string-concatenation.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>performance-inefficient-vector-operation</key>
+  <name>performance-inefficient-vector-operation</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - performance-inefficient-vector-operation</p>
+</div>
+<h1 id="performance-inefficient-vector-operation">performance-inefficient-vector-operation</h1>
+<p>Finds possible inefficient <code>std::vector</code> operations (e.g. <code>push_back</code>, <code>emplace_back</code>) that may cause unnecessary memory reallocations.</p>
+<p>Currently, the check only detects following kinds of loops with a single statement body:</p>
+<ul>
+<li>Counter-based for loops start with 0:</li>
+</ul>
+<pre class="sourceCode c++"><code>std::vector&lt;int&gt; v;
+for (int i = 0; i &lt; n; ++i) {
+  v.push_back(n);
+  // This will trigger the warning since the push_back may cause multiple
+  // memory reallocations in v. This can be avoid by inserting a &#39;reserve(n)&#39;
+  // statement before the for statement.
+}</code></pre>
+<ul>
+<li>For-range loops like <code>for (range-declaration : range_expression)</code>, the type of <code>range_expression</code> can be <code>std::vector</code>, <code>std::array</code>, <code>std::deque</code>, <code>std::set</code>, <code>std::unordered_set</code>, <code>std::map</code>, <code>std::unordered_set</code>:</li>
+</ul>
+<pre class="sourceCode c++"><code>std::vector&lt;int&gt; data;
+std::vector&lt;int&gt; v;
+
+for (auto element : data) {
+  v.push_back(element);
+  // This will trigger the warning since the &#39;push_back&#39; may cause multiple
+  // memory reallocations in v. This can be avoid by inserting a
+  // &#39;reserve(data.size())&#39; statement before the for statement.
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>VectorLikeClasses</p>
+<p>Semicolon-separated list of names of vector-like classes. By default only <code>::std::vector</code> is considered.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-inefficient-vector-operation.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>performance-move-const-arg</key>
+  <name>performance-move-const-arg</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - performance-move-const-arg</p>
+</div>
+<h1 id="performance-move-const-arg">performance-move-const-arg</h1>
+<p>The check warns</p>
+<ul>
+<li>if <code>std::move()</code> is called with a constant argument,</li>
+<li>if <code>std::move()</code> is called with an argument of a trivially-copyable type,</li>
+<li>if the result of <code>std::move()</code> is passed as a const reference argument.</li>
+</ul>
+<p>In all three cases, the check will suggest a fix that removes the <code>std::move()</code>.</p>
+<p>Here are examples of each of the three cases:</p>
+<pre class="sourceCode c++"><code>const string s;
+return std::move(s);  // Warning: std::move of the const variable has no effect
+
+int x;
+return std::move(x);  // Warning: std::move of the variable of a trivially-copyable type has no effect
+
+void f(const string &amp;s);
+string s;
+f(std::move(s));  // Warning: passing result of std::move as a const reference argument; no move will actually happen</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>CheckTriviallyCopyableMove</p>
+<p>If non-zero, enables detection of trivially copyable types that do not have a move constructor. Default is non-zero.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-move-const-arg.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>performance-move-constructor-init</key>
+  <name>performance-move-constructor-init</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - performance-move-constructor-init</p>
+</div>
+<h1 id="performance-move-constructor-init">performance-move-constructor-init</h1>
+<p>&quot;cert-oop11-cpp&quot; redirects here as an alias for this check.</p>
+<p>The check flags user-defined move constructors that have a ctor-initializer initializing a member or base class through a copy constructor instead of a move constructor.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IncludeStyle</p>
+<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-move-constructor-init.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>performance-noexcept-move-constructor</key>
+  <name>performance-noexcept-move-constructor</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - performance-noexcept-move-constructor</p>
+</div>
+<h1 id="performance-noexcept-move-constructor">performance-noexcept-move-constructor</h1>
+<p>The check flags user-defined move constructors and assignment operators not marked with <code>noexcept</code> or marked with <code>noexcept(expr)</code> where <code>expr</code> evaluates to <code>false</code> (but is not a <code>false</code> literal itself).</p>
+<p>Move constructors of all the types used with STL containers, for example, need to be declared <code>noexcept</code>. Otherwise STL will choose copy constructors instead. The same is valid for move assignment operations.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-noexcept-move-constructor.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>performance-type-promotion-in-math-fn</key>
+  <name>performance-type-promotion-in-math-fn</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - performance-type-promotion-in-math-fn</p>
+</div>
+<h1 id="performance-type-promotion-in-math-fn">performance-type-promotion-in-math-fn</h1>
+<p>Finds calls to C math library functions (from <code>math.h</code> or, in C++, <code>cmath</code>) with implicit <code>float</code> to <code>double</code> promotions.</p>
+<p>For example, warns on <code>::sin(0.f)</code>, because this funciton's parameter is a double. You probably meant to call <code>std::sin(0.f)</code> (in C++), or <code>sinf(0.f)</code> (in C).</p>
+<pre class="sourceCode c++"><code>float a;
+asin(a);
+
+// becomes
+
+float a;
+std::asin(a);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-type-promotion-in-math-fn.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>portability-simd-intrinsics</key>
+  <name>portability-simd-intrinsics</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - portability-simd-intrinsics</p>
+</div>
+<h1 id="portability-simd-intrinsics">portability-simd-intrinsics</h1>
+<p>Finds SIMD intrinsics calls and suggests <code>std::experimental::simd</code> (<a href="http://wg21.link/p0214">P0214</a>) alternatives.</p>
+<p>If the option <code>Suggest</code> is set to non-zero, for</p>
+<pre class="sourceCode c++"><code>_mm_add_epi32(a, b); // x86
+vec_add(a, b);       // Power</code></pre>
+<p>the check suggests an alternative: <code>operator+</code> on <code>std::experimental::simd</code> objects.</p>
+<p>Otherwise, it just complains the intrinsics are non-portable (and there are <a href="http://wg21.link/p0214">P0214</a> alternatives).</p>
+<p>Many architectures provide SIMD operations (e.g. x86 SSE/AVX, Power AltiVec/VSX, ARM NEON). It is common that SIMD code implementing the same algorithm, is written in multiple target-dispatching pieces to optimize for different architectures or micro-architectures.</p>
+<p>The C++ standard proposal <a href="http://wg21.link/p0214">P0214</a> and its extensions cover many common SIMD operations. By migrating from target-dependent intrinsics to <a href="http://wg21.link/p0214">P0214</a> operations, the SIMD code can be simplified and pieces for different targets can be unified.</p>
+<p>Refer to <a href="http://wg21.link/p0214">P0214</a> for introduction and motivation for the data-parallel standard library.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>Suggest</p>
+<p>If this option is set to non-zero (default is <span class="title-ref">0</span>), the check will suggest <a href="http://wg21.link/p0214">P0214</a> alternatives, otherwise it only points out the intrinsic function is non-portable.</p>
+</div>
+<div class="option">
+<p>Std</p>
+<p>The namespace used to suggest <a href="http://wg21.link/p0214">P0214</a> alternatives. If not specified, <span class="title-ref">std::</span> for <span class="title-ref">-std=c++2a</span> and <span class="title-ref">std::experimental::</span> for <span class="title-ref">-std=c++11</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/portability-simd-intrinsics.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>readability-delete-null-pointer</key>
+  <name>readability-delete-null-pointer</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-delete-null-pointer</p>
+</div>
+<h1 id="readability-delete-null-pointer">readability-delete-null-pointer</h1>
+<p>Checks the <code>if</code> statements where a pointer's existence is checked and then deletes the pointer. The check is unnecessary as deleting a null pointer has no effect.</p>
+<pre class="sourceCode c++"><code>int *p;
+if (p)
+  delete p;</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-delete-null-pointer.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>readability-implicit-bool-conversion</key>
+  <name>readability-implicit-bool-conversion</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-implicit-bool-conversion</p>
+</div>
+<h1 id="readability-implicit-bool-conversion">readability-implicit-bool-conversion</h1>
+<p>This check can be used to find implicit conversions between built-in types and booleans. Depending on use case, it may simply help with readability of the code, or in some cases, point to potential bugs which remain unnoticed due to implicit conversions.</p>
+<p>The following is a real-world example of bug which was hiding behind implicit <code>bool</code> conversion:</p>
+<pre class="sourceCode c++"><code>class Foo {
+  int m_foo;
+
+public:
+  void setFoo(bool foo) { m_foo = foo; } // warning: implicit conversion bool -&gt; int
+  int getFoo() { return m_foo; }
+};
+
+void use(Foo&amp; foo) {
+  bool value = foo.getFoo(); // warning: implicit conversion int -&gt; bool
+}</code></pre>
+<p>This code is the result of unsuccessful refactoring, where type of <code>m_foo</code> changed from <code>bool</code> to <code>int</code>. The programmer forgot to change all occurrences of <code>bool</code>, and the remaining code is no longer correct, yet it still compiles without any visible warnings.</p>
+<p>In addition to issuing warnings, fix-it hints are provided to help solve the reported issues. This can be used for improving readability of code, for example:</p>
+<pre class="sourceCode c++"><code>void conversionsToBool() {
+  float floating;
+  bool boolean = floating;
+  // ^ propose replacement: bool boolean = floating != 0.0f;
+
+  int integer;
+  if (integer) {}
+  // ^ propose replacement: if (integer != 0) {}
+
+  int* pointer;
+  if (!pointer) {}
+  // ^ propose replacement: if (pointer == nullptr) {}
+
+  while (1) {}
+  // ^ propose replacement: while (true) {}
+}
+
+void functionTakingInt(int param);
+
+void conversionsFromBool() {
+  bool boolean;
+  functionTakingInt(boolean);
+  // ^ propose replacement: functionTakingInt(static_cast&lt;int&gt;(boolean));
+
+  functionTakingInt(true);
+  // ^ propose replacement: functionTakingInt(1);
+}</code></pre>
+<p>In general, the following conversion types are checked:</p>
+<ul>
+<li>integer expression/literal to boolean,</li>
+<li>floating expression/literal to boolean,</li>
+<li>pointer/pointer to member/<code>nullptr</code>/<code>NULL</code> to boolean,</li>
+<li>boolean expression/literal to integer,</li>
+<li>boolean expression/literal to floating.</li>
+</ul>
+<p>The rules for generating fix-it hints are:</p>
+<ul>
+<li>in case of conversions from other built-in type to bool, an explicit comparison is proposed to make it clear what exaclty is being compared:
+<ul>
+<li><code>bool boolean = floating;</code> is changed to <code>bool boolean = floating == 0.0f;</code>,</li>
+<li>for other types, appropriate literals are used (<code>0</code>, <code>0u</code>, <code>0.0f</code>, <code>0.0</code>, <code>nullptr</code>),</li>
+</ul></li>
+<li>in case of negated expressions conversion to bool, the proposed replacement with comparison is simplified:
+<ul>
+<li><code>if (!pointer)</code> is changed to <code>if (pointer == nullptr)</code>,</li>
+</ul></li>
+<li>in case of conversions from bool to other built-in types, an explicit <code>static_cast</code> is proposed to make it clear that a conversion is taking place:
+<ul>
+<li><code>int integer = boolean;</code> is changed to <code>int integer = static_cast&lt;int&gt;(boolean);</code>,</li>
+</ul></li>
+<li>if the conversion is performed on type literals, an equivalent literal is proposed, according to what type is actually expected, for example:
+<ul>
+<li><code>functionTakingBool(0);</code> is changed to <code>functionTakingBool(false);</code>,</li>
+<li><code>functionTakingInt(true);</code> is changed to <code>functionTakingInt(1);</code>,</li>
+<li>for other types, appropriate literals are used (<code>false</code>, <code>true</code>, <code>0</code>, <code>1</code>, <code>0u</code>, <code>1u</code>, <code>0.0f</code>, <code>1.0f</code>, <code>0.0</code>, <code>1.0f</code>).</li>
+</ul></li>
+</ul>
+<p>Some additional accommodations are made for pre-C++11 dialects:</p>
+<ul>
+<li><code>false</code> literal conversion to pointer is detected,</li>
+<li>instead of <code>nullptr</code> literal, <code>0</code> is proposed as replacement.</li>
+</ul>
+<p>Occurrences of implicit conversions inside macros and template instantiations are deliberately ignored, as it is not clear how to deal with such cases.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>AllowIntegerConditions</p>
+<p>When non-zero, the check will allow conditional integer conversions. Default is <span class="title-ref">0</span>.</p>
+</div>
+<div class="option">
+<p>AllowPointerConditions</p>
+<p>When non-zero, the check will allow conditional pointer conversions. Default is <span class="title-ref">0</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-implicit-bool-conversion.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>readability-magic-numbers</key>
+  <name>readability-magic-numbers</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-magic-numbers</p>
+</div>
+<h1 id="readability-magic-numbers">readability-magic-numbers</h1>
+<p>Detects magic numbers, integer or floating point literals that are embedded in code and not introduced via constants or symbols.</p>
+<p>Many coding guidelines advise replacing the magic values with symbolic constants to improve readability. Here are a few references:</p>
+<blockquote>
+<ul>
+<li><a href="http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-magic">Rule ES.45: Avoid “magic constants”; use symbolic constants in C++ Core Guidelines</a></li>
+<li><a href="http://www.codingstandard.com/rule/5-1-1-use-symbolic-names-instead-of-literal-values-in-code/">Rule 5.1.1 Use symbolic names instead of literal values in code in High Integrity C++</a></li>
+<li>Item 17 in &quot;C++ Coding Standards: 101 Rules, Guidelines and Best Practices&quot; by Herb Sutter and Andrei Alexandrescu</li>
+<li>Chapter 17 in &quot;Clean Code - A handbook of agile software craftsmanship.&quot; by Robert C. Martin</li>
+<li>Rule 20701 in &quot;TRAIN REAL TIME DATA PROTOCOL Coding Rules&quot; by Armin-Hagen Weiss, Bombardier</li>
+<li><a href="http://wiki.c2.com/?MagicNumber" class="uri">http://wiki.c2.com/?MagicNumber</a></li>
+</ul>
+</blockquote>
+<p>Examples of magic values:</p>
+<pre class="sourceCode c++"><code>double circleArea = 3.1415926535 * radius * radius;
+
+double totalCharge = 1.08 * itemPrice;
+
+int getAnswer() {
+   return -3; // FILENOTFOUND
+}
+
+for (int mm = 1; mm &lt;= 12; ++mm) {
+   std::cout &lt;&lt; month[mm] &lt;&lt; &#39;\n&#39;;
+}</code></pre>
+<p>Example with magic values refactored:</p>
+<pre class="sourceCode c++"><code>double circleArea = M_PI * radius * radius;
+
+const double TAX_RATE = 0.08;  // or make it variable and read from a file
+
+double totalCharge = (1.0 + TAX_RATE) * itemPrice;
+
+int getAnswer() {
+   return E_FILE_NOT_FOUND;
+}
+
+for (int mm = 1; mm &lt;= MONTHS_IN_A_YEAR; ++mm) {
+   std::cout &lt;&lt; month[mm] &lt;&lt; &#39;\n&#39;;
+}</code></pre>
+<p>For integral literals by default only <span class="title-ref">0</span> and <span class="title-ref">1</span> (and <span class="title-ref">-1</span>) integer values are accepted without a warning. This can be overridden with the <code class="interpreted-text" data-role="option">IgnoredIntegerValues</code> option. Negative values are accepted if their absolute value is present in the <code class="interpreted-text" data-role="option">IgnoredIntegerValues</code> list.</p>
+<p>As a special case for integral values, all powers of two can be accepted without warning by enabling the <code class="interpreted-text" data-role="option">IgnorePowersOf2IntegerValues</code> option.</p>
+<p>For floating point literals by default the <span class="title-ref">0.0</span> floating point value is accepted without a warning. The set of ignored floating point literals can be configured using the <code class="interpreted-text" data-role="option">IgnoredFloatingPointValues</code> option. For each value in that set, the given string value is converted to a floating-point value representation used by the target architecture. If a floating-point literal value compares equal to one of the converted values, then that literal is not diagnosed by this check. Because floating-point equality is used to determine whether to diagnose or not, the user needs to be aware of the details of floating-point representations for any values that cannot be precisely represented for their target architecture.</p>
+<p>For each value in the <code class="interpreted-text" data-role="option">IgnoredFloatingPointValues</code> set, both the single-precision form and double-precision form are accepted (for example, if 3.14 is in the set, neither 3.14f nor 3.14 will produce a warning).</p>
+<p>Scientific notation is supported for both source code input and option. Alternatively, the check for the floating point numbers can be disabled for all floating point values by enabling the <code class="interpreted-text" data-role="option">IgnoreAllFloatingPointValues</code> option.</p>
+<p>Since values <span class="title-ref">0</span> and <span class="title-ref">0.0</span> are so common as the base counter of loops, or initialization values for sums, they are always accepted without warning, even if not present in the respective ignored values list.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoredIntegerValues</p>
+<p>Semicolon-separated list of magic positive integers that will be accepted without a warning. Default values are <span class="title-ref">{1, 2, 3, 4}</span>, and <span class="title-ref">0</span> is accepted unconditionally.</p>
+</div>
+<div class="option">
+<p>IgnorePowersOf2IntegerValues</p>
+<p>Boolean value indicating whether to accept all powers-of-two integer values without warning. Default value is <span class="title-ref">false</span>.</p>
+</div>
+<div class="option">
+<p>IgnoredFloatingPointValues</p>
+<p>Semicolon-separated list of magic positive floating point values that will be accepted without a warning. Default values are <span class="title-ref">{1.0, 100.0}</span> and <span class="title-ref">0.0</span> is accepted unconditionally.</p>
+</div>
+<div class="option">
+<p>IgnoreAllFloatingPointValues</p>
+<p>Boolean value indicating whether to accept all floating point values without warning. Default value is <span class="title-ref">false</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-magic-numbers.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>readability-misleading-indentation</key>
+  <name>readability-misleading-indentation</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-misleading-indentation</p>
+</div>
+<h1 id="readability-misleading-indentation">readability-misleading-indentation</h1>
+<p>Correct indentation helps to understand code. Mismatch of the syntactical structure and the indentation of the code may hide serious problems. Missing braces can also make it significantly harder to read the code, therefore it is important to use braces.</p>
+<p>The way to avoid dangling else is to always check that an <code>else</code> belongs to the <code>if</code> that begins in the same column.</p>
+<p>You can omit braces when your inner part of e.g. an <code>if</code> statement has only one statement in it. Although in that case you should begin the next statement in the same column with the <code>if</code>.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>// Dangling else:
+if (cond1)
+  if (cond2)
+    foo1();
+else
+  foo2();  // Wrong indentation: else belongs to if(cond2) statement.
+
+// Missing braces:
+if (cond1)
+  foo1();
+  foo2();  // Not guarded by if(cond1).</code></pre>
+<h2 id="limitations">Limitations</h2>
+<p>Note that this check only works as expected when the tabs or spaces are used consistently and not mixed.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-misleading-indentation.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>readability-misplaced-array-index</key>
+  <name>readability-misplaced-array-index</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-misplaced-array-index</p>
+</div>
+<h1 id="readability-misplaced-array-index">readability-misplaced-array-index</h1>
+<p>This check warns for unusual array index syntax.</p>
+<p>The following code has unusual array index syntax:</p>
+<pre class="sourceCode c++"><code>void f(int *X, int Y) {
+  Y[X] = 0;
+}</code></pre>
+<p>becomes</p>
+<pre class="sourceCode c++"><code>void f(int *X, int Y) {
+  X[Y] = 0;
+}</code></pre>
+<dl>
+<dt>The check warns about such unusual syntax for readability reasons:</dt>
+<dd><ul>
+<li>There are programmers that are not familiar with this unusual syntax.</li>
+<li>It is possible that variables are mixed up.</li>
+</ul>
+</dd>
+</dl>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-misplaced-array-index.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>readability-non-const-parameter</key>
+  <name>readability-non-const-parameter</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-non-const-parameter</p>
+</div>
+<h1 id="readability-non-const-parameter">readability-non-const-parameter</h1>
+<p>The check finds function parameters of a pointer type that could be changed to point to a constant type instead.</p>
+<p>When <code>const</code> is used properly, many mistakes can be avoided. Advantages when using <code>const</code> properly:</p>
+<ul>
+<li>prevent unintentional modification of data;</li>
+<li>get additional warnings such as using uninitialized data;</li>
+<li>make it easier for developers to see possible side effects.</li>
+</ul>
+<p>This check is not strict about constness, it only warns when the constness will make the function interface safer.</p>
+<pre class="sourceCode c++"><code>// warning here; the declaration &quot;const char *p&quot; would make the function
+// interface safer.
+char f1(char *p) {
+  return *p;
+}
+
+// no warning; the declaration could be more const &quot;const int * const p&quot; but
+// that does not make the function interface safer.
+int f2(const int *p) {
+  return *p;
+}
+
+// no warning; making x const does not make the function interface safer
+int f3(int x) {
+  return x;
+}
+
+// no warning; Technically, *p can be const (&quot;const struct S *p&quot;). But making
+// *p const could be misleading. People might think that it&#39;s safe to pass
+// const data to this function.
+struct S { int *a; int *b; };
+int f3(struct S *p) {
+  *(p-&gt;a) = 0;
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-non-const-parameter.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>readability-redundant-declaration</key>
+  <name>readability-redundant-declaration</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-redundant-declaration</p>
+</div>
+<h1 id="readability-redundant-declaration">readability-redundant-declaration</h1>
+<p>Finds redundant variable and function declarations.</p>
+<pre class="sourceCode c++"><code>extern int X;
+extern int X;</code></pre>
+<p>becomes</p>
+<pre class="sourceCode c++"><code>extern int X;</code></pre>
+<p>Such redundant declarations can be removed without changing program behaviour. They can for instance be unintentional left overs from previous refactorings when code has been moved around. Having redundant declarations could in worst case mean that there are typos in the code that cause bugs.</p>
+<p>Normally the code can be automatically fixed, <code class="interpreted-text" data-role="program">clang-tidy</code> can remove the second declaration. However there are 2 cases when you need to fix the code manually:</p>
+<ul>
+<li>When the declarations are in different header files;</li>
+<li>When multiple variables are declared together.</li>
+</ul>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>If set to non-zero, the check will not give warnings inside macros. Default is <span class="title-ref">1</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-declaration.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>readability-redundant-function-ptr-dereference</key>
+  <name>readability-redundant-function-ptr-dereference</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-redundant-function-ptr-dereference</p>
+</div>
+<h1 id="readability-redundant-function-ptr-dereference">readability-redundant-function-ptr-dereference</h1>
+<p>Finds redundant dereferences of a function pointer.</p>
+<p>Before:</p>
+<pre class="sourceCode c++"><code>int f(int,int);
+int (*p)(int, int) = &amp;f;
+
+int i = (**p)(10, 50);</code></pre>
+<p>After:</p>
+<pre class="sourceCode c++"><code>int f(int,int);
+int (*p)(int, int) = &amp;f;
+
+int i = (*p)(10, 50);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-function-ptr-dereference.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>readability-redundant-member-init</key>
+  <name>readability-redundant-member-init</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-redundant-member-init</p>
+</div>
+<h1 id="readability-redundant-member-init">readability-redundant-member-init</h1>
+<p>Finds member initializations that are unnecessary because the same default constructor would be called if they were not present.</p>
+<p>Example:</p>
+<pre class="sourceCode c++"><code>// Explicitly initializing the member s is unnecessary.
+class Foo {
+public:
+  Foo() : s() {}
+
+private:
+  std::string s;
+};</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-member-init.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>readability-simplify-subscript-expr</key>
+  <name>readability-simplify-subscript-expr</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-simplify-subscript-expr</p>
+</div>
+<h1 id="readability-simplify-subscript-expr">readability-simplify-subscript-expr</h1>
+<p>This check simplifies subscript expressions. Currently this covers calling <code>.data()</code> and immediately doing an array subscript operation to obtain a single element, in which case simply calling <code>operator[]</code> suffice.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>std::string s = ...;
+char c = s.data()[i];  // char c = s[i];</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>Types</p>
+<p>The list of type(s) that triggers this check. Default is <span class="title-ref">::std::basic_string;::std::basic_string_view;::std::vector;::std::array</span></p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-simplify-subscript-expr.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>readability-static-accessed-through-instance</key>
+  <name>readability-static-accessed-through-instance</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-static-accessed-through-instance</p>
+</div>
+<h1 id="readability-static-accessed-through-instance">readability-static-accessed-through-instance</h1>
+<p>Checks for member expressions that access static members through instances, and replaces them with uses of the appropriate qualified-id.</p>
+<p>Example:</p>
+<p>The following code:</p>
+<pre class="sourceCode c++"><code>struct C {
+  static void foo();
+  static int x;
+};
+
+C *c1 = new C();
+c1-&gt;foo();
+c1-&gt;x;</code></pre>
+<p>is changed to:</p>
+<pre class="sourceCode c++"><code>C *c1 = new C();
+C::foo();
+C::x;</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-static-accessed-through-instance.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>readability-string-compare</key>
+  <name>readability-string-compare</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-string-compare</p>
+</div>
+<h1 id="readability-string-compare">readability-string-compare</h1>
+<p>Finds string comparisons using the compare method.</p>
+<p>A common mistake is to use the string's <code>compare</code> method instead of using the equality or inequality operators. The compare method is intended for sorting functions and thus returns a negative number, a positive number or zero depending on the lexicographical relationship between the strings compared. If an equality or inequality check can suffice, that is recommended. This is recommended to avoid the risk of incorrect interpretation of the return value and to simplify the code. The string equality and inequality operators can also be faster than the <code>compare</code> method due to early termination.</p>
+<p>Examples:</p>
+<pre class="sourceCode c++"><code>std::string str1{&quot;a&quot;};
+std::string str2{&quot;b&quot;};
+
+// use str1 != str2 instead.
+if (str1.compare(str2)) {
+}
+
+// use str1 == str2 instead.
+if (!str1.compare(str2)) {
+}
+
+// use str1 == str2 instead.
+if (str1.compare(str2) == 0) {
+}
+
+// use str1 != str2 instead.
+if (str1.compare(str2) != 0) {
+}
+
+// use str1 == str2 instead.
+if (0 == str1.compare(str2)) {
+}
+
+// use str1 != str2 instead.
+if (0 != str1.compare(str2)) {
+}
+
+// Use str1 == &quot;foo&quot; instead.
+if (str1.compare(&quot;foo&quot;) == 0) {
+}</code></pre>
+<p>The above code examples shows the list of if-statements that this check will give a warning for. All of them uses <code>compare</code> to check if equality or inequality of two strings instead of using the correct operators.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-string-compare.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>zircon-temporary-objects</key>
+  <name>zircon-temporary-objects</name>
+  <description><![CDATA[
+      <div class="title">
+<p>clang-tidy - zircon-temporary-objects</p>
+</div>
+<h1 id="zircon-temporary-objects">zircon-temporary-objects</h1>
+<p>Warns on construction of specific temporary objects in the Zircon kernel. If the object should be flagged, If the object should be flagged, the fully qualified type name must be explicitly passed to the check.</p>
+<p>For example, given the list of classes &quot;Foo&quot; and &quot;NS::Bar&quot;, all of the following will trigger the warning:</p>
+<pre class="sourceCode c++"><code>Foo();
+Foo F = Foo();
+func(Foo());
+
+namespace NS {
+
+Bar();
+
+}</code></pre>
+<p>With the same list, the following will not trigger the warning:</p>
+<pre class="sourceCode c++"><code>Foo F;                         // Non-temporary construction okay
+Foo F(param);              // Non-temporary construction okay
+Foo *F = new Foo();      // New construction okay
+
+Bar();                         // Not NS::Bar, so okay
+NS::Bar B;                   // Non-temporary construction okay</code></pre>
+<p>Note that objects must be explicitly specified in order to be flagged, and so objects that inherit a specified object will not be flagged.</p>
+<p>This check matches temporary objects without regard for inheritance and so a prohibited base class type does not similarly prohibit derived class types.</p>
+<pre class="sourceCode c++"><code>class Derived : Foo {} // Derived is not explicitly disallowed
+Derived();             // and so temporary construction is okay</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>Names</p>
+<p>A semi-colon-separated list of fully-qualified names of C++ classes that should not be constructed as temporaries. Default is empty.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/zircon-temporary-objects.html" target="_blank">clang.llvm.org</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
 </rules>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
@@ -41,6 +41,6 @@ public class CxxClangTidyRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxClangTidyRuleRepository.getRepositoryKey(language));
-    assertEquals(155, repo.rules().size());
+    assertEquals(311, repo.rules().size());
   }
 }

--- a/cxx-sensors/src/tools/check_rules.sh
+++ b/cxx-sensors/src/tools/check_rules.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# use cppcheck_createrules.py in order to check the validity of created rules
+# use utils_createrules.py in order to check the validity of created rules
 #
 # currently available checks:
 #
@@ -27,7 +27,7 @@ do
    BASE_NAME="$(basename $ABS_PATH_TO_RULE)"
    REPORT_PATH="${PWD}/${BASE_NAME}.tidy"
    declare -i RC=0
-   $(python ${SCRIPT_DIR}/cppcheck_createrules.py check ${ABS_PATH_TO_RULE} > ${REPORT_PATH})
+   $(python ${SCRIPT_DIR}/utils_createrules.py check ${ABS_PATH_TO_RULE} > ${REPORT_PATH})
    RC=$?
    if [[ ${RC} -ne 0 ]]
    then

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -1,0 +1,105 @@
+# Sonar C++ Plugin (Community)
+# Copyright (C) 2010-2018 SonarOpenCommunity
+# http://github.com/SonarOpenCommunity/sonar-cxx
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import sys
+import os
+import subprocess
+
+from utils_createrules import CDATA
+from utils_createrules import write_rules_xml
+from utils_createrules import get_cdata_capable_xml_etree
+
+et = get_cdata_capable_xml_etree()
+
+
+def rstfile_to_description(path, filename):
+    html = subprocess.check_output(
+        ['pandoc', path, '--no-highlight', '-f', 'rst', '-t', 'html5'])
+    footer = """<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/%s.html" target="_blank">clang.llvm.org</a></p>""" % (filename)
+
+    return html + footer
+
+
+def rstfile_to_rule(path):
+    rule = et.Element('rule')
+
+    filename_with_extension = os.path.basename(path)
+    filename = os.path.splitext(filename_with_extension)[0]
+
+    key = filename
+    name = filename
+    description = rstfile_to_description(path, filename)
+
+    default_issue_type = "CODE_SMELL"
+    default_issue_severity = "MAJOR"
+
+    et.SubElement(rule, 'key').text = key
+    et.SubElement(rule, 'name').text = name
+
+    cdata = CDATA(description)
+    et.SubElement(rule, 'description').append(cdata)
+    et.SubElement(rule, 'severity').text = default_issue_severity
+    et.SubElement(rule, 'type').text = default_issue_type
+
+    return rule
+
+
+def rstfiles_to_rules_xml(directory):
+    rules = et.Element('rules')
+    for subdir, _, files in os.walk(directory):
+        for f in files:
+            ext = os.path.splitext(f)[-1].lower()
+            if ext == ".rst" and f != "list.rst":
+                rst_file_path = os.path.join(subdir, f)
+                rules.append(rstfile_to_rule(rst_file_path))
+    write_rules_xml(rules, sys.stdout)
+
+# 0. install pandoc
+# see https://pandoc.org/
+#
+# 1. download clang-tidy source code:
+# cd /tmp
+# svn co http://llvm.org/svn/llvm-project/clang-tools-extra/trunk
+# cd -
+#
+# 2. generate the new version of the rules file
+# python clangtidy_createrules.py rules /tmp/trunk/docs/clang-tidy/checks > clangtidy_new.xml
+#
+# 3. compare the new version with the old one
+# python utils_createrules.py comparerules clangtidy_new.xml clangtidy.xml
+# meld clangtidy.xml clangtidy_new.xml.comparable
+
+
+def print_usage_and_exit():
+    script_name = os.path.basename(sys.argv[0])
+    print """Usage: %s rules <path to clang-tidy source directory with RST files>
+       see generate_cppcheck_resources.sh for more details""" % (script_name)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+
+    if len(sys.argv) < 2:
+        print_usage_and_exit()
+
+    # transform to an other elementtree
+    if sys.argv[1] == "rules":
+        rstfiles_to_rules_xml(sys.argv[2])
+    else:
+        print_usage_and_exit()

--- a/cxx-sensors/src/tools/cppcheck_createrules.py
+++ b/cxx-sensors/src/tools/cppcheck_createrules.py
@@ -1,35 +1,30 @@
-# Sonar Python Plugin
-# Copyright (C) 2011 Waleri Enns
-# Author(s) : Waleri Enns
-# waleri.enns@gmail.com
-
+# Sonar C++ Plugin (Community)
+# Copyright (C) 2010-2018 SonarOpenCommunity
+# http://github.com/SonarOpenCommunity/sonar-cxx
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public
-# License along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
-
-
 #
-# Reads cppcheck --errostlist from the stdin and writes XML to the stdout.
-# The latter is compatible with sonar rules.xml-schema.
-#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import sys
 import os
-import subprocess
-import xml.etree.ElementTree as et
 import textwrap
 
-severity_2_sonarqube = {
+from utils_createrules import CDATA
+from utils_createrules import write_rules_xml
+from utils_createrules import get_cdata_capable_xml_etree
+
+SEVERITY_TO_SONARQUBE = {
     "error": {"type": "BUG", "priority": "MAJOR"},
     "warning": {"type": "BUG", "priority": "MINOR"},
     "portability": {"type": "BUG", "priority": "MINOR"},
@@ -39,61 +34,21 @@ severity_2_sonarqube = {
 }
 
 CWE_MAP = None
-
-# xml prettifyer
-#
+et = get_cdata_capable_xml_etree()
 
 
-def indent(elem, level=0):
-    i = "\n" + level * "  "
-    if len(elem):
-        if not elem.text or not elem.text.strip():
-            elem.text = i + "  "
-        if not elem.tail or not elem.tail.strip():
-            elem.tail = i
-        for elem in elem:
-            indent(elem, level + 1)
-        if not elem.tail or not elem.tail.strip():
-            elem.tail = i
-    else:
-        if level and (not elem.tail or not elem.tail.strip()):
-            elem.tail = i
-
-# see https://stackoverflow.com/questions/174890/how-to-output-cdata-using-elementtree
-
-
-def CDATA(text=None):
-    element = et.Element('![CDATA[')
-    element.text = text
-    return element
-
-et._original_serialize_xml = et._serialize_xml
-
-
-def _serialize_xml(write, elem, encoding, qnames, namespaces):
-    if elem.tag == '![CDATA[':
-        write("<%s%s]]>%s" % (elem.tag, elem.text, "" if elem.tail is None else elem.tail))
-    else:
-        et._original_serialize_xml(write, elem, encoding, qnames, namespaces)
-
-et._serialize_xml = et._serialize['xml'] = _serialize_xml
-
-
-def header():
-    return '<?xml version="1.0" encoding="UTF-8"?>\n'
-
-
-def message_with_CWE_reference(msg, cwe_nr):
+def message_with_cwe_reference(msg, cwe_nr):
     cwe_msg = CWE_MAP.get(str(cwe_nr), None)
     if cwe_msg is None:
         sys.stderr.write('CWE ID ' + cwe_nr + ' was not found!\n')
-    href_text = "CWE-{}".format(cwe_nr) if cwe_msg is None else "CWE-{}: {}".format(cwe_nr, cwe_msg)
-    msgWrapped = textwrap.fill(msg)
+    href_text = "CWE-{}".format(
+        cwe_nr) if cwe_msg is None else "CWE-{}: {}".format(cwe_nr, cwe_msg)
+    msg_wrapped = textwrap.fill(msg)
     return """<p>
 {}
 </p>
 <h2>References</h2>
-<p><a href="https://cwe.mitre.org/data/definitions/{}.html" target="_blank">{}</a></p>""".format(msgWrapped.replace("\\012", "\n"), cwe_nr, href_text)
+<p><a href="https://cwe.mitre.org/data/definitions/{}.html" target="_blank">{}</a></p>""".format(msg_wrapped.replace("\\012", "\n"), cwe_nr, href_text)
 
 
 def error_to_rule(error):
@@ -104,11 +59,12 @@ def error_to_rule(error):
     errDetails = error.attrib["verbose"]
     errSeverity = error.attrib["severity"]
 
-    sonarQubeIssueType = severity_2_sonarqube[errSeverity]["type"]
-    sonarQubeIssueSeverity = severity_2_sonarqube[errSeverity]["priority"]
+    sonarQubeIssueType = SEVERITY_TO_SONARQUBE[errSeverity]["type"]
+    sonarQubeIssueSeverity = SEVERITY_TO_SONARQUBE[errSeverity]["priority"]
 
     et.SubElement(rule, 'key').text = errId
-    et.SubElement(rule, 'name').text = errMsg if not errMsg.endswith(".") else errMsg[:-1]
+    et.SubElement(rule, 'name').text = errMsg if not errMsg.endswith(
+        ".") else errMsg[:-1]
 
     cweNr = None
 
@@ -120,7 +76,7 @@ def error_to_rule(error):
         cweNr = 477
 
     if cweNr is not None:
-        errDetails = message_with_CWE_reference(errDetails, cweNr)
+        errDetails = message_with_cwe_reference(errDetails, cweNr)
 
     # encode description tag always as CDATA
     cdata = CDATA(errDetails)
@@ -140,46 +96,20 @@ def error_to_rule(error):
     return rule
 
 
-def error_to_rule_in_profile(error):
-    rule = et.Element('rule')
-
-    errId = error.attrib["id"]
-    errSeverity = error.attrib["severity"]
-    et.SubElement(rule, 'repositoryKey').text = "cppcheck"
-    et.SubElement(rule, 'key').text = errId
-    et.SubElement(rule, 'priority').text = severity_2_sonarqube[errSeverity]["priority"]
-
-    return rule
-
-
-def createRules(errors, converter):
+def create_cppcheck_rules(cppcheck_errors):
     rules = et.Element('rules')
-    for error in errors:
-        rules.append(converter(error))
+    for cppcheck_error in cppcheck_errors:
+        rules.append(error_to_rule(cppcheck_error))
     return rules
 
 
-def parseRules(path):
-    tree = et.parse(path)
-    root = tree.getroot()
-    keys = []
-    keys_to_ruleelement = {}
-
-    for rules_tag in root.iter('rules'):
-        for rule_tag in rules_tag.iter('rule'):
-            for key_tag in rule_tag.iter('key'):
-                keys.append(key_tag.text)
-                keys_to_ruleelement[key_tag.text] = rule_tag
-    return keys, keys_to_ruleelement
-
-
-def loadCWE(path):
+def load_cwe(path):
     id_to_name = {}
 
     tree = et.parse(path)
-    root = tree.getroot()
+    cwe_root = tree.getroot()
     ns0 = '{http://cwe.mitre.org/cwe-6}'
-    for catalog_tag in root.iter(ns0 + 'Weakness_Catalog'):
+    for catalog_tag in cwe_root.iter(ns0 + 'Weakness_Catalog'):
         for weaknesses_tag in catalog_tag.iter(ns0 + 'Weaknesses'):
             for weakness_tag in weaknesses_tag.iter(ns0 + 'Weakness'):
                 id_attr = weakness_tag.attrib["ID"]
@@ -195,192 +125,32 @@ def loadCWE(path):
     return id_to_name
 
 
-def makeDescriptionToCDATA(rule_t):
-    """after parsing we lost the CDATA information
-       restore it for <description> tag, assume it always encoded as CDATA"""
-    for description_tag in rule_t.iter('description'):
-        desc = description_tag.text
-        description_tag.text = ""
-        description_tag.append(CDATA(desc))
+def print_usage_and_exit():
+    script_name = os.path.basename(sys.argv[0])
+    print """Usage: %s rules <cwec_vN.N.xml> < cppcheck --errorlist --xml-version=2 --library=<lib0.cfg> --library=<lib1.cfg>
+       see generate_cppcheck_resources.sh for more details""" % (script_name)
+    sys.exit(1)
 
 
-def call_xmllint(file_path):
-    command = ["xmllint", file_path]
-    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = p.communicate()
-    if p.returncode != 0:
-        print "### XMLLINT", file_path
-        print "### ERR"
-        print err
-        print "### OUT"
-        print out
-        print "\n"
-        return True
-    return False
-
-
-def call_tidy(file_path):
-    command = ["tidy", file_path]
-    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = p.communicate()
-    if p.returncode != 0:
-        print "### TIDY ", file_path
-        print "### ERR"
-        print err
-        print "### SUGGESTION FOR FIXING"
-        print out
-        print "\n"
-        return True
-    return False
-
-
-def checkRules(path):
-    print "### CHECK ", path
-    has_xmllint_errors = call_xmllint(path)
-    if has_xmllint_errors:
-        return 1
-
-    has_tidy_errors = False
-    keys, keys_mapping = parseRules(path)
-    for key in keys:
-        for rule_tag in keys_mapping[key].iter('rule'):
-            for description_tag in rule_tag.iter('description'):
-                description_dump_path = "/tmp/" + key + ".ruledump"
-                with open(description_dump_path, "w") as f:
-                    html_start = u"""<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset=\"utf-8\">
-    <title>Rule Description</title>
-  </head>
-  <body>
-"""
-                    html_stop = u"""
-  </body>
-</html>"""
-
-                    f.write(html_start)
-                    f.write(description_tag.text.encode("UTF-8"))
-                    f.write(html_stop)
-                is_tidy_error = call_tidy(description_dump_path)
-                has_tidy_errors = has_tidy_errors or is_tidy_error
-
-    if has_tidy_errors:
-        return 2
-
-    print "no errors found"
-    return 0
-
-
-def compareRules(old_path, new_path):
-    old_keys, _ = parseRules(old_path)
-    new_keys, new_keys_mapping = parseRules(new_path)
-    old_keys_set = set(old_keys)
-    new_keys_set = set(new_keys)
-    print "# OLD RULE SET vs NEW RULE SET\n"
-
-    print "## OLD RULE SET\n"
-    print "nr of xml entries: ", len(old_keys), "\n"
-    print "nr of unique rules: ", len(old_keys_set), "\n"
-    print "rules which are only in the old rule set:"
-    only_in_old = old_keys_set.difference(new_keys_set)
-    for key in sorted(only_in_old):
-        print "*", key
-    print ""
-
-    print "## NEW RULE SET\n"
-    print "nr of xml entries: ", len(new_keys), "\n"
-    print "nr of unique rules: ", len(new_keys_set), "\n"
-    print "rules which are only in the new rule set:"
-    only_in_new = new_keys_set.difference(old_keys_set)
-    for key in sorted(only_in_new):
-        print "*", key
-    print ""
-
-    print "## COMMON RULES\n"
-    common_keys = old_keys_set.intersection(new_keys_set)
-    print "nr of rules: ", len(common_keys), "\n"
-    for key in sorted(common_keys):
-        print "*", key
-    print ""
-
-    print "### NEW RULES WHICH MUST BE ADDED\n"
-    print "```XML"
-    for key in sorted(only_in_new):
-        rule_tag = new_keys_mapping[key]
-        indent(rule_tag)
-        makeDescriptionToCDATA(rule_tag)
-        et.ElementTree(rule_tag).write(sys.stdout)
-    print "```\n"
-
-    # create a rule xml from the new rules, where rules are stored in the same
-    # order as in the old rule file. this will make xml files comparable by diff/meld etc.
-    comparable_rules = et.Element('rules')
-    for common_key in old_keys:
-        if common_key in new_keys_mapping:
-            rule_tag = new_keys_mapping[common_key]
-            makeDescriptionToCDATA(rule_tag)
-            comparable_rules.append(rule_tag)
-    for only_new_key in sorted(only_in_new):
-        rule_tag = new_keys_mapping[only_new_key]
-        makeDescriptionToCDATA(rule_tag)
-        comparable_rules.append(rule_tag)
-
-    with open(new_path + ".comparable", 'w') as f:
-        writeXML(comparable_rules, f)
-
-    print """### DIFF EXISTRING vs GENERATED"""
-    print "run\n\n"
-    print "```bash"
-    print "<your favorite diff>", os.path.abspath(old_path), os.path.abspath(new_path) + ".comparable # e.g."
-    print "meld", os.path.abspath(old_path), os.path.abspath(new_path) + ".comparable"
-    print "```\n"
-
-
-def usage():
-    return """Usage: %s <"rules"|"profile"> < cppcheck --errorlist
-       %s comparerules old_cppcheck.xml new_cppcheck.xml
-           """ % (sys.argv[0], sys.argv[0])
-
-
-def parseCppcheckErrorlist(f):
+def parse_cppcheck_errorlist(f):
     tree = et.parse(f)
-    root = tree.getroot()
-    errors = []
-    for errors_tag in root.iter('errors'):
+    cppcheck_root = tree.getroot()
+    cppcheck_errors = []
+    for errors_tag in cppcheck_root.iter('errors'):
         for error_tag in errors_tag.iter('error'):
-            errors.append(error_tag)
-    return errors
+            cppcheck_errors.append(error_tag)
+    return cppcheck_errors
 
+if __name__ == "__main__":
 
-def writeXML(root, f):
-    indent(root)
-    f.write(header())
-    et.ElementTree(root).write(f)
+    if len(sys.argv) < 3:
+        print_usage_and_exit()
 
-if len(sys.argv) < 2:
-    print usage()
-    exit()
-
-# transform to an other elementtree
-if sys.argv[1] == "rules":
-    errors = parseCppcheckErrorlist(sys.stdin)
-    CWE_MAP = loadCWE(sys.argv[2])
-    root = createRules(errors, error_to_rule)
-    writeXML(root, sys.stdout)
-elif sys.argv[1] == "profile":
-    errors = parseCppcheckErrorlist(sys.stdin)
-    rules = createRules(errors, error_to_rule_in_profile)
-    root = et.Element('profile')
-    et.SubElement(root, 'name').text = "Default C++ Profile"
-    et.SubElement(root, 'language').text = "c++"
-    root.append(rules)
-    writeXML(root, sys.stdout)
-elif sys.argv[1] == "comparerules" and len(sys.argv) == 4:
-    compareRules(sys.argv[2], sys.argv[3])
-elif sys.argv[1] == "check" and len(sys.argv) == 3:
-    rc = checkRules(sys.argv[2])
-    sys.exit(rc)
-else:
-    print usage()
-    exit()
+    # transform to an other elementtree
+    if sys.argv[1] == "rules":
+        errors = parse_cppcheck_errorlist(sys.stdin)
+        CWE_MAP = load_cwe(sys.argv[2])
+        root = create_cppcheck_rules(errors)
+        write_rules_xml(root, sys.stdout)
+    else:
+        print_usage_and_exit()

--- a/cxx-sensors/src/tools/generate_cppcheck_resources.sh
+++ b/cxx-sensors/src/tools/generate_cppcheck_resources.sh
@@ -19,5 +19,4 @@ wget https://cwe.mitre.org/data/xml/cwec_v3.1.xml.zip --output-document=cwec_v3.
 
 cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist --xml-version=2 > cppcheck-errorlist.xml
 cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist --xml-version=2 | python cppcheck_createrules.py rules cwec_v3.1.xml > cppcheck.xml
-cppcheck ${CPPCHECK_LIBRARY_ARGS} --errorlist --xml-version=2 | python cppcheck_createrules.py profile > cppcheck-profile.xml
-python cppcheck_createrules.py comparerules $SCRIPT_DIR/../main/resources/cppcheck.xml cppcheck.xml > cppcheck-comparison.md
+python utils_createrules.py comparerules $SCRIPT_DIR/../main/resources/cppcheck.xml cppcheck.xml > cppcheck-comparison.md

--- a/cxx-sensors/src/tools/utils_createrules.py
+++ b/cxx-sensors/src/tools/utils_createrules.py
@@ -1,0 +1,267 @@
+# Sonar C++ Plugin (Community)
+# Copyright (C) 2010-2018 SonarOpenCommunity
+# http://github.com/SonarOpenCommunity/sonar-cxx
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import sys
+import os
+import subprocess
+import xml.etree.ElementTree as et
+
+# xml prettifyer
+#
+
+
+def indent(elem, level=0):
+    i = "\n" + level * "  "
+    if len(elem):
+        if not elem.text or not elem.text.strip():
+            elem.text = i + "  "
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+        for sub_elem in elem:
+            indent(sub_elem, level + 1)
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+    else:
+        if level and (not elem.tail or not elem.tail.strip()):
+            elem.tail = i
+
+# see
+# https://stackoverflow.com/questions/174890/how-to-output-cdata-using-elementtree
+
+
+def CDATA(text=None):
+    element = et.Element('![CDATA[')
+    element.text = text
+    return element
+
+et._original_serialize_xml = et._serialize_xml
+
+
+def _serialize_xml(write, elem, encoding, qnames, namespaces):
+    if elem.tag == '![CDATA[':
+        tail = "" if elem.tail is None else elem.tail
+        try:
+            write("<%s%s]]>%s" % (elem.tag, elem.text, tail))
+        except UnicodeEncodeError:
+            write(("<%s%s]]>%s" % (elem.tag, elem.text, tail)).encode('utf-8'))
+
+    else:
+        et._original_serialize_xml(write, elem, encoding, qnames, namespaces)
+
+et._serialize_xml = et._serialize['xml'] = _serialize_xml
+
+
+def get_cdata_capable_xml_etree():
+    return et
+
+
+def _header():
+    return '<?xml version="1.0" encoding="UTF-8"?>\n'
+
+
+def write_rules_xml(root, f):
+    indent(root)
+    f.write(_header())
+    et.ElementTree(root).write(f)
+
+
+def parse_rules_xml(path):
+    tree = et.parse(path)
+    root = tree.getroot()
+    keys = []
+    keys_to_ruleelement = {}
+
+    for rules_tag in root.iter('rules'):
+        for rule_tag in rules_tag.iter('rule'):
+            for key_tag in rule_tag.iter('key'):
+                keys.append(key_tag.text)
+                keys_to_ruleelement[key_tag.text] = rule_tag
+    return keys, keys_to_ruleelement
+
+
+def make_rules_description_to_cdata(rule_t):
+    """after parsing we lost the CDATA information
+       restore it for <description> tag, assume it always encoded as CDATA"""
+    for description_tag in rule_t.iter('description'):
+        desc = description_tag.text
+        description_tag.text = ""
+        description_tag.append(CDATA(desc))
+
+
+def call_xmllint(file_path):
+    command = ["xmllint", file_path]
+    p = subprocess.Popen(command, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
+    out, err = p.communicate()
+    if p.returncode != 0:
+        print "### XMLLINT", file_path
+        print "### ERR"
+        print err
+        print "### OUT"
+        print out
+        print "\n"
+        return True
+    return False
+
+
+def call_tidy(file_path):
+    command = ["tidy", file_path]
+    p = subprocess.Popen(command, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
+    out, err = p.communicate()
+    if p.returncode != 0:
+        print "### TIDY ", file_path
+        print "### ERR"
+        print err
+        print "### SUGGESTION FOR FIXING"
+        print out
+        print "\n"
+        return True
+    return False
+
+
+def check_rules(path):
+    print "### CHECK ", path
+    has_xmllint_errors = call_xmllint(path)
+    if has_xmllint_errors:
+        return 1
+
+    has_tidy_errors = False
+    keys, keys_mapping = parse_rules_xml(path)
+    for key in keys:
+        for rule_tag in keys_mapping[key].iter('rule'):
+            for description_tag in rule_tag.iter('description'):
+                description_dump_path = "/tmp/" + key + ".ruledump"
+                with open(description_dump_path, "w") as f:
+                    html_start = u"""<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=\"utf-8\">
+    <title>Rule Description</title>
+  </head>
+  <body>
+"""
+                    html_stop = u"""
+  </body>
+</html>"""
+
+                    f.write(html_start)
+                    f.write(description_tag.text.encode("UTF-8"))
+                    f.write(html_stop)
+                is_tidy_error = call_tidy(description_dump_path)
+                has_tidy_errors = has_tidy_errors or is_tidy_error
+
+    if has_tidy_errors:
+        return 2
+
+    print "no errors found"
+    return 0
+
+
+def compare_rules(old_path, new_path):
+    old_keys, _ = parse_rules_xml(old_path)
+    new_keys, new_keys_mapping = parse_rules_xml(new_path)
+    old_keys_set = set(old_keys)
+    new_keys_set = set(new_keys)
+    print "# OLD RULE SET vs NEW RULE SET\n"
+
+    print "## OLD RULE SET\n"
+    print "nr of xml entries: ", len(old_keys), "\n"
+    print "nr of unique rules: ", len(old_keys_set), "\n"
+    print "rules which are only in the old rule set:"
+    only_in_old = old_keys_set.difference(new_keys_set)
+    for key in sorted(only_in_old):
+        print "*", key
+    print ""
+
+    print "## NEW RULE SET\n"
+    print "nr of xml entries: ", len(new_keys), "\n"
+    print "nr of unique rules: ", len(new_keys_set), "\n"
+    print "rules which are only in the new rule set:"
+    only_in_new = new_keys_set.difference(old_keys_set)
+    for key in sorted(only_in_new):
+        print "*", key
+    print ""
+
+    print "## COMMON RULES\n"
+    common_keys = old_keys_set.intersection(new_keys_set)
+    print "nr of rules: ", len(common_keys), "\n"
+    for key in sorted(common_keys):
+        print "*", key
+    print ""
+
+    print "### NEW RULES WHICH MUST BE ADDED\n"
+    print "```XML"
+    for key in sorted(only_in_new):
+        rule_tag = new_keys_mapping[key]
+        indent(rule_tag)
+        make_rules_description_to_cdata(rule_tag)
+        et.ElementTree(rule_tag).write(sys.stdout)
+    print "```\n"
+
+    # create a rule xml from the new rules, where rules are stored in the same
+    # order as in the old rule file. this will make xml files comparable by
+    # diff/meld etc.
+    comparable_rules = et.Element('rules')
+    for common_key in old_keys:
+        if common_key in new_keys_mapping:
+            rule_tag = new_keys_mapping[common_key]
+            make_rules_description_to_cdata(rule_tag)
+            comparable_rules.append(rule_tag)
+    for only_new_key in sorted(only_in_new):
+        rule_tag = new_keys_mapping[only_new_key]
+        make_rules_description_to_cdata(rule_tag)
+        comparable_rules.append(rule_tag)
+
+    with open(new_path + ".comparable", 'w') as f:
+        write_rules_xml(comparable_rules, f)
+
+    print """### DIFF EXISTRING vs GENERATED"""
+    print "run\n\n"
+    print "```bash"
+    print "<your favorite diff>", os.path.abspath(old_path), os.path.abspath(new_path) + ".comparable # e.g."
+    print "meld", os.path.abspath(old_path), os.path.abspath(new_path) + ".comparable"
+    print "```\n"
+
+
+def print_usage_and_exit():
+    script_name = os.path.basename(sys.argv[0])
+    print """%s comparerules <old_rules.xml> <new_rules.xml>
+%s check <rules.xml>
+
+comparerules: generates <new_rules.xml.comparable> which re-sorts new rules according to the order of old_rules.xml
+              call 'diff <old_rules.xml> <new_rules.xml.comparable>' in order to see how the existing <old_rules.xml> must be updated
+              also generates the human-readable summary to STDOUT
+
+check:        for each rule in <rules.xml> generate a file "/tmp/<rule_key>.ruledump", which contains the HTML code of rules description
+              check each *.ruledump file with tidy in order to validate the HTML description""" % (script_name, script_name)
+    sys.exit(1)
+
+if __name__ == "__main__":
+
+    if len(sys.argv) < 2:
+        print_usage_and_exit()
+
+    # transform to an other elementtree
+    if sys.argv[1] == "comparerules" and len(sys.argv) == 4:
+        compare_rules(sys.argv[2], sys.argv[3])
+    elif sys.argv[1] == "check" and len(sys.argv) == 3:
+        rc = check_rules(sys.argv[2])
+        sys.exit(rc)
+    else:
+        print_usage_and_exit()


### PR DESCRIPTION
* use the newest clang-tidy source code (documentation)
* still existing rules (87) were updated: original description is used
* new rules were added (156)

closes #1536

TODO manual review of rules' severities

Full list of new rules:

* abseil-duration-division
* abseil-faster-strsplit-delimiter
* abseil-no-internal-dependencies
* abseil-no-namespace
* abseil-redundant-strcat-calls
* abseil-str-cat-append
* abseil-string-find-startswith
* android-cloexec-accept
* android-cloexec-accept4
* android-cloexec-creat
* android-cloexec-dup
* android-cloexec-epoll-create
* android-cloexec-epoll-create1
* android-cloexec-fopen
* android-cloexec-inotify-init
* android-cloexec-inotify-init1
* android-cloexec-memfd-create
* android-cloexec-open
* android-cloexec-socket
* android-comparison-in-temp-failure-retry
* bugprone-argument-comment
* bugprone-assert-side-effect
* bugprone-bool-pointer-implicit-conversion
* bugprone-copy-constructor-init
* bugprone-dangling-handle
* bugprone-exception-escape
* bugprone-fold-init-type
* bugprone-forward-declaration-namespace
* bugprone-forwarding-reference-overload
* bugprone-inaccurate-erase
* bugprone-incorrect-roundings
* bugprone-integer-division
* bugprone-lambda-function-name
* bugprone-macro-parentheses
* bugprone-macro-repeated-side-effects
* bugprone-misplaced-operator-in-strlen-in-alloc
* bugprone-misplaced-widening-cast
* bugprone-move-forwarding-reference
* bugprone-multiple-statement-macro
* bugprone-parent-virtual-call
* bugprone-sizeof-container
* bugprone-sizeof-expression
* bugprone-string-constructor
* bugprone-string-integer-assignment
* bugprone-string-literal-with-embedded-nul
* bugprone-suspicious-enum-usage
* bugprone-suspicious-memset-usage
* bugprone-suspicious-missing-comma
* bugprone-suspicious-semicolon
* bugprone-suspicious-string-compare
* bugprone-swapped-arguments
* bugprone-terminating-continue
* bugprone-throw-keyword-missing
* bugprone-undefined-memory-manipulation
* bugprone-undelegated-constructor
* bugprone-unused-raii
* bugprone-unused-return-value
* bugprone-use-after-move
* bugprone-virtual-near-miss
* cert-dcl03-c
* cert-dcl21-cpp
* cert-dcl54-cpp
* cert-dcl58-cpp
* cert-dcl59-cpp
* cert-err09-cpp
* cert-err61-cpp
* cert-fio38-c
* cert-msc30-c
* cert-msc32-c
* cert-msc50-cpp
* cert-msc51-cpp
* cert-oop11-cpp
* cppcoreguidelines-avoid-goto
* cppcoreguidelines-avoid-magic-numbers
* cppcoreguidelines-c-copy-assignment-signature
* cppcoreguidelines-narrowing-conversions
* cppcoreguidelines-owning-memory
* cppcoreguidelines-slicing
* cppcoreguidelines-special-member-functions
* fuchsia-default-arguments
* fuchsia-header-anon-namespaces
* fuchsia-multiple-inheritance
* fuchsia-overloaded-operator
* fuchsia-restrict-system-includes
* fuchsia-statically-constructed-objects
* fuchsia-trailing-return
* fuchsia-virtual-inheritance
* google-objc-avoid-throwing-exception
* google-objc-global-variable-declaration
* google-readability-braces-around-statements
* google-readability-function-size
* hicpp-avoid-goto
* hicpp-braces-around-statements
* hicpp-deprecated-headers
* hicpp-exception-baseclass
* hicpp-explicit-conversions
* hicpp-function-size
* hicpp-invalid-access-moved
* hicpp-member-init
* hicpp-move-const-arg
* hicpp-multiway-paths-covered
* hicpp-named-parameter
* hicpp-new-delete-operators
* hicpp-no-array-decay
* hicpp-no-assembler
* hicpp-no-malloc
* hicpp-noexcept-move
* hicpp-signed-bitwise
* hicpp-special-member-functions
* hicpp-static-assert
* hicpp-undelegated-constructor
* hicpp-use-auto
* hicpp-use-emplace
* hicpp-use-equals-default
* hicpp-use-equals-delete
* hicpp-use-noexcept
* hicpp-use-nullptr
* hicpp-use-override
* hicpp-vararg
* modernize-replace-random-shuffle
* modernize-return-braced-init-list
* modernize-unary-static-assert
* modernize-use-default-member-init
* modernize-use-equals-default
* modernize-use-equals-delete
* modernize-use-noexcept
* modernize-use-transparent-functors
* modernize-use-uncaught-exceptions
* mpi-buffer-deref
* mpi-type-mismatch
* objc-avoid-nserror-init
* objc-avoid-spinlock
* objc-forbidden-subclassing
* objc-property-declaration
* performance-implicit-conversion-in-loop
* performance-inefficient-algorithm
* performance-inefficient-string-concatenation
* performance-inefficient-vector-operation
* performance-move-const-arg
* performance-move-constructor-init
* performance-noexcept-move-constructor
* performance-type-promotion-in-math-fn
* portability-simd-intrinsics
* readability-delete-null-pointer
* readability-implicit-bool-conversion
* readability-magic-numbers
* readability-misleading-indentation
* readability-misplaced-array-index
* readability-non-const-parameter
* readability-redundant-declaration
* readability-redundant-function-ptr-dereference
* readability-redundant-member-init
* readability-simplify-subscript-expr
* readability-static-accessed-through-instance
* readability-string-compare
* zircon-temporary-objects