### PR TITLE
cppcheck.xml fix name and description of unmatchedSuppression

### DIFF
--- a/cxx-sensors/src/main/resources/cppcheck.xml
+++ b/cxx-sensors/src/main/resources/cppcheck.xml
@@ -6112,9 +6112,15 @@ Did you intend to pass 'arg2'?
   </rule>
   <rule>
     <key>unmatchedSuppression</key>
-    <name>Unmatched suppression: unusedFunction</name>
+    <name>Unmatched suppression</name>
     <description>
-      Unmatched suppression: unusedFunction.
+      <![CDATA[
+<p>cppcheck produces the warning "Unmatched suppression: <code>cppcheck-error-id</code>" if</p>
+<ol>
+<li>user suppressed <code>cppcheck-error-id</code> by means of command-line arguments or inline suppression, but...</li>
+<li>this <code>cppcheck-error-id</code> didn't appear while static code analysis</li>
+</ol>
+    ]]>
     </description>
     <internalKey>unmatchedSuppression</internalKey>
     <severity>MAJOR</severity>


### PR DESCRIPTION
the wrong documentation was discovered by chance

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1564)
<!-- Reviewable:end -->
