### PR TITLE
Update clang-tidy rules; Add clang diagnostics

### DIFF
--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -8255,4 +8255,12042 @@ Derived();             // and so temporary construction is okay</code></pre>
   <severity>MAJOR</severity>
   <type>BUG</type>
   </rule>
+<rule>
+  <key>clang-diagnostic-#pragma-messages</key>
+  <name>clang-diagnostic-#pragma-messages</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#w-pragma-messages" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-#warnings</key>
+  <name>clang-diagnostic-#warnings</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#w-warnings" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-CFString-literal</key>
+  <name>clang-diagnostic-CFString-literal</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: input conversion stopped due to an input byte that does not belong to the input codeset UTF-8</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wCFString-literal" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-CL4</key>
+  <name>clang-diagnostic-CL4</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma warning expected '%0'</li>
+<li>warning: #pragma warning expected 'push', 'pop', 'default', 'disable', 'error', 'once', 'suppress', 1, 2, 3, or 4</li>
+<li>warning: #pragma warning expected a warning number</li>
+<li>warning: #pragma warning(push, level) requires a level between 0 and 4</li>
+<li>warning: %0</li>
+<li>warning: %0 has C-linkage specified, but returns incomplete type %1 which could be incompatible with C</li>
+<li>warning: %0 has C-linkage specified, but returns user-defined type %1 which is incompatible with C</li>
+<li>warning: %0 has lower precedence than %1; %1 will be evaluated first</li>
+<li>warning: %2 defined as %select{a struct|an interface|a class}0%select{| template}1 here but previously declared as %select{a struct|an interface|a class}3%select{| template}1</li>
+<li>warning: %plural{1:enumeration value %1 not handled in switch|2:enumeration values %1 and %2 not handled in switch|3:enumeration values %1, %2, and %3 not handled in switch|:%0 enumeration values not handled in switch: %1, %2, %3...}0</li>
+<li>warning: %q0 hides overloaded virtual %select{function|functions}1</li>
+<li>warning: %select{delete|destructor}0 called on %1 that is abstract but has non-virtual destructor</li>
+<li>warning: %select{delete|destructor}0 called on non-final %1 that has virtual functions but non-virtual destructor</li>
+<li>warning: %select{equality|inequality|relational|three-way}0 comparison result unused</li>
+<li>warning: %select{field width|precision}0 used with '%1' conversion specifier, resulting in undefined behavior</li>
+<li>warning: %select{field|base class}0 %1 will be initialized after %select{field|base}2 %3</li>
+<li>warning: %select{function|variable}0 %1 is not needed and will not be emitted</li>
+<li>warning: %select{struct|interface|class}0%select{| template}1 %2 was previously declared as a %select{struct|interface|class}3%select{| template}1</li>
+<li>warning: %select{values of type|enum values with underlying type}2 '%0' should not be used as format arguments; add an explicit cast to %1 instead</li>
+<li>warning: %select{void function|void method|constructor|destructor}1 %0 should not return a value</li>
+<li>warning: %select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++</li>
+<li>warning: '%0' is not a valid object format flag</li>
+<li>warning: '%0' qualifier on function type %1 has no effect</li>
+<li>warning: '%0' qualifier on omitted return type %1 has no effect</li>
+<li>warning: '%0' qualifier on reference type %1 has no effect</li>
+<li>warning: '%0' type qualifier%s1 on return type %plural{1:has|:have}1 no effect</li>
+<li>warning: '%0' within '%1'</li>
+<li>warning: '%select{*|.*}0' specified field %select{width|precision}0 is missing a matching 'int' argument</li>
+<li>warning: '&amp;&amp;' within '||'</li>
+<li>warning: '/*' within block comment</li>
+<li>warning: 'static' function %0 declared in header file should be declared 'static inline'</li>
+<li>warning: // comments are not allowed in this language</li>
+<li>warning: ARC %select{unused|__unsafe_unretained|__strong|__weak|__autoreleasing}0 lifetime qualifier on return type is ignored</li>
+<li>warning: add explicit braces to avoid dangling else</li>
+<li>warning: adding %0 to a string does not append to the string</li>
+<li>warning: all paths through this function will call itself</li>
+<li>warning: angle-bracketed include &lt;%0&gt; cannot be aliased to double-quoted include "%1"</li>
+<li>warning: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension</li>
+<li>warning: array section %select{lower bound|length}0 is of type 'char'</li>
+<li>warning: array subscript is of type 'char'</li>
+<li>warning: assigning %select{field|instance variable}0 to itself</li>
+<li>warning: base class %0 is uninitialized when used here to access %q1</li>
+<li>warning: block pointer variable %0 is uninitialized when captured by block</li>
+<li>warning: call to function without interrupt attribute could clobber interruptee's VFP registers</li>
+<li>warning: cannot mix positional and non-positional arguments in format string</li>
+<li>warning: case value not in enumerated type %0</li>
+<li>warning: cast of type %0 to %1 is deprecated; use sel_getName instead</li>
+<li>warning: comparison of integers of different signs: %0 and %1</li>
+<li>warning: container access result unused - container access should not be used for side effects</li>
+<li>warning: control may reach end of coroutine; which is undefined behavior because the promise type %0 does not declare 'return_void()'</li>
+<li>warning: control may reach end of non-void function</li>
+<li>warning: control may reach end of non-void lambda</li>
+<li>warning: control reaches end of coroutine; which is undefined behavior because the promise type %0 does not declare 'return_void()'</li>
+<li>warning: control reaches end of non-void function</li>
+<li>warning: control reaches end of non-void lambda</li>
+<li>warning: convenience initializer missing a 'self' call to another initializer</li>
+<li>warning: convenience initializer should not invoke an initializer on 'super'</li>
+<li>warning: data argument not used by format string</li>
+<li>warning: data argument position '%0' exceeds the number of data arguments (%1)</li>
+<li>warning: designated initializer invoked a non-designated initializer</li>
+<li>warning: designated initializer missing a 'super' call to a designated initializer of the super class</li>
+<li>warning: designated initializer should only invoke a designated initializer on 'super'</li>
+<li>warning: double-quoted include "%0" cannot be aliased to angle-bracketed include &lt;%1&gt;</li>
+<li>warning: equality comparison with extraneous parentheses</li>
+<li>warning: escaped newline between */ characters at block comment end</li>
+<li>warning: expected 'ON' or 'OFF' or 'DEFAULT' in pragma</li>
+<li>warning: expected end of directive in pragma</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself</li>
+<li>warning: explicitly moving variable of type %0 to itself</li>
+<li>warning: explicitly moving variable of type %0 to itself</li>
+<li>warning: expression result unused</li>
+<li>warning: expression result unused; should this cast be to 'void'?</li>
+<li>warning: expression with side effects has no effect in an unevaluated context</li>
+<li>warning: expression with side effects will be evaluated despite being used as an operand to 'typeid'</li>
+<li>warning: field %0 can overwrite instance variable %1 with variable sized type %2 in superclass %3</li>
+<li>warning: field %0 is uninitialized when used here</li>
+<li>warning: field %0 with variable sized type %1 is not visible to subclasses and can conflict with their instance variables</li>
+<li>warning: field %select{width|precision}0 should have type %1, but argument has type %2</li>
+<li>warning: flag '%0' is ignored when flag '%1' is present</li>
+<li>warning: flag '%0' results in undefined behavior with '%1' conversion specifier</li>
+<li>warning: format specifies type %0 but the argument has %select{type|underlying type}2 %1</li>
+<li>warning: format string contains '\0' within the string body</li>
+<li>warning: format string is empty</li>
+<li>warning: format string is not a string literal (potentially insecure)</li>
+<li>warning: format string is not null-terminated</li>
+<li>warning: format string missing</li>
+<li>warning: format string should not be a wide string</li>
+<li>warning: ignored trigraph would end block comment</li>
+<li>warning: ignoring return value of function declared with %0 attribute</li>
+<li>warning: ignoring return value of function declared with %0 attribute</li>
+<li>warning: implicit declaration of function %0</li>
+<li>warning: implicit declaration of function %0 is invalid in C99</li>
+<li>warning: implicitly declaring library function '%0' with type %1</li>
+<li>warning: incomplete format specifier</li>
+<li>warning: initializer overrides prior initialization of this subobject</li>
+<li>warning: invalid conversion specifier '%0'</li>
+<li>warning: invalid position specified for %select{field width|field precision}0</li>
+<li>warning: ivar %0 which backs the property is not referenced in this property's accessor</li>
+<li>warning: lambda capture %0 is not %select{used|required to be captured for this use}1</li>
+<li>warning: length modifier '%0' results in undefined behavior or no effect with '%1' conversion specifier</li>
+<li>warning: local variable %0 will be copied despite being %select{returned|thrown}1 by name</li>
+<li>warning: logical not is only applied to the left hand side of this %select{comparison|bitwise operator}0</li>
+<li>warning: method has no return type specified; defaults to 'id'</li>
+<li>warning: method override for the designated initializer of the superclass %objcinstance0 not found</li>
+<li>warning: method possibly missing a [super %0] call</li>
+<li>warning: missing field %0 initializer</li>
+<li>warning: missing object format flag</li>
+<li>warning: more '%%' conversions than data arguments</li>
+<li>warning: moving a local object in a return statement prevents copy elision</li>
+<li>warning: moving a temporary object prevents copy elision</li>
+<li>warning: multi-character character constant</li>
+<li>warning: multi-line // comment</li>
+<li>warning: no closing ']' for '%%[' in scanf format string</li>
+<li>warning: non-void %select{function|method}1 %0 should return a value</li>
+<li>warning: non-void %select{function|method}1 %0 should return a value</li>
+<li>warning: null passed to a callee that requires a non-null argument</li>
+<li>warning: null returned from %select{function|method}0 that requires a non-null return value</li>
+<li>warning: object format flags cannot be used with '%0' conversion specifier</li>
+<li>warning: operator '%0' has lower precedence than '%1'; '%1' will be evaluated first</li>
+<li>warning: operator '?:' has lower precedence than '%0'; '%0' will be evaluated first</li>
+<li>warning: overflow converting case value to switch condition type (%0 to %1)</li>
+<li>warning: overloaded operator %select{&gt;&gt;|&lt;&lt;}0 has higher precedence than comparison operator</li>
+<li>warning: performing pointer arithmetic on a null pointer has undefined behavior%select{| if the offset is nonzero}0</li>
+<li>warning: position arguments in format strings start counting at 1 (not 0)</li>
+<li>warning: pragma STDC FENV_ACCESS ON is not supported, ignoring pragma</li>
+<li>warning: pragma diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'</li>
+<li>warning: pragma diagnostic expected option name (e.g. "-Wundef")</li>
+<li>warning: pragma diagnostic pop could not pop, no matching push</li>
+<li>warning: pragma include_alias expected '%0'</li>
+<li>warning: pragma include_alias expected include filename</li>
+<li>warning: private field %0 is not used</li>
+<li>warning: redundant move in return statement</li>
+<li>warning: reference %0 is not yet bound to a value when used here</li>
+<li>warning: reference %0 is not yet bound to a value when used within its own initialization</li>
+<li>warning: semicolon before method body is ignored</li>
+<li>warning: sizeof on array function parameter will return size of %0 instead of %1</li>
+<li>warning: sizeof on pointer operation will return size of %0 instead of %1</li>
+<li>warning: static variable %0 is suspiciously used within its own initialization</li>
+<li>warning: subobject initialization overrides initialization of other fields within its enclosing subobject</li>
+<li>warning: suggest braces around initialization of subobject</li>
+<li>warning: switch condition has boolean value</li>
+<li>warning: trigraph converted to '%0' character</li>
+<li>warning: trigraph ends block comment</li>
+<li>warning: trigraph ignored</li>
+<li>warning: type specifier missing, defaults to 'int'</li>
+<li>warning: unexpected token in pragma diagnostic</li>
+<li>warning: unknown pragma ignored</li>
+<li>warning: unknown pragma in STDC namespace</li>
+<li>warning: unused %select{typedef|type alias}0 %1</li>
+<li>warning: unused function %0</li>
+<li>warning: unused label %0</li>
+<li>warning: unused parameter %0</li>
+<li>warning: unused variable %0</li>
+<li>warning: unused variable %0</li>
+<li>warning: use of __private_extern__ on a declaration may not produce external symbol private to the linkage unit and is deprecated</li>
+<li>warning: use of unknown builtin %0</li>
+<li>warning: using '%%P' format specifier without precision</li>
+<li>warning: using '%0' format specifier annotation outside of os_log()/os_trace()</li>
+<li>warning: using the result of an assignment as a condition without parentheses</li>
+<li>warning: variable %0 is %select{decremented|incremented}1 both in the loop header and in the loop body</li>
+<li>warning: variable %0 is %select{used|captured}1 uninitialized whenever %select{'%3' condition is %select{true|false}4|'%3' loop %select{is entered|exits because its condition is false}4|'%3' loop %select{condition is true|exits because its condition is false}4|switch %3 is taken|its declaration is reached|%3 is called}2</li>
+<li>warning: variable %0 is uninitialized when %select{used here|captured by block}1</li>
+<li>warning: variable %0 is uninitialized when used within its own initialization</li>
+<li>warning: variable%select{s| %1|s %1 and %2|s %1, %2, and %3|s %1, %2, %3, and %4}0 used in loop condition not modified in loop body</li>
+<li>warning: zero field width in scanf format string is unused</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wCL4" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-IndependentClass-attribute</key>
+  <name>clang-diagnostic-IndependentClass-attribute</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'objc_independent_class' attribute may be put on Objective-C object pointer type only; attribute is ignored</li>
+<li>warning: 'objc_independent_class' attribute may be put on a typedef only; attribute is ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wIndependentClass-attribute" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-NSObject-attribute</key>
+  <name>clang-diagnostic-NSObject-attribute</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'NSObject' attribute may be put on a typedef only; attribute is ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wNSObject-attribute" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-absolute-value</key>
+  <name>clang-diagnostic-absolute-value</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: absolute value function %0 given an argument of type %1 but has parameter of type %2 which may cause truncation of value</li>
+<li>warning: taking the absolute value of %select{pointer|function|array}0 type %1 is suspicious</li>
+<li>warning: taking the absolute value of unsigned type %0 has no effect</li>
+<li>warning: using %select{integer|floating point|complex}1 absolute value function %0 when argument is of %select{integer|floating point|complex}2 type</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wabsolute-value" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-abstract-final-class</key>
+  <name>clang-diagnostic-abstract-final-class</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: abstract class is marked '%select{final|sealed}0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wabstract-final-class" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-abstract-vbase-init</key>
+  <name>clang-diagnostic-abstract-vbase-init</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: initializer for virtual base class %0 of abstract class %1 will never be used</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wabstract-vbase-init" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-address</key>
+  <name>clang-diagnostic-address</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: address of%select{| function| array}0 '%1' will always evaluate to 'true'</li>
+<li>warning: comparison of %select{address of|function|array}0 '%1' %select{not |}2equal to a null pointer is always %select{true|false}2</li>
+<li>warning: comparison of nonnull %select{function call|parameter}0 '%1' %select{not |}2equal to a null pointer is '%select{true|false}2' on first encounter</li>
+<li>warning: nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter</li>
+<li>warning: result of comparison against %select{a string literal|@encode}0 is unspecified (use strncmp instead)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waddress" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-address-of-packed-member</key>
+  <name>clang-diagnostic-address-of-packed-member</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: taking address of packed member %0 of class or structure %q1 may result in an unaligned pointer value</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waddress-of-packed-member" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-address-of-temporary</key>
+  <name>clang-diagnostic-address-of-temporary</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: taking the address of a temporary object of type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waddress-of-temporary" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-all</key>
+  <name>clang-diagnostic-all</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma warning expected '%0'</li>
+<li>warning: #pragma warning expected 'push', 'pop', 'default', 'disable', 'error', 'once', 'suppress', 1, 2, 3, or 4</li>
+<li>warning: #pragma warning expected a warning number</li>
+<li>warning: #pragma warning(push, level) requires a level between 0 and 4</li>
+<li>warning: %0</li>
+<li>warning: %0 has C-linkage specified, but returns incomplete type %1 which could be incompatible with C</li>
+<li>warning: %0 has C-linkage specified, but returns user-defined type %1 which is incompatible with C</li>
+<li>warning: %0 has lower precedence than %1; %1 will be evaluated first</li>
+<li>warning: %2 defined as %select{a struct|an interface|a class}0%select{| template}1 here but previously declared as %select{a struct|an interface|a class}3%select{| template}1</li>
+<li>warning: %plural{1:enumeration value %1 not handled in switch|2:enumeration values %1 and %2 not handled in switch|3:enumeration values %1, %2, and %3 not handled in switch|:%0 enumeration values not handled in switch: %1, %2, %3...}0</li>
+<li>warning: %q0 hides overloaded virtual %select{function|functions}1</li>
+<li>warning: %select{delete|destructor}0 called on %1 that is abstract but has non-virtual destructor</li>
+<li>warning: %select{delete|destructor}0 called on non-final %1 that has virtual functions but non-virtual destructor</li>
+<li>warning: %select{equality|inequality|relational|three-way}0 comparison result unused</li>
+<li>warning: %select{field width|precision}0 used with '%1' conversion specifier, resulting in undefined behavior</li>
+<li>warning: %select{field|base class}0 %1 will be initialized after %select{field|base}2 %3</li>
+<li>warning: %select{function|variable}0 %1 is not needed and will not be emitted</li>
+<li>warning: %select{struct|interface|class}0%select{| template}1 %2 was previously declared as a %select{struct|interface|class}3%select{| template}1</li>
+<li>warning: %select{values of type|enum values with underlying type}2 '%0' should not be used as format arguments; add an explicit cast to %1 instead</li>
+<li>warning: %select{void function|void method|constructor|destructor}1 %0 should not return a value</li>
+<li>warning: %select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++</li>
+<li>warning: '%0' is not a valid object format flag</li>
+<li>warning: '%0' within '%1'</li>
+<li>warning: '%select{*|.*}0' specified field %select{width|precision}0 is missing a matching 'int' argument</li>
+<li>warning: '&amp;&amp;' within '||'</li>
+<li>warning: '/*' within block comment</li>
+<li>warning: 'static' function %0 declared in header file should be declared 'static inline'</li>
+<li>warning: // comments are not allowed in this language</li>
+<li>warning: add explicit braces to avoid dangling else</li>
+<li>warning: adding %0 to a string does not append to the string</li>
+<li>warning: all paths through this function will call itself</li>
+<li>warning: angle-bracketed include &lt;%0&gt; cannot be aliased to double-quoted include "%1"</li>
+<li>warning: array section %select{lower bound|length}0 is of type 'char'</li>
+<li>warning: array subscript is of type 'char'</li>
+<li>warning: assigning %select{field|instance variable}0 to itself</li>
+<li>warning: base class %0 is uninitialized when used here to access %q1</li>
+<li>warning: block pointer variable %0 is uninitialized when captured by block</li>
+<li>warning: cannot mix positional and non-positional arguments in format string</li>
+<li>warning: case value not in enumerated type %0</li>
+<li>warning: cast of type %0 to %1 is deprecated; use sel_getName instead</li>
+<li>warning: container access result unused - container access should not be used for side effects</li>
+<li>warning: control may reach end of coroutine; which is undefined behavior because the promise type %0 does not declare 'return_void()'</li>
+<li>warning: control may reach end of non-void function</li>
+<li>warning: control may reach end of non-void lambda</li>
+<li>warning: control reaches end of coroutine; which is undefined behavior because the promise type %0 does not declare 'return_void()'</li>
+<li>warning: control reaches end of non-void function</li>
+<li>warning: control reaches end of non-void lambda</li>
+<li>warning: convenience initializer missing a 'self' call to another initializer</li>
+<li>warning: convenience initializer should not invoke an initializer on 'super'</li>
+<li>warning: data argument not used by format string</li>
+<li>warning: data argument position '%0' exceeds the number of data arguments (%1)</li>
+<li>warning: designated initializer invoked a non-designated initializer</li>
+<li>warning: designated initializer missing a 'super' call to a designated initializer of the super class</li>
+<li>warning: designated initializer should only invoke a designated initializer on 'super'</li>
+<li>warning: double-quoted include "%0" cannot be aliased to angle-bracketed include &lt;%1&gt;</li>
+<li>warning: equality comparison with extraneous parentheses</li>
+<li>warning: escaped newline between */ characters at block comment end</li>
+<li>warning: expected 'ON' or 'OFF' or 'DEFAULT' in pragma</li>
+<li>warning: expected end of directive in pragma</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself</li>
+<li>warning: explicitly moving variable of type %0 to itself</li>
+<li>warning: explicitly moving variable of type %0 to itself</li>
+<li>warning: expression result unused</li>
+<li>warning: expression result unused; should this cast be to 'void'?</li>
+<li>warning: expression with side effects has no effect in an unevaluated context</li>
+<li>warning: expression with side effects will be evaluated despite being used as an operand to 'typeid'</li>
+<li>warning: field %0 can overwrite instance variable %1 with variable sized type %2 in superclass %3</li>
+<li>warning: field %0 is uninitialized when used here</li>
+<li>warning: field %0 with variable sized type %1 is not visible to subclasses and can conflict with their instance variables</li>
+<li>warning: field %select{width|precision}0 should have type %1, but argument has type %2</li>
+<li>warning: flag '%0' is ignored when flag '%1' is present</li>
+<li>warning: flag '%0' results in undefined behavior with '%1' conversion specifier</li>
+<li>warning: format specifies type %0 but the argument has %select{type|underlying type}2 %1</li>
+<li>warning: format string contains '\0' within the string body</li>
+<li>warning: format string is empty</li>
+<li>warning: format string is not a string literal (potentially insecure)</li>
+<li>warning: format string is not null-terminated</li>
+<li>warning: format string missing</li>
+<li>warning: format string should not be a wide string</li>
+<li>warning: ignored trigraph would end block comment</li>
+<li>warning: ignoring return value of function declared with %0 attribute</li>
+<li>warning: ignoring return value of function declared with %0 attribute</li>
+<li>warning: implicit declaration of function %0</li>
+<li>warning: implicit declaration of function %0 is invalid in C99</li>
+<li>warning: implicitly declaring library function '%0' with type %1</li>
+<li>warning: incomplete format specifier</li>
+<li>warning: invalid conversion specifier '%0'</li>
+<li>warning: invalid position specified for %select{field width|field precision}0</li>
+<li>warning: ivar %0 which backs the property is not referenced in this property's accessor</li>
+<li>warning: lambda capture %0 is not %select{used|required to be captured for this use}1</li>
+<li>warning: length modifier '%0' results in undefined behavior or no effect with '%1' conversion specifier</li>
+<li>warning: local variable %0 will be copied despite being %select{returned|thrown}1 by name</li>
+<li>warning: logical not is only applied to the left hand side of this %select{comparison|bitwise operator}0</li>
+<li>warning: method override for the designated initializer of the superclass %objcinstance0 not found</li>
+<li>warning: method possibly missing a [super %0] call</li>
+<li>warning: missing object format flag</li>
+<li>warning: more '%%' conversions than data arguments</li>
+<li>warning: moving a local object in a return statement prevents copy elision</li>
+<li>warning: moving a temporary object prevents copy elision</li>
+<li>warning: multi-character character constant</li>
+<li>warning: multi-line // comment</li>
+<li>warning: no closing ']' for '%%[' in scanf format string</li>
+<li>warning: non-void %select{function|method}1 %0 should return a value</li>
+<li>warning: non-void %select{function|method}1 %0 should return a value</li>
+<li>warning: null passed to a callee that requires a non-null argument</li>
+<li>warning: null returned from %select{function|method}0 that requires a non-null return value</li>
+<li>warning: object format flags cannot be used with '%0' conversion specifier</li>
+<li>warning: operator '%0' has lower precedence than '%1'; '%1' will be evaluated first</li>
+<li>warning: operator '?:' has lower precedence than '%0'; '%0' will be evaluated first</li>
+<li>warning: overflow converting case value to switch condition type (%0 to %1)</li>
+<li>warning: overloaded operator %select{&gt;&gt;|&lt;&lt;}0 has higher precedence than comparison operator</li>
+<li>warning: position arguments in format strings start counting at 1 (not 0)</li>
+<li>warning: pragma STDC FENV_ACCESS ON is not supported, ignoring pragma</li>
+<li>warning: pragma diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'</li>
+<li>warning: pragma diagnostic expected option name (e.g. "-Wundef")</li>
+<li>warning: pragma diagnostic pop could not pop, no matching push</li>
+<li>warning: pragma include_alias expected '%0'</li>
+<li>warning: pragma include_alias expected include filename</li>
+<li>warning: private field %0 is not used</li>
+<li>warning: redundant move in return statement</li>
+<li>warning: reference %0 is not yet bound to a value when used here</li>
+<li>warning: reference %0 is not yet bound to a value when used within its own initialization</li>
+<li>warning: sizeof on array function parameter will return size of %0 instead of %1</li>
+<li>warning: sizeof on pointer operation will return size of %0 instead of %1</li>
+<li>warning: static variable %0 is suspiciously used within its own initialization</li>
+<li>warning: suggest braces around initialization of subobject</li>
+<li>warning: switch condition has boolean value</li>
+<li>warning: trigraph converted to '%0' character</li>
+<li>warning: trigraph ends block comment</li>
+<li>warning: trigraph ignored</li>
+<li>warning: type specifier missing, defaults to 'int'</li>
+<li>warning: unexpected token in pragma diagnostic</li>
+<li>warning: unknown pragma ignored</li>
+<li>warning: unknown pragma in STDC namespace</li>
+<li>warning: unused %select{typedef|type alias}0 %1</li>
+<li>warning: unused function %0</li>
+<li>warning: unused label %0</li>
+<li>warning: unused variable %0</li>
+<li>warning: unused variable %0</li>
+<li>warning: use of __private_extern__ on a declaration may not produce external symbol private to the linkage unit and is deprecated</li>
+<li>warning: use of unknown builtin %0</li>
+<li>warning: using '%%P' format specifier without precision</li>
+<li>warning: using '%0' format specifier annotation outside of os_log()/os_trace()</li>
+<li>warning: using the result of an assignment as a condition without parentheses</li>
+<li>warning: variable %0 is %select{decremented|incremented}1 both in the loop header and in the loop body</li>
+<li>warning: variable %0 is %select{used|captured}1 uninitialized whenever %select{'%3' condition is %select{true|false}4|'%3' loop %select{is entered|exits because its condition is false}4|'%3' loop %select{condition is true|exits because its condition is false}4|switch %3 is taken|its declaration is reached|%3 is called}2</li>
+<li>warning: variable %0 is uninitialized when %select{used here|captured by block}1</li>
+<li>warning: variable %0 is uninitialized when used within its own initialization</li>
+<li>warning: variable%select{s| %1|s %1 and %2|s %1, %2, and %3|s %1, %2, %3, and %4}0 used in loop condition not modified in loop body</li>
+<li>warning: zero field width in scanf format string is unused</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wall" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-alloca-with-align-alignof</key>
+  <name>clang-diagnostic-alloca-with-align-alignof</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: second argument to __builtin_alloca_with_align is supposed to be in bits</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walloca-with-align-alignof" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-ambiguous-delete</key>
+  <name>clang-diagnostic-ambiguous-delete</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: multiple suitable %0 functions for %1; no 'operator delete' function will be invoked if initialization throws an exception</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wambiguous-delete" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-ambiguous-ellipsis</key>
+  <name>clang-diagnostic-ambiguous-ellipsis</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '...' in this location creates a C-style varargs function%select{, not a function parameter pack|}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wambiguous-ellipsis" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-ambiguous-macro</key>
+  <name>clang-diagnostic-ambiguous-macro</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ambiguous expansion of macro %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wambiguous-macro" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-ambiguous-member-template</key>
+  <name>clang-diagnostic-ambiguous-member-template</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: lookup of %0 in member access expression is ambiguous; using member of %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wambiguous-member-template" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-analyzer-incompatible-plugin</key>
+  <name>clang-diagnostic-analyzer-incompatible-plugin</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: checker plugin '%0' is not compatible with this version of the analyzer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wanalyzer-incompatible-plugin" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-anonymous-pack-parens</key>
+  <name>clang-diagnostic-anonymous-pack-parens</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++11 requires a parenthesized pack declaration to have a name</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wanonymous-pack-parens" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-arc</key>
+  <name>clang-diagnostic-arc</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{destination for|source of}0 this %1 call is a pointer to ownership-qualified type %2</li>
+<li>warning: assigning %select{array literal|dictionary literal|numeric literal|boxed expression|&lt;should not happen&gt;|block literal}0 to a weak %select{property|variable}1; object will be released after assignment</li>
+<li>warning: assigning retained object to %select{weak|unsafe_unretained}0 %select{property|variable}1; object will be released after assignment</li>
+<li>warning: assigning retained object to unsafe property; object will be released after assignment</li>
+<li>warning: capturing %0 strongly in this block is likely to lead to a retain cycle</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-arc-bridge-casts-disallowed-in-nonarc</key>
+  <name>clang-diagnostic-arc-bridge-casts-disallowed-in-nonarc</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' casts have no effect when not using ARC</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-bridge-casts-disallowed-in-nonarc" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-arc-maybe-repeated-use-of-weak</key>
+  <name>clang-diagnostic-arc-maybe-repeated-use-of-weak</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: weak %select{variable|property|implicit property|instance variable}0 %1 may be accessed multiple times in this %select{function|method|block|lambda}2 and may be unpredictably set to nil; assign to a strong variable to keep the object alive</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-maybe-repeated-use-of-weak" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-arc-non-pod-memaccess</key>
+  <name>clang-diagnostic-arc-non-pod-memaccess</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{destination for|source of}0 this %1 call is a pointer to ownership-qualified type %2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-non-pod-memaccess" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-arc-performSelector-leaks</key>
+  <name>clang-diagnostic-arc-performSelector-leaks</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: performSelector may cause a leak because its selector is unknown</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-performSelector-leaks" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-arc-repeated-use-of-weak</key>
+  <name>clang-diagnostic-arc-repeated-use-of-weak</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: weak %select{variable|property|implicit property|instance variable}0 %1 is accessed multiple times in this %select{function|method|block|lambda}2 but may be unpredictably set to nil; assign to a strong variable to keep the object alive</li>
+<li>warning: weak %select{variable|property|implicit property|instance variable}0 %1 may be accessed multiple times in this %select{function|method|block|lambda}2 and may be unpredictably set to nil; assign to a strong variable to keep the object alive</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-repeated-use-of-weak" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-arc-retain-cycles</key>
+  <name>clang-diagnostic-arc-retain-cycles</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: capturing %0 strongly in this block is likely to lead to a retain cycle</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-retain-cycles" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-arc-unsafe-retained-assign</key>
+  <name>clang-diagnostic-arc-unsafe-retained-assign</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: assigning %select{array literal|dictionary literal|numeric literal|boxed expression|&lt;should not happen&gt;|block literal}0 to a weak %select{property|variable}1; object will be released after assignment</li>
+<li>warning: assigning retained object to %select{weak|unsafe_unretained}0 %select{property|variable}1; object will be released after assignment</li>
+<li>warning: assigning retained object to unsafe property; object will be released after assignment</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-unsafe-retained-assign" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-argument-outside-range</key>
+  <name>clang-diagnostic-argument-outside-range</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: argument value %0 is outside the valid range [%1, %2]</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wargument-outside-range" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-array-bounds</key>
+  <name>clang-diagnostic-array-bounds</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'static' has no effect on zero-length arrays</li>
+<li>warning: array argument is too small; contains %0 elements, callee requires at least %1</li>
+<li>warning: array index %0 is before the beginning of the array</li>
+<li>warning: array index %0 is past the end of the array (which contains %1 element%s2)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warray-bounds" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-array-bounds-pointer-arithmetic</key>
+  <name>clang-diagnostic-array-bounds-pointer-arithmetic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: the pointer decremented by %0 refers before the beginning of the array</li>
+<li>warning: the pointer incremented by %0 refers past the end of the array (that contains %1 element%s2)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warray-bounds-pointer-arithmetic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-asm</key>
+  <name>clang-diagnostic-asm</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ignored %0 qualifier on asm</li>
+<li>warning: meaningless 'volatile' on asm outside function</li>
+<li>warning: value size does not match register size specified by the constraint and modifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wasm" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-asm-ignored-qualifier</key>
+  <name>clang-diagnostic-asm-ignored-qualifier</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ignored %0 qualifier on asm</li>
+<li>warning: meaningless 'volatile' on asm outside function</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wasm-ignored-qualifier" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-asm-operand-widths</key>
+  <name>clang-diagnostic-asm-operand-widths</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: value size does not match register size specified by the constraint and modifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wasm-operand-widths" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-assign-enum</key>
+  <name>clang-diagnostic-assign-enum</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: integer constant not in range of enumerated type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wassign-enum" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-assume</key>
+  <name>clang-diagnostic-assume</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: the argument to %0 has side effects that will be discarded</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wassume" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-atimport-in-framework-header</key>
+  <name>clang-diagnostic-atimport-in-framework-header</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: use of '@import' in framework header is discouraged, including this header requires -fmodules</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watimport-in-framework-header" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-atomic-alignment</key>
+  <name>clang-diagnostic-atomic-alignment</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{large|misaligned}0 atomic operation may incur significant performance penalty</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-alignment" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-atomic-implicit-seq-cst</key>
+  <name>clang-diagnostic-atomic-implicit-seq-cst</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit use of sequentially-consistent atomic may incur stronger memory barriers than necessary</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-implicit-seq-cst" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-atomic-memory-ordering</key>
+  <name>clang-diagnostic-atomic-memory-ordering</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: memory order argument to atomic operation is invalid</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-memory-ordering" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-atomic-properties</key>
+  <name>clang-diagnostic-atomic-properties</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: atomic by default property %0 has a user defined %select{getter|setter}1 (property should be marked 'atomic' if this is intended)</li>
+<li>warning: property is assumed atomic by default</li>
+<li>warning: property is assumed atomic when auto-synthesizing the property</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-properties" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-atomic-property-with-user-defined-accessor</key>
+  <name>clang-diagnostic-atomic-property-with-user-defined-accessor</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: writable atomic property %0 cannot pair a synthesized %select{getter|setter}1 with a user defined %select{getter|setter}2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-property-with-user-defined-accessor" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-attribute-packed-for-bitfield</key>
+  <name>clang-diagnostic-attribute-packed-for-bitfield</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'packed' attribute was ignored on bit-fields with single-byte alignment in older versions of GCC and Clang</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wattribute-packed-for-bitfield" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-attributes</key>
+  <name>clang-diagnostic-attributes</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 attribute argument not supported: %1</li>
+<li>warning: %0 attribute can only be applied to instance variables or properties</li>
+<li>warning: %0 attribute ignored</li>
+<li>warning: %0 attribute ignored for field of type %1</li>
+<li>warning: %0 attribute ignored on inline function</li>
+<li>warning: %0 attribute ignored when parsing type</li>
+<li>warning: %0 attribute is deprecated and ignored in OpenCL version %1</li>
+<li>warning: %0 attribute only applies to %1</li>
+<li>warning: %0 attribute only applies to %select{Objective-C object|pointer|pointer-to-CF-pointer}1 parameters</li>
+<li>warning: %0 attribute only applies to %select{functions|methods|properties}1 that return %select{an Objective-C object|a pointer|a non-retainable pointer}2</li>
+<li>warning: %0 attribute only applies to %select{functions|unions|variables and functions|functions and methods|functions, methods and blocks|functions, methods, and parameters|variables|variables and fields|variables, data members and tag types|types and namespaces|variables, functions and classes|kernel functions|non-K&amp;R-style functions}1</li>
+<li>warning: %0 attribute only applies to a pointer or reference (%1 is invalid)</li>
+<li>warning: %0 attribute only applies to return values that are pointers</li>
+<li>warning: %0 attribute only applies to return values that are pointers or references</li>
+<li>warning: %0 attribute only applies to%select{| constant}1 pointer arguments</li>
+<li>warning: %0 calling convention ignored on constructor/destructor</li>
+<li>warning: %0 calling convention ignored on variadic function</li>
+<li>warning: %q0 redeclared inline; %1 attribute ignored</li>
+<li>warning: %select{alias|ifunc}1 will not be in section '%0' but in the same section as the %select{aliasee|resolver}2</li>
+<li>warning: %select{alias|ifunc}2 will always resolve to %0 even if weak definition of %1 is overridden</li>
+<li>warning: %select{alignment|size}0 of field %1 (%2 bits) does not match the %select{alignment|size}0 of the first field in transparent union; transparent_union attribute ignored</li>
+<li>warning: %select{unsupported|duplicate}0%select{| architecture}1 '%2' in the 'target' attribute string; 'target' attribute ignored</li>
+<li>warning: '%0' attribute cannot be specified on a definition</li>
+<li>warning: '%0' only applies to %select{function|pointer|Objective-C object or block pointer}1 types; type here is %2</li>
+<li>warning: 'abi_tag' attribute on %select{non-inline|anonymous}0 namespace ignored</li>
+<li>warning: 'deprecated' attribute on anonymous namespace ignored</li>
+<li>warning: 'gnu_inline' attribute requires function to be marked 'inline', attribute ignored</li>
+<li>warning: 'internal_linkage' attribute on a non-static local variable is ignored</li>
+<li>warning: 'nocf_check' attribute ignored; use -fcf-protection to enable the attribute</li>
+<li>warning: 'nonnull' attribute applied to function with no pointer arguments</li>
+<li>warning: 'nonnull' attribute when used on parameters takes no arguments</li>
+<li>warning: 'sentinel' attribute only supported for variadic %select{functions|blocks}0</li>
+<li>warning: 'sentinel' attribute requires named arguments</li>
+<li>warning: 'trivial_abi' cannot be applied to %0</li>
+<li>warning: MIPS 'interrupt' attribute only applies to functions that have %select{no parameters|a 'void' return type}0</li>
+<li>warning: Objective-C GC does not allow weak variables on the stack</li>
+<li>warning: RISC-V 'interrupt' attribute only applies to functions that have %select{no parameters|a 'void' return type}0</li>
+<li>warning: __declspec attribute %0 is not supported</li>
+<li>warning: __weak attribute cannot be specified on a field declaration</li>
+<li>warning: __weak attribute cannot be specified on an automatic variable when ARC is not enabled</li>
+<li>warning: attribute %0 after definition is ignored</li>
+<li>warning: attribute %0 cannot be applied to %select{functions|Objective-C method}1 without return value</li>
+<li>warning: attribute %0 ignored, because it cannot be applied to a type</li>
+<li>warning: attribute %0 ignored, because it cannot be applied to omitted return type</li>
+<li>warning: attribute %0 ignored, because it is not attached to a declaration</li>
+<li>warning: attribute %0 is already applied</li>
+<li>warning: attribute %0 is already applied with different parameters</li>
+<li>warning: attribute %0 is ignored, place it after "%select{class|struct|interface|union|enum}1" to apply attribute to type declaration</li>
+<li>warning: attribute declaration must precede definition</li>
+<li>warning: calling convention %0 ignored for this target</li>
+<li>warning: first field of a transparent union cannot have %select{floating point|vector}0 type %1; transparent_union attribute ignored</li>
+<li>warning: inheritance model ignored on %select{primary template|partial specialization}0</li>
+<li>warning: qualifiers after comma in declarator list are ignored</li>
+<li>warning: repeated RISC-V 'interrupt' attribute</li>
+<li>warning: transparent union definition must contain at least one field; transparent_union attribute ignored</li>
+<li>warning: transparent_union attribute can only be applied to a union definition; attribute ignored</li>
+<li>warning: unknown attribute %0 ignored</li>
+<li>warning: unknown attribute '%0'</li>
+<li>warning: unknown visibility %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wattributes" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-auto-disable-vptr-sanitizer</key>
+  <name>clang-diagnostic-auto-disable-vptr-sanitizer</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicitly disabling vptr sanitizer because rtti wasn't enabled</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wauto-disable-vptr-sanitizer" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-auto-import</key>
+  <name>clang-diagnostic-auto-import</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: treating #%select{include|import|include_next|__include_macros}0 as an import of module '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wauto-import" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-auto-storage-class</key>
+  <name>clang-diagnostic-auto-storage-class</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'auto' storage class specifier is not permitted in C++11, and will not be supported in future releases</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wauto-storage-class" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-auto-var-id</key>
+  <name>clang-diagnostic-auto-var-id</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'auto' deduced as 'id' in declaration of %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wauto-var-id" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-availability</key>
+  <name>clang-diagnostic-availability</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{|overriding }1method cannot be unavailable on %0 when %select{the protocol method it implements|its overridden method}1 is available</li>
+<li>warning: %select{|overriding }4method %select{introduced after|deprecated before|obsoleted before}0 %select{the protocol method it implements|overridden method}4 on %1 (%2 vs. %3)</li>
+<li>warning: 'unavailable' availability overrides all other availability information</li>
+<li>warning: availability does not match previous declaration</li>
+<li>warning: feature cannot be %select{introduced|deprecated|obsoleted}0 in %1 version %2 before it was %select{introduced|deprecated|obsoleted}3 in version %4; attribute ignored</li>
+<li>warning: ignoring availability attribute %select{on '+load' method|with constructor attribute|with destructor attribute}0</li>
+<li>warning: unknown platform %0 in availability macro</li>
+<li>warning: use same version number separators '_' or '.'; as in 'major[.minor[.subminor]]'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wavailability" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-backend-plugin</key>
+  <name>clang-diagnostic-backend-plugin</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbackend-plugin" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-backslash-newline-escape</key>
+  <name>clang-diagnostic-backslash-newline-escape</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: backslash and newline separated by space</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbackslash-newline-escape" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-bad-function-cast</key>
+  <name>clang-diagnostic-bad-function-cast</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: cast from function call of type %0 to non-matching type %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbad-function-cast" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-binary-literal</key>
+  <name>clang-diagnostic-binary-literal</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: binary integer literals are a C++14 extension</li>
+<li>warning: binary integer literals are a GNU extension</li>
+<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbinary-literal" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-bind-to-temporary-copy</key>
+  <name>clang-diagnostic-bind-to-temporary-copy</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %sub{select_initialized_entity_kind}1 of type %2 when binding a reference to a temporary would %select{invoke an inaccessible constructor|find no viable constructor|find ambiguous constructors|invoke a deleted constructor}0 in C++98</li>
+<li>warning: C++98 requires an accessible copy constructor for class %2 when binding a reference to a temporary; was %select{private|protected}0</li>
+<li>warning: no viable constructor %sub{select_initialized_entity_kind}0 of type %1; C++98 requires a copy constructor when binding a reference to a temporary</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbind-to-temporary-copy" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-binding-in-condition</key>
+  <name>clang-diagnostic-binding-in-condition</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++17 does not permit structured binding declaration in a condition</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbinding-in-condition" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-bitfield-constant-conversion</key>
+  <name>clang-diagnostic-bitfield-constant-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit truncation from %2 to bit-field changes value from %0 to %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbitfield-constant-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-bitfield-enum-conversion</key>
+  <name>clang-diagnostic-bitfield-enum-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: assigning value of signed enum type %1 to unsigned bit-field %0; negative enumerators of enum %1 will be converted to positive values</li>
+<li>warning: bit-field %0 is not wide enough to store all enumerators of %1</li>
+<li>warning: signed bit-field %0 needs an extra bit to represent the largest positive enumerators of %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbitfield-enum-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-bitfield-width</key>
+  <name>clang-diagnostic-bitfield-width</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: width of anonymous bit-field (%0 bits) exceeds width of its type; value will be truncated to %1 bit%s1</li>
+<li>warning: width of bit-field %0 (%1 bits) exceeds the width of its type; value will be truncated to %2 bit%s2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbitfield-width" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-bitwise-op-parentheses</key>
+  <name>clang-diagnostic-bitwise-op-parentheses</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' within '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbitwise-op-parentheses" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-block-capture-autoreleasing</key>
+  <name>clang-diagnostic-block-capture-autoreleasing</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: block captures an autoreleasing out-parameter, which may result in use-after-free bugs</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wblock-capture-autoreleasing" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-bool-conversion</key>
+  <name>clang-diagnostic-bool-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true</li>
+<li>warning: address of%select{| function| array}0 '%1' will always evaluate to 'true'</li>
+<li>warning: initialization of pointer of type %0 to null from a constant boolean expression</li>
+<li>warning: nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter</li>
+<li>warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; pointer may be assumed to always convert to true</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbool-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-bool-conversions</key>
+  <name>clang-diagnostic-bool-conversions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true</li>
+<li>warning: address of%select{| function| array}0 '%1' will always evaluate to 'true'</li>
+<li>warning: initialization of pointer of type %0 to null from a constant boolean expression</li>
+<li>warning: nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter</li>
+<li>warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; pointer may be assumed to always convert to true</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbool-conversions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-braced-scalar-init</key>
+  <name>clang-diagnostic-braced-scalar-init</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: braces around scalar initializer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbraced-scalar-init" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-bridge-cast</key>
+  <name>clang-diagnostic-bridge-cast</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 bridges to %1, not %2</li>
+<li>warning: %0 cannot bridge to %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbridge-cast" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-builtin-macro-redefined</key>
+  <name>clang-diagnostic-builtin-macro-redefined</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: redefining builtin macro</li>
+<li>warning: undefining builtin macro</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbuiltin-macro-redefined" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-builtin-memcpy-chk-size</key>
+  <name>clang-diagnostic-builtin-memcpy-chk-size</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' will always overflow; destination buffer has size %1, but size argument is %2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbuiltin-memcpy-chk-size" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-builtin-requires-header</key>
+  <name>clang-diagnostic-builtin-requires-header</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration of built-in function '%1' requires inclusion of the header &lt;%0&gt;</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbuiltin-requires-header" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++-compat</key>
+  <name>clang-diagnostic-c++-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++0x-compat</key>
+  <name>clang-diagnostic-c++0x-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|constexpr if condition}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: '%0' is a keyword in C++11</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: 'auto' storage class specifier is redundant and incompatible with C++11</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: conversion from string literal to %0 is deprecated</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicit instantiation cannot be 'inline'</li>
+<li>warning: explicit instantiation of %0 must occur at global scope</li>
+<li>warning: explicit instantiation of %0 not in a namespace enclosing %1</li>
+<li>warning: explicit instantiation of %q0 must occur in namespace %1</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: identifier after literal will be treated as a reserved user-defined literal suffix in C++11</li>
+<li>warning: identifier after literal will be treated as a user-defined literal suffix in C++11</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
+<li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: static_assert with no message is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: use of right-shift operator ('&gt;&gt;') in template argument will require parentheses in C++11</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++0x-extensions</key>
+  <name>clang-diagnostic-c++0x-extensions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{defaulted|deleted}0 function definitions are a C++11 extension</li>
+<li>warning: '%0' keyword is a C++11 extension</li>
+<li>warning: 'auto' type specifier is a C++11 extension</li>
+<li>warning: 'long long' is a C++11 extension</li>
+<li>warning: 'template' keyword outside of a template</li>
+<li>warning: 'typename' occurs outside of a template</li>
+<li>warning: alias declarations are a C++11 extension</li>
+<li>warning: befriending enumeration type %0 is a C++11 extension</li>
+<li>warning: commas at the end of enumerator lists are a C++11 extension</li>
+<li>warning: default template arguments for a function template are a C++11 extension</li>
+<li>warning: enumeration types with a fixed underlying type are a C++11 extension</li>
+<li>warning: explicit conversion functions are a C++11 extension</li>
+<li>warning: extern templates are a C++11 extension</li>
+<li>warning: extra ';' outside of a function is a C++11 extension</li>
+<li>warning: generalized initializer lists are a C++11 extension</li>
+<li>warning: implicit conversion from array size expression of type %0 to %select{integral|enumeration}1 type %2 is a C++11 extension</li>
+<li>warning: in-class initialization of non-static data member is a C++11 extension</li>
+<li>warning: inline namespaces are a C++11 feature</li>
+<li>warning: non-class friend type %0 is a C++11 extension</li>
+<li>warning: non-type template argument referring to %select{function|object}0 %1 with internal linkage is a C++11 extension</li>
+<li>warning: range-based for loop is a C++11 extension</li>
+<li>warning: reference qualifiers on functions are a C++11 extension</li>
+<li>warning: rvalue references are a C++11 extension</li>
+<li>warning: scoped enumerations are a C++11 extension</li>
+<li>warning: static data member %0 in union is a C++11 extension</li>
+<li>warning: unelaborated friend declaration is a C++11 extension; specify '%select{struct|interface|union|class|enum}0' to befriend %1</li>
+<li>warning: use of enumeration in a nested name specifier is a C++11 extension</li>
+<li>warning: variadic templates are a C++11 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-extensions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++0x-narrowing</key>
+  <name>clang-diagnostic-c++0x-narrowing</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|constexpr if condition}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-narrowing" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++11-compat</key>
+  <name>clang-diagnostic-c++11-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|constexpr if condition}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: '%0' is a keyword in C++11</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: 'auto' storage class specifier is redundant and incompatible with C++11</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: conversion from string literal to %0 is deprecated</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicit instantiation cannot be 'inline'</li>
+<li>warning: explicit instantiation of %0 must occur at global scope</li>
+<li>warning: explicit instantiation of %0 not in a namespace enclosing %1</li>
+<li>warning: explicit instantiation of %q0 must occur in namespace %1</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: identifier after literal will be treated as a reserved user-defined literal suffix in C++11</li>
+<li>warning: identifier after literal will be treated as a user-defined literal suffix in C++11</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
+<li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: static_assert with no message is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: use of right-shift operator ('&gt;&gt;') in template argument will require parentheses in C++11</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++11-compat-deprecated-writable-strings</key>
+  <name>clang-diagnostic-c++11-compat-deprecated-writable-strings</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: conversion from string literal to %0 is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-compat-deprecated-writable-strings" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++11-compat-pedantic</key>
+  <name>clang-diagnostic-c++11-compat-pedantic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|constexpr if condition}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: '%0' is a keyword in C++11</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: 'auto' storage class specifier is redundant and incompatible with C++11</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
+<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: conversion from string literal to %0 is deprecated</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicit instantiation cannot be 'inline'</li>
+<li>warning: explicit instantiation of %0 must occur at global scope</li>
+<li>warning: explicit instantiation of %0 not in a namespace enclosing %1</li>
+<li>warning: explicit instantiation of %q0 must occur in namespace %1</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: hexadecimal floating literals are incompatible with C++ standards before C++17</li>
+<li>warning: identifier after literal will be treated as a reserved user-defined literal suffix in C++11</li>
+<li>warning: identifier after literal will be treated as a user-defined literal suffix in C++11</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
+<li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
+<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++2a</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: static_assert with no message is incompatible with C++ standards before C++17</li>
+<li>warning: static_assert with no message is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: use of right-shift operator ('&gt;&gt;') in template argument will require parentheses in C++11</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++11-compat-reserved-user-defined-literal</key>
+  <name>clang-diagnostic-c++11-compat-reserved-user-defined-literal</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: identifier after literal will be treated as a reserved user-defined literal suffix in C++11</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-compat-reserved-user-defined-literal" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++11-extensions</key>
+  <name>clang-diagnostic-c++11-extensions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{defaulted|deleted}0 function definitions are a C++11 extension</li>
+<li>warning: '%0' keyword is a C++11 extension</li>
+<li>warning: 'auto' type specifier is a C++11 extension</li>
+<li>warning: 'long long' is a C++11 extension</li>
+<li>warning: 'template' keyword outside of a template</li>
+<li>warning: 'typename' occurs outside of a template</li>
+<li>warning: alias declarations are a C++11 extension</li>
+<li>warning: befriending enumeration type %0 is a C++11 extension</li>
+<li>warning: commas at the end of enumerator lists are a C++11 extension</li>
+<li>warning: default template arguments for a function template are a C++11 extension</li>
+<li>warning: enumeration types with a fixed underlying type are a C++11 extension</li>
+<li>warning: explicit conversion functions are a C++11 extension</li>
+<li>warning: extern templates are a C++11 extension</li>
+<li>warning: extra ';' outside of a function is a C++11 extension</li>
+<li>warning: generalized initializer lists are a C++11 extension</li>
+<li>warning: implicit conversion from array size expression of type %0 to %select{integral|enumeration}1 type %2 is a C++11 extension</li>
+<li>warning: in-class initialization of non-static data member is a C++11 extension</li>
+<li>warning: inline namespaces are a C++11 feature</li>
+<li>warning: non-class friend type %0 is a C++11 extension</li>
+<li>warning: non-type template argument referring to %select{function|object}0 %1 with internal linkage is a C++11 extension</li>
+<li>warning: range-based for loop is a C++11 extension</li>
+<li>warning: reference qualifiers on functions are a C++11 extension</li>
+<li>warning: rvalue references are a C++11 extension</li>
+<li>warning: scoped enumerations are a C++11 extension</li>
+<li>warning: static data member %0 in union is a C++11 extension</li>
+<li>warning: unelaborated friend declaration is a C++11 extension; specify '%select{struct|interface|union|class|enum}0' to befriend %1</li>
+<li>warning: use of enumeration in a nested name specifier is a C++11 extension</li>
+<li>warning: variadic templates are a C++11 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-extensions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++11-extra-semi</key>
+  <name>clang-diagnostic-c++11-extra-semi</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: extra ';' outside of a function is a C++11 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-extra-semi" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++11-inline-namespace</key>
+  <name>clang-diagnostic-c++11-inline-namespace</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: inline namespaces are a C++11 feature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-inline-namespace" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++11-long-long</key>
+  <name>clang-diagnostic-c++11-long-long</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'long long' is a C++11 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-long-long" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++11-narrowing</key>
+  <name>clang-diagnostic-c++11-narrowing</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|constexpr if condition}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-narrowing" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++14-binary-literal</key>
+  <name>clang-diagnostic-c++14-binary-literal</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: binary integer literals are a C++14 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-14-binary-literal" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++14-compat</key>
+  <name>clang-diagnostic-c++14-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+<li>warning: static_assert with no message is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-14-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++14-compat-pedantic</key>
+  <name>clang-diagnostic-c++14-compat-pedantic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: hexadecimal floating literals are incompatible with C++ standards before C++17</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++2a</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+<li>warning: static_assert with no message is incompatible with C++ standards before C++17</li>
+<li>warning: static_assert with no message is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-14-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++14-extensions</key>
+  <name>clang-diagnostic-c++14-extensions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'decltype(auto)' type specifier is a C++14 extension</li>
+<li>warning: binary integer literals are a C++14 extension</li>
+<li>warning: initialized lambda captures are a C++14 extension</li>
+<li>warning: multiple return statements in constexpr function is a C++14 extension</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is a C++14 extension</li>
+<li>warning: use of the %0 attribute is a C++14 extension</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++14 extension</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is a C++14 extension</li>
+<li>warning: variable templates are a C++14 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-14-extensions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++17-compat</key>
+  <name>clang-diagnostic-c++17-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
+<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-17-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++17-compat-mangling</key>
+  <name>clang-diagnostic-c++17-compat-mangling</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-17-compat-mangling" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++17-compat-pedantic</key>
+  <name>clang-diagnostic-c++17-compat-pedantic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
+<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++2a</li>
+<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-17-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++17-extensions</key>
+  <name>clang-diagnostic-c++17-extensions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%select{if|switch}0' initialization statements are a C++17 extension</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is a C++17 extension</li>
+<li>warning: 'constexpr' on lambda expressions is a C++17 extension</li>
+<li>warning: ISO C++ standards before C++17 do not allow new expression for type %0 to use list-initialization</li>
+<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are a C++17 extension</li>
+<li>warning: capture of '*this' by copy is a C++17 extension</li>
+<li>warning: constexpr if is a C++17 extension</li>
+<li>warning: decomposition declarations are a C++17 extension</li>
+<li>warning: default scope specifier for attributes is a C++17 extension</li>
+<li>warning: hexadecimal floating literals are a C++17 feature</li>
+<li>warning: inline variables are a C++17 extension</li>
+<li>warning: nested namespace definition is a C++17 extension; define each namespace separately</li>
+<li>warning: pack expansion of using declaration is a C++17 extension</li>
+<li>warning: pack fold expression is a C++17 extension</li>
+<li>warning: static_assert with no message is a C++17 extension</li>
+<li>warning: template template parameter using 'typename' is a C++17 extension</li>
+<li>warning: use of multiple declarators in a single using declaration is a C++17 extension</li>
+<li>warning: use of the %0 attribute is a C++17 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-17-extensions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++1y-extensions</key>
+  <name>clang-diagnostic-c++1y-extensions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'decltype(auto)' type specifier is a C++14 extension</li>
+<li>warning: binary integer literals are a C++14 extension</li>
+<li>warning: initialized lambda captures are a C++14 extension</li>
+<li>warning: multiple return statements in constexpr function is a C++14 extension</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is a C++14 extension</li>
+<li>warning: use of the %0 attribute is a C++14 extension</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++14 extension</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is a C++14 extension</li>
+<li>warning: variable templates are a C++14 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1y-extensions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++1z-compat</key>
+  <name>clang-diagnostic-c++1z-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
+<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++1z-compat-mangling</key>
+  <name>clang-diagnostic-c++1z-compat-mangling</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat-mangling" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++1z-extensions</key>
+  <name>clang-diagnostic-c++1z-extensions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%select{if|switch}0' initialization statements are a C++17 extension</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is a C++17 extension</li>
+<li>warning: 'constexpr' on lambda expressions is a C++17 extension</li>
+<li>warning: ISO C++ standards before C++17 do not allow new expression for type %0 to use list-initialization</li>
+<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are a C++17 extension</li>
+<li>warning: capture of '*this' by copy is a C++17 extension</li>
+<li>warning: constexpr if is a C++17 extension</li>
+<li>warning: decomposition declarations are a C++17 extension</li>
+<li>warning: default scope specifier for attributes is a C++17 extension</li>
+<li>warning: hexadecimal floating literals are a C++17 feature</li>
+<li>warning: inline variables are a C++17 extension</li>
+<li>warning: nested namespace definition is a C++17 extension; define each namespace separately</li>
+<li>warning: pack expansion of using declaration is a C++17 extension</li>
+<li>warning: pack fold expression is a C++17 extension</li>
+<li>warning: static_assert with no message is a C++17 extension</li>
+<li>warning: template template parameter using 'typename' is a C++17 extension</li>
+<li>warning: use of multiple declarators in a single using declaration is a C++17 extension</li>
+<li>warning: use of the %0 attribute is a C++17 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-extensions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++2a-compat</key>
+  <name>clang-diagnostic-c++2a-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' is a keyword in C++2a</li>
+<li>warning: '&lt;=&gt;' is a single token in C++2a; add a space to avoid a change in behavior</li>
+<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++2a</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++2a-compat-pedantic</key>
+  <name>clang-diagnostic-c++2a-compat-pedantic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' is a keyword in C++2a</li>
+<li>warning: '&lt;=&gt;' is a single token in C++2a; add a space to avoid a change in behavior</li>
+<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++2a</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++2a-extensions</key>
+  <name>clang-diagnostic-c++2a-extensions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: default member initializer for bit-field is a C++2a extension</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is a C++2a extension</li>
+<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is a C++2a extension</li>
+<li>warning: range-based for loop initialization statements are a C++2a extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-extensions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat</key>
+  <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</key>
+  <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++2a</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++98-c++11-c++14-compat</key>
+  <name>clang-diagnostic-c++98-c++11-c++14-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: static_assert with no message is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</key>
+  <name>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: hexadecimal floating literals are incompatible with C++ standards before C++17</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: static_assert with no message is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++98-c++11-compat</key>
+  <name>clang-diagnostic-c++98-c++11-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++98-c++11-compat-binary-literal</key>
+  <name>clang-diagnostic-c++98-c++11-compat-binary-literal</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat-binary-literal" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++98-c++11-compat-pedantic</key>
+  <name>clang-diagnostic-c++98-c++11-compat-pedantic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++98-compat</key>
+  <name>clang-diagnostic-c++98-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{anonymous struct|union}0 member %1 with a non-trivial %sub{select_special_member_kind}2 is incompatible with C++98</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: %select{defaulted|deleted}0 function definitions are incompatible with C++98</li>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: '%0' keyword is incompatible with C++98</li>
+<li>warning: '%0' type specifier is incompatible with C++98</li>
+<li>warning: '&lt;::' is treated as digraph '&lt;:' (aka '[') followed by ':' in C++98</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: 'alignas' is incompatible with C++98</li>
+<li>warning: 'auto' type specifier is incompatible with C++98</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'constexpr' specifier is incompatible with C++98</li>
+<li>warning: 'decltype' type specifier is incompatible with C++98</li>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: 'nullptr' is incompatible with C++98</li>
+<li>warning: C++11 attribute syntax is incompatible with C++98</li>
+<li>warning: alias declarations are incompatible with C++98</li>
+<li>warning: alignof expressions are incompatible with C++98</li>
+<li>warning: befriending %1 without '%select{struct|interface|union|class|enum}0' keyword is incompatible with C++98</li>
+<li>warning: befriending enumeration type %0 is incompatible with C++98</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: consecutive right angle brackets are incompatible with C++98 (use '&gt; &gt;')</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: constructor call from initializer list is incompatible with C++98</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: default template arguments for a function template are incompatible with C++98</li>
+<li>warning: delegating constructors are incompatible with C++98</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: enumeration type in nested name specifier is incompatible with C++98</li>
+<li>warning: enumeration types with a fixed underlying type are incompatible with C++98</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicit conversion functions are incompatible with C++98</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: friend declaration naming a member of the declaring class is incompatible with C++98</li>
+<li>warning: generalized initializer lists are incompatible with C++98</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: in-class initialization of non-static data members is incompatible with C++98</li>
+<li>warning: inheriting constructors are incompatible with C++98</li>
+<li>warning: initialization of initializer_list object is incompatible with C++98</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: inline namespaces are incompatible with C++98</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: jump from switch statement to this case label is incompatible with C++98</li>
+<li>warning: jump from this goto statement to its label is incompatible with C++98</li>
+<li>warning: jump from this indirect goto statement to one of its possible targets is incompatible with C++98</li>
+<li>warning: lambda expressions are incompatible with C++98</li>
+<li>warning: literal operators are incompatible with C++98</li>
+<li>warning: local type %0 as template argument is incompatible with C++98</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: noexcept expressions are incompatible with C++98</li>
+<li>warning: noexcept specifications are incompatible with C++98</li>
+<li>warning: non-class friend type %0 is incompatible with C++98</li>
+<li>warning: non-type template argument referring to %select{function|object}0 %1 with internal linkage is incompatible with C++98</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: passing object of trivial but non-POD type %0 through variadic %select{function|block|method|constructor}1 is incompatible with C++98</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+<li>warning: range-based for loop is incompatible with C++98</li>
+<li>warning: raw string literals are incompatible with C++98</li>
+<li>warning: redundant parentheses surrounding address non-type template argument are incompatible with C++98</li>
+<li>warning: reference initialized from initializer list is incompatible with C++98</li>
+<li>warning: reference qualifiers on functions are incompatible with C++98</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: rvalue references are incompatible with C++98</li>
+<li>warning: scalar initialized from empty initializer list is incompatible with C++98</li>
+<li>warning: scoped enumerations are incompatible with C++98</li>
+<li>warning: specifying character '%0' with a universal character name is incompatible with C++98</li>
+<li>warning: static data member %0 in union is incompatible with C++98</li>
+<li>warning: static_assert declarations are incompatible with C++98</li>
+<li>warning: static_assert with no message is incompatible with C++ standards before C++17</li>
+<li>warning: substitution failure due to access control is incompatible with C++98</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: trailing return types are incompatible with C++98</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++98</li>
+<li>warning: universal character name referring to a control character is incompatible with C++98</li>
+<li>warning: unnamed type as template argument is incompatible with C++98</li>
+<li>warning: use of 'template' keyword outside of a template is incompatible with C++98</li>
+<li>warning: use of 'typename' outside of a template is incompatible with C++98</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: use of non-static data member %0 in an unevaluated context is incompatible with C++98</li>
+<li>warning: use of null pointer as non-type template argument is incompatible with C++98</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: using this character in an identifier is incompatible with C++98</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+<li>warning: variadic templates are incompatible with C++98</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++98-compat-bind-to-temporary-copy</key>
+  <name>clang-diagnostic-c++98-compat-bind-to-temporary-copy</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %sub{select_initialized_entity_kind}1 of type %2 when binding a reference to a temporary would %select{invoke an inaccessible constructor|find no viable constructor|find ambiguous constructors|invoke a deleted constructor}0 in C++98</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-compat-bind-to-temporary-copy" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++98-compat-extra-semi</key>
+  <name>clang-diagnostic-c++98-compat-extra-semi</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: extra ';' outside of a function is incompatible with C++98</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-compat-extra-semi" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++98-compat-local-type-template-args</key>
+  <name>clang-diagnostic-c++98-compat-local-type-template-args</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: local type %0 as template argument is incompatible with C++98</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-compat-local-type-template-args" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++98-compat-pedantic</key>
+  <name>clang-diagnostic-c++98-compat-pedantic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #line number greater than 32767 is incompatible with C++98</li>
+<li>warning: %select{anonymous struct|union}0 member %1 with a non-trivial %sub{select_special_member_kind}2 is incompatible with C++98</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++2a</li>
+<li>warning: %select{defaulted|deleted}0 function definitions are incompatible with C++98</li>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: %sub{select_initialized_entity_kind}1 of type %2 when binding a reference to a temporary would %select{invoke an inaccessible constructor|find no viable constructor|find ambiguous constructors|invoke a deleted constructor}0 in C++98</li>
+<li>warning: '%0' keyword is incompatible with C++98</li>
+<li>warning: '%0' type specifier is incompatible with C++98</li>
+<li>warning: '&lt;::' is treated as digraph '&lt;:' (aka '[') followed by ':' in C++98</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++2a</li>
+<li>warning: 'alignas' is incompatible with C++98</li>
+<li>warning: 'auto' type specifier is incompatible with C++98</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'constexpr' specifier is incompatible with C++98</li>
+<li>warning: 'decltype' type specifier is incompatible with C++98</li>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: 'long long' is incompatible with C++98</li>
+<li>warning: 'nullptr' is incompatible with C++98</li>
+<li>warning: C++11 attribute syntax is incompatible with C++98</li>
+<li>warning: C++98 requires newline at end of file</li>
+<li>warning: alias declarations are incompatible with C++98</li>
+<li>warning: alignof expressions are incompatible with C++98</li>
+<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
+<li>warning: befriending %1 without '%select{struct|interface|union|class|enum}0' keyword is incompatible with C++98</li>
+<li>warning: befriending enumeration type %0 is incompatible with C++98</li>
+<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: cast between pointer-to-function and pointer-to-object is incompatible with C++98</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: commas at the end of enumerator lists are incompatible with C++98</li>
+<li>warning: consecutive right angle brackets are incompatible with C++98 (use '&gt; &gt;')</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: constructor call from initializer list is incompatible with C++98</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++2a</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: default template arguments for a function template are incompatible with C++98</li>
+<li>warning: delegating constructors are incompatible with C++98</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: empty macro arguments are incompatible with C++98</li>
+<li>warning: enumeration type in nested name specifier is incompatible with C++98</li>
+<li>warning: enumeration types with a fixed underlying type are incompatible with C++98</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++2a</li>
+<li>warning: explicit conversion functions are incompatible with C++98</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++2a</li>
+<li>warning: extern templates are incompatible with C++98</li>
+<li>warning: extra ';' outside of a function is incompatible with C++98</li>
+<li>warning: friend declaration naming a member of the declaring class is incompatible with C++98</li>
+<li>warning: generalized initializer lists are incompatible with C++98</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: hexadecimal floating literals are incompatible with C++ standards before C++17</li>
+<li>warning: implicit conversion from array size expression of type %0 to %select{integral|enumeration}1 type %2 is incompatible with C++98</li>
+<li>warning: in-class initialization of non-static data members is incompatible with C++98</li>
+<li>warning: inheriting constructors are incompatible with C++98</li>
+<li>warning: initialization of initializer_list object is incompatible with C++98</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: inline namespaces are incompatible with C++98</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++2a</li>
+<li>warning: jump from switch statement to this case label is incompatible with C++98</li>
+<li>warning: jump from this goto statement to its label is incompatible with C++98</li>
+<li>warning: jump from this indirect goto statement to one of its possible targets is incompatible with C++98</li>
+<li>warning: lambda expressions are incompatible with C++98</li>
+<li>warning: literal operators are incompatible with C++98</li>
+<li>warning: local type %0 as template argument is incompatible with C++98</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: noexcept expressions are incompatible with C++98</li>
+<li>warning: noexcept specifications are incompatible with C++98</li>
+<li>warning: non-class friend type %0 is incompatible with C++98</li>
+<li>warning: non-type template argument referring to %select{function|object}0 %1 with internal linkage is incompatible with C++98</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: passing object of trivial but non-POD type %0 through variadic %select{function|block|method|constructor}1 is incompatible with C++98</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++2a</li>
+<li>warning: range-based for loop is incompatible with C++98</li>
+<li>warning: raw string literals are incompatible with C++98</li>
+<li>warning: redundant parentheses surrounding address non-type template argument are incompatible with C++98</li>
+<li>warning: reference initialized from initializer list is incompatible with C++98</li>
+<li>warning: reference qualifiers on functions are incompatible with C++98</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: rvalue references are incompatible with C++98</li>
+<li>warning: scalar initialized from empty initializer list is incompatible with C++98</li>
+<li>warning: scoped enumerations are incompatible with C++98</li>
+<li>warning: specifying character '%0' with a universal character name is incompatible with C++98</li>
+<li>warning: static data member %0 in union is incompatible with C++98</li>
+<li>warning: static_assert declarations are incompatible with C++98</li>
+<li>warning: static_assert with no message is incompatible with C++ standards before C++17</li>
+<li>warning: static_assert with no message is incompatible with C++ standards before C++17</li>
+<li>warning: substitution failure due to access control is incompatible with C++98</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: trailing return types are incompatible with C++98</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++98</li>
+<li>warning: universal character name referring to a control character is incompatible with C++98</li>
+<li>warning: unnamed type as template argument is incompatible with C++98</li>
+<li>warning: use of 'template' keyword outside of a template is incompatible with C++98</li>
+<li>warning: use of 'typename' outside of a template is incompatible with C++98</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: use of non-static data member %0 in an unevaluated context is incompatible with C++98</li>
+<li>warning: use of null pointer as non-type template argument is incompatible with C++98</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: using this character in an identifier is incompatible with C++98</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+<li>warning: variadic macros are incompatible with C++98</li>
+<li>warning: variadic templates are incompatible with C++98</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c++98-compat-unnamed-type-template-args</key>
+  <name>clang-diagnostic-c++98-compat-unnamed-type-template-args</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unnamed type as template argument is incompatible with C++98</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-compat-unnamed-type-template-args" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c11-extensions</key>
+  <name>clang-diagnostic-c11-extensions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is a C11-specific feature</li>
+<li>warning: _Noreturn functions are a C11-specific feature</li>
+<li>warning: _Static_assert is a C11-specific feature</li>
+<li>warning: anonymous structs are a C11 extension</li>
+<li>warning: anonymous unions are a C11 extension</li>
+<li>warning: generic selections are a C11-specific feature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc11-extensions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c99-compat</key>
+  <name>clang-diagnostic-c99-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{using this character in an identifier|starting an identifier with this character}0 is incompatible with C99</li>
+<li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C89; this literal will %select{have type 'long long'|be ill-formed}0 in C99 onwards</li>
+<li>warning: unicode literals are incompatible with C99</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc99-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-c99-extensions</key>
+  <name>clang-diagnostic-c99-extensions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{qualifier in |static |}0array size %select{||'[*] '}0is a C99 feature</li>
+<li>warning: ISO C99 requires whitespace after the macro name</li>
+<li>warning: commas at the end of enumerator lists are a C99-specific feature</li>
+<li>warning: compound literals are a C99-specific feature</li>
+<li>warning: designated initializers are a C99 feature</li>
+<li>warning: empty macro arguments are a C99 feature</li>
+<li>warning: flexible array members are a C99 feature</li>
+<li>warning: hexadecimal floating constants are a C99 feature</li>
+<li>warning: initializer for aggregate is not a compile-time constant</li>
+<li>warning: variable declaration in for loop is a C99-specific feature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc99-extensions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-cast-align</key>
+  <name>clang-diagnostic-cast-align</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: cast from %0 to %1 increases required alignment from %2 to %3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-align" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-cast-calling-convention</key>
+  <name>clang-diagnostic-cast-calling-convention</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: cast between incompatible calling conventions '%0' and '%1'; calls through this pointer may abort at runtime</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-calling-convention" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-cast-of-sel-type</key>
+  <name>clang-diagnostic-cast-of-sel-type</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: cast of type %0 to %1 is deprecated; use sel_getName instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-of-sel-type" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-cast-qual</key>
+  <name>clang-diagnostic-cast-qual</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: cast from %0 to %1 drops %select{const and volatile qualifiers|const qualifier|volatile qualifier}2</li>
+<li>warning: cast from %0 to %1 must have all intermediate pointers const qualified to be safe</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-qual" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-cast-qual-unrelated</key>
+  <name>clang-diagnostic-cast-qual-unrelated</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++ does not allow %select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast}0 from %1 to %2 because it casts away qualifiers, even though the source and destination types are unrelated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-qual-unrelated" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-char-subscripts</key>
+  <name>clang-diagnostic-char-subscripts</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: array section %select{lower bound|length}0 is of type 'char'</li>
+<li>warning: array subscript is of type 'char'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wchar-subscripts" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-clang-cl-pch</key>
+  <name>clang-diagnostic-clang-cl-pch</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma hdrstop filename not supported, /Fp can be used to specify precompiled header filename</li>
+<li>warning: definition of macro %0 does not match definition in precompiled header</li>
+<li>warning: support for '%0' without a corresponding /FI flag not implemented yet; flag ignored</li>
+<li>warning: support for '/Yc' and '/Yu' with different filenames not implemented yet; flags ignored</li>
+<li>warning: support for '/Yc' with more than one source file not implemented yet; flag ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wclang-cl-pch" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-class-varargs</key>
+  <name>clang-diagnostic-class-varargs</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: cannot pass %select{non-POD|non-trivial}0 object of type %1 to variadic %select{function|block|method|constructor}2; expected type from format string was %3</li>
+<li>warning: cannot pass object of %select{non-POD|non-trivial}0 type %1 through variadic %select{function|block|method|constructor}2; call will abort at runtime</li>
+<li>warning: passing object of class type %0 through variadic %select{function|block|method|constructor}1%select{|; did you mean to call '%3'?}2</li>
+<li>warning: second argument to 'va_arg' is of ARC ownership-qualified type %0</li>
+<li>warning: second argument to 'va_arg' is of non-POD type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wclass-varargs" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-comma</key>
+  <name>clang-diagnostic-comma</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: possible misuse of comma operator here</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcomma" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-comment</key>
+  <name>clang-diagnostic-comment</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '/*' within block comment</li>
+<li>warning: // comments are not allowed in this language</li>
+<li>warning: escaped newline between */ characters at block comment end</li>
+<li>warning: multi-line // comment</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcomment" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-comments</key>
+  <name>clang-diagnostic-comments</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '/*' within block comment</li>
+<li>warning: // comments are not allowed in this language</li>
+<li>warning: escaped newline between */ characters at block comment end</li>
+<li>warning: multi-line // comment</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcomments" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-compare-distinct-pointer-types</key>
+  <name>clang-diagnostic-compare-distinct-pointer-types</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: comparison of distinct pointer types%diff{ ($ and $)|}0,1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcompare-distinct-pointer-types" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-complex-component-init</key>
+  <name>clang-diagnostic-complex-component-init</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: complex initialization specifying real and imaginary components is an extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcomplex-component-init" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-conditional-type-mismatch</key>
+  <name>clang-diagnostic-conditional-type-mismatch</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: pointer/integer type mismatch in conditional expression%diff{ ($ and $)|}0,1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconditional-type-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-conditional-uninitialized</key>
+  <name>clang-diagnostic-conditional-uninitialized</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: variable %0 may be uninitialized when %select{used here|captured by block}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconditional-uninitialized" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-config-macros</key>
+  <name>clang-diagnostic-config-macros</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{definition|#undef}0 of configuration macro '%1' has no effect on the import of '%2'; pass '%select{-D%1=...|-U%1}0' on the command line to configure the module</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconfig-macros" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-constant-conversion</key>
+  <name>clang-diagnostic-constant-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion from %2 to %3 changes value from %0 to %1</li>
+<li>warning: implicit truncation from %2 to bit-field changes value from %0 to %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconstant-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-constant-logical-operand</key>
+  <name>clang-diagnostic-constant-logical-operand</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: use of logical '%0' with constant operand</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconstant-logical-operand" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-constexpr-not-const</key>
+  <name>clang-diagnostic-constexpr-not-const</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconstexpr-not-const" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-consumed</key>
+  <name>clang-diagnostic-consumed</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: argument not in expected state; expected '%0', observed '%1'</li>
+<li>warning: consumed analysis attribute is attached to member of class '%0' which isn't marked as consumable</li>
+<li>warning: invalid invocation of method '%0' on a temporary object while it is in the '%1' state</li>
+<li>warning: invalid invocation of method '%0' on object '%1' while it is in the '%2' state</li>
+<li>warning: parameter '%0' not in expected state when the function returns: expected '%1', observed '%2'</li>
+<li>warning: return state set for an unconsumable type '%0'</li>
+<li>warning: return value not in expected state; expected '%0', observed '%1'</li>
+<li>warning: state of variable '%0' must match at the entry and exit of loop</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconsumed" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-conversion</key>
+  <name>clang-diagnostic-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true</li>
+<li>warning: address of%select{| function| array}0 '%1' will always evaluate to 'true'</li>
+<li>warning: assigning value of signed enum type %1 to unsigned bit-field %0; negative enumerators of enum %1 will be converted to positive values</li>
+<li>warning: bit-field %0 is not wide enough to store all enumerators of %1</li>
+<li>warning: expression which evaluates to zero treated as a null pointer constant of type %0</li>
+<li>warning: implicit boolean conversion of Objective-C object literal always evaluates to true</li>
+<li>warning: implicit conversion changes signedness: %0 to %1</li>
+<li>warning: implicit conversion discards imaginary component: %0 to %1</li>
+<li>warning: implicit conversion from %0 to %1 changes non-zero value from %2 to %3</li>
+<li>warning: implicit conversion from %0 to %1 changes value from %2 to %3</li>
+<li>warning: implicit conversion from %0 to %1 changes value from %2 to %3</li>
+<li>warning: implicit conversion from %2 to %3 changes value from %0 to %1</li>
+<li>warning: implicit conversion from enumeration type %0 to different enumeration type %1</li>
+<li>warning: implicit conversion loses floating-point precision: %0 to %1</li>
+<li>warning: implicit conversion loses integer precision: %0 to %1</li>
+<li>warning: implicit conversion loses integer precision: %0 to %1</li>
+<li>warning: implicit conversion of %select{NULL|nullptr}0 constant to %1</li>
+<li>warning: implicit conversion of out of range value from %0 to %1 is undefined</li>
+<li>warning: implicit conversion of out of range value from %0 to %1 is undefined</li>
+<li>warning: implicit conversion turns floating-point number into integer: %0 to %1</li>
+<li>warning: implicit conversion turns string literal into bool: %0 to %1</li>
+<li>warning: implicit conversion turns vector to scalar: %0 to %1</li>
+<li>warning: implicit conversion when assigning computation result loses floating-point precision: %0 to %1</li>
+<li>warning: implicit truncation from %2 to bit-field changes value from %0 to %1</li>
+<li>warning: incompatible integer to pointer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+<li>warning: incompatible pointer to integer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+<li>warning: initialization of pointer of type %0 to null from a constant boolean expression</li>
+<li>warning: non-type template argument value '%0' truncated to '%1' for template parameter of type %2</li>
+<li>warning: non-type template argument with value '%0' converted to '%1' for unsigned template parameter of type %2</li>
+<li>warning: nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter</li>
+<li>warning: object of type %0 is not compatible with %select{array element type|dictionary key type|dictionary value type}1 %2</li>
+<li>warning: operand of ? changes signedness: %0 to %1</li>
+<li>warning: passing non-generic address space pointer to %0 may cause dynamic conversion affecting performance</li>
+<li>warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; pointer may be assumed to always convert to true</li>
+<li>warning: signed bit-field %0 needs an extra bit to represent the largest positive enumerators of %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-conversion-null</key>
+  <name>clang-diagnostic-conversion-null</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion of %select{NULL|nullptr}0 constant to %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconversion-null" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-coroutine</key>
+  <name>clang-diagnostic-coroutine</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is required to declare the member 'unhandled_exception()' when exceptions are enabled</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcoroutine" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-coroutine-missing-unhandled-exception</key>
+  <name>clang-diagnostic-coroutine-missing-unhandled-exception</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is required to declare the member 'unhandled_exception()' when exceptions are enabled</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcoroutine-missing-unhandled-exception" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-covered-switch-default</key>
+  <name>clang-diagnostic-covered-switch-default</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: default label in switch which covers all enumeration values</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcovered-switch-default" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-cpp</key>
+  <name>clang-diagnostic-cpp</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcpp" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-cstring-format-directive</key>
+  <name>clang-diagnostic-cstring-format-directive</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: using %0 directive in %select{NSString|CFString}1 which is being passed as a formatting argument to the formatting %select{method|CFfunction}2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcstring-format-directive" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-cuda-compat</key>
+  <name>clang-diagnostic-cuda-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 attribute parameter %1 is negative and will be ignored</li>
+<li>warning: argument to '#pragma unroll' should not be in parentheses in CUDA C/C++</li>
+<li>warning: ignored 'inline' attribute on kernel function %0</li>
+<li>warning: kernel function %0 is a member function; this may not be accepted by nvcc</li>
+<li>warning: nvcc does not allow '__%0__' to appear after '()' in lambdas</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcuda-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-custom-atomic-properties</key>
+  <name>clang-diagnostic-custom-atomic-properties</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: atomic by default property %0 has a user defined %select{getter|setter}1 (property should be marked 'atomic' if this is intended)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcustom-atomic-properties" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-dangling</key>
+  <name>clang-diagnostic-dangling</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{address of|reference to}0 stack memory associated with %select{local variable|parameter}2 %1 returned</li>
+<li>warning: %select{reference|backing array for 'std::initializer_list'}2 %select{|subobject of }1member %0 %select{binds to|is}2 a temporary object whose lifetime is shorter than the lifetime of the constructed object</li>
+<li>warning: %select{temporary %select{whose address is used as value of|%select{|implicitly }2bound to}4 %select{%select{|reference }4member of local variable|local %select{variable|reference}4}1|array backing %select{initializer list subobject of local variable|local initializer list}1}0 %select{%3 |}2will be destroyed at the end of the full-expression</li>
+<li>warning: array backing %select{initializer list subobject of the allocated object|the allocated initializer list}0 will be destroyed at the end of the full-expression</li>
+<li>warning: binding reference member %0 to stack allocated %select{variable|parameter}2 %1</li>
+<li>warning: initializing pointer member %0 with the stack address of %select{variable|parameter}2 %1</li>
+<li>warning: returning %select{address of|reference to}0 local temporary object</li>
+<li>warning: returning address of label, which is local</li>
+<li>warning: sorry, lifetime extension of %select{temporary|backing array of initializer list}0 created by aggregate initialization using default member initializer is not supported; lifetime of %select{temporary|backing array}0 will end at the end of the full-expression</li>
+<li>warning: temporary bound to reference member of allocated object will be destroyed at the end of the full-expression</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdangling" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-dangling-else</key>
+  <name>clang-diagnostic-dangling-else</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: add explicit braces to avoid dangling else</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdangling-else" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-dangling-field</key>
+  <name>clang-diagnostic-dangling-field</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{reference|backing array for 'std::initializer_list'}2 %select{|subobject of }1member %0 %select{binds to|is}2 a temporary object whose lifetime is shorter than the lifetime of the constructed object</li>
+<li>warning: binding reference member %0 to stack allocated %select{variable|parameter}2 %1</li>
+<li>warning: initializing pointer member %0 with the stack address of %select{variable|parameter}2 %1</li>
+<li>warning: temporary bound to reference member of allocated object will be destroyed at the end of the full-expression</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdangling-field" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-dangling-initializer-list</key>
+  <name>clang-diagnostic-dangling-initializer-list</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: array backing %select{initializer list subobject of the allocated object|the allocated initializer list}0 will be destroyed at the end of the full-expression</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdangling-initializer-list" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-date-time</key>
+  <name>clang-diagnostic-date-time</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: expansion of date or time macro is not reproducible</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdate-time" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-dealloc-in-category</key>
+  <name>clang-diagnostic-dealloc-in-category</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: -dealloc is being overridden in a category</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdealloc-in-category" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-debug-compression-unavailable</key>
+  <name>clang-diagnostic-debug-compression-unavailable</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: cannot compress debug sections (zlib not installed)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdebug-compression-unavailable" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-declaration-after-statement</key>
+  <name>clang-diagnostic-declaration-after-statement</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C90 forbids mixing declarations and code</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeclaration-after-statement" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-defaulted-function-deleted</key>
+  <name>clang-diagnostic-defaulted-function-deleted</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: explicitly defaulted %sub{select_special_member_kind}0 is implicitly deleted</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdefaulted-function-deleted" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-delegating-ctor-cycles</key>
+  <name>clang-diagnostic-delegating-ctor-cycles</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: constructor for %0 creates a delegation cycle</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdelegating-ctor-cycles" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-delete-incomplete</key>
+  <name>clang-diagnostic-delete-incomplete</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: cannot delete expression with pointer-to-'void' type %0</li>
+<li>warning: deleting pointer to incomplete type %0 may cause undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdelete-incomplete" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-delete-non-virtual-dtor</key>
+  <name>clang-diagnostic-delete-non-virtual-dtor</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{delete|destructor}0 called on %1 that is abstract but has non-virtual destructor</li>
+<li>warning: %select{delete|destructor}0 called on non-final %1 that has virtual functions but non-virtual destructor</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdelete-non-virtual-dtor" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-deprecated</key>
+  <name>clang-diagnostic-deprecated</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is deprecated</li>
+<li>warning: %0 is deprecated: %1</li>
+<li>warning: %0 may be deprecated because the receiver type is unknown</li>
+<li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
+<li>warning: -O4 is equivalent to -O3</li>
+<li>warning: OpenCL version %0 does not support the option '%1'</li>
+<li>warning: Use of 'long' with '__vector' is deprecated</li>
+<li>warning: access declarations are deprecated; use using declarations instead</li>
+<li>warning: argument '%0' is deprecated, use '%1' instead</li>
+<li>warning: conversion from string literal to %0 is deprecated</li>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared %select{copy %select{assignment operator|constructor}1|destructor}2</li>
+<li>warning: dynamic exception specifications are deprecated</li>
+<li>warning: implicit capture of 'this' with a capture default of '=' is deprecated</li>
+<li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
+<li>warning: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated</li>
+<li>warning: property access is using %0 method which is deprecated</li>
+<li>warning: specifying 'uuid' as an ATL attribute is deprecated; use __declspec instead</li>
+<li>warning: specifying vector types with the 'mode' attribute is deprecated; use the 'vector_size' attribute instead</li>
+<li>warning: treating '%0' input as '%1' when in C++ mode, this behavior is deprecated</li>
+<li>warning: use of C-style parameters in Objective-C method declarations is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-deprecated-attributes</key>
+  <name>clang-diagnostic-deprecated-attributes</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: specifying vector types with the 'mode' attribute is deprecated; use the 'vector_size' attribute instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-attributes" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-deprecated-declarations</key>
+  <name>clang-diagnostic-deprecated-declarations</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is deprecated</li>
+<li>warning: %0 is deprecated: %1</li>
+<li>warning: %0 may be deprecated because the receiver type is unknown</li>
+<li>warning: property access is using %0 method which is deprecated</li>
+<li>warning: specifying 'uuid' as an ATL attribute is deprecated; use __declspec instead</li>
+<li>warning: use of C-style parameters in Objective-C method declarations is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-declarations" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-deprecated-dynamic-exception-spec</key>
+  <name>clang-diagnostic-deprecated-dynamic-exception-spec</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: dynamic exception specifications are deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-dynamic-exception-spec" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-deprecated-implementations</key>
+  <name>clang-diagnostic-deprecated-implementations</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implementing deprecated %select{method|class|category}0</li>
+<li>warning: implementing unavailable method</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-implementations" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-deprecated-increment-bool</key>
+  <name>clang-diagnostic-deprecated-increment-bool</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-increment-bool" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-deprecated-objc-isa-usage</key>
+  <name>clang-diagnostic-deprecated-objc-isa-usage</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: assignment to Objective-C's isa is deprecated in favor of object_setClass()</li>
+<li>warning: direct access to Objective-C's isa is deprecated in favor of object_getClass()</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-objc-isa-usage" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-deprecated-objc-pointer-introspection</key>
+  <name>clang-diagnostic-deprecated-objc-pointer-introspection</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: bitmasking for introspection of Objective-C object pointers is strongly discouraged</li>
+<li>warning: bitmasking for introspection of Objective-C object pointers is strongly discouraged</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-objc-pointer-introspection" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-deprecated-objc-pointer-introspection-performSelector</key>
+  <name>clang-diagnostic-deprecated-objc-pointer-introspection-performSelector</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: bitmasking for introspection of Objective-C object pointers is strongly discouraged</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-objc-pointer-introspection-performSelector" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-deprecated-register</key>
+  <name>clang-diagnostic-deprecated-register</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-register" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-deprecated-this-capture</key>
+  <name>clang-diagnostic-deprecated-this-capture</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit capture of 'this' with a capture default of '=' is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-this-capture" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-deprecated-writable-strings</key>
+  <name>clang-diagnostic-deprecated-writable-strings</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: conversion from string literal to %0 is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-writable-strings" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-direct-ivar-access</key>
+  <name>clang-diagnostic-direct-ivar-access</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: instance variable %0 is being directly accessed</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdirect-ivar-access" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-disabled-macro-expansion</key>
+  <name>clang-diagnostic-disabled-macro-expansion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: disabled expansion of recursive macro</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdisabled-macro-expansion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-distributed-object-modifiers</key>
+  <name>clang-diagnostic-distributed-object-modifiers</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: conflicting distributed object modifiers on parameter type in implementation of %0</li>
+<li>warning: conflicting distributed object modifiers on return type in implementation of %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdistributed-object-modifiers" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-div-by-zero</key>
+  <name>clang-diagnostic-div-by-zero</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{remainder|division}0 by zero is undefined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdiv-by-zero" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-division-by-zero</key>
+  <name>clang-diagnostic-division-by-zero</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{remainder|division}0 by zero is undefined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdivision-by-zero" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-dll-attribute-on-redeclaration</key>
+  <name>clang-diagnostic-dll-attribute-on-redeclaration</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: redeclaration of %q0 should not add %q1 attribute</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdll-attribute-on-redeclaration" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-dllexport-explicit-instantiation-decl</key>
+  <name>clang-diagnostic-dllexport-explicit-instantiation-decl</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: explicit instantiation declaration should not be 'dllexport'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdllexport-explicit-instantiation-decl" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-dllimport-static-field-def</key>
+  <name>clang-diagnostic-dllimport-static-field-def</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: definition of dllimport static field</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdllimport-static-field-def" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-documentation</key>
+  <name>clang-diagnostic-documentation</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%select{\|@}0%1' command does not terminate a verbatim text block</li>
+<li>warning: '%select{\|@}0%1' command used in a comment that is attached to a %select{function returning void|constructor|destructor|method returning void}2</li>
+<li>warning: '%select{\|@}0%1' command used in a comment that is not attached to a function or method declaration</li>
+<li>warning: '%select{\|@}0%select{classdesign|coclass|dependency|helper|helperclass|helps|instancesize|ownership|performance|security|superclass}1' command should not be used in a comment attached to a non-container declaration</li>
+<li>warning: '%select{\|@}0%select{class|interface|protocol|struct|union}1' command should not be used in a comment attached to a non-%select{class|interface|protocol|struct|union}2 declaration</li>
+<li>warning: '%select{\|@}0%select{function|functiongroup|method|methodgroup|callback}1' command should be used in a comment attached to %select{a function|a function|an Objective-C method|an Objective-C method|a pointer to function}2 declaration</li>
+<li>warning: '%select{\|@}0param' command used in a comment that is not attached to a function declaration</li>
+<li>warning: '%select{\|@}0tparam' command used in a comment that is not attached to a template declaration</li>
+<li>warning: HTML end tag '%0' is forbidden</li>
+<li>warning: HTML end tag does not match any start tag</li>
+<li>warning: HTML start tag '%0' closed by '%1'</li>
+<li>warning: HTML start tag prematurely ended, expected attribute name or '&gt;'</li>
+<li>warning: HTML tag '%0' requires an end tag</li>
+<li>warning: declaration is marked with '\deprecated' command but does not have a deprecation attribute</li>
+<li>warning: duplicated command '%select{\|@}0%1'</li>
+<li>warning: empty paragraph passed to '%select{\|@}0%1' command</li>
+<li>warning: expected quoted string after equals sign</li>
+<li>warning: not a Doxygen trailing comment</li>
+<li>warning: parameter '%0' is already documented</li>
+<li>warning: parameter '%0' not found in the function declaration</li>
+<li>warning: template parameter '%0' is already documented</li>
+<li>warning: template parameter '%0' not found in the template declaration</li>
+<li>warning: unrecognized parameter passing direction, valid directions are '[in]', '[out]' and '[in,out]'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdocumentation" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-documentation-deprecated-sync</key>
+  <name>clang-diagnostic-documentation-deprecated-sync</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration is marked with '\deprecated' command but does not have a deprecation attribute</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdocumentation-deprecated-sync" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-documentation-html</key>
+  <name>clang-diagnostic-documentation-html</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: HTML end tag '%0' is forbidden</li>
+<li>warning: HTML end tag does not match any start tag</li>
+<li>warning: HTML start tag '%0' closed by '%1'</li>
+<li>warning: HTML tag '%0' requires an end tag</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdocumentation-html" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-documentation-pedantic</key>
+  <name>clang-diagnostic-documentation-pedantic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unknown command tag name</li>
+<li>warning: unknown command tag name '%0'; did you mean '%1'?</li>
+<li>warning: whitespace is not allowed in parameter passing direction</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdocumentation-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-documentation-unknown-command</key>
+  <name>clang-diagnostic-documentation-unknown-command</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unknown command tag name</li>
+<li>warning: unknown command tag name '%0'; did you mean '%1'?</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdocumentation-unknown-command" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-dollar-in-identifier-extension</key>
+  <name>clang-diagnostic-dollar-in-identifier-extension</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '$' in identifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdollar-in-identifier-extension" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-double-promotion</key>
+  <name>clang-diagnostic-double-promotion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion increases floating-point precision: %0 to %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdouble-promotion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-duplicate-decl-specifier</key>
+  <name>clang-diagnostic-duplicate-decl-specifier</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: duplicate '%0' declaration specifier</li>
+<li>warning: duplicate '%0' declaration specifier</li>
+<li>warning: multiple identical address spaces specified for type</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-decl-specifier" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-duplicate-enum</key>
+  <name>clang-diagnostic-duplicate-enum</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: element %0 has been implicitly assigned %1 which another element has been assigned</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-enum" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-duplicate-method-arg</key>
+  <name>clang-diagnostic-duplicate-method-arg</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: redeclaration of method parameter %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-method-arg" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-duplicate-method-match</key>
+  <name>clang-diagnostic-duplicate-method-match</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: multiple declarations of method %0 found and ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-method-match" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-duplicate-protocol</key>
+  <name>clang-diagnostic-duplicate-protocol</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: duplicate protocol definition of %0 is ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-protocol" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-dynamic-class-memaccess</key>
+  <name>clang-diagnostic-dynamic-class-memaccess</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{destination for|source of|first operand of|second operand of}0 this %1 call is a pointer to %select{|class containing a }2dynamic class %3; vtable pointer will be %select{overwritten|copied|moved|compared}4</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdynamic-class-memaccess" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-dynamic-exception-spec</key>
+  <name>clang-diagnostic-dynamic-exception-spec</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++17 does not allow dynamic exception specifications</li>
+<li>warning: dynamic exception specifications are deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdynamic-exception-spec" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-effc++</key>
+  <name>clang-diagnostic-effc++</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 has virtual functions but non-virtual destructor</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#weffc-" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-embedded-directive</key>
+  <name>clang-diagnostic-embedded-directive</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: embedding a directive within macro arguments has undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wembedded-directive" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-empty-body</key>
+  <name>clang-diagnostic-empty-body</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: for loop has empty body</li>
+<li>warning: if statement has empty body</li>
+<li>warning: range-based for loop has empty body</li>
+<li>warning: switch statement has empty body</li>
+<li>warning: while loop has empty body</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wempty-body" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-empty-decomposition</key>
+  <name>clang-diagnostic-empty-decomposition</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++17 does not allow a decomposition group to be empty</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wempty-decomposition" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-empty-translation-unit</key>
+  <name>clang-diagnostic-empty-translation-unit</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C requires a translation unit to contain at least one declaration</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wempty-translation-unit" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-encode-type</key>
+  <name>clang-diagnostic-encode-type</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: encoding of %0 type is incomplete because %1 component has unknown encoding</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wencode-type" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-endif-labels</key>
+  <name>clang-diagnostic-endif-labels</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: extra tokens at end of #%0 directive</li>
+<li>warning: extra tokens at the end of '#pragma omp %0' are ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wendif-labels" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-enum-compare</key>
+  <name>clang-diagnostic-enum-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: comparison of two values with different enumeration types in switch statement%diff{ ($ and $)|}0,1</li>
+<li>warning: comparison of two values with different enumeration types%diff{ ($ and $)|}0,1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wenum-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-enum-compare-switch</key>
+  <name>clang-diagnostic-enum-compare-switch</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: comparison of two values with different enumeration types in switch statement%diff{ ($ and $)|}0,1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wenum-compare-switch" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-enum-conversion</key>
+  <name>clang-diagnostic-enum-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion from enumeration type %0 to different enumeration type %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wenum-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-enum-too-large</key>
+  <name>clang-diagnostic-enum-too-large</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: enumeration values exceed range of largest integer</li>
+<li>warning: incremented enumerator value %0 is not representable in the largest integer type</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wenum-too-large" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-exceptions</key>
+  <name>clang-diagnostic-exceptions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 has a non-throwing exception specification but can still throw</li>
+<li>warning: cannot refer to a non-static member from the handler of a %select{constructor|destructor}0 function try block</li>
+<li>warning: exception of type %0 will be caught by earlier handler</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexceptions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-exit-time-destructors</key>
+  <name>clang-diagnostic-exit-time-destructors</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration requires an exit-time destructor</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexit-time-destructors" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-expansion-to-defined</key>
+  <name>clang-diagnostic-expansion-to-defined</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: macro expansion producing 'defined' has undefined behavior</li>
+<li>warning: macro expansion producing 'defined' has undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexpansion-to-defined" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-experimental-isel</key>
+  <name>clang-diagnostic-experimental-isel</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: -fexperimental-isel support for the '%0' architecture is incomplete</li>
+<li>warning: -fexperimental-isel support is incomplete for this architecture at the current optimization level</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexperimental-isel" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-explicit-initialize-call</key>
+  <name>clang-diagnostic-explicit-initialize-call</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: explicit call to +initialize results in duplicate call to +initialize</li>
+<li>warning: explicit call to [super initialize] should only be in implementation of +initialize</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexplicit-initialize-call" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-explicit-ownership-type</key>
+  <name>clang-diagnostic-explicit-ownership-type</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: method parameter of type %0 with no explicit ownership</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexplicit-ownership-type" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-extern-c-compat</key>
+  <name>clang-diagnostic-extern-c-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextern-c-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-extern-initializer</key>
+  <name>clang-diagnostic-extern-initializer</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'extern' variable has an initializer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextern-initializer" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-extra</key>
+  <name>clang-diagnostic-extra</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' qualifier on function type %1 has no effect</li>
+<li>warning: '%0' qualifier on omitted return type %1 has no effect</li>
+<li>warning: '%0' qualifier on reference type %1 has no effect</li>
+<li>warning: '%0' type qualifier%s1 on return type %plural{1:has|:have}1 no effect</li>
+<li>warning: ARC %select{unused|__unsafe_unretained|__strong|__weak|__autoreleasing}0 lifetime qualifier on return type is ignored</li>
+<li>warning: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension</li>
+<li>warning: call to function without interrupt attribute could clobber interruptee's VFP registers</li>
+<li>warning: comparison of integers of different signs: %0 and %1</li>
+<li>warning: initializer overrides prior initialization of this subobject</li>
+<li>warning: method has no return type specified; defaults to 'id'</li>
+<li>warning: missing field %0 initializer</li>
+<li>warning: performing pointer arithmetic on a null pointer has undefined behavior%select{| if the offset is nonzero}0</li>
+<li>warning: semicolon before method body is ignored</li>
+<li>warning: subobject initialization overrides initialization of other fields within its enclosing subobject</li>
+<li>warning: unused parameter %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextra" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-extra-qualification</key>
+  <name>clang-diagnostic-extra-qualification</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: extra qualification on member %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextra-qualification" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-extra-semi</key>
+  <name>clang-diagnostic-extra-semi</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: extra ';' %select{outside of a function|inside a %1|inside instance variable list|after member function definition}0</li>
+<li>warning: extra ';' after member function definition</li>
+<li>warning: extra ';' outside of a function is a C++11 extension</li>
+<li>warning: extra ';' outside of a function is incompatible with C++98</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextra-semi" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-extra-tokens</key>
+  <name>clang-diagnostic-extra-tokens</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: extra tokens at end of #%0 directive</li>
+<li>warning: extra tokens at the end of '#pragma omp %0' are ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextra-tokens" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-fallback</key>
+  <name>clang-diagnostic-fallback</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: falling back to %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfallback" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-fixed-enum-extension</key>
+  <name>clang-diagnostic-fixed-enum-extension</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: enumeration types with a fixed underlying type are a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfixed-enum-extension" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-flag-enum</key>
+  <name>clang-diagnostic-flag-enum</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: enumeration value %0 is out of range of flags in enumeration type %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wflag-enum" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-flexible-array-extensions</key>
+  <name>clang-diagnostic-flexible-array-extensions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 may not be nested in a struct due to flexible array member</li>
+<li>warning: %0 may not be used as an array element due to flexible array member</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wflexible-array-extensions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-float-conversion</key>
+  <name>clang-diagnostic-float-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion from %0 to %1 changes non-zero value from %2 to %3</li>
+<li>warning: implicit conversion from %0 to %1 changes value from %2 to %3</li>
+<li>warning: implicit conversion of out of range value from %0 to %1 is undefined</li>
+<li>warning: implicit conversion turns floating-point number into integer: %0 to %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfloat-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-float-equal</key>
+  <name>clang-diagnostic-float-equal</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: comparing floating point with == or != is unsafe</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfloat-equal" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-float-overflow-conversion</key>
+  <name>clang-diagnostic-float-overflow-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion from %0 to %1 changes value from %2 to %3</li>
+<li>warning: implicit conversion of out of range value from %0 to %1 is undefined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfloat-overflow-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-float-zero-conversion</key>
+  <name>clang-diagnostic-float-zero-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion from %0 to %1 changes non-zero value from %2 to %3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfloat-zero-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-for-loop-analysis</key>
+  <name>clang-diagnostic-for-loop-analysis</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: variable %0 is %select{decremented|incremented}1 both in the loop header and in the loop body</li>
+<li>warning: variable%select{s| %1|s %1 and %2|s %1, %2, and %3|s %1, %2, %3, and %4}0 used in loop condition not modified in loop body</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfor-loop-analysis" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-format</key>
+  <name>clang-diagnostic-format</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{field width|precision}0 used with '%1' conversion specifier, resulting in undefined behavior</li>
+<li>warning: %select{values of type|enum values with underlying type}2 '%0' should not be used as format arguments; add an explicit cast to %1 instead</li>
+<li>warning: '%0' is not a valid object format flag</li>
+<li>warning: '%select{*|.*}0' specified field %select{width|precision}0 is missing a matching 'int' argument</li>
+<li>warning: cannot mix positional and non-positional arguments in format string</li>
+<li>warning: data argument not used by format string</li>
+<li>warning: data argument position '%0' exceeds the number of data arguments (%1)</li>
+<li>warning: field %select{width|precision}0 should have type %1, but argument has type %2</li>
+<li>warning: flag '%0' is ignored when flag '%1' is present</li>
+<li>warning: flag '%0' results in undefined behavior with '%1' conversion specifier</li>
+<li>warning: format specifies type %0 but the argument has %select{type|underlying type}2 %1</li>
+<li>warning: format string contains '\0' within the string body</li>
+<li>warning: format string is empty</li>
+<li>warning: format string is not a string literal (potentially insecure)</li>
+<li>warning: format string is not null-terminated</li>
+<li>warning: format string missing</li>
+<li>warning: format string should not be a wide string</li>
+<li>warning: incomplete format specifier</li>
+<li>warning: invalid conversion specifier '%0'</li>
+<li>warning: invalid position specified for %select{field width|field precision}0</li>
+<li>warning: length modifier '%0' results in undefined behavior or no effect with '%1' conversion specifier</li>
+<li>warning: missing object format flag</li>
+<li>warning: more '%%' conversions than data arguments</li>
+<li>warning: no closing ']' for '%%[' in scanf format string</li>
+<li>warning: null passed to a callee that requires a non-null argument</li>
+<li>warning: null returned from %select{function|method}0 that requires a non-null return value</li>
+<li>warning: object format flags cannot be used with '%0' conversion specifier</li>
+<li>warning: position arguments in format strings start counting at 1 (not 0)</li>
+<li>warning: using '%%P' format specifier without precision</li>
+<li>warning: using '%0' format specifier annotation outside of os_log()/os_trace()</li>
+<li>warning: zero field width in scanf format string is unused</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-format-extra-args</key>
+  <name>clang-diagnostic-format-extra-args</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: data argument not used by format string</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-extra-args" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-format-invalid-specifier</key>
+  <name>clang-diagnostic-format-invalid-specifier</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: invalid conversion specifier '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-invalid-specifier" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-format-non-iso</key>
+  <name>clang-diagnostic-format-non-iso</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' %select{length modifier|conversion specifier}1 is not supported by ISO C</li>
+<li>warning: positional arguments are not supported by ISO C</li>
+<li>warning: using length modifier '%0' with conversion specifier '%1' is not supported by ISO C</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-non-iso" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-format-nonliteral</key>
+  <name>clang-diagnostic-format-nonliteral</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: format string is not a string literal</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-nonliteral" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-format-pedantic</key>
+  <name>clang-diagnostic-format-pedantic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{values of type|enum values with underlying type}2 '%0' should not be used as format arguments; add an explicit cast to %1 instead</li>
+<li>warning: format specifies type %0 but the argument has %select{type|underlying type}2 %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-format-security</key>
+  <name>clang-diagnostic-format-security</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: format string is not a string literal (potentially insecure)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-security" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-format-zero-length</key>
+  <name>clang-diagnostic-format-zero-length</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: format string is empty</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-zero-length" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-format=2</key>
+  <name>clang-diagnostic-format=2</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: format string is not a string literal</li>
+<li>warning: format string is not a string literal (potentially insecure)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat=2" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-four-char-constants</key>
+  <name>clang-diagnostic-four-char-constants</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: multi-character character constant</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfour-char-constants" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-frame-larger-than=</key>
+  <name>clang-diagnostic-frame-larger-than=</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+<li>warning: stack frame size of %0 bytes in %q1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wframe-larger-than=" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-framework-include-private-from-public</key>
+  <name>clang-diagnostic-framework-include-private-from-public</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: public framework header includes private framework header '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wframework-include-private-from-public" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-function-def-in-objc-container</key>
+  <name>clang-diagnostic-function-def-in-objc-container</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: function definition inside an Objective-C container is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfunction-def-in-objc-container" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-function-multiversion</key>
+  <name>clang-diagnostic-function-multiversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: CPU list contains duplicate entries; attribute ignored</li>
+<li>warning: body of cpu_dispatch function will be ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfunction-multiversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gcc-compat</key>
+  <name>clang-diagnostic-gcc-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' is bound to current loop, GCC binds it to the enclosing loop</li>
+<li>warning: 'break' is bound to loop, GCC binds it to switch</li>
+<li>warning: 'diagnose_if' is a clang extension</li>
+<li>warning: 'enable_if' is a clang extension</li>
+<li>warning: GCC does not allow %0 attribute in this position on a function definition</li>
+<li>warning: GCC does not allow an attribute in this position on a function declaration</li>
+<li>warning: GCC does not allow the %0 attribute to be written on a type</li>
+<li>warning: GCC does not allow the 'cleanup' attribute argument to be anything other than a simple identifier</li>
+<li>warning: GCC does not allow variable declarations in for loop initializers before C99</li>
+<li>warning: __final is a GNU extension, consider using C++11 final</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgcc-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-global-constructors</key>
+  <name>clang-diagnostic-global-constructors</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration requires a global constructor</li>
+<li>warning: declaration requires a global destructor</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wglobal-constructors" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu</key>
+  <name>clang-diagnostic-gnu</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #include_next is a language extension</li>
+<li>warning: #line directive with zero argument is a GNU extension</li>
+<li>warning: %0 applied to an expression is a GNU extension</li>
+<li>warning: %select{struct|union}0 without named members is a GNU extension</li>
+<li>warning: '__auto_type' is a GNU extension</li>
+<li>warning: anonymous structs are a GNU extension</li>
+<li>warning: binary integer literals are a GNU extension</li>
+<li>warning: cast to union type is a GNU extension</li>
+<li>warning: class member cannot be redeclared</li>
+<li>warning: complex integer types are a GNU extension</li>
+<li>warning: empty %select{struct|union}0 is a GNU extension</li>
+<li>warning: expression is not an %select{integer|integral}0 constant expression; folding it to a constant is a GNU extension</li>
+<li>warning: field %0 with variable sized type %1 not at the end of a struct or class is a GNU extension</li>
+<li>warning: flexible array initialization is a GNU extension</li>
+<li>warning: flexible array member %0 in a union is a GNU extension</li>
+<li>warning: flexible array member %0 in otherwise empty %select{struct|interface|union|class|enum}1 is a GNU extension</li>
+<li>warning: imaginary constants are a GNU extension</li>
+<li>warning: in-class initializer for static data member is not a constant expression; folding it to a constant is a GNU extension</li>
+<li>warning: in-class initializer for static data member of type %0 is a GNU extension</li>
+<li>warning: initialization of an array %diff{of type $ from a compound literal of type $|from a compound literal}0,1 is a GNU extension</li>
+<li>warning: must specify at least one argument for '...' parameter of variadic macro</li>
+<li>warning: redeclaration of already-defined enum %0 is a GNU extension</li>
+<li>warning: string literal operator templates are a GNU extension</li>
+<li>warning: token pasting of ',' and __VA_ARGS__ is a GNU extension</li>
+<li>warning: use of GNU 'missing =' extension in designator</li>
+<li>warning: use of GNU ?: conditional expression extension, omitting middle operand</li>
+<li>warning: use of GNU address-of-label extension</li>
+<li>warning: use of GNU array range extension</li>
+<li>warning: use of GNU case range extension</li>
+<li>warning: use of GNU empty initializer extension</li>
+<li>warning: use of GNU indirect-goto extension</li>
+<li>warning: use of GNU old-style field designator extension</li>
+<li>warning: use of GNU statement expression extension</li>
+<li>warning: variable length array folded to constant array as an extension</li>
+<li>warning: variable length arrays are a C99 feature</li>
+<li>warning: zero size arrays are an extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-alignof-expression</key>
+  <name>clang-diagnostic-gnu-alignof-expression</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 applied to an expression is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-alignof-expression" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-anonymous-struct</key>
+  <name>clang-diagnostic-gnu-anonymous-struct</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: anonymous structs are a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-anonymous-struct" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-array-member-paren-init</key>
+  <name>clang-diagnostic-gnu-array-member-paren-init</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: parenthesized initialization of a member array is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-array-member-paren-init" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-auto-type</key>
+  <name>clang-diagnostic-gnu-auto-type</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '__auto_type' is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-auto-type" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-binary-literal</key>
+  <name>clang-diagnostic-gnu-binary-literal</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: binary integer literals are a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-binary-literal" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-case-range</key>
+  <name>clang-diagnostic-gnu-case-range</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: use of GNU case range extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-case-range" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-complex-integer</key>
+  <name>clang-diagnostic-gnu-complex-integer</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: complex integer types are a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-complex-integer" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-compound-literal-initializer</key>
+  <name>clang-diagnostic-gnu-compound-literal-initializer</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: initialization of an array %diff{of type $ from a compound literal of type $|from a compound literal}0,1 is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-compound-literal-initializer" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-conditional-omitted-operand</key>
+  <name>clang-diagnostic-gnu-conditional-omitted-operand</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: use of GNU ?: conditional expression extension, omitting middle operand</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-conditional-omitted-operand" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-designator</key>
+  <name>clang-diagnostic-gnu-designator</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: use of GNU 'missing =' extension in designator</li>
+<li>warning: use of GNU array range extension</li>
+<li>warning: use of GNU old-style field designator extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-designator" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-empty-initializer</key>
+  <name>clang-diagnostic-gnu-empty-initializer</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: use of GNU empty initializer extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-empty-initializer" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-empty-struct</key>
+  <name>clang-diagnostic-gnu-empty-struct</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{struct|union}0 without named members is a GNU extension</li>
+<li>warning: empty %select{struct|union}0 is a GNU extension</li>
+<li>warning: flexible array member %0 in otherwise empty %select{struct|interface|union|class|enum}1 is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-empty-struct" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-flexible-array-initializer</key>
+  <name>clang-diagnostic-gnu-flexible-array-initializer</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: flexible array initialization is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-flexible-array-initializer" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-flexible-array-union-member</key>
+  <name>clang-diagnostic-gnu-flexible-array-union-member</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: flexible array member %0 in a union is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-flexible-array-union-member" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-folding-constant</key>
+  <name>clang-diagnostic-gnu-folding-constant</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: expression is not an %select{integer|integral}0 constant expression; folding it to a constant is a GNU extension</li>
+<li>warning: in-class initializer for static data member is not a constant expression; folding it to a constant is a GNU extension</li>
+<li>warning: variable length array folded to constant array as an extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-folding-constant" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-imaginary-constant</key>
+  <name>clang-diagnostic-gnu-imaginary-constant</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: imaginary constants are a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-imaginary-constant" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-include-next</key>
+  <name>clang-diagnostic-gnu-include-next</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #include_next is a language extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-include-next" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-label-as-value</key>
+  <name>clang-diagnostic-gnu-label-as-value</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: use of GNU address-of-label extension</li>
+<li>warning: use of GNU indirect-goto extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-label-as-value" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-redeclared-enum</key>
+  <name>clang-diagnostic-gnu-redeclared-enum</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: redeclaration of already-defined enum %0 is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-redeclared-enum" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-statement-expression</key>
+  <name>clang-diagnostic-gnu-statement-expression</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: use of GNU statement expression extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-statement-expression" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-static-float-init</key>
+  <name>clang-diagnostic-gnu-static-float-init</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: in-class initializer for static data member of type %0 is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-static-float-init" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-string-literal-operator-template</key>
+  <name>clang-diagnostic-gnu-string-literal-operator-template</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: string literal operator templates are a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-string-literal-operator-template" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-union-cast</key>
+  <name>clang-diagnostic-gnu-union-cast</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: cast to union type is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-union-cast" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-variable-sized-type-not-at-end</key>
+  <name>clang-diagnostic-gnu-variable-sized-type-not-at-end</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: field %0 with variable sized type %1 not at the end of a struct or class is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-variable-sized-type-not-at-end" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-zero-line-directive</key>
+  <name>clang-diagnostic-gnu-zero-line-directive</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #line directive with zero argument is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-zero-line-directive" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-gnu-zero-variadic-macro-arguments</key>
+  <name>clang-diagnostic-gnu-zero-variadic-macro-arguments</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: must specify at least one argument for '...' parameter of variadic macro</li>
+<li>warning: token pasting of ',' and __VA_ARGS__ is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-zero-variadic-macro-arguments" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-header-guard</key>
+  <name>clang-diagnostic-header-guard</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is used as a header guard here, followed by #define of a different macro</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wheader-guard" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-header-hygiene</key>
+  <name>clang-diagnostic-header-hygiene</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: using namespace directive in global context in header</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wheader-hygiene" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-idiomatic-parentheses</key>
+  <name>clang-diagnostic-idiomatic-parentheses</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: using the result of an assignment as a condition without parentheses</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#widiomatic-parentheses" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-ignored-attributes</key>
+  <name>clang-diagnostic-ignored-attributes</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 attribute argument not supported: %1</li>
+<li>warning: %0 attribute can only be applied to instance variables or properties</li>
+<li>warning: %0 attribute ignored</li>
+<li>warning: %0 attribute ignored for field of type %1</li>
+<li>warning: %0 attribute ignored on inline function</li>
+<li>warning: %0 attribute ignored when parsing type</li>
+<li>warning: %0 attribute is deprecated and ignored in OpenCL version %1</li>
+<li>warning: %0 attribute only applies to %1</li>
+<li>warning: %0 attribute only applies to %select{Objective-C object|pointer|pointer-to-CF-pointer}1 parameters</li>
+<li>warning: %0 attribute only applies to %select{functions|methods|properties}1 that return %select{an Objective-C object|a pointer|a non-retainable pointer}2</li>
+<li>warning: %0 attribute only applies to %select{functions|unions|variables and functions|functions and methods|functions, methods and blocks|functions, methods, and parameters|variables|variables and fields|variables, data members and tag types|types and namespaces|variables, functions and classes|kernel functions|non-K&amp;R-style functions}1</li>
+<li>warning: %0 attribute only applies to a pointer or reference (%1 is invalid)</li>
+<li>warning: %0 attribute only applies to return values that are pointers</li>
+<li>warning: %0 attribute only applies to return values that are pointers or references</li>
+<li>warning: %0 attribute only applies to%select{| constant}1 pointer arguments</li>
+<li>warning: %0 calling convention ignored on constructor/destructor</li>
+<li>warning: %0 calling convention ignored on variadic function</li>
+<li>warning: %q0 redeclared inline; %1 attribute ignored</li>
+<li>warning: %select{alias|ifunc}1 will not be in section '%0' but in the same section as the %select{aliasee|resolver}2</li>
+<li>warning: %select{alias|ifunc}2 will always resolve to %0 even if weak definition of %1 is overridden</li>
+<li>warning: %select{alignment|size}0 of field %1 (%2 bits) does not match the %select{alignment|size}0 of the first field in transparent union; transparent_union attribute ignored</li>
+<li>warning: %select{unsupported|duplicate}0%select{| architecture}1 '%2' in the 'target' attribute string; 'target' attribute ignored</li>
+<li>warning: '%0' attribute cannot be specified on a definition</li>
+<li>warning: '%0' only applies to %select{function|pointer|Objective-C object or block pointer}1 types; type here is %2</li>
+<li>warning: 'abi_tag' attribute on %select{non-inline|anonymous}0 namespace ignored</li>
+<li>warning: 'deprecated' attribute on anonymous namespace ignored</li>
+<li>warning: 'gnu_inline' attribute requires function to be marked 'inline', attribute ignored</li>
+<li>warning: 'internal_linkage' attribute on a non-static local variable is ignored</li>
+<li>warning: 'nocf_check' attribute ignored; use -fcf-protection to enable the attribute</li>
+<li>warning: 'nonnull' attribute applied to function with no pointer arguments</li>
+<li>warning: 'nonnull' attribute when used on parameters takes no arguments</li>
+<li>warning: 'sentinel' attribute only supported for variadic %select{functions|blocks}0</li>
+<li>warning: 'sentinel' attribute requires named arguments</li>
+<li>warning: 'trivial_abi' cannot be applied to %0</li>
+<li>warning: MIPS 'interrupt' attribute only applies to functions that have %select{no parameters|a 'void' return type}0</li>
+<li>warning: Objective-C GC does not allow weak variables on the stack</li>
+<li>warning: RISC-V 'interrupt' attribute only applies to functions that have %select{no parameters|a 'void' return type}0</li>
+<li>warning: __declspec attribute %0 is not supported</li>
+<li>warning: __weak attribute cannot be specified on a field declaration</li>
+<li>warning: __weak attribute cannot be specified on an automatic variable when ARC is not enabled</li>
+<li>warning: attribute %0 after definition is ignored</li>
+<li>warning: attribute %0 cannot be applied to %select{functions|Objective-C method}1 without return value</li>
+<li>warning: attribute %0 ignored, because it cannot be applied to a type</li>
+<li>warning: attribute %0 ignored, because it cannot be applied to omitted return type</li>
+<li>warning: attribute %0 ignored, because it is not attached to a declaration</li>
+<li>warning: attribute %0 is already applied</li>
+<li>warning: attribute %0 is already applied with different parameters</li>
+<li>warning: attribute %0 is ignored, place it after "%select{class|struct|interface|union|enum}1" to apply attribute to type declaration</li>
+<li>warning: attribute declaration must precede definition</li>
+<li>warning: calling convention %0 ignored for this target</li>
+<li>warning: first field of a transparent union cannot have %select{floating point|vector}0 type %1; transparent_union attribute ignored</li>
+<li>warning: inheritance model ignored on %select{primary template|partial specialization}0</li>
+<li>warning: qualifiers after comma in declarator list are ignored</li>
+<li>warning: repeated RISC-V 'interrupt' attribute</li>
+<li>warning: transparent union definition must contain at least one field; transparent_union attribute ignored</li>
+<li>warning: transparent_union attribute can only be applied to a union definition; attribute ignored</li>
+<li>warning: unknown attribute '%0'</li>
+<li>warning: unknown visibility %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-attributes" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-ignored-optimization-argument</key>
+  <name>clang-diagnostic-ignored-optimization-argument</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: optimization flag '%0' is not supported</li>
+<li>warning: optimization flag '%0' is not supported for target '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-optimization-argument" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-ignored-pragma-intrinsic</key>
+  <name>clang-diagnostic-ignored-pragma-intrinsic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is not a recognized builtin%select{|; consider including &lt;intrin.h&gt; to access non-builtin intrinsics}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-pragma-intrinsic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-ignored-pragma-optimize</key>
+  <name>clang-diagnostic-ignored-pragma-optimize</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '#pragma optimize' is not supported</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-pragma-optimize" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-ignored-pragmas</key>
+  <name>clang-diagnostic-ignored-pragmas</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma %0(pop, ...) failed: %1</li>
+<li>warning: #pragma options align=reset failed: %0</li>
+<li>warning: %0 is not a recognized builtin%select{|; consider including &lt;intrin.h&gt; to access non-builtin intrinsics}1</li>
+<li>warning: '#pragma comment %0' ignored</li>
+<li>warning: '#pragma init_seg' is only supported when targeting a Microsoft environment</li>
+<li>warning: '#pragma optimize' is not supported</li>
+<li>warning: OpenCL extension end directive mismatches begin directive - ignoring</li>
+<li>warning: expected #pragma pack parameter to be '1', '2', '4', '8', or '16'</li>
+<li>warning: expected %select{'enable', 'disable', 'begin' or 'end'|'disable'}0 - ignoring</li>
+<li>warning: expected '#pragma unused' argument to be a variable name</li>
+<li>warning: expected ')' or ',' in '#pragma %0'</li>
+<li>warning: expected ',' in '#pragma %0'</li>
+<li>warning: expected '=' following '#pragma %select{align|options align}0' - ignored</li>
+<li>warning: expected 'align' following '#pragma options' - ignored</li>
+<li>warning: expected 'compiler', 'lib', 'user', or a string literal for the section name in '#pragma %0' - ignored</li>
+<li>warning: expected a stack label or a string literal for the section name in '#pragma %0' - ignored</li>
+<li>warning: expected a string literal for the section name in '#pragma %0' - ignored</li>
+<li>warning: expected action or ')' in '#pragma %0' - ignored</li>
+<li>warning: expected identifier in '#pragma %0' - ignored</li>
+<li>warning: expected integer between %0 and %1 inclusive in '#pragma %2' - ignored</li>
+<li>warning: expected integer or identifier in '#pragma pack' - ignored</li>
+<li>warning: expected non-wide string literal in '#pragma %0'</li>
+<li>warning: expected push, pop or a string literal for the section name in '#pragma %0' - ignored</li>
+<li>warning: expected string literal in '#pragma %0' - ignoring</li>
+<li>warning: extra tokens at end of '#pragma %0' - ignored</li>
+<li>warning: incorrect use of #pragma clang force_cuda_host_device begin|end</li>
+<li>warning: incorrect use of '#pragma ms_struct on|off' - ignored</li>
+<li>warning: invalid alignment option in '#pragma %select{align|options align}0' - ignored</li>
+<li>warning: known but unsupported action '%1' for '#pragma %0' - ignored</li>
+<li>warning: missing '(' after '#pragma %0' - ignoring</li>
+<li>warning: missing ')' after '#pragma %0' - ignoring</li>
+<li>warning: missing ':' after %0 - ignoring</li>
+<li>warning: missing ':' or ')' after %0 - ignoring</li>
+<li>warning: missing argument to '#pragma %0'%select{|; expected %2}1</li>
+<li>warning: missing argument to debug command '%0'</li>
+<li>warning: only variables can be arguments to '#pragma unused'</li>
+<li>warning: pragma pop_macro could not pop '%0', no matching push_macro</li>
+<li>warning: undeclared variable %0 used as an argument for '#pragma unused'</li>
+<li>warning: unexpected argument '%0' to '#pragma %1'%select{|; expected %3}2</li>
+<li>warning: unexpected debug command '%0'</li>
+<li>warning: unknown OpenCL extension %0 - ignoring</li>
+<li>warning: unknown action '%1' for '#pragma %0' - ignored</li>
+<li>warning: unknown action for '#pragma %0' - ignored</li>
+<li>warning: unsupported OpenCL extension %0 - ignoring</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-pragmas" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-ignored-qualifiers</key>
+  <name>clang-diagnostic-ignored-qualifiers</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' qualifier on function type %1 has no effect</li>
+<li>warning: '%0' qualifier on omitted return type %1 has no effect</li>
+<li>warning: '%0' qualifier on reference type %1 has no effect</li>
+<li>warning: '%0' type qualifier%s1 on return type %plural{1:has|:have}1 no effect</li>
+<li>warning: ARC %select{unused|__unsafe_unretained|__strong|__weak|__autoreleasing}0 lifetime qualifier on return type is ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-qualifiers" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-implicit</key>
+  <name>clang-diagnostic-implicit</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit declaration of function %0</li>
+<li>warning: implicit declaration of function %0 is invalid in C99</li>
+<li>warning: implicitly declaring library function '%0' with type %1</li>
+<li>warning: type specifier missing, defaults to 'int'</li>
+<li>warning: use of unknown builtin %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-implicit-atomic-properties</key>
+  <name>clang-diagnostic-implicit-atomic-properties</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: property is assumed atomic by default</li>
+<li>warning: property is assumed atomic when auto-synthesizing the property</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-atomic-properties" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-implicit-conversion-floating-point-to-bool</key>
+  <name>clang-diagnostic-implicit-conversion-floating-point-to-bool</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion turns floating-point number into bool: %0 to %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-conversion-floating-point-to-bool" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-implicit-exception-spec-mismatch</key>
+  <name>clang-diagnostic-implicit-exception-spec-mismatch</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: function previously declared with an %select{explicit|implicit}0 exception specification redeclared with an %select{implicit|explicit}0 exception specification</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-exception-spec-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-implicit-fallthrough</key>
+  <name>clang-diagnostic-implicit-fallthrough</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: fallthrough annotation in unreachable code</li>
+<li>warning: unannotated fall-through between switch labels</li>
+<li>warning: unannotated fall-through between switch labels in partly-annotated function</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-fallthrough" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-implicit-fallthrough-per-function</key>
+  <name>clang-diagnostic-implicit-fallthrough-per-function</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unannotated fall-through between switch labels in partly-annotated function</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-fallthrough-per-function" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-implicit-function-declaration</key>
+  <name>clang-diagnostic-implicit-function-declaration</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit declaration of function %0</li>
+<li>warning: implicit declaration of function %0 is invalid in C99</li>
+<li>warning: implicitly declaring library function '%0' with type %1</li>
+<li>warning: use of unknown builtin %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-function-declaration" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-implicit-int</key>
+  <name>clang-diagnostic-implicit-int</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: type specifier missing, defaults to 'int'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-int" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-implicit-retain-self</key>
+  <name>clang-diagnostic-implicit-retain-self</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-retain-self" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-implicitly-unsigned-literal</key>
+  <name>clang-diagnostic-implicitly-unsigned-literal</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: integer literal is too large to be represented in a signed integer type, interpreting as unsigned</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicitly-unsigned-literal" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-import-preprocessor-directive-pedantic</key>
+  <name>clang-diagnostic-import-preprocessor-directive-pedantic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #import is a language extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimport-preprocessor-directive-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-inaccessible-base</key>
+  <name>clang-diagnostic-inaccessible-base</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: direct base %0 is inaccessible due to ambiguity:%1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winaccessible-base" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-include-next-absolute-path</key>
+  <name>clang-diagnostic-include-next-absolute-path</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #include_next with absolute path</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winclude-next-absolute-path" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-include-next-outside-header</key>
+  <name>clang-diagnostic-include-next-outside-header</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #include_next in primary source file</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winclude-next-outside-header" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-incompatible-exception-spec</key>
+  <name>clang-diagnostic-incompatible-exception-spec</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: exception specifications of %select{return|argument}0 types differ</li>
+<li>warning: target exception specification is not superset of source</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-exception-spec" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-incompatible-function-pointer-types</key>
+  <name>clang-diagnostic-incompatible-function-pointer-types</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: incompatible function pointer types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-function-pointer-types" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-incompatible-library-redeclaration</key>
+  <name>clang-diagnostic-incompatible-library-redeclaration</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: incompatible redeclaration of library function %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-library-redeclaration" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-incompatible-ms-struct</key>
+  <name>clang-diagnostic-incompatible-ms-struct</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ms_struct may not produce Microsoft-compatible layouts for classes with base classes or virtual functions</li>
+<li>warning: ms_struct may not produce Microsoft-compatible layouts with fundamental data types with sizes that aren't a power of two</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-ms-struct" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-incompatible-pointer-types</key>
+  <name>clang-diagnostic-incompatible-pointer-types</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2 discards qualifiers</li>
+<li>warning: %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2 discards qualifiers in nested pointer types</li>
+<li>warning: incompatible function pointer types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+<li>warning: incompatible pointer types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-pointer-types" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-incompatible-pointer-types-discards-qualifiers</key>
+  <name>clang-diagnostic-incompatible-pointer-types-discards-qualifiers</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2 discards qualifiers</li>
+<li>warning: %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2 discards qualifiers in nested pointer types</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-pointer-types-discards-qualifiers" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-incompatible-property-type</key>
+  <name>clang-diagnostic-incompatible-property-type</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: property type %0 is incompatible with type %1 inherited from %2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-property-type" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-incompatible-sysroot</key>
+  <name>clang-diagnostic-incompatible-sysroot</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: using sysroot for '%0' but targeting '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-sysroot" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-incomplete-framework-module-declaration</key>
+  <name>clang-diagnostic-incomplete-framework-module-declaration</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: skipping '%0' because module declaration of '%1' lacks the 'framework' qualifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincomplete-framework-module-declaration" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-incomplete-implementation</key>
+  <name>clang-diagnostic-incomplete-implementation</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: method definition for %0 not found</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincomplete-implementation" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-incomplete-module</key>
+  <name>clang-diagnostic-incomplete-module</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: include of non-modular header inside framework module '%0': '%1'</li>
+<li>warning: include of non-modular header inside module '%0': '%1'</li>
+<li>warning: missing submodule '%0'</li>
+<li>warning: umbrella directory '%0' not found</li>
+<li>warning: umbrella header for module '%0' does not include header '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincomplete-module" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-incomplete-umbrella</key>
+  <name>clang-diagnostic-incomplete-umbrella</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: missing submodule '%0'</li>
+<li>warning: umbrella directory '%0' not found</li>
+<li>warning: umbrella header for module '%0' does not include header '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincomplete-umbrella" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-inconsistent-dllimport</key>
+  <name>clang-diagnostic-inconsistent-dllimport</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %q0 redeclared without %1 attribute: previous %1 ignored</li>
+<li>warning: %q0 redeclared without 'dllimport' attribute: 'dllexport' attribute added</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winconsistent-dllimport" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-inconsistent-missing-destructor-override</key>
+  <name>clang-diagnostic-inconsistent-missing-destructor-override</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 overrides a destructor but is not marked 'override'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winconsistent-missing-destructor-override" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-inconsistent-missing-override</key>
+  <name>clang-diagnostic-inconsistent-missing-override</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 overrides a member function but is not marked 'override'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winconsistent-missing-override" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-increment-bool</key>
+  <name>clang-diagnostic-increment-bool</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++17 does not allow incrementing expression of type bool</li>
+<li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincrement-bool" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-infinite-recursion</key>
+  <name>clang-diagnostic-infinite-recursion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: all paths through this function will call itself</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winfinite-recursion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-initializer-overrides</key>
+  <name>clang-diagnostic-initializer-overrides</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: initializer overrides prior initialization of this subobject</li>
+<li>warning: subobject initialization overrides initialization of other fields within its enclosing subobject</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winitializer-overrides" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-injected-class-name</key>
+  <name>clang-diagnostic-injected-class-name</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++ specifies that qualified reference to %0 is a constructor name rather than a %select{template name|type}1 in this context, despite preceding %select{'typename'|'template'}2 keyword</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winjected-class-name" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-inline-asm</key>
+  <name>clang-diagnostic-inline-asm</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winline-asm" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-inline-new-delete</key>
+  <name>clang-diagnostic-inline-new-delete</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: replacement function %0 cannot be declared 'inline'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winline-new-delete" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-instantiation-after-specialization</key>
+  <name>clang-diagnostic-instantiation-after-specialization</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: explicit instantiation of %0 that occurs after an explicit specialization has no effect</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winstantiation-after-specialization" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-int-conversion</key>
+  <name>clang-diagnostic-int-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: incompatible integer to pointer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+<li>warning: incompatible pointer to integer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wint-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-int-conversions</key>
+  <name>clang-diagnostic-int-conversions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: incompatible integer to pointer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+<li>warning: incompatible pointer to integer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wint-conversions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-int-to-pointer-cast</key>
+  <name>clang-diagnostic-int-to-pointer-cast</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: cast to %1 from smaller integer type %0</li>
+<li>warning: cast to %1 from smaller integer type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wint-to-pointer-cast" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-int-to-void-pointer-cast</key>
+  <name>clang-diagnostic-int-to-void-pointer-cast</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: cast to %1 from smaller integer type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wint-to-void-pointer-cast" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-integer-overflow</key>
+  <name>clang-diagnostic-integer-overflow</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: overflow in expression; result is %0 with type %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winteger-overflow" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-invalid-command-line-argument</key>
+  <name>clang-diagnostic-invalid-command-line-argument</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: optimization flag '%0' is not supported</li>
+<li>warning: optimization flag '%0' is not supported for target '%1'</li>
+<li>warning: optimization level '%0' is not supported; using '%1%2' instead</li>
+<li>warning: the object size sanitizer has no effect at -O0, but is explicitly enabled: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-command-line-argument" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-invalid-constexpr</key>
+  <name>clang-diagnostic-invalid-constexpr</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: constexpr %select{function|constructor}0 never produces a constant expression</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-constexpr" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-invalid-iboutlet</key>
+  <name>clang-diagnostic-invalid-iboutlet</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{instance variable|property}2 with %0 attribute must be an object type (invalid %1)</li>
+<li>warning: IBOutletCollection properties should be copy/strong and not assign</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-iboutlet" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-invalid-initializer-from-system-header</key>
+  <name>clang-diagnostic-invalid-initializer-from-system-header</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: invalid constructor form class in system header, should not be explicit</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-initializer-from-system-header" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-invalid-ios-deployment-target</key>
+  <name>clang-diagnostic-invalid-ios-deployment-target</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: invalid iOS deployment version '%0', iOS 10 is the maximum deployment target for 32-bit targets</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-ios-deployment-target" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-invalid-noreturn</key>
+  <name>clang-diagnostic-invalid-noreturn</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: function %0 declared 'noreturn' should not return</li>
+<li>warning: function declared 'noreturn' should not return</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-noreturn" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-invalid-offsetof</key>
+  <name>clang-diagnostic-invalid-offsetof</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: offset of on non-POD type %0</li>
+<li>warning: offset of on non-standard-layout type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-offsetof" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-invalid-or-nonexistent-directory</key>
+  <name>clang-diagnostic-invalid-or-nonexistent-directory</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: environment variable SCE_ORBIS_SDK_DIR is set, but points to invalid or nonexistent directory '%0'</li>
+<li>warning: unable to find %0 directory, expected to be in '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-or-nonexistent-directory" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-invalid-partial-specialization</key>
+  <name>clang-diagnostic-invalid-partial-specialization</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{class|variable}0 template partial specialization is not more specialized than the primary template</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-partial-specialization" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-invalid-pp-token</key>
+  <name>clang-diagnostic-invalid-pp-token</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: empty character constant</li>
+<li>warning: missing terminating %select{'|'"'}0 character</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-pp-token" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-invalid-source-encoding</key>
+  <name>clang-diagnostic-invalid-source-encoding</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: illegal character encoding in character literal</li>
+<li>warning: illegal character encoding in string literal</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-source-encoding" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-invalid-token-paste</key>
+  <name>clang-diagnostic-invalid-token-paste</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: pasting formed '%0', an invalid preprocessing token</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-token-paste" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-jump-seh-finally</key>
+  <name>clang-diagnostic-jump-seh-finally</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: jump out of __finally block has undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wjump-seh-finally" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-keyword-compat</key>
+  <name>clang-diagnostic-keyword-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: keyword '%0' will be made available as an identifier %select{here|for the remainder of the translation unit}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wkeyword-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-keyword-macro</key>
+  <name>clang-diagnostic-keyword-macro</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: keyword is hidden by macro definition</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wkeyword-macro" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-knr-promoted-parameter</key>
+  <name>clang-diagnostic-knr-promoted-parameter</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %diff{promoted type $ of K&amp;R function parameter is not compatible with the parameter type $|promoted type of K&amp;R function parameter is not compatible with parameter type}0,1 declared in a previous prototype</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wknr-promoted-parameter" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-language-extension-token</key>
+  <name>clang-diagnostic-language-extension-token</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: extension used</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wlanguage-extension-token" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-large-by-value-copy</key>
+  <name>clang-diagnostic-large-by-value-copy</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is a large (%1 bytes) pass-by-value argument; pass it by reference instead ?</li>
+<li>warning: return value of %0 is a large (%1 bytes) pass-by-value object; pass it by reference instead ?</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wlarge-by-value-copy" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-literal-conversion</key>
+  <name>clang-diagnostic-literal-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion from %0 to %1 changes value from %2 to %3</li>
+<li>warning: implicit conversion of out of range value from %0 to %1 is undefined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wliteral-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-literal-range</key>
+  <name>clang-diagnostic-literal-range</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: magnitude of floating-point constant too large for type %0; maximum is %1</li>
+<li>warning: magnitude of floating-point constant too small for type %0; minimum is %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wliteral-range" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-local-type-template-args</key>
+  <name>clang-diagnostic-local-type-template-args</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: local type %0 as template argument is incompatible with C++98</li>
+<li>warning: template argument uses local type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wlocal-type-template-args" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-logical-not-parentheses</key>
+  <name>clang-diagnostic-logical-not-parentheses</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: logical not is only applied to the left hand side of this %select{comparison|bitwise operator}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wlogical-not-parentheses" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-logical-op-parentheses</key>
+  <name>clang-diagnostic-logical-op-parentheses</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '&amp;&amp;' within '||'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wlogical-op-parentheses" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-long-long</key>
+  <name>clang-diagnostic-long-long</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'long long' is a C++11 extension</li>
+<li>warning: 'long long' is an extension when C99 mode is not enabled</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wlong-long" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-loop-analysis</key>
+  <name>clang-diagnostic-loop-analysis</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: loop variable %0 %diff{has type $ but is initialized with type $| is initialized with a value of a different type}1,2 resulting in a copy</li>
+<li>warning: loop variable %0 is always a copy because the range of type %1 does not return a reference</li>
+<li>warning: loop variable %0 of type %1 creates a copy from type %2</li>
+<li>warning: variable %0 is %select{decremented|incremented}1 both in the loop header and in the loop body</li>
+<li>warning: variable%select{s| %1|s %1 and %2|s %1, %2, and %3|s %1, %2, %3, and %4}0 used in loop condition not modified in loop body</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wloop-analysis" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-macro-redefined</key>
+  <name>clang-diagnostic-macro-redefined</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 macro redefined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmacro-redefined" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-main</key>
+  <name>clang-diagnostic-main</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'main' is not allowed to be declared _Noreturn</li>
+<li>warning: 'main' is not allowed to be declared variadic</li>
+<li>warning: 'main' should not be declared static</li>
+<li>warning: ISO C++ does not allow 'main' to be used by a program</li>
+<li>warning: bool literal returned from 'main'</li>
+<li>warning: only one parameter on 'main' declaration</li>
+<li>warning: variable named 'main' with external linkage has undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmain" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-main-return-type</key>
+  <name>clang-diagnostic-main-return-type</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: return type of 'main' is not 'int'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmain-return-type" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-malformed-warning-check</key>
+  <name>clang-diagnostic-malformed-warning-check</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: __has_warning expected option name (e.g. "-Wundef")</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmalformed-warning-check" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-many-braces-around-scalar-init</key>
+  <name>clang-diagnostic-many-braces-around-scalar-init</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: too many braces around scalar initializer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmany-braces-around-scalar-init" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-max-unsigned-zero</key>
+  <name>clang-diagnostic-max-unsigned-zero</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: taking the max of %select{a value and unsigned zero|unsigned zero and a value}0 is always equal to the other value</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmax-unsigned-zero" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-memset-transposed-args</key>
+  <name>clang-diagnostic-memset-transposed-args</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{'size' argument to memset is '0'|setting buffer to a 'sizeof' expression}0; did you mean to transpose the last two arguments?</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmemset-transposed-args" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-memsize-comparison</key>
+  <name>clang-diagnostic-memsize-comparison</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: size argument in %0 call is a comparison</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmemsize-comparison" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-method-signatures</key>
+  <name>clang-diagnostic-method-signatures</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: conflicting parameter types in implementation of %0: %1 vs %2</li>
+<li>warning: conflicting return type in implementation of %0: %1 vs %2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmethod-signatures" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft</key>
+  <name>clang-diagnostic-microsoft</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #include resolved using non-portable Microsoft search rules as: %0</li>
+<li>warning: %0 is missing exception specification '%1'</li>
+<li>warning: %q0 redeclared without %1 attribute: previous %1 ignored</li>
+<li>warning: %q0 redeclared without 'dllimport' attribute: 'dllexport' attribute added</li>
+<li>warning: %select{class template|class template partial|variable template|variable template partial|function template|member function|static data member|member class|member enumeration}0 specialization of %1 not in %select{a namespace enclosing %2|class %2 or an enclosing namespace}3 is a Microsoft extension</li>
+<li>warning: %select{|pointer to |reference to }0incomplete type %1 is not allowed in exception specification</li>
+<li>warning: 'mutable' on a reference type is a Microsoft extension</li>
+<li>warning: 'sealed' keyword is a Microsoft extension</li>
+<li>warning: C++ operator %0 (aka %1) used as a macro name</li>
+<li>warning: anonymous %select{structs|unions}0 are a Microsoft extension</li>
+<li>warning: charizing operator #@ is a Microsoft extension</li>
+<li>warning: default initialization of an object of const type %0%select{| without a user-provided default constructor}1 is a Microsoft extension</li>
+<li>warning: duplicate explicit instantiation of %0 ignored as a Microsoft extension</li>
+<li>warning: enumeration types with a fixed underlying type are a Microsoft extension</li>
+<li>warning: enumerator value is not representable in the underlying type %0</li>
+<li>warning: exception specification in declaration does not match previous declaration</li>
+<li>warning: exception specification in explicit instantiation does not match instantiated one</li>
+<li>warning: exception specification of '...' is a Microsoft extension</li>
+<li>warning: exception specification of overriding function is more lax than base version</li>
+<li>warning: explicit constructor calls are a Microsoft extension</li>
+<li>warning: extra qualification on member %0</li>
+<li>warning: flexible array member %0 in a union is a Microsoft extension</li>
+<li>warning: flexible array member %0 in otherwise empty %select{struct|interface|union|class|enum}1 is a Microsoft extension</li>
+<li>warning: forward references to 'enum' types are a Microsoft extension</li>
+<li>warning: function definition with pure-specifier is a Microsoft extension</li>
+<li>warning: implicit conversion between pointer-to-function and pointer-to-object is a Microsoft extension</li>
+<li>warning: jump from this goto statement to its label is a Microsoft extension</li>
+<li>warning: non-type template argument containing a dereference operation is a Microsoft extension</li>
+<li>warning: pasting two '/' tokens into a '//' comment is a Microsoft extension</li>
+<li>warning: pseudo-destructors on type void are a Microsoft extension</li>
+<li>warning: redeclaring non-static %0 as static is a Microsoft extension</li>
+<li>warning: redefinition of default argument</li>
+<li>warning: static_cast between pointer-to-function and pointer-to-object is a Microsoft extension</li>
+<li>warning: template argument for template type parameter must be a type; omitted 'typename' is a Microsoft extension</li>
+<li>warning: treating Ctrl-Z as end-of-file is a Microsoft extension</li>
+<li>warning: types declared in an anonymous %select{struct|union}0 are a Microsoft extension</li>
+<li>warning: union member %0 has reference type %1, which is a Microsoft extension</li>
+<li>warning: unqualified friend declaration referring to type outside of the nearest enclosing namespace is a Microsoft extension; add a nested name specifier</li>
+<li>warning: use of identifier %0 found via unqualified lookup into dependent bases of class templates is a Microsoft extension</li>
+<li>warning: use of undeclared identifier %0; unqualified lookup into dependent bases of class template %1 is a Microsoft extension</li>
+<li>warning: using declaration referring to inaccessible member '%0' (which refers to accessible member '%1') is a Microsoft compatibility extension</li>
+<li>warning: using the undeclared type %0 as a default template argument is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-anon-tag</key>
+  <name>clang-diagnostic-microsoft-anon-tag</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: anonymous %select{structs|unions}0 are a Microsoft extension</li>
+<li>warning: types declared in an anonymous %select{struct|union}0 are a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-anon-tag" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-cast</key>
+  <name>clang-diagnostic-microsoft-cast</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion between pointer-to-function and pointer-to-object is a Microsoft extension</li>
+<li>warning: static_cast between pointer-to-function and pointer-to-object is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-cast" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-charize</key>
+  <name>clang-diagnostic-microsoft-charize</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: charizing operator #@ is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-charize" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-comment-paste</key>
+  <name>clang-diagnostic-microsoft-comment-paste</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: pasting two '/' tokens into a '//' comment is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-comment-paste" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-const-init</key>
+  <name>clang-diagnostic-microsoft-const-init</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: default initialization of an object of const type %0%select{| without a user-provided default constructor}1 is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-const-init" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-cpp-macro</key>
+  <name>clang-diagnostic-microsoft-cpp-macro</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: C++ operator %0 (aka %1) used as a macro name</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-cpp-macro" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-default-arg-redefinition</key>
+  <name>clang-diagnostic-microsoft-default-arg-redefinition</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: redefinition of default argument</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-default-arg-redefinition" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-end-of-file</key>
+  <name>clang-diagnostic-microsoft-end-of-file</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: treating Ctrl-Z as end-of-file is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-end-of-file" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-enum-forward-reference</key>
+  <name>clang-diagnostic-microsoft-enum-forward-reference</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: forward references to 'enum' types are a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-enum-forward-reference" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-enum-value</key>
+  <name>clang-diagnostic-microsoft-enum-value</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: enumerator value is not representable in the underlying type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-enum-value" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-exception-spec</key>
+  <name>clang-diagnostic-microsoft-exception-spec</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is missing exception specification '%1'</li>
+<li>warning: %select{|pointer to |reference to }0incomplete type %1 is not allowed in exception specification</li>
+<li>warning: exception specification in declaration does not match previous declaration</li>
+<li>warning: exception specification in explicit instantiation does not match instantiated one</li>
+<li>warning: exception specification of '...' is a Microsoft extension</li>
+<li>warning: exception specification of overriding function is more lax than base version</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-exception-spec" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-exists</key>
+  <name>clang-diagnostic-microsoft-exists</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: dependent %select{__if_not_exists|__if_exists}0 declarations are ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-exists" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-explicit-constructor-call</key>
+  <name>clang-diagnostic-microsoft-explicit-constructor-call</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: explicit constructor calls are a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-explicit-constructor-call" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-extra-qualification</key>
+  <name>clang-diagnostic-microsoft-extra-qualification</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: extra qualification on member %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-extra-qualification" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-fixed-enum</key>
+  <name>clang-diagnostic-microsoft-fixed-enum</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: enumeration types with a fixed underlying type are a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-fixed-enum" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-flexible-array</key>
+  <name>clang-diagnostic-microsoft-flexible-array</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: flexible array member %0 in a union is a Microsoft extension</li>
+<li>warning: flexible array member %0 in otherwise empty %select{struct|interface|union|class|enum}1 is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-flexible-array" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-goto</key>
+  <name>clang-diagnostic-microsoft-goto</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: jump from this goto statement to its label is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-goto" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-inaccessible-base</key>
+  <name>clang-diagnostic-microsoft-inaccessible-base</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: accessing inaccessible direct base %0 of %1 is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-inaccessible-base" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-include</key>
+  <name>clang-diagnostic-microsoft-include</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #include resolved using non-portable Microsoft search rules as: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-include" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-mutable-reference</key>
+  <name>clang-diagnostic-microsoft-mutable-reference</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'mutable' on a reference type is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-mutable-reference" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-pure-definition</key>
+  <name>clang-diagnostic-microsoft-pure-definition</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: function definition with pure-specifier is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-pure-definition" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-redeclare-static</key>
+  <name>clang-diagnostic-microsoft-redeclare-static</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: redeclaring non-static %0 as static is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-redeclare-static" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-sealed</key>
+  <name>clang-diagnostic-microsoft-sealed</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'sealed' keyword is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-sealed" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-template</key>
+  <name>clang-diagnostic-microsoft-template</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{class template|class template partial|variable template|variable template partial|function template|member function|static data member|member class|member enumeration}0 specialization of %1 not in %select{a namespace enclosing %2|class %2 or an enclosing namespace}3 is a Microsoft extension</li>
+<li>warning: duplicate explicit instantiation of %0 ignored as a Microsoft extension</li>
+<li>warning: non-type template argument containing a dereference operation is a Microsoft extension</li>
+<li>warning: template argument for template type parameter must be a type; omitted 'typename' is a Microsoft extension</li>
+<li>warning: use of identifier %0 found via unqualified lookup into dependent bases of class templates is a Microsoft extension</li>
+<li>warning: use of undeclared identifier %0; unqualified lookup into dependent bases of class template %1 is a Microsoft extension</li>
+<li>warning: using the undeclared type %0 as a default template argument is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-template" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-union-member-reference</key>
+  <name>clang-diagnostic-microsoft-union-member-reference</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: union member %0 has reference type %1, which is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-union-member-reference" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-unqualified-friend</key>
+  <name>clang-diagnostic-microsoft-unqualified-friend</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unqualified friend declaration referring to type outside of the nearest enclosing namespace is a Microsoft extension; add a nested name specifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-unqualified-friend" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-using-decl</key>
+  <name>clang-diagnostic-microsoft-using-decl</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: using declaration referring to inaccessible member '%0' (which refers to accessible member '%1') is a Microsoft compatibility extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-using-decl" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-microsoft-void-pseudo-dtor</key>
+  <name>clang-diagnostic-microsoft-void-pseudo-dtor</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: pseudo-destructors on type void are a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-void-pseudo-dtor" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-mismatched-new-delete</key>
+  <name>clang-diagnostic-mismatched-new-delete</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'delete%select{|[]}0' applied to a pointer that was allocated with 'new%select{[]|}0'; did you mean 'delete%select{[]|}0'?</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmismatched-new-delete" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-mismatched-parameter-types</key>
+  <name>clang-diagnostic-mismatched-parameter-types</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: conflicting parameter types in implementation of %0%diff{: $ vs $|}1,2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmismatched-parameter-types" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-mismatched-return-types</key>
+  <name>clang-diagnostic-mismatched-return-types</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: conflicting return type in implementation of %0%diff{: $ vs $|}1,2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmismatched-return-types" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-mismatched-tags</key>
+  <name>clang-diagnostic-mismatched-tags</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %2 defined as %select{a struct|an interface|a class}0%select{| template}1 here but previously declared as %select{a struct|an interface|a class}3%select{| template}1</li>
+<li>warning: %select{struct|interface|class}0%select{| template}1 %2 was previously declared as a %select{struct|interface|class}3%select{| template}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmismatched-tags" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-missing-braces</key>
+  <name>clang-diagnostic-missing-braces</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: suggest braces around initialization of subobject</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-braces" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-missing-declarations</key>
+  <name>clang-diagnostic-missing-declarations</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' ignored on this declaration</li>
+<li>warning: '%0' is not permitted on a declaration of a type</li>
+<li>warning: declaration does not declare anything</li>
+<li>warning: typedef requires a name</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-declarations" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-missing-exception-spec</key>
+  <name>clang-diagnostic-missing-exception-spec</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is missing exception specification '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-exception-spec" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-missing-field-initializers</key>
+  <name>clang-diagnostic-missing-field-initializers</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: missing field %0 initializer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-field-initializers" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-missing-method-return-type</key>
+  <name>clang-diagnostic-missing-method-return-type</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: method has no return type specified; defaults to 'id'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-method-return-type" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-missing-noescape</key>
+  <name>clang-diagnostic-missing-noescape</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: parameter of overriding method should be annotated with __attribute__((noescape))</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-noescape" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-missing-noreturn</key>
+  <name>clang-diagnostic-missing-noreturn</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{function|method}0 %1 could be declared with attribute 'noreturn'</li>
+<li>warning: block could be declared with attribute 'noreturn'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-noreturn" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-missing-prototype-for-cc</key>
+  <name>clang-diagnostic-missing-prototype-for-cc</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: function with no prototype cannot use the %0 calling convention</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-prototype-for-cc" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-missing-prototypes</key>
+  <name>clang-diagnostic-missing-prototypes</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: no previous prototype for function %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-prototypes" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-missing-selector-name</key>
+  <name>clang-diagnostic-missing-selector-name</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 used as the name of the previous parameter rather than as part of the selector</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-selector-name" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-missing-sysroot</key>
+  <name>clang-diagnostic-missing-sysroot</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: no such sysroot directory: '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-sysroot" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-missing-variable-declarations</key>
+  <name>clang-diagnostic-missing-variable-declarations</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: no previous extern declaration for non-static variable %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-variable-declarations" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-module-build</key>
+  <name>clang-diagnostic-module-build</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>remark: building module '%0' as '%1'</li>
+<li>remark: could not acquire lock file for module '%0': %1</li>
+<li>remark: finished building module '%0'</li>
+<li>remark: timed out waiting to acquire lock file for module '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rmodule-build" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-module-conflict</key>
+  <name>clang-diagnostic-module-conflict</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: module '%0' conflicts with already-imported module '%1': %2</li>
+<li>warning: module file '%0' was validated as a system module and is now being imported as a non-system module; any difference in diagnostic options will be ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodule-conflict" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-module-file-config-mismatch</key>
+  <name>clang-diagnostic-module-file-config-mismatch</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: module file %0 cannot be loaded due to a configuration mismatch with the current compilation</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodule-file-config-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-module-file-extension</key>
+  <name>clang-diagnostic-module-file-extension</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: duplicate module file extension block name '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodule-file-extension" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-module-import-in-extern-c</key>
+  <name>clang-diagnostic-module-import-in-extern-c</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: import of C++ module '%0' appears within extern "C" language linkage specification</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodule-import-in-extern-c" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-modules-ambiguous-internal-linkage</key>
+  <name>clang-diagnostic-modules-ambiguous-internal-linkage</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ambiguous use of internal linkage declaration %0 defined in multiple modules</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodules-ambiguous-internal-linkage" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-modules-import-nested-redundant</key>
+  <name>clang-diagnostic-modules-import-nested-redundant</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: redundant #include of module '%0' appears within %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodules-import-nested-redundant" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-most</key>
+  <name>clang-diagnostic-most</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma warning expected '%0'</li>
+<li>warning: #pragma warning expected 'push', 'pop', 'default', 'disable', 'error', 'once', 'suppress', 1, 2, 3, or 4</li>
+<li>warning: #pragma warning expected a warning number</li>
+<li>warning: #pragma warning(push, level) requires a level between 0 and 4</li>
+<li>warning: %0</li>
+<li>warning: %0 has C-linkage specified, but returns incomplete type %1 which could be incompatible with C</li>
+<li>warning: %0 has C-linkage specified, but returns user-defined type %1 which is incompatible with C</li>
+<li>warning: %2 defined as %select{a struct|an interface|a class}0%select{| template}1 here but previously declared as %select{a struct|an interface|a class}3%select{| template}1</li>
+<li>warning: %q0 hides overloaded virtual %select{function|functions}1</li>
+<li>warning: %select{delete|destructor}0 called on %1 that is abstract but has non-virtual destructor</li>
+<li>warning: %select{delete|destructor}0 called on non-final %1 that has virtual functions but non-virtual destructor</li>
+<li>warning: %select{equality|inequality|relational|three-way}0 comparison result unused</li>
+<li>warning: %select{field width|precision}0 used with '%1' conversion specifier, resulting in undefined behavior</li>
+<li>warning: %select{field|base class}0 %1 will be initialized after %select{field|base}2 %3</li>
+<li>warning: %select{function|variable}0 %1 is not needed and will not be emitted</li>
+<li>warning: %select{struct|interface|class}0%select{| template}1 %2 was previously declared as a %select{struct|interface|class}3%select{| template}1</li>
+<li>warning: %select{values of type|enum values with underlying type}2 '%0' should not be used as format arguments; add an explicit cast to %1 instead</li>
+<li>warning: %select{void function|void method|constructor|destructor}1 %0 should not return a value</li>
+<li>warning: %select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++</li>
+<li>warning: '%0' is not a valid object format flag</li>
+<li>warning: '%select{*|.*}0' specified field %select{width|precision}0 is missing a matching 'int' argument</li>
+<li>warning: '/*' within block comment</li>
+<li>warning: 'static' function %0 declared in header file should be declared 'static inline'</li>
+<li>warning: // comments are not allowed in this language</li>
+<li>warning: adding %0 to a string does not append to the string</li>
+<li>warning: all paths through this function will call itself</li>
+<li>warning: angle-bracketed include &lt;%0&gt; cannot be aliased to double-quoted include "%1"</li>
+<li>warning: array section %select{lower bound|length}0 is of type 'char'</li>
+<li>warning: array subscript is of type 'char'</li>
+<li>warning: assigning %select{field|instance variable}0 to itself</li>
+<li>warning: base class %0 is uninitialized when used here to access %q1</li>
+<li>warning: block pointer variable %0 is uninitialized when captured by block</li>
+<li>warning: cannot mix positional and non-positional arguments in format string</li>
+<li>warning: cast of type %0 to %1 is deprecated; use sel_getName instead</li>
+<li>warning: container access result unused - container access should not be used for side effects</li>
+<li>warning: control may reach end of coroutine; which is undefined behavior because the promise type %0 does not declare 'return_void()'</li>
+<li>warning: control may reach end of non-void function</li>
+<li>warning: control may reach end of non-void lambda</li>
+<li>warning: control reaches end of coroutine; which is undefined behavior because the promise type %0 does not declare 'return_void()'</li>
+<li>warning: control reaches end of non-void function</li>
+<li>warning: control reaches end of non-void lambda</li>
+<li>warning: convenience initializer missing a 'self' call to another initializer</li>
+<li>warning: convenience initializer should not invoke an initializer on 'super'</li>
+<li>warning: data argument not used by format string</li>
+<li>warning: data argument position '%0' exceeds the number of data arguments (%1)</li>
+<li>warning: designated initializer invoked a non-designated initializer</li>
+<li>warning: designated initializer missing a 'super' call to a designated initializer of the super class</li>
+<li>warning: designated initializer should only invoke a designated initializer on 'super'</li>
+<li>warning: double-quoted include "%0" cannot be aliased to angle-bracketed include &lt;%1&gt;</li>
+<li>warning: escaped newline between */ characters at block comment end</li>
+<li>warning: expected 'ON' or 'OFF' or 'DEFAULT' in pragma</li>
+<li>warning: expected end of directive in pragma</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself</li>
+<li>warning: explicitly moving variable of type %0 to itself</li>
+<li>warning: explicitly moving variable of type %0 to itself</li>
+<li>warning: expression result unused</li>
+<li>warning: expression result unused; should this cast be to 'void'?</li>
+<li>warning: expression with side effects has no effect in an unevaluated context</li>
+<li>warning: expression with side effects will be evaluated despite being used as an operand to 'typeid'</li>
+<li>warning: field %0 can overwrite instance variable %1 with variable sized type %2 in superclass %3</li>
+<li>warning: field %0 is uninitialized when used here</li>
+<li>warning: field %0 with variable sized type %1 is not visible to subclasses and can conflict with their instance variables</li>
+<li>warning: field %select{width|precision}0 should have type %1, but argument has type %2</li>
+<li>warning: flag '%0' is ignored when flag '%1' is present</li>
+<li>warning: flag '%0' results in undefined behavior with '%1' conversion specifier</li>
+<li>warning: format specifies type %0 but the argument has %select{type|underlying type}2 %1</li>
+<li>warning: format string contains '\0' within the string body</li>
+<li>warning: format string is empty</li>
+<li>warning: format string is not a string literal (potentially insecure)</li>
+<li>warning: format string is not null-terminated</li>
+<li>warning: format string missing</li>
+<li>warning: format string should not be a wide string</li>
+<li>warning: ignored trigraph would end block comment</li>
+<li>warning: ignoring return value of function declared with %0 attribute</li>
+<li>warning: ignoring return value of function declared with %0 attribute</li>
+<li>warning: implicit declaration of function %0</li>
+<li>warning: implicit declaration of function %0 is invalid in C99</li>
+<li>warning: implicitly declaring library function '%0' with type %1</li>
+<li>warning: incomplete format specifier</li>
+<li>warning: invalid conversion specifier '%0'</li>
+<li>warning: invalid position specified for %select{field width|field precision}0</li>
+<li>warning: ivar %0 which backs the property is not referenced in this property's accessor</li>
+<li>warning: lambda capture %0 is not %select{used|required to be captured for this use}1</li>
+<li>warning: length modifier '%0' results in undefined behavior or no effect with '%1' conversion specifier</li>
+<li>warning: local variable %0 will be copied despite being %select{returned|thrown}1 by name</li>
+<li>warning: method override for the designated initializer of the superclass %objcinstance0 not found</li>
+<li>warning: method possibly missing a [super %0] call</li>
+<li>warning: missing object format flag</li>
+<li>warning: more '%%' conversions than data arguments</li>
+<li>warning: moving a local object in a return statement prevents copy elision</li>
+<li>warning: moving a temporary object prevents copy elision</li>
+<li>warning: multi-character character constant</li>
+<li>warning: multi-line // comment</li>
+<li>warning: no closing ']' for '%%[' in scanf format string</li>
+<li>warning: non-void %select{function|method}1 %0 should return a value</li>
+<li>warning: non-void %select{function|method}1 %0 should return a value</li>
+<li>warning: null passed to a callee that requires a non-null argument</li>
+<li>warning: null returned from %select{function|method}0 that requires a non-null return value</li>
+<li>warning: object format flags cannot be used with '%0' conversion specifier</li>
+<li>warning: position arguments in format strings start counting at 1 (not 0)</li>
+<li>warning: pragma STDC FENV_ACCESS ON is not supported, ignoring pragma</li>
+<li>warning: pragma diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'</li>
+<li>warning: pragma diagnostic expected option name (e.g. "-Wundef")</li>
+<li>warning: pragma diagnostic pop could not pop, no matching push</li>
+<li>warning: pragma include_alias expected '%0'</li>
+<li>warning: pragma include_alias expected include filename</li>
+<li>warning: private field %0 is not used</li>
+<li>warning: redundant move in return statement</li>
+<li>warning: reference %0 is not yet bound to a value when used here</li>
+<li>warning: reference %0 is not yet bound to a value when used within its own initialization</li>
+<li>warning: sizeof on array function parameter will return size of %0 instead of %1</li>
+<li>warning: sizeof on pointer operation will return size of %0 instead of %1</li>
+<li>warning: static variable %0 is suspiciously used within its own initialization</li>
+<li>warning: suggest braces around initialization of subobject</li>
+<li>warning: trigraph converted to '%0' character</li>
+<li>warning: trigraph ends block comment</li>
+<li>warning: trigraph ignored</li>
+<li>warning: type specifier missing, defaults to 'int'</li>
+<li>warning: unexpected token in pragma diagnostic</li>
+<li>warning: unknown pragma ignored</li>
+<li>warning: unknown pragma in STDC namespace</li>
+<li>warning: unused %select{typedef|type alias}0 %1</li>
+<li>warning: unused function %0</li>
+<li>warning: unused label %0</li>
+<li>warning: unused variable %0</li>
+<li>warning: unused variable %0</li>
+<li>warning: use of __private_extern__ on a declaration may not produce external symbol private to the linkage unit and is deprecated</li>
+<li>warning: use of unknown builtin %0</li>
+<li>warning: using '%%P' format specifier without precision</li>
+<li>warning: using '%0' format specifier annotation outside of os_log()/os_trace()</li>
+<li>warning: variable %0 is %select{decremented|incremented}1 both in the loop header and in the loop body</li>
+<li>warning: variable %0 is %select{used|captured}1 uninitialized whenever %select{'%3' condition is %select{true|false}4|'%3' loop %select{is entered|exits because its condition is false}4|'%3' loop %select{condition is true|exits because its condition is false}4|switch %3 is taken|its declaration is reached|%3 is called}2</li>
+<li>warning: variable %0 is uninitialized when %select{used here|captured by block}1</li>
+<li>warning: variable %0 is uninitialized when used within its own initialization</li>
+<li>warning: variable%select{s| %1|s %1 and %2|s %1, %2, and %3|s %1, %2, %3, and %4}0 used in loop condition not modified in loop body</li>
+<li>warning: zero field width in scanf format string is unused</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmost" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-move</key>
+  <name>clang-diagnostic-move</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: explicitly moving variable of type %0 to itself</li>
+<li>warning: local variable %0 will be copied despite being %select{returned|thrown}1 by name</li>
+<li>warning: moving a local object in a return statement prevents copy elision</li>
+<li>warning: moving a temporary object prevents copy elision</li>
+<li>warning: redundant move in return statement</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmove" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-msvc-include</key>
+  <name>clang-diagnostic-msvc-include</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #include resolved using non-portable Microsoft search rules as: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmsvc-include" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-msvc-not-found</key>
+  <name>clang-diagnostic-msvc-not-found</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unable to find a Visual Studio installation; try running Clang from a developer command prompt</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmsvc-not-found" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-multichar</key>
+  <name>clang-diagnostic-multichar</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: multi-character character constant</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmultichar" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-multiple-move-vbase</key>
+  <name>clang-diagnostic-multiple-move-vbase</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: defaulted move assignment operator of %0 will move assign virtual base class %1 multiple times</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmultiple-move-vbase" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-narrowing</key>
+  <name>clang-diagnostic-narrowing</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|constexpr if condition}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnarrowing" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nested-anon-types</key>
+  <name>clang-diagnostic-nested-anon-types</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: anonymous types declared in an anonymous %select{struct|union}0 are an extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnested-anon-types" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-new-returns-null</key>
+  <name>clang-diagnostic-new-returns-null</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 should not return a null pointer unless it is declared 'throw()'%select{| or 'noexcept'}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnew-returns-null" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-newline-eof</key>
+  <name>clang-diagnostic-newline-eof</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: no newline at end of file</li>
+<li>warning: no newline at end of file</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnewline-eof" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-noexcept-type</key>
+  <name>clang-diagnostic-noexcept-type</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnoexcept-type" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-non-gcc</key>
+  <name>clang-diagnostic-non-gcc</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true</li>
+<li>warning: address of%select{| function| array}0 '%1' will always evaluate to 'true'</li>
+<li>warning: assigning value of signed enum type %1 to unsigned bit-field %0; negative enumerators of enum %1 will be converted to positive values</li>
+<li>warning: bit-field %0 is not wide enough to store all enumerators of %1</li>
+<li>warning: comparison of integers of different signs: %0 and %1</li>
+<li>warning: expression which evaluates to zero treated as a null pointer constant of type %0</li>
+<li>warning: implicit boolean conversion of Objective-C object literal always evaluates to true</li>
+<li>warning: implicit conversion changes signedness: %0 to %1</li>
+<li>warning: implicit conversion discards imaginary component: %0 to %1</li>
+<li>warning: implicit conversion from %0 to %1 changes non-zero value from %2 to %3</li>
+<li>warning: implicit conversion from %0 to %1 changes value from %2 to %3</li>
+<li>warning: implicit conversion from %0 to %1 changes value from %2 to %3</li>
+<li>warning: implicit conversion from %2 to %3 changes value from %0 to %1</li>
+<li>warning: implicit conversion from enumeration type %0 to different enumeration type %1</li>
+<li>warning: implicit conversion loses floating-point precision: %0 to %1</li>
+<li>warning: implicit conversion loses integer precision: %0 to %1</li>
+<li>warning: implicit conversion loses integer precision: %0 to %1</li>
+<li>warning: implicit conversion of %select{NULL|nullptr}0 constant to %1</li>
+<li>warning: implicit conversion of out of range value from %0 to %1 is undefined</li>
+<li>warning: implicit conversion of out of range value from %0 to %1 is undefined</li>
+<li>warning: implicit conversion turns floating-point number into integer: %0 to %1</li>
+<li>warning: implicit conversion turns string literal into bool: %0 to %1</li>
+<li>warning: implicit conversion turns vector to scalar: %0 to %1</li>
+<li>warning: implicit conversion when assigning computation result loses floating-point precision: %0 to %1</li>
+<li>warning: implicit truncation from %2 to bit-field changes value from %0 to %1</li>
+<li>warning: incompatible integer to pointer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+<li>warning: incompatible pointer to integer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+<li>warning: initialization of pointer of type %0 to null from a constant boolean expression</li>
+<li>warning: magnitude of floating-point constant too large for type %0; maximum is %1</li>
+<li>warning: magnitude of floating-point constant too small for type %0; minimum is %1</li>
+<li>warning: non-type template argument value '%0' truncated to '%1' for template parameter of type %2</li>
+<li>warning: non-type template argument with value '%0' converted to '%1' for unsigned template parameter of type %2</li>
+<li>warning: nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter</li>
+<li>warning: object of type %0 is not compatible with %select{array element type|dictionary key type|dictionary value type}1 %2</li>
+<li>warning: operand of ? changes signedness: %0 to %1</li>
+<li>warning: passing non-generic address space pointer to %0 may cause dynamic conversion affecting performance</li>
+<li>warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; pointer may be assumed to always convert to true</li>
+<li>warning: signed bit-field %0 needs an extra bit to represent the largest positive enumerators of %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnon-gcc" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-non-literal-null-conversion</key>
+  <name>clang-diagnostic-non-literal-null-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: expression which evaluates to zero treated as a null pointer constant of type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnon-literal-null-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-non-modular-include-in-framework-module</key>
+  <name>clang-diagnostic-non-modular-include-in-framework-module</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: include of non-modular header inside framework module '%0': '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnon-modular-include-in-framework-module" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-non-modular-include-in-module</key>
+  <name>clang-diagnostic-non-modular-include-in-module</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: include of non-modular header inside framework module '%0': '%1'</li>
+<li>warning: include of non-modular header inside module '%0': '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnon-modular-include-in-module" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-non-pod-varargs</key>
+  <name>clang-diagnostic-non-pod-varargs</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: cannot pass %select{non-POD|non-trivial}0 object of type %1 to variadic %select{function|block|method|constructor}2; expected type from format string was %3</li>
+<li>warning: cannot pass object of %select{non-POD|non-trivial}0 type %1 through variadic %select{function|block|method|constructor}2; call will abort at runtime</li>
+<li>warning: second argument to 'va_arg' is of ARC ownership-qualified type %0</li>
+<li>warning: second argument to 'va_arg' is of non-POD type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnon-pod-varargs" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-non-virtual-dtor</key>
+  <name>clang-diagnostic-non-virtual-dtor</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 has virtual functions but non-virtual destructor</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnon-virtual-dtor" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nonnull</key>
+  <name>clang-diagnostic-nonnull</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: null passed to a callee that requires a non-null argument</li>
+<li>warning: null returned from %select{function|method}0 that requires a non-null return value</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonnull" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nonportable-include-path</key>
+  <name>clang-diagnostic-nonportable-include-path</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: non-portable path to file '%0'; specified path differs in case from file name on disk</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-include-path" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nonportable-system-include-path</key>
+  <name>clang-diagnostic-nonportable-system-include-path</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: non-portable path to file '%0'; specified path differs in case from file name on disk</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-system-include-path" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nonportable-vector-initialization</key>
+  <name>clang-diagnostic-nonportable-vector-initialization</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: vector initializers are not compatible with NEON intrinsics in big endian mode</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-vector-initialization" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nontrivial-memaccess</key>
+  <name>clang-diagnostic-nontrivial-memaccess</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{destination for|source of|first operand of|second operand of}0 this %1 call is a pointer to record %2 that is not trivial to %select{primitive-default-initialize|primitive-copy}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnontrivial-memaccess" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nsconsumed-mismatch</key>
+  <name>clang-diagnostic-nsconsumed-mismatch</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: overriding method has mismatched ns_consumed attribute on its parameter</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnsconsumed-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nsreturns-mismatch</key>
+  <name>clang-diagnostic-nsreturns-mismatch</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: overriding method has mismatched ns_returns_%select{not_retained|retained}0 attributes</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnsreturns-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-null-arithmetic</key>
+  <name>clang-diagnostic-null-arithmetic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: comparison between NULL and non-pointer %select{(%1 and NULL)|(NULL and %1)}0</li>
+<li>warning: use of NULL in arithmetic operation</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnull-arithmetic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-null-character</key>
+  <name>clang-diagnostic-null-character</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: null character ignored</li>
+<li>warning: null character(s) preserved in %select{char|string}0 literal</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnull-character" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-null-conversion</key>
+  <name>clang-diagnostic-null-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion of %select{NULL|nullptr}0 constant to %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnull-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-null-dereference</key>
+  <name>clang-diagnostic-null-dereference</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: binding dereferenced null pointer to reference has undefined behavior</li>
+<li>warning: indirection of non-volatile null pointer will be deleted, not trap</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnull-dereference" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-null-pointer-arithmetic</key>
+  <name>clang-diagnostic-null-pointer-arithmetic</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension</li>
+<li>warning: performing pointer arithmetic on a null pointer has undefined behavior%select{| if the offset is nonzero}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnull-pointer-arithmetic" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nullability</key>
+  <name>clang-diagnostic-nullability</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: conflicting nullability specifier on parameter types, %0 conflicts with existing specifier %1</li>
+<li>warning: conflicting nullability specifier on return types, %0 conflicts with existing specifier %1</li>
+<li>warning: duplicate nullability specifier %0</li>
+<li>warning: nullability specifier %0 conflicts with existing specifier %1</li>
+<li>warning: synthesized setter %0 for null_resettable property %1 does not handle nil</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnullability" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nullability-completeness</key>
+  <name>clang-diagnostic-nullability-completeness</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{pointer|block pointer|member pointer}0 is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)</li>
+<li>warning: array parameter is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnullability-completeness" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nullability-completeness-on-arrays</key>
+  <name>clang-diagnostic-nullability-completeness-on-arrays</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: array parameter is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnullability-completeness-on-arrays" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nullability-declspec</key>
+  <name>clang-diagnostic-nullability-declspec</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: nullability specifier %0 cannot be applied to non-pointer type %1; did you mean to apply the specifier to the %select{pointer|block pointer|member pointer|function pointer|member function pointer}2?</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnullability-declspec" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nullability-extension</key>
+  <name>clang-diagnostic-nullability-extension</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: type nullability specifier %0 is a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnullability-extension" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nullability-inferred-on-nested-type</key>
+  <name>clang-diagnostic-nullability-inferred-on-nested-type</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: inferring '_Nonnull' for pointer type within %select{array|reference}0 is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnullability-inferred-on-nested-type" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-nullable-to-nonnull-conversion</key>
+  <name>clang-diagnostic-nullable-to-nonnull-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion from nullable pointer %0 to non-nullable pointer type %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnullable-to-nonnull-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-autosynthesis-property-ivar-name-match</key>
+  <name>clang-diagnostic-objc-autosynthesis-property-ivar-name-match</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: autosynthesized property %0 will use %select{|synthesized}1 instance variable %2, not existing instance variable %3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-autosynthesis-property-ivar-name-match" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-circular-container</key>
+  <name>clang-diagnostic-objc-circular-container</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: adding %0 to %1 might cause circular dependency in container</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-circular-container" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-cocoa-api</key>
+  <name>clang-diagnostic-objc-cocoa-api</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: using %0 with a literal is redundant</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-cocoa-api" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-designated-initializers</key>
+  <name>clang-diagnostic-objc-designated-initializers</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: convenience initializer missing a 'self' call to another initializer</li>
+<li>warning: convenience initializer should not invoke an initializer on 'super'</li>
+<li>warning: designated initializer invoked a non-designated initializer</li>
+<li>warning: designated initializer missing a 'super' call to a designated initializer of the super class</li>
+<li>warning: designated initializer should only invoke a designated initializer on 'super'</li>
+<li>warning: method override for the designated initializer of the superclass %objcinstance0 not found</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-designated-initializers" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-flexible-array</key>
+  <name>clang-diagnostic-objc-flexible-array</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: field %0 can overwrite instance variable %1 with variable sized type %2 in superclass %3</li>
+<li>warning: field %0 with variable sized type %1 is not visible to subclasses and can conflict with their instance variables</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-flexible-array" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-forward-class-redefinition</key>
+  <name>clang-diagnostic-objc-forward-class-redefinition</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: redefinition of forward class %0 of a typedef name of an object type is ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-forward-class-redefinition" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-interface-ivars</key>
+  <name>clang-diagnostic-objc-interface-ivars</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration of instance variables in the interface is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-interface-ivars" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-literal-compare</key>
+  <name>clang-diagnostic-objc-literal-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: direct comparison of %select{an array literal|a dictionary literal|a numeric literal|a boxed expression|}0 has undefined behavior</li>
+<li>warning: direct comparison of a string literal has undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-literal-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-literal-conversion</key>
+  <name>clang-diagnostic-objc-literal-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit boolean conversion of Objective-C object literal always evaluates to true</li>
+<li>warning: object of type %0 is not compatible with %select{array element type|dictionary key type|dictionary value type}1 %2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-literal-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-macro-redefinition</key>
+  <name>clang-diagnostic-objc-macro-redefinition</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ignoring redefinition of Objective-C qualifier macro</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-macro-redefinition" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-messaging-id</key>
+  <name>clang-diagnostic-objc-messaging-id</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: messaging unqualified id</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-messaging-id" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-method-access</key>
+  <name>clang-diagnostic-objc-method-access</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: class method %objcclass0 not found (return type defaults to 'id')</li>
+<li>warning: class method %objcclass0 not found (return type defaults to 'id'); did you mean %objcclass2?</li>
+<li>warning: instance method %0 found instead of class method %1</li>
+<li>warning: instance method %0 is being used on 'Class' which is not in the root class</li>
+<li>warning: instance method %objcinstance0 not found (return type defaults to 'id')</li>
+<li>warning: instance method %objcinstance0 not found (return type defaults to 'id'); did you mean %objcinstance2?</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-method-access" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-missing-property-synthesis</key>
+  <name>clang-diagnostic-objc-missing-property-synthesis</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: auto property synthesis is synthesizing property not explicitly synthesized</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-missing-property-synthesis" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-missing-super-calls</key>
+  <name>clang-diagnostic-objc-missing-super-calls</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: method possibly missing a [super %0] call</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-missing-super-calls" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-multiple-method-names</key>
+  <name>clang-diagnostic-objc-multiple-method-names</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: multiple methods named %0 found</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-multiple-method-names" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-noncopy-retain-block-property</key>
+  <name>clang-diagnostic-objc-noncopy-retain-block-property</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: retain'ed block property does not copy the block - use copy attribute instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-noncopy-retain-block-property" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-nonunified-exceptions</key>
+  <name>clang-diagnostic-objc-nonunified-exceptions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: cannot catch an exception thrown with @throw in C++ in the non-unified exception model</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-nonunified-exceptions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-property-assign-on-object-type</key>
+  <name>clang-diagnostic-objc-property-assign-on-object-type</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'assign' property of object type may become a dangling reference; consider using 'unsafe_unretained'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-assign-on-object-type" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-property-implementation</key>
+  <name>clang-diagnostic-objc-property-implementation</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: class property %0 requires method %1 to be defined - use @dynamic or provide a method implementation in this category</li>
+<li>warning: class property %0 requires method %1 to be defined - use @dynamic or provide a method implementation in this class implementation</li>
+<li>warning: property %0 requires method %1 to be defined - use @dynamic or provide a method implementation in this category</li>
+<li>warning: property %0 requires method %1 to be defined - use @synthesize, @dynamic or provide a method implementation in this class implementation</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-implementation" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-property-implicit-mismatch</key>
+  <name>clang-diagnostic-objc-property-implicit-mismatch</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: primary property declaration is implicitly strong while redeclaration in class extension is weak</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-implicit-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-property-matches-cocoa-ownership-rule</key>
+  <name>clang-diagnostic-objc-property-matches-cocoa-ownership-rule</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: property follows Cocoa naming convention for returning 'owned' objects</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-matches-cocoa-ownership-rule" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-property-no-attribute</key>
+  <name>clang-diagnostic-objc-property-no-attribute</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: default property attribute 'assign' not appropriate for object</li>
+<li>warning: no 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-no-attribute" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-property-synthesis</key>
+  <name>clang-diagnostic-objc-property-synthesis</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: auto property synthesis will not synthesize property %0 because it cannot share an ivar with another synthesized property</li>
+<li>warning: auto property synthesis will not synthesize property %0 because it is 'readwrite' but it will be synthesized 'readonly' via another property</li>
+<li>warning: auto property synthesis will not synthesize property %0; it will be implemented by its superclass, use @dynamic to acknowledge intention</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-synthesis" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-protocol-method-implementation</key>
+  <name>clang-diagnostic-objc-protocol-method-implementation</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: category is implementing a method which will also be implemented by its primary class</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-protocol-method-implementation" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-protocol-property-synthesis</key>
+  <name>clang-diagnostic-objc-protocol-property-synthesis</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: auto property synthesis will not synthesize property %0 declared in protocol %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-protocol-property-synthesis" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-protocol-qualifiers</key>
+  <name>clang-diagnostic-objc-protocol-qualifiers</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: parameterized class %0 already conforms to the protocols listed; did you forget a '*'?</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-protocol-qualifiers" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-readonly-with-setter-property</key>
+  <name>clang-diagnostic-objc-readonly-with-setter-property</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: setter cannot be specified for a readonly property</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-readonly-with-setter-property" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-redundant-api-use</key>
+  <name>clang-diagnostic-objc-redundant-api-use</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: using %0 with a literal is redundant</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-redundant-api-use" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-redundant-literal-use</key>
+  <name>clang-diagnostic-objc-redundant-literal-use</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: using %0 with a literal is redundant</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-redundant-literal-use" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-root-class</key>
+  <name>clang-diagnostic-objc-root-class</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: class %0 defined without specifying a base class</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-root-class" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-string-compare</key>
+  <name>clang-diagnostic-objc-string-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: direct comparison of a string literal has undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-string-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-string-concatenation</key>
+  <name>clang-diagnostic-objc-string-concatenation</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: concatenated NSString literal for an NSArray expression - possibly missing a comma</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-string-concatenation" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-objc-unsafe-perform-selector</key>
+  <name>clang-diagnostic-objc-unsafe-perform-selector</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is incompatible with selectors that return a %select{struct|union|vector}1 type</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-unsafe-perform-selector" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-odr</key>
+  <name>clang-diagnostic-odr</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: type %0 has incompatible definitions in different translation units</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wodr" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-old-style-cast</key>
+  <name>clang-diagnostic-old-style-cast</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: use of old-style cast</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wold-style-cast" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-opencl-unsupported-rgba</key>
+  <name>clang-diagnostic-opencl-unsupported-rgba</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: vector component name '%0' is an OpenCL version 2.2 feature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopencl-unsupported-rgba" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-openmp-clauses</key>
+  <name>clang-diagnostic-openmp-clauses</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: aligned clause will be ignored because the requested alignment is not a power of 2</li>
+<li>warning: zero linear step (%0 %select{|and other variables in clause }1should probably be const)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenmp-clauses" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-openmp-loop-form</key>
+  <name>clang-diagnostic-openmp-loop-form</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: OpenMP loop iteration variable cannot have more than 64 bits size and will be narrowed</li>
+<li>warning: initialization clause of OpenMP for loop is not in canonical form ('var = init' or 'T var = init')</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenmp-loop-form" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-openmp-target</key>
+  <name>clang-diagnostic-openmp-target</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: No library '%0' found in the default clang lib directory or in LIBRARY_PATH. Expect degraded performance due to no inlining of runtime functions on target devices.</li>
+<li>warning: Non-trivial type %0 is mapped, only trivial types are guaranteed to be mapped correctly</li>
+<li>warning: The OpenMP offloading target '%0' is similar to target '%1' already specified - will be ignored.</li>
+<li>warning: declaration is not declared in any declare target region</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenmp-target" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-option-ignored</key>
+  <name>clang-diagnostic-option-ignored</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: The '%0' architecture does not support -moutline; flag ignored</li>
+<li>warning: auto-vectorization requires HVX, use -mhvx to enable it</li>
+<li>warning: ignoring '%0' option as it cannot be used with %select{implicit usage of|}1 -mabicalls and the N64 ABI</li>
+<li>warning: ignoring '-mlong-calls' option as it is not currently supported with %select{|the implicit usage of }0-mabicalls</li>
+<li>warning: option '%0' was ignored by the PS4 toolchain, using '-fPIC'</li>
+<li>warning: option '-ffine-grained-bitfield-accesses' cannot be enabled together with a sanitizer; flag ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woption-ignored" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-ordered-compare-function-pointers</key>
+  <name>clang-diagnostic-ordered-compare-function-pointers</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ordered comparison of function pointers (%0 and %1)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wordered-compare-function-pointers" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-out-of-line-declaration</key>
+  <name>clang-diagnostic-out-of-line-declaration</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: out-of-line declaration of a member must be a definition</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wout-of-line-declaration" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-out-of-scope-function</key>
+  <name>clang-diagnostic-out-of-scope-function</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: use of out-of-scope declaration of %0%select{| whose type is not compatible with that of an implicit declaration}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wout-of-scope-function" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-over-aligned</key>
+  <name>clang-diagnostic-over-aligned</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: type %0 requires %1 bytes of alignment and the default allocator only guarantees %2 bytes</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wover-aligned" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-overlength-strings</key>
+  <name>clang-diagnostic-overlength-strings</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: string literal of length %0 exceeds maximum length %1 that %select{C90|ISO C99|C++}2 compilers are required to support</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverlength-strings" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-overloaded-shift-op-parentheses</key>
+  <name>clang-diagnostic-overloaded-shift-op-parentheses</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: overloaded operator %select{&gt;&gt;|&lt;&lt;}0 has higher precedence than comparison operator</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverloaded-shift-op-parentheses" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-overloaded-virtual</key>
+  <name>clang-diagnostic-overloaded-virtual</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %q0 hides overloaded virtual %select{function|functions}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverloaded-virtual" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-override-module</key>
+  <name>clang-diagnostic-override-module</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: overriding the module target triple with %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverride-module" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-overriding-method-mismatch</key>
+  <name>clang-diagnostic-overriding-method-mismatch</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: conflicting distributed object modifiers on parameter type in declaration of %0</li>
+<li>warning: conflicting distributed object modifiers on return type in declaration of %0</li>
+<li>warning: conflicting parameter types in declaration of %0%diff{: $ vs $|}1,2</li>
+<li>warning: conflicting parameter types in declaration of %0: %1 vs %2</li>
+<li>warning: conflicting return type in declaration of %0%diff{: $ vs $|}1,2</li>
+<li>warning: conflicting return type in declaration of %0: %1 vs %2</li>
+<li>warning: conflicting variadic declaration of method and its implementation</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverriding-method-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-overriding-t-option</key>
+  <name>clang-diagnostic-overriding-t-option</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: overriding '%0' option with '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverriding-t-option" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-packed</key>
+  <name>clang-diagnostic-packed</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: packed attribute is unnecessary for %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpacked" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-padded</key>
+  <name>clang-diagnostic-padded</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: padding %select{struct|interface|class}0 %1 with %2 %select{byte|bit}3%s2 to align %4</li>
+<li>warning: padding %select{struct|interface|class}0 %1 with %2 %select{byte|bit}3%s2 to align anonymous bit-field</li>
+<li>warning: padding size of %0 with %1 %select{byte|bit}2%s1 to alignment boundary</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpadded" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-parentheses</key>
+  <name>clang-diagnostic-parentheses</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 has lower precedence than %1; %1 will be evaluated first</li>
+<li>warning: '%0' within '%1'</li>
+<li>warning: '&amp;&amp;' within '||'</li>
+<li>warning: add explicit braces to avoid dangling else</li>
+<li>warning: equality comparison with extraneous parentheses</li>
+<li>warning: logical not is only applied to the left hand side of this %select{comparison|bitwise operator}0</li>
+<li>warning: operator '%0' has lower precedence than '%1'; '%1' will be evaluated first</li>
+<li>warning: operator '?:' has lower precedence than '%0'; '%0' will be evaluated first</li>
+<li>warning: overloaded operator %select{&gt;&gt;|&lt;&lt;}0 has higher precedence than comparison operator</li>
+<li>warning: using the result of an assignment as a condition without parentheses</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wparentheses" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-parentheses-equality</key>
+  <name>clang-diagnostic-parentheses-equality</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: equality comparison with extraneous parentheses</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wparentheses-equality" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-partial-availability</key>
+  <name>clang-diagnostic-partial-availability</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is only available on %1 %2 or newer</li>
+<li>warning: %0 is only available on %1 %2 or newer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpartial-availability" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pass</key>
+  <name>clang-diagnostic-pass</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>remark: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rpass" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pass-analysis</key>
+  <name>clang-diagnostic-pass-analysis</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>remark: %0</li>
+<li>remark: %0; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'.</li>
+<li>remark: %0; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied!</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rpass-analysis" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pass-failed</key>
+  <name>clang-diagnostic-pass-failed</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpass-failed" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pass-missed</key>
+  <name>clang-diagnostic-pass-missed</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>remark: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rpass-missed" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pch-date-time</key>
+  <name>clang-diagnostic-pch-date-time</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{precompiled header|module}0 uses __DATE__ or __TIME__</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpch-date-time" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pedantic-core-features</key>
+  <name>clang-diagnostic-pedantic-core-features</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: OpenCL extension %0 is core feature or supported optional core feature - ignoring</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpedantic-core-features" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pessimizing-move</key>
+  <name>clang-diagnostic-pessimizing-move</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: moving a local object in a return statement prevents copy elision</li>
+<li>warning: moving a temporary object prevents copy elision</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpessimizing-move" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pointer-arith</key>
+  <name>clang-diagnostic-pointer-arith</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: arithmetic on%select{ a|}0 pointer%select{|s}0 to void is a GNU extension</li>
+<li>warning: arithmetic on%select{ a|}0 pointer%select{|s}0 to%select{ the|}2 function type%select{|s}2 %1%select{| and %3}2 is a GNU extension</li>
+<li>warning: invalid application of '%select{sizeof|alignof|vec_step}0' to a function type</li>
+<li>warning: invalid application of '%select{sizeof|alignof|vec_step}0' to a void type</li>
+<li>warning: subscript of a pointer to void is a GNU extension</li>
+<li>warning: subtraction of pointers to type %0 of zero size has undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-arith" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pointer-bool-conversion</key>
+  <name>clang-diagnostic-pointer-bool-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: address of%select{| function| array}0 '%1' will always evaluate to 'true'</li>
+<li>warning: nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-bool-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pointer-sign</key>
+  <name>clang-diagnostic-pointer-sign</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2 converts between pointers to integer types with different sign</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-sign" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pointer-type-mismatch</key>
+  <name>clang-diagnostic-pointer-type-mismatch</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: pointer type mismatch%diff{ ($ and $)|}0,1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-type-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-potentially-evaluated-expression</key>
+  <name>clang-diagnostic-potentially-evaluated-expression</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: expression with side effects will be evaluated despite being used as an operand to 'typeid'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpotentially-evaluated-expression" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pragma-clang-attribute</key>
+  <name>clang-diagnostic-pragma-clang-attribute</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unused attribute %0 in '#pragma clang attribute push' region</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-clang-attribute" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pragma-once-outside-header</key>
+  <name>clang-diagnostic-pragma-once-outside-header</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma once in main file</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-once-outside-header" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pragma-pack</key>
+  <name>clang-diagnostic-pragma-pack</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: non-default #pragma pack value changes the alignment of struct or union members in the included file</li>
+<li>warning: the current #pragma pack alignment value is modified in the included file</li>
+<li>warning: unterminated '#pragma pack (push, ...)' at end of file</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-pack" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pragma-pack-suspicious-include</key>
+  <name>clang-diagnostic-pragma-pack-suspicious-include</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: non-default #pragma pack value changes the alignment of struct or union members in the included file</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-pack-suspicious-include" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pragma-system-header-outside-header</key>
+  <name>clang-diagnostic-pragma-system-header-outside-header</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma system_header ignored in main file</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-system-header-outside-header" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-pragmas</key>
+  <name>clang-diagnostic-pragmas</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma %0(pop, ...) failed: %1</li>
+<li>warning: #pragma options align=reset failed: %0</li>
+<li>warning: #pragma redefine_extname is applicable to external C declarations only; not applied to %select{function|variable}0 %1</li>
+<li>warning: #pragma warning expected '%0'</li>
+<li>warning: #pragma warning expected 'push', 'pop', 'default', 'disable', 'error', 'once', 'suppress', 1, 2, 3, or 4</li>
+<li>warning: #pragma warning expected a warning number</li>
+<li>warning: #pragma warning(push, level) requires a level between 0 and 4</li>
+<li>warning: %0 is not a recognized builtin%select{|; consider including &lt;intrin.h&gt; to access non-builtin intrinsics}1</li>
+<li>warning: '#pragma comment %0' ignored</li>
+<li>warning: '#pragma init_seg' is only supported when targeting a Microsoft environment</li>
+<li>warning: '#pragma optimize' is not supported</li>
+<li>warning: OpenCL extension end directive mismatches begin directive - ignoring</li>
+<li>warning: angle-bracketed include &lt;%0&gt; cannot be aliased to double-quoted include "%1"</li>
+<li>warning: double-quoted include "%0" cannot be aliased to angle-bracketed include &lt;%1&gt;</li>
+<li>warning: expected #pragma pack parameter to be '1', '2', '4', '8', or '16'</li>
+<li>warning: expected %select{'enable', 'disable', 'begin' or 'end'|'disable'}0 - ignoring</li>
+<li>warning: expected '#pragma unused' argument to be a variable name</li>
+<li>warning: expected ')' or ',' in '#pragma %0'</li>
+<li>warning: expected ',' in '#pragma %0'</li>
+<li>warning: expected '=' following '#pragma %select{align|options align}0' - ignored</li>
+<li>warning: expected 'ON' or 'OFF' or 'DEFAULT' in pragma</li>
+<li>warning: expected 'align' following '#pragma options' - ignored</li>
+<li>warning: expected 'compiler', 'lib', 'user', or a string literal for the section name in '#pragma %0' - ignored</li>
+<li>warning: expected a stack label or a string literal for the section name in '#pragma %0' - ignored</li>
+<li>warning: expected a string literal for the section name in '#pragma %0' - ignored</li>
+<li>warning: expected action or ')' in '#pragma %0' - ignored</li>
+<li>warning: expected end of directive in pragma</li>
+<li>warning: expected identifier in '#pragma %0' - ignored</li>
+<li>warning: expected integer between %0 and %1 inclusive in '#pragma %2' - ignored</li>
+<li>warning: expected integer or identifier in '#pragma pack' - ignored</li>
+<li>warning: expected non-wide string literal in '#pragma %0'</li>
+<li>warning: expected push, pop or a string literal for the section name in '#pragma %0' - ignored</li>
+<li>warning: expected string literal in '#pragma %0' - ignoring</li>
+<li>warning: extra tokens at end of '#pragma %0' - ignored</li>
+<li>warning: incorrect use of #pragma clang force_cuda_host_device begin|end</li>
+<li>warning: incorrect use of '#pragma ms_struct on|off' - ignored</li>
+<li>warning: invalid alignment option in '#pragma %select{align|options align}0' - ignored</li>
+<li>warning: known but unsupported action '%1' for '#pragma %0' - ignored</li>
+<li>warning: missing '(' after '#pragma %0' - ignoring</li>
+<li>warning: missing ')' after '#pragma %0' - ignoring</li>
+<li>warning: missing ':' after %0 - ignoring</li>
+<li>warning: missing ':' or ')' after %0 - ignoring</li>
+<li>warning: missing argument to '#pragma %0'%select{|; expected %2}1</li>
+<li>warning: missing argument to debug command '%0'</li>
+<li>warning: non-default #pragma pack value changes the alignment of struct or union members in the included file</li>
+<li>warning: only variables can be arguments to '#pragma unused'</li>
+<li>warning: pragma STDC FENV_ACCESS ON is not supported, ignoring pragma</li>
+<li>warning: pragma diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'</li>
+<li>warning: pragma diagnostic expected option name (e.g. "-Wundef")</li>
+<li>warning: pragma diagnostic pop could not pop, no matching push</li>
+<li>warning: pragma include_alias expected '%0'</li>
+<li>warning: pragma include_alias expected include filename</li>
+<li>warning: pragma pop_macro could not pop '%0', no matching push_macro</li>
+<li>warning: the current #pragma pack alignment value is modified in the included file</li>
+<li>warning: undeclared variable %0 used as an argument for '#pragma unused'</li>
+<li>warning: unexpected argument '%0' to '#pragma %1'%select{|; expected %3}2</li>
+<li>warning: unexpected debug command '%0'</li>
+<li>warning: unexpected token in pragma diagnostic</li>
+<li>warning: unknown OpenCL extension %0 - ignoring</li>
+<li>warning: unknown action '%1' for '#pragma %0' - ignored</li>
+<li>warning: unknown action for '#pragma %0' - ignored</li>
+<li>warning: unknown pragma ignored</li>
+<li>warning: unknown pragma in STDC namespace</li>
+<li>warning: unsupported OpenCL extension %0 - ignoring</li>
+<li>warning: unterminated '#pragma pack (push, ...)' at end of file</li>
+<li>warning: unused attribute %0 in '#pragma clang attribute push' region</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragmas" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-predefined-identifier-outside-function</key>
+  <name>clang-diagnostic-predefined-identifier-outside-function</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: predefined identifier is only valid inside function</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpredefined-identifier-outside-function" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-private-extern</key>
+  <name>clang-diagnostic-private-extern</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: use of __private_extern__ on a declaration may not produce external symbol private to the linkage unit and is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprivate-extern" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-private-header</key>
+  <name>clang-diagnostic-private-header</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: use of private header from outside its module: '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprivate-header" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-private-module</key>
+  <name>clang-diagnostic-private-module</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: expected canonical name for private module '%0'</li>
+<li>warning: module '%0' already re-exported as '%1'</li>
+<li>warning: no submodule named %0 in module '%1'; using top level '%2'</li>
+<li>warning: private submodule '%0' in private module map, expected top-level module</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprivate-module" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-profile-instr-missing</key>
+  <name>clang-diagnostic-profile-instr-missing</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: profile data may be incomplete: of %0 function%s0, %1 %plural{1:has|:have}1 no data</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprofile-instr-missing" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-profile-instr-out-of-date</key>
+  <name>clang-diagnostic-profile-instr-out-of-date</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: profile data may be out of date: of %0 function%s0, %1 %plural{1:has|:have}1 mismatched data that will be ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprofile-instr-out-of-date" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-profile-instr-unprofiled</key>
+  <name>clang-diagnostic-profile-instr-unprofiled</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: no profile data available for file "%0"</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprofile-instr-unprofiled" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-property-access-dot-syntax</key>
+  <name>clang-diagnostic-property-access-dot-syntax</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: property %0 not found on object of type %1; did you mean to access property %2?</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wproperty-access-dot-syntax" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-property-attribute-mismatch</key>
+  <name>clang-diagnostic-property-attribute-mismatch</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%1' attribute on property %0 does not match the property inherited from %2</li>
+<li>warning: attribute 'readonly' of property %0 restricts attribute 'readwrite' of property inherited from %1</li>
+<li>warning: getter name mismatch between property redeclaration (%1) and its original declaration (%0)</li>
+<li>warning: property attribute in class extension does not match the primary class</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wproperty-attribute-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-protocol</key>
+  <name>clang-diagnostic-protocol</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: method %0 in protocol %1 not implemented</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprotocol" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-protocol-property-synthesis-ambiguity</key>
+  <name>clang-diagnostic-protocol-property-synthesis-ambiguity</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: property %select{of type %1|with attribute '%1'|without attribute '%1'|with getter %1|with setter %1}0 was selected for synthesis</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprotocol-property-synthesis-ambiguity" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-qualified-void-return-type</key>
+  <name>clang-diagnostic-qualified-void-return-type</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: function cannot return qualified void type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wqualified-void-return-type" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-quoted-include-in-framework-header</key>
+  <name>clang-diagnostic-quoted-include-in-framework-header</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: double-quoted include "%0" in framework header, expected angle-bracketed instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wquoted-include-in-framework-header" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-range-loop-analysis</key>
+  <name>clang-diagnostic-range-loop-analysis</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: loop variable %0 %diff{has type $ but is initialized with type $| is initialized with a value of a different type}1,2 resulting in a copy</li>
+<li>warning: loop variable %0 is always a copy because the range of type %1 does not return a reference</li>
+<li>warning: loop variable %0 of type %1 creates a copy from type %2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrange-loop-analysis" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-readonly-iboutlet-property</key>
+  <name>clang-diagnostic-readonly-iboutlet-property</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: readonly IBOutlet property %0 when auto-synthesized may not work correctly with 'nib' loader</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreadonly-iboutlet-property" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-receiver-expr</key>
+  <name>clang-diagnostic-receiver-expr</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: receiver type %0 is not 'id' or interface pointer, consider casting it to 'id'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreceiver-expr" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-receiver-forward-class</key>
+  <name>clang-diagnostic-receiver-forward-class</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: receiver %0 is a forward class and corresponding @interface may not exist</li>
+<li>warning: receiver type %0 for instance message is a forward declaration</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreceiver-forward-class" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-redeclared-class-member</key>
+  <name>clang-diagnostic-redeclared-class-member</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: class member cannot be redeclared</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wredeclared-class-member" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-redundant-move</key>
+  <name>clang-diagnostic-redundant-move</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: redundant move in return statement</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wredundant-move" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-redundant-parens</key>
+  <name>clang-diagnostic-redundant-parens</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: redundant parentheses surrounding declarator</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wredundant-parens" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-register</key>
+  <name>clang-diagnostic-register</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
+<li>warning: ISO C++17 does not allow 'register' storage class specifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wregister" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-reinterpret-base-class</key>
+  <name>clang-diagnostic-reinterpret-base-class</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'reinterpret_cast' %select{from|to}3 class %0 %select{to|from}3 its %select{virtual base|base at non-zero offset}2 %1 behaves differently from 'static_cast'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreinterpret-base-class" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-remark-backend-plugin</key>
+  <name>clang-diagnostic-remark-backend-plugin</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>remark: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rremark-backend-plugin" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-reorder</key>
+  <name>clang-diagnostic-reorder</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{field|base class}0 %1 will be initialized after %select{field|base}2 %3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreorder" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-requires-super-attribute</key>
+  <name>clang-diagnostic-requires-super-attribute</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 attribute cannot be applied to %select{methods in protocols|dealloc}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrequires-super-attribute" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-reserved-id-macro</key>
+  <name>clang-diagnostic-reserved-id-macro</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: macro name is a reserved identifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreserved-id-macro" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-reserved-user-defined-literal</key>
+  <name>clang-diagnostic-reserved-user-defined-literal</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: identifier after literal will be treated as a reserved user-defined literal suffix in C++11</li>
+<li>warning: invalid suffix on literal; C++11 requires a space between literal and identifier</li>
+<li>warning: invalid suffix on literal; C++11 requires a space between literal and identifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreserved-user-defined-literal" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-retained-language-linkage</key>
+  <name>clang-diagnostic-retained-language-linkage</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: friend function %0 retaining previous language linkage is an extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wretained-language-linkage" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-return-stack-address</key>
+  <name>clang-diagnostic-return-stack-address</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{address of|reference to}0 stack memory associated with %select{local variable|parameter}2 %1 returned</li>
+<li>warning: returning %select{address of|reference to}0 local temporary object</li>
+<li>warning: returning address of label, which is local</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-stack-address" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-return-std-move</key>
+  <name>clang-diagnostic-return-std-move</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: local variable %0 will be copied despite being %select{returned|thrown}1 by name</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-std-move" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-return-std-move-in-c++11</key>
+  <name>clang-diagnostic-return-std-move-in-c++11</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: prior to the resolution of a defect report against ISO C++11, local variable %0 would have been copied despite being returned by name, due to its not matching the function return type%diff{ ($ vs $)|}1,2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-std-move-in-c-11" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-return-type</key>
+  <name>clang-diagnostic-return-type</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 has C-linkage specified, but returns incomplete type %1 which could be incompatible with C</li>
+<li>warning: %0 has C-linkage specified, but returns user-defined type %1 which is incompatible with C</li>
+<li>warning: %select{void function|void method|constructor|destructor}1 %0 should not return a value</li>
+<li>warning: control may reach end of coroutine; which is undefined behavior because the promise type %0 does not declare 'return_void()'</li>
+<li>warning: control may reach end of non-void function</li>
+<li>warning: control may reach end of non-void lambda</li>
+<li>warning: control reaches end of coroutine; which is undefined behavior because the promise type %0 does not declare 'return_void()'</li>
+<li>warning: control reaches end of non-void function</li>
+<li>warning: control reaches end of non-void lambda</li>
+<li>warning: non-void %select{function|method}1 %0 should return a value</li>
+<li>warning: non-void %select{function|method}1 %0 should return a value</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-type" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-return-type-c-linkage</key>
+  <name>clang-diagnostic-return-type-c-linkage</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 has C-linkage specified, but returns incomplete type %1 which could be incompatible with C</li>
+<li>warning: %0 has C-linkage specified, but returns user-defined type %1 which is incompatible with C</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-type-c-linkage" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-sanitize-address</key>
+  <name>clang-diagnostic-sanitize-address</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>remark: -fsanitize-address-field-padding applied to %0</li>
+<li>remark: -fsanitize-address-field-padding ignored for %0 because it %select{is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rsanitize-address" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-section</key>
+  <name>clang-diagnostic-section</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{codeseg|section}0 does not match previous declaration</li>
+<li>warning: duplicate code segment specifiers</li>
+<li>warning: section attribute is specified on redeclared variable</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsection" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-selector</key>
+  <name>clang-diagnostic-selector</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: no method with selector %0 is implemented in this translation unit</li>
+<li>warning: several methods with selector %0 of mismatched types are found for the @selector expression</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wselector" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-selector-type-mismatch</key>
+  <name>clang-diagnostic-selector-type-mismatch</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: several methods with selector %0 of mismatched types are found for the @selector expression</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wselector-type-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-self-assign</key>
+  <name>clang-diagnostic-self-assign</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: assigning %select{field|instance variable}0 to itself</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wself-assign" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-self-assign-field</key>
+  <name>clang-diagnostic-self-assign-field</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: assigning %select{field|instance variable}0 to itself</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wself-assign-field" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-self-assign-overloaded</key>
+  <name>clang-diagnostic-self-assign-overloaded</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: explicitly assigning value of variable of type %0 to itself</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wself-assign-overloaded" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-self-move</key>
+  <name>clang-diagnostic-self-move</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: explicitly moving variable of type %0 to itself</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wself-move" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-semicolon-before-method-body</key>
+  <name>clang-diagnostic-semicolon-before-method-body</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: semicolon before method body is ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsemicolon-before-method-body" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-sentinel</key>
+  <name>clang-diagnostic-sentinel</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: missing sentinel in %select{function call|method dispatch|block call}0</li>
+<li>warning: not enough variable arguments in %0 declaration to fit a sentinel</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsentinel" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-sequence-point</key>
+  <name>clang-diagnostic-sequence-point</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: multiple unsequenced modifications to %0</li>
+<li>warning: unsequenced modification and access to %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsequence-point" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-serialized-diagnostics</key>
+  <name>clang-diagnostic-serialized-diagnostics</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unable to merge a subprocess's serialized diagnostics</li>
+<li>warning: unable to open file %0 for serializing diagnostics (%1)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wserialized-diagnostics" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-shadow</key>
+  <name>clang-diagnostic-shadow</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration shadows a %select{local variable|variable in %2|static data member of %2|field of %2|typedef in %2|type alias in %2}1</li>
+<li>warning: local declaration of %0 hides instance variable</li>
+<li>warning: modifying constructor parameter %0 that shadows a field of %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshadow" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-shadow-all</key>
+  <name>clang-diagnostic-shadow-all</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: constructor parameter %0 shadows the field %1 of %2</li>
+<li>warning: declaration shadows a %select{local variable|variable in %2|static data member of %2|field of %2|typedef in %2|type alias in %2}1</li>
+<li>warning: declaration shadows a %select{local variable|variable in %2|static data member of %2|field of %2|typedef in %2|type alias in %2}1</li>
+<li>warning: local declaration of %0 hides instance variable</li>
+<li>warning: modifying constructor parameter %0 that shadows a field of %1</li>
+<li>warning: modifying constructor parameter %0 that shadows a field of %1</li>
+<li>warning: non-static data member %0 of %1 shadows member inherited from type %2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshadow-all" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-shadow-field</key>
+  <name>clang-diagnostic-shadow-field</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: non-static data member %0 of %1 shadows member inherited from type %2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshadow-field" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-shadow-field-in-constructor</key>
+  <name>clang-diagnostic-shadow-field-in-constructor</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: constructor parameter %0 shadows the field %1 of %2</li>
+<li>warning: modifying constructor parameter %0 that shadows a field of %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshadow-field-in-constructor" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-shadow-field-in-constructor-modified</key>
+  <name>clang-diagnostic-shadow-field-in-constructor-modified</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: modifying constructor parameter %0 that shadows a field of %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshadow-field-in-constructor-modified" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-shadow-ivar</key>
+  <name>clang-diagnostic-shadow-ivar</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: local declaration of %0 hides instance variable</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshadow-ivar" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-shadow-uncaptured-local</key>
+  <name>clang-diagnostic-shadow-uncaptured-local</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration shadows a %select{local variable|variable in %2|static data member of %2|field of %2|typedef in %2|type alias in %2}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshadow-uncaptured-local" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-shift-count-negative</key>
+  <name>clang-diagnostic-shift-count-negative</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: shift count is negative</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-count-negative" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-shift-count-overflow</key>
+  <name>clang-diagnostic-shift-count-overflow</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: shift count &gt;= width of type</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-count-overflow" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-shift-negative-value</key>
+  <name>clang-diagnostic-shift-negative-value</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: shifting a negative signed value is undefined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-negative-value" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-shift-op-parentheses</key>
+  <name>clang-diagnostic-shift-op-parentheses</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: operator '%0' has lower precedence than '%1'; '%1' will be evaluated first</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-op-parentheses" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-shift-overflow</key>
+  <name>clang-diagnostic-shift-overflow</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: signed shift result (%0) requires %1 bits to represent, but %2 only has %3 bits</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-overflow" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-shift-sign-overflow</key>
+  <name>clang-diagnostic-shift-sign-overflow</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: signed shift result (%0) sets the sign bit of the shift expression's type (%1) and becomes negative</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-sign-overflow" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-shorten-64-to-32</key>
+  <name>clang-diagnostic-shorten-64-to-32</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion loses integer precision: %0 to %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshorten-64-to-32" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-sign-compare</key>
+  <name>clang-diagnostic-sign-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: comparison of integers of different signs: %0 and %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsign-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-sign-conversion</key>
+  <name>clang-diagnostic-sign-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion changes signedness: %0 to %1</li>
+<li>warning: operand of ? changes signedness: %0 to %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsign-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-signed-enum-bitfield</key>
+  <name>clang-diagnostic-signed-enum-bitfield</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: enums in the Microsoft ABI are signed integers by default; consider giving the enum %0 an unsigned underlying type to make this code portable</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsigned-enum-bitfield" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-sizeof-array-argument</key>
+  <name>clang-diagnostic-sizeof-array-argument</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: sizeof on array function parameter will return size of %0 instead of %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsizeof-array-argument" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-sizeof-array-decay</key>
+  <name>clang-diagnostic-sizeof-array-decay</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: sizeof on pointer operation will return size of %0 instead of %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsizeof-array-decay" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-sizeof-pointer-memaccess</key>
+  <name>clang-diagnostic-sizeof-pointer-memaccess</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' call operates on objects of type %1 while the size is based on a different type %2</li>
+<li>warning: argument to 'sizeof' in %0 call is the same pointer type %1 as the %select{destination|source}2; expected %3 or an explicit length</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsizeof-pointer-memaccess" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-slash-u-filename</key>
+  <name>clang-diagnostic-slash-u-filename</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: '/U%0' treated as the '/U' option</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wslash-u-filename" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-sometimes-uninitialized</key>
+  <name>clang-diagnostic-sometimes-uninitialized</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: variable %0 is %select{used|captured}1 uninitialized whenever %select{'%3' condition is %select{true|false}4|'%3' loop %select{is entered|exits because its condition is false}4|'%3' loop %select{condition is true|exits because its condition is false}4|switch %3 is taken|its declaration is reached|%3 is called}2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsometimes-uninitialized" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-source-uses-openmp</key>
+  <name>clang-diagnostic-source-uses-openmp</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: OpenMP only allows an ordered construct with the simd clause nested in a simd construct</li>
+<li>warning: unexpected '#pragma omp ...' in program</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsource-uses-openmp" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-spir-compat</key>
+  <name>clang-diagnostic-spir-compat</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: sampler initializer has invalid %0 bits</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wspir-compat" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-static-float-init</key>
+  <name>clang-diagnostic-static-float-init</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: in-class initializer for static data member of type %0 is a GNU extension</li>
+<li>warning: in-class initializer for static data member of type %0 requires 'constexpr' specifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstatic-float-init" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-static-in-inline</key>
+  <name>clang-diagnostic-static-in-inline</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: static %select{function|variable}0 %1 is used in an inline function with external linkage</li>
+<li>warning: static %select{function|variable}0 %1 is used in an inline function with external linkage</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstatic-in-inline" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-static-inline-explicit-instantiation</key>
+  <name>clang-diagnostic-static-inline-explicit-instantiation</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ignoring '%select{static|inline}0' keyword on explicit template instantiation</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstatic-inline-explicit-instantiation" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-static-local-in-inline</key>
+  <name>clang-diagnostic-static-local-in-inline</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: non-constant static local variable in inline function may be different in different files</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstatic-local-in-inline" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-static-self-init</key>
+  <name>clang-diagnostic-static-self-init</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: static variable %0 is suspiciously used within its own initialization</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstatic-self-init" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-stdlibcxx-not-found</key>
+  <name>clang-diagnostic-stdlibcxx-not-found</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: include path for stdlibc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstdlibcxx-not-found" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-strict-prototypes</key>
+  <name>clang-diagnostic-strict-prototypes</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: this %select{function declaration is not|block declaration is not|old-style function definition is not preceded by}0 a prototype</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrict-prototypes" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-strict-selector-match</key>
+  <name>clang-diagnostic-strict-selector-match</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: multiple methods named %0 found</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrict-selector-match" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-string-compare</key>
+  <name>clang-diagnostic-string-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: result of comparison against %select{a string literal|@encode}0 is unspecified (use strncmp instead)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstring-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-string-conversion</key>
+  <name>clang-diagnostic-string-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion turns string literal into bool: %0 to %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstring-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-string-plus-char</key>
+  <name>clang-diagnostic-string-plus-char</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: adding %0 to a string pointer does not append to the string</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstring-plus-char" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-string-plus-int</key>
+  <name>clang-diagnostic-string-plus-int</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: adding %0 to a string does not append to the string</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstring-plus-int" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-strlcpy-strlcat-size</key>
+  <name>clang-diagnostic-strlcpy-strlcat-size</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: size argument in %0 call appears to be size of the source; expected the size of the destination</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrlcpy-strlcat-size" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-strncat-size</key>
+  <name>clang-diagnostic-strncat-size</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: size argument in 'strncat' call appears to be size of the source</li>
+<li>warning: the value of the size argument in 'strncat' is too large, might lead to a buffer overflow</li>
+<li>warning: the value of the size argument to 'strncat' is wrong</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrncat-size" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-super-class-method-mismatch</key>
+  <name>clang-diagnostic-super-class-method-mismatch</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: method parameter type %diff{$ does not match super class method parameter type $|does not match super class method parameter type}0,1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsuper-class-method-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-suspicious-bzero</key>
+  <name>clang-diagnostic-suspicious-bzero</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'size' argument to bzero is '0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsuspicious-bzero" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-suspicious-memaccess</key>
+  <name>clang-diagnostic-suspicious-memaccess</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{'size' argument to memset is '0'|setting buffer to a 'sizeof' expression}0; did you mean to transpose the last two arguments?</li>
+<li>warning: %select{destination for|source of|first operand of|second operand of}0 this %1 call is a pointer to %select{|class containing a }2dynamic class %3; vtable pointer will be %select{overwritten|copied|moved|compared}4</li>
+<li>warning: %select{destination for|source of|first operand of|second operand of}0 this %1 call is a pointer to record %2 that is not trivial to %select{primitive-default-initialize|primitive-copy}3</li>
+<li>warning: '%0' call operates on objects of type %1 while the size is based on a different type %2</li>
+<li>warning: 'size' argument to bzero is '0'</li>
+<li>warning: argument to 'sizeof' in %0 call is the same pointer type %1 as the %select{destination|source}2; expected %3 or an explicit length</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsuspicious-memaccess" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-switch</key>
+  <name>clang-diagnostic-switch</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %plural{1:enumeration value %1 not handled in switch|2:enumeration values %1 and %2 not handled in switch|3:enumeration values %1, %2, and %3 not handled in switch|:%0 enumeration values not handled in switch: %1, %2, %3...}0</li>
+<li>warning: case value not in enumerated type %0</li>
+<li>warning: overflow converting case value to switch condition type (%0 to %1)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wswitch" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-switch-bool</key>
+  <name>clang-diagnostic-switch-bool</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: switch condition has boolean value</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wswitch-bool" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-switch-enum</key>
+  <name>clang-diagnostic-switch-enum</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %plural{1:enumeration value %1 not explicitly handled in switch|2:enumeration values %1 and %2 not explicitly handled in switch|3:enumeration values %1, %2, and %3 not explicitly handled in switch|:%0 enumeration values not explicitly handled in switch: %1, %2, %3...}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wswitch-enum" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-sync-fetch-and-nand-semantics-changed</key>
+  <name>clang-diagnostic-sync-fetch-and-nand-semantics-changed</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: the semantics of this intrinsic changed with GCC version 4.4 - the newer semantics are provided here</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsync-fetch-and-nand-semantics-changed" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-tautological-compare</key>
+  <name>clang-diagnostic-tautological-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{self-|array }0comparison always evaluates to %select{a constant|%2}1</li>
+<li>warning: 'this' pointer cannot be null in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0</li>
+<li>warning: bitwise comparison always evaluates to %select{false|true}0</li>
+<li>warning: comparison of %select{address of|function|array}0 '%1' %select{not |}2equal to a null pointer is always %select{true|false}2</li>
+<li>warning: comparison of nonnull %select{function call|parameter}0 '%1' %select{not |}2equal to a null pointer is '%select{true|false}2' on first encounter</li>
+<li>warning: overlapping comparisons always evaluate to %select{false|true}0</li>
+<li>warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0</li>
+<li>warning: result of comparison of %select{constant %0|true|false}1 with %select{expression of type %2|boolean expression}3 is always %4</li>
+<li>warning: result of comparison of %select{constant %0|true|false}1 with %select{expression of type %2|boolean expression}3 is always %4</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-tautological-constant-compare</key>
+  <name>clang-diagnostic-tautological-constant-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: result of comparison of %select{constant %0|true|false}1 with %select{expression of type %2|boolean expression}3 is always %4</li>
+<li>warning: result of comparison of %select{constant %0|true|false}1 with %select{expression of type %2|boolean expression}3 is always %4</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-constant-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-tautological-constant-in-range-compare</key>
+  <name>clang-diagnostic-tautological-constant-in-range-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: result of comparison %select{%3|%1}0 %2 %select{%1|%3}0 is always %4</li>
+<li>warning: result of comparison of %select{%3|unsigned enum expression}0 %2 %select{unsigned enum expression|%3}0 is always %4</li>
+<li>warning: result of comparison of %select{%3|unsigned expression}0 %2 %select{unsigned expression|%3}0 is always %4</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-constant-in-range-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-tautological-constant-out-of-range-compare</key>
+  <name>clang-diagnostic-tautological-constant-out-of-range-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: result of comparison of %select{constant %0|true|false}1 with %select{expression of type %2|boolean expression}3 is always %4</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-constant-out-of-range-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-tautological-overlap-compare</key>
+  <name>clang-diagnostic-tautological-overlap-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: overlapping comparisons always evaluate to %select{false|true}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-overlap-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-tautological-pointer-compare</key>
+  <name>clang-diagnostic-tautological-pointer-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: comparison of %select{address of|function|array}0 '%1' %select{not |}2equal to a null pointer is always %select{true|false}2</li>
+<li>warning: comparison of nonnull %select{function call|parameter}0 '%1' %select{not |}2equal to a null pointer is '%select{true|false}2' on first encounter</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-pointer-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-tautological-type-limit-compare</key>
+  <name>clang-diagnostic-tautological-type-limit-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: result of comparison %select{%3|%1}0 %2 %select{%1|%3}0 is always %4</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-type-limit-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-tautological-undefined-compare</key>
+  <name>clang-diagnostic-tautological-undefined-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'this' pointer cannot be null in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0</li>
+<li>warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-undefined-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-tautological-unsigned-enum-zero-compare</key>
+  <name>clang-diagnostic-tautological-unsigned-enum-zero-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: result of comparison of %select{%3|unsigned enum expression}0 %2 %select{unsigned enum expression|%3}0 is always %4</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-unsigned-enum-zero-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-tautological-unsigned-zero-compare</key>
+  <name>clang-diagnostic-tautological-unsigned-zero-compare</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: result of comparison of %select{%3|unsigned expression}0 %2 %select{unsigned expression|%3}0 is always %4</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-unsigned-zero-compare" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-tentative-definition-incomplete-type</key>
+  <name>clang-diagnostic-tentative-definition-incomplete-type</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: tentative definition of variable with internal linkage has incomplete non-array type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtentative-definition-incomplete-type" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-thread-safety</key>
+  <name>clang-diagnostic-thread-safety</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 '%1' is acquired exclusively and shared in the same scope</li>
+<li>warning: %0 '%1' is not held on every path through here</li>
+<li>warning: %0 '%1' is still held at the end of function</li>
+<li>warning: %0 '%1' must be acquired before '%2'</li>
+<li>warning: %0 attribute can only be applied in a context annotated with 'capability("mutex")' attribute</li>
+<li>warning: %0 attribute requires arguments whose type is annotated with 'capability' attribute; type here is %1</li>
+<li>warning: %0 attribute without capability arguments can only be applied to non-static methods of a class</li>
+<li>warning: %0 attribute without capability arguments refers to 'this', but %1 isn't annotated with 'capability' or 'scoped_lockable' attribute</li>
+<li>warning: %0 only applies to pointer types; type here is %1</li>
+<li>warning: %select{reading|writing}1 the value pointed to by %0 requires holding %select{any mutex|any mutex exclusively}1</li>
+<li>warning: %select{reading|writing}1 variable %0 requires holding %select{any mutex|any mutex exclusively}1</li>
+<li>warning: %select{reading|writing}3 the value pointed to by %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: %select{reading|writing}3 the value pointed to by %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: %select{reading|writing}3 variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: %select{reading|writing}3 variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: Cycle in acquired_before/after dependencies, starting with '%0'</li>
+<li>warning: acquiring %0 '%1' that is already held</li>
+<li>warning: calling function %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: calling function %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: cannot call function '%1' while %0 '%2' is held</li>
+<li>warning: cannot resolve lock expression</li>
+<li>warning: expecting %0 '%1' to be held at start of each loop</li>
+<li>warning: expecting %0 '%1' to be held at the end of function</li>
+<li>warning: ignoring %0 attribute because its argument is invalid</li>
+<li>warning: invalid capability name '%0'; capability name must be 'mutex' or 'role'</li>
+<li>warning: passing the value that %1 points to by reference requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: passing variable %1 by reference requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: releasing %0 '%1' that was not held</li>
+<li>warning: releasing %0 '%1' using %select{shared|exclusive}2 access, expected %select{shared|exclusive}3 access</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wthread-safety" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-thread-safety-analysis</key>
+  <name>clang-diagnostic-thread-safety-analysis</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 '%1' is acquired exclusively and shared in the same scope</li>
+<li>warning: %0 '%1' is not held on every path through here</li>
+<li>warning: %0 '%1' is still held at the end of function</li>
+<li>warning: %0 '%1' must be acquired before '%2'</li>
+<li>warning: %select{reading|writing}1 the value pointed to by %0 requires holding %select{any mutex|any mutex exclusively}1</li>
+<li>warning: %select{reading|writing}1 variable %0 requires holding %select{any mutex|any mutex exclusively}1</li>
+<li>warning: %select{reading|writing}3 the value pointed to by %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: %select{reading|writing}3 variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: Cycle in acquired_before/after dependencies, starting with '%0'</li>
+<li>warning: acquiring %0 '%1' that is already held</li>
+<li>warning: calling function %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: cannot call function '%1' while %0 '%2' is held</li>
+<li>warning: cannot resolve lock expression</li>
+<li>warning: expecting %0 '%1' to be held at start of each loop</li>
+<li>warning: expecting %0 '%1' to be held at the end of function</li>
+<li>warning: releasing %0 '%1' that was not held</li>
+<li>warning: releasing %0 '%1' using %select{shared|exclusive}2 access, expected %select{shared|exclusive}3 access</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wthread-safety-analysis" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-thread-safety-attributes</key>
+  <name>clang-diagnostic-thread-safety-attributes</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 attribute can only be applied in a context annotated with 'capability("mutex")' attribute</li>
+<li>warning: %0 attribute requires arguments whose type is annotated with 'capability' attribute; type here is %1</li>
+<li>warning: %0 attribute without capability arguments can only be applied to non-static methods of a class</li>
+<li>warning: %0 attribute without capability arguments refers to 'this', but %1 isn't annotated with 'capability' or 'scoped_lockable' attribute</li>
+<li>warning: %0 only applies to pointer types; type here is %1</li>
+<li>warning: ignoring %0 attribute because its argument is invalid</li>
+<li>warning: invalid capability name '%0'; capability name must be 'mutex' or 'role'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wthread-safety-attributes" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-thread-safety-beta</key>
+  <name>clang-diagnostic-thread-safety-beta</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: Thread safety beta warning.</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wthread-safety-beta" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-thread-safety-negative</key>
+  <name>clang-diagnostic-thread-safety-negative</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: acquiring %0 '%1' requires negative capability '%2'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wthread-safety-negative" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-thread-safety-precise</key>
+  <name>clang-diagnostic-thread-safety-precise</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{reading|writing}3 the value pointed to by %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: %select{reading|writing}3 variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: calling function %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wthread-safety-precise" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-thread-safety-reference</key>
+  <name>clang-diagnostic-thread-safety-reference</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: passing the value that %1 points to by reference requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: passing variable %1 by reference requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wthread-safety-reference" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-thread-safety-verbose</key>
+  <name>clang-diagnostic-thread-safety-verbose</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: Thread safety verbose warning.</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wthread-safety-verbose" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-trigraphs</key>
+  <name>clang-diagnostic-trigraphs</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ignored trigraph would end block comment</li>
+<li>warning: trigraph converted to '%0' character</li>
+<li>warning: trigraph ends block comment</li>
+<li>warning: trigraph ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtrigraphs" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-type-safety</key>
+  <name>clang-diagnostic-type-safety</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: argument type %0 doesn't match specified %1 type tag %select{that requires %3|}2</li>
+<li>warning: specified %0 type tag requires a null pointer</li>
+<li>warning: this type tag was not designed to be used with this function</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtype-safety" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-typedef-redefinition</key>
+  <name>clang-diagnostic-typedef-redefinition</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: redefinition of typedef %0 is a C11 feature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtypedef-redefinition" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-typename-missing</key>
+  <name>clang-diagnostic-typename-missing</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: missing 'typename' prior to dependent type name '%0%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtypename-missing" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unable-to-open-stats-file</key>
+  <name>clang-diagnostic-unable-to-open-stats-file</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unable to open statistics output file '%0': '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunable-to-open-stats-file" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unavailable-declarations</key>
+  <name>clang-diagnostic-unavailable-declarations</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 may be unavailable because the receiver type is unknown</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunavailable-declarations" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-undeclared-selector</key>
+  <name>clang-diagnostic-undeclared-selector</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: undeclared selector %0</li>
+<li>warning: undeclared selector %0; did you mean %1?</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundeclared-selector" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-undef</key>
+  <name>clang-diagnostic-undef</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is not defined, evaluates to 0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundef" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-undefined-bool-conversion</key>
+  <name>clang-diagnostic-undefined-bool-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true</li>
+<li>warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; pointer may be assumed to always convert to true</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-bool-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-undefined-func-template</key>
+  <name>clang-diagnostic-undefined-func-template</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: instantiation of function %q0 required here, but no definition is available</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-func-template" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-undefined-inline</key>
+  <name>clang-diagnostic-undefined-inline</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: inline function %q0 is not defined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-inline" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-undefined-internal</key>
+  <name>clang-diagnostic-undefined-internal</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{function|variable}0 %q1 has internal linkage but is not defined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-internal" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-undefined-internal-type</key>
+  <name>clang-diagnostic-undefined-internal-type</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++ requires a definition in this translation unit for %select{function|variable}0 %q1 because its type does not have linkage</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-internal-type" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-undefined-reinterpret-cast</key>
+  <name>clang-diagnostic-undefined-reinterpret-cast</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: dereference of type %1 that was reinterpret_cast from type %0 has undefined behavior</li>
+<li>warning: reinterpret_cast from %0 to %1 has undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-reinterpret-cast" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-undefined-var-template</key>
+  <name>clang-diagnostic-undefined-var-template</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: instantiation of variable %q0 required here, but no definition is available</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-var-template" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unevaluated-expression</key>
+  <name>clang-diagnostic-unevaluated-expression</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: expression with side effects has no effect in an unevaluated context</li>
+<li>warning: expression with side effects will be evaluated despite being used as an operand to 'typeid'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunevaluated-expression" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unguarded-availability</key>
+  <name>clang-diagnostic-unguarded-availability</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is only available on %1 %2 or newer</li>
+<li>warning: %0 is only available on %1 %2 or newer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunguarded-availability" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unguarded-availability-new</key>
+  <name>clang-diagnostic-unguarded-availability-new</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is only available on %1 %2 or newer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunguarded-availability-new" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unicode</key>
+  <name>clang-diagnostic-unicode</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: \%0 used with no following hex digits; treating as '\' followed by identifier</li>
+<li>warning: incomplete universal character name; treating as '\' followed by identifier</li>
+<li>warning: universal character name refers to a surrogate character</li>
+<li>warning: universal character names are only valid in C99 or C++</li>
+<li>warning: universal character names are only valid in C99 or C++; treating as '\' followed by identifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unicode-homoglyph</key>
+  <name>clang-diagnostic-unicode-homoglyph</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: treating Unicode character &lt;U+%0&gt; as identifier character rather than as '%1' symbol</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-homoglyph" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unicode-whitespace</key>
+  <name>clang-diagnostic-unicode-whitespace</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: treating Unicode character as whitespace</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-whitespace" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unicode-zero-width</key>
+  <name>clang-diagnostic-unicode-zero-width</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: identifier contains Unicode character &lt;U+%0&gt; that is invisible in some environments</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-zero-width" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-uninitialized</key>
+  <name>clang-diagnostic-uninitialized</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: base class %0 is uninitialized when used here to access %q1</li>
+<li>warning: block pointer variable %0 is uninitialized when captured by block</li>
+<li>warning: field %0 is uninitialized when used here</li>
+<li>warning: reference %0 is not yet bound to a value when used here</li>
+<li>warning: reference %0 is not yet bound to a value when used within its own initialization</li>
+<li>warning: static variable %0 is suspiciously used within its own initialization</li>
+<li>warning: variable %0 is %select{used|captured}1 uninitialized whenever %select{'%3' condition is %select{true|false}4|'%3' loop %select{is entered|exits because its condition is false}4|'%3' loop %select{condition is true|exits because its condition is false}4|switch %3 is taken|its declaration is reached|%3 is called}2</li>
+<li>warning: variable %0 is uninitialized when %select{used here|captured by block}1</li>
+<li>warning: variable %0 is uninitialized when used within its own initialization</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wuninitialized" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unknown-argument</key>
+  <name>clang-diagnostic-unknown-argument</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unknown argument ignored in clang-cl '%0' (did you mean '%1'?)</li>
+<li>warning: unknown argument ignored in clang-cl: '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-argument" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unknown-attributes</key>
+  <name>clang-diagnostic-unknown-attributes</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unknown attribute %0 ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-attributes" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unknown-escape-sequence</key>
+  <name>clang-diagnostic-unknown-escape-sequence</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unknown escape sequence '\%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-escape-sequence" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unknown-pragmas</key>
+  <name>clang-diagnostic-unknown-pragmas</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma warning expected '%0'</li>
+<li>warning: #pragma warning expected 'push', 'pop', 'default', 'disable', 'error', 'once', 'suppress', 1, 2, 3, or 4</li>
+<li>warning: #pragma warning expected a warning number</li>
+<li>warning: #pragma warning(push, level) requires a level between 0 and 4</li>
+<li>warning: angle-bracketed include &lt;%0&gt; cannot be aliased to double-quoted include "%1"</li>
+<li>warning: double-quoted include "%0" cannot be aliased to angle-bracketed include &lt;%1&gt;</li>
+<li>warning: expected 'ON' or 'OFF' or 'DEFAULT' in pragma</li>
+<li>warning: expected end of directive in pragma</li>
+<li>warning: pragma STDC FENV_ACCESS ON is not supported, ignoring pragma</li>
+<li>warning: pragma diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'</li>
+<li>warning: pragma diagnostic expected option name (e.g. "-Wundef")</li>
+<li>warning: pragma diagnostic pop could not pop, no matching push</li>
+<li>warning: pragma include_alias expected '%0'</li>
+<li>warning: pragma include_alias expected include filename</li>
+<li>warning: unexpected token in pragma diagnostic</li>
+<li>warning: unknown pragma ignored</li>
+<li>warning: unknown pragma in STDC namespace</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-pragmas" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unknown-sanitizers</key>
+  <name>clang-diagnostic-unknown-sanitizers</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unknown sanitizer '%0' ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-sanitizers" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unknown-warning-option</key>
+  <name>clang-diagnostic-unknown-warning-option</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unknown %0 warning specifier: '%1'</li>
+<li>warning: unknown %select{warning|remark}0 option '%1'%select{|; did you mean '%3'?}2</li>
+<li>warning: unknown warning group '%0', ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-warning-option" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unnamed-type-template-args</key>
+  <name>clang-diagnostic-unnamed-type-template-args</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: template argument uses unnamed type</li>
+<li>warning: unnamed type as template argument is incompatible with C++98</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunnamed-type-template-args" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unneeded-internal-declaration</key>
+  <name>clang-diagnostic-unneeded-internal-declaration</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{function|variable}0 %1 is not needed and will not be emitted</li>
+<li>warning: 'static' function %0 declared in header file should be declared 'static inline'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunneeded-internal-declaration" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unneeded-member-function</key>
+  <name>clang-diagnostic-unneeded-member-function</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: member function %0 is not needed and will not be emitted</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunneeded-member-function" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unreachable-code</key>
+  <name>clang-diagnostic-unreachable-code</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: code will never be executed</li>
+<li>warning: loop will run at most once (loop increment never executed)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunreachable-code" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unreachable-code-aggressive</key>
+  <name>clang-diagnostic-unreachable-code-aggressive</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'break' will never be executed</li>
+<li>warning: 'return' will never be executed</li>
+<li>warning: code will never be executed</li>
+<li>warning: loop will run at most once (loop increment never executed)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunreachable-code-aggressive" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unreachable-code-break</key>
+  <name>clang-diagnostic-unreachable-code-break</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'break' will never be executed</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunreachable-code-break" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unreachable-code-loop-increment</key>
+  <name>clang-diagnostic-unreachable-code-loop-increment</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: loop will run at most once (loop increment never executed)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunreachable-code-loop-increment" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unreachable-code-return</key>
+  <name>clang-diagnostic-unreachable-code-return</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: 'return' will never be executed</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunreachable-code-return" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unsequenced</key>
+  <name>clang-diagnostic-unsequenced</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: multiple unsequenced modifications to %0</li>
+<li>warning: unsequenced modification and access to %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsequenced" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unsupported-abs</key>
+  <name>clang-diagnostic-unsupported-abs</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ignoring '-mabs=2008' option because the '%0' architecture does not support it</li>
+<li>warning: ignoring '-mabs=legacy' option because the '%0' architecture does not support it</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-abs" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unsupported-availability-guard</key>
+  <name>clang-diagnostic-unsupported-availability-guard</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{@available|__builtin_available}0 does not guard availability here; use if (%select{@available|__builtin_available}0) instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-availability-guard" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unsupported-cb</key>
+  <name>clang-diagnostic-unsupported-cb</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ignoring '-mcompact-branches=' option because the '%0' architecture does not support it</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-cb" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unsupported-dll-base-class-template</key>
+  <name>clang-diagnostic-unsupported-dll-base-class-template</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: propagating dll attribute to %select{already instantiated|explicitly specialized}0 base class template without dll attribute is not supported</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-dll-base-class-template" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unsupported-friend</key>
+  <name>clang-diagnostic-unsupported-friend</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: dependent nested name specifier '%0' for friend class declaration is not supported; turning off access control for %1</li>
+<li>warning: dependent nested name specifier '%0' for friend template declaration is not supported; ignoring this friend declaration</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-friend" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unsupported-gpopt</key>
+  <name>clang-diagnostic-unsupported-gpopt</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ignoring '-mgpopt' option as it cannot be used with %select{|the implicit usage of }0-mabicalls</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-gpopt" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unsupported-nan</key>
+  <name>clang-diagnostic-unsupported-nan</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ignoring '-mnan=2008' option because the '%0' architecture does not support it</li>
+<li>warning: ignoring '-mnan=legacy' option because the '%0' architecture does not support it</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-nan" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unsupported-target-opt</key>
+  <name>clang-diagnostic-unsupported-target-opt</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: debug information option '%0' is not supported for target '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-target-opt" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unsupported-visibility</key>
+  <name>clang-diagnostic-unsupported-visibility</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: target does not support 'protected' visibility; using 'default'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-visibility" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unusable-partial-specialization</key>
+  <name>clang-diagnostic-unusable-partial-specialization</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{class|variable}0 template partial specialization contains %select{a template parameter|template parameters}1 that cannot be deduced; this partial specialization will never be used</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunusable-partial-specialization" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused</key>
+  <name>clang-diagnostic-unused</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{equality|inequality|relational|three-way}0 comparison result unused</li>
+<li>warning: %select{function|variable}0 %1 is not needed and will not be emitted</li>
+<li>warning: 'static' function %0 declared in header file should be declared 'static inline'</li>
+<li>warning: container access result unused - container access should not be used for side effects</li>
+<li>warning: expression result unused</li>
+<li>warning: expression result unused; should this cast be to 'void'?</li>
+<li>warning: expression with side effects has no effect in an unevaluated context</li>
+<li>warning: expression with side effects will be evaluated despite being used as an operand to 'typeid'</li>
+<li>warning: ignoring return value of function declared with %0 attribute</li>
+<li>warning: ignoring return value of function declared with %0 attribute</li>
+<li>warning: ivar %0 which backs the property is not referenced in this property's accessor</li>
+<li>warning: lambda capture %0 is not %select{used|required to be captured for this use}1</li>
+<li>warning: private field %0 is not used</li>
+<li>warning: unused %select{typedef|type alias}0 %1</li>
+<li>warning: unused function %0</li>
+<li>warning: unused label %0</li>
+<li>warning: unused variable %0</li>
+<li>warning: unused variable %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-command-line-argument</key>
+  <name>clang-diagnostic-unused-command-line-argument</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0: '%1' input unused in cpp mode</li>
+<li>warning: %0: '%1' input unused%select{ when '%3' is present|}2</li>
+<li>warning: %0: previously preprocessed input%select{ unused when '%2' is present|}1</li>
+<li>warning: argument '%0' requires profile-guided optimization information</li>
+<li>warning: argument unused during compilation: '%0'</li>
+<li>warning: joined argument expects additional value: '%0'</li>
+<li>warning: the flag '%0' has been deprecated and will be ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-command-line-argument" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-comparison</key>
+  <name>clang-diagnostic-unused-comparison</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{equality|inequality|relational|three-way}0 comparison result unused</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-comparison" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-const-variable</key>
+  <name>clang-diagnostic-unused-const-variable</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unused variable %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-const-variable" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-exception-parameter</key>
+  <name>clang-diagnostic-unused-exception-parameter</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unused exception parameter %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-exception-parameter" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-function</key>
+  <name>clang-diagnostic-unused-function</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{function|variable}0 %1 is not needed and will not be emitted</li>
+<li>warning: 'static' function %0 declared in header file should be declared 'static inline'</li>
+<li>warning: unused function %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-function" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-getter-return-value</key>
+  <name>clang-diagnostic-unused-getter-return-value</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: property access result unused - getters should not be used for side effects</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-getter-return-value" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-label</key>
+  <name>clang-diagnostic-unused-label</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unused label %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-label" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-lambda-capture</key>
+  <name>clang-diagnostic-unused-lambda-capture</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: lambda capture %0 is not %select{used|required to be captured for this use}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-lambda-capture" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-local-typedef</key>
+  <name>clang-diagnostic-unused-local-typedef</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unused %select{typedef|type alias}0 %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-local-typedef" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-local-typedefs</key>
+  <name>clang-diagnostic-unused-local-typedefs</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unused %select{typedef|type alias}0 %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-local-typedefs" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-macros</key>
+  <name>clang-diagnostic-unused-macros</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: macro is not used</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-macros" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-member-function</key>
+  <name>clang-diagnostic-unused-member-function</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: member function %0 is not needed and will not be emitted</li>
+<li>warning: unused member function %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-member-function" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-parameter</key>
+  <name>clang-diagnostic-unused-parameter</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unused parameter %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-parameter" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-private-field</key>
+  <name>clang-diagnostic-unused-private-field</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: private field %0 is not used</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-private-field" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-property-ivar</key>
+  <name>clang-diagnostic-unused-property-ivar</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ivar %0 which backs the property is not referenced in this property's accessor</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-property-ivar" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-result</key>
+  <name>clang-diagnostic-unused-result</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ignoring return value of function declared with %0 attribute</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-result" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-template</key>
+  <name>clang-diagnostic-unused-template</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{function|variable}0 %1 is not needed and will not be emitted</li>
+<li>warning: 'static' function %0 declared in header file should be declared 'static inline'</li>
+<li>warning: unused %select{function|variable}0 template %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-template" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-value</key>
+  <name>clang-diagnostic-unused-value</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{equality|inequality|relational|three-way}0 comparison result unused</li>
+<li>warning: container access result unused - container access should not be used for side effects</li>
+<li>warning: expression result unused</li>
+<li>warning: expression result unused; should this cast be to 'void'?</li>
+<li>warning: expression with side effects has no effect in an unevaluated context</li>
+<li>warning: expression with side effects will be evaluated despite being used as an operand to 'typeid'</li>
+<li>warning: ignoring return value of function declared with %0 attribute</li>
+<li>warning: ignoring return value of function declared with %0 attribute</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-value" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-variable</key>
+  <name>clang-diagnostic-unused-variable</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: unused variable %0</li>
+<li>warning: unused variable %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-variable" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-unused-volatile-lvalue</key>
+  <name>clang-diagnostic-unused-volatile-lvalue</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: expression result unused; assign into a variable to force a volatile load</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-volatile-lvalue" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-used-but-marked-unused</key>
+  <name>clang-diagnostic-used-but-marked-unused</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 was marked unused but was used</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wused-but-marked-unused" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-user-defined-literals</key>
+  <name>clang-diagnostic-user-defined-literals</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: user-defined literal suffixes not starting with '_' are reserved%select{; no literal will invoke this operator|}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wuser-defined-literals" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-user-defined-warnings</key>
+  <name>clang-diagnostic-user-defined-warnings</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wuser-defined-warnings" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-varargs</key>
+  <name>clang-diagnostic-varargs</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: passing %select{an object that undergoes default argument promotion|an object of reference type|a parameter declared with the 'register' keyword}0 to 'va_start' has undefined behavior</li>
+<li>warning: second argument to 'va_arg' is of promotable type %0; this va_arg has undefined behavior because arguments will be promoted to %1</li>
+<li>warning: second argument to 'va_start' is not the last named parameter</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvarargs" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-variadic-macros</key>
+  <name>clang-diagnostic-variadic-macros</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: __VA_OPT__ can only appear in the expansion of a variadic macro</li>
+<li>warning: named variadic macros are a GNU extension</li>
+<li>warning: variadic macros are a C99 feature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvariadic-macros" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-vec-elem-size</key>
+  <name>clang-diagnostic-vec-elem-size</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: vector operands do not have the same elements sizes (%0 and %1)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvec-elem-size" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>CRITICAL</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-vector-conversion</key>
+  <name>clang-diagnostic-vector-conversion</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: incompatible vector types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvector-conversion" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-vector-conversions</key>
+  <name>clang-diagnostic-vector-conversions</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: incompatible vector types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvector-conversions" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-vexing-parse</key>
+  <name>clang-diagnostic-vexing-parse</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: empty parentheses interpreted as a function declaration</li>
+<li>warning: parentheses were disambiguated as a function declaration</li>
+<li>warning: parentheses were disambiguated as redundant parentheses around declaration of variable named %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvexing-parse" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-visibility</key>
+  <name>clang-diagnostic-visibility</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration of %0 will not be visible outside of this function</li>
+<li>warning: redefinition of %0 will not be visible outside of this function</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvisibility" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-vla</key>
+  <name>clang-diagnostic-vla</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: variable length array used</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvla" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-vla-extension</key>
+  <name>clang-diagnostic-vla-extension</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: variable length arrays are a C99 feature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvla-extension" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-void-ptr-dereference</key>
+  <name>clang-diagnostic-void-ptr-dereference</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++ does not allow indirection on operand of type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvoid-ptr-dereference" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-weak-template-vtables</key>
+  <name>clang-diagnostic-weak-template-vtables</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: explicit template instantiation %0 will emit a vtable in every translation unit</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wweak-template-vtables" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-weak-vtables</key>
+  <name>clang-diagnostic-weak-vtables</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wweak-vtables" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-writable-strings</key>
+  <name>clang-diagnostic-writable-strings</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++11 does not allow conversion from string literal to %0</li>
+<li>warning: conversion from string literal to %0 is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wwritable-strings" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-write-strings</key>
+  <name>clang-diagnostic-write-strings</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++11 does not allow conversion from string literal to %0</li>
+<li>warning: conversion from string literal to %0 is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wwrite-strings" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-zero-as-null-pointer-constant</key>
+  <name>clang-diagnostic-zero-as-null-pointer-constant</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: zero as null pointer constant</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wzero-as-null-pointer-constant" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
+<rule>
+  <key>clang-diagnostic-zero-length-array</key>
+  <name>clang-diagnostic-zero-length-array</name>
+  <description><![CDATA[
+      <p>Diagnostic text:</p>
+<ul>
+<li>warning: zero size arrays are an extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wzero-length-array" target="_blank">Diagnostic flags in Clang</a></p>
+      ]]></description>
+  <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+  </rule>
 </rules>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
@@ -41,6 +41,6 @@ public class CxxClangTidyRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxClangTidyRuleRepository.getRepositoryKey(language));
-    assertEquals(311, repo.rules().size());
+    assertEquals(1014, repo.rules().size());
   }
 }


### PR DESCRIPTION
addresses #1560
fixes #1548

* gnerate JSON file from Diagnositc.td
  `llvm-tblgen -dump-json <src_dir>/tools/clang/include/clang/Basic/Diagnostic.td > output.json`
* parse JSON in order to generate rules ( incl. types, severities and descriptions)
* the result is identical to http://clang.llvm.org/docs/DiagnosticsReference.html
* the list of checks matches with the list in https://reviews.llvm.org/D38171?id=120597#change-UUbS_JS9e2RG (see test/clang-tidy/list-clang-diagnostics.cpp)

TODO
* check if rule-IDs in clang-tidy report match the rule-IDs in the clangtidy.xml

New rules:
* clang-diagnostic-#pragma-messages
* clang-diagnostic-#warnings
* clang-diagnostic-CFString-literal
* clang-diagnostic-CL4
* clang-diagnostic-IndependentClass-attribute
* clang-diagnostic-NSObject-attribute
* clang-diagnostic-absolute-value
* clang-diagnostic-abstract-final-class
* clang-diagnostic-abstract-vbase-init
* clang-diagnostic-address
* clang-diagnostic-address-of-packed-member
* clang-diagnostic-address-of-temporary
* clang-diagnostic-all
* clang-diagnostic-alloca-with-align-alignof
* clang-diagnostic-ambiguous-delete
* clang-diagnostic-ambiguous-ellipsis
* clang-diagnostic-ambiguous-macro
* clang-diagnostic-ambiguous-member-template
* clang-diagnostic-analyzer-incompatible-plugin
* clang-diagnostic-anonymous-pack-parens
* clang-diagnostic-arc
* clang-diagnostic-arc-bridge-casts-disallowed-in-nonarc
* clang-diagnostic-arc-maybe-repeated-use-of-weak
* clang-diagnostic-arc-non-pod-memaccess
* clang-diagnostic-arc-performSelector-leaks
* clang-diagnostic-arc-repeated-use-of-weak
* clang-diagnostic-arc-retain-cycles
* clang-diagnostic-arc-unsafe-retained-assign
* clang-diagnostic-argument-outside-range
* clang-diagnostic-array-bounds
* clang-diagnostic-array-bounds-pointer-arithmetic
* clang-diagnostic-asm
* clang-diagnostic-asm-ignored-qualifier
* clang-diagnostic-asm-operand-widths
* clang-diagnostic-assign-enum
* clang-diagnostic-assume
* clang-diagnostic-atimport-in-framework-header
* clang-diagnostic-atomic-alignment
* clang-diagnostic-atomic-implicit-seq-cst
* clang-diagnostic-atomic-memory-ordering
* clang-diagnostic-atomic-properties
* clang-diagnostic-atomic-property-with-user-defined-accessor
* clang-diagnostic-attribute-packed-for-bitfield
* clang-diagnostic-attributes
* clang-diagnostic-auto-disable-vptr-sanitizer
* clang-diagnostic-auto-import
* clang-diagnostic-auto-storage-class
* clang-diagnostic-auto-var-id
* clang-diagnostic-availability
* clang-diagnostic-backend-plugin
* clang-diagnostic-backslash-newline-escape
* clang-diagnostic-bad-function-cast
* clang-diagnostic-binary-literal
* clang-diagnostic-bind-to-temporary-copy
* clang-diagnostic-binding-in-condition
* clang-diagnostic-bitfield-constant-conversion
* clang-diagnostic-bitfield-enum-conversion
* clang-diagnostic-bitfield-width
* clang-diagnostic-bitwise-op-parentheses
* clang-diagnostic-block-capture-autoreleasing
* clang-diagnostic-bool-conversion
* clang-diagnostic-bool-conversions
* clang-diagnostic-braced-scalar-init
* clang-diagnostic-bridge-cast
* clang-diagnostic-builtin-macro-redefined
* clang-diagnostic-builtin-memcpy-chk-size
* clang-diagnostic-builtin-requires-header
* clang-diagnostic-c++-compat
* clang-diagnostic-c++0x-compat
* clang-diagnostic-c++0x-extensions
* clang-diagnostic-c++0x-narrowing
* clang-diagnostic-c++11-compat
* clang-diagnostic-c++11-compat-deprecated-writable-strings
* clang-diagnostic-c++11-compat-pedantic
* clang-diagnostic-c++11-compat-reserved-user-defined-literal
* clang-diagnostic-c++11-extensions
* clang-diagnostic-c++11-extra-semi
* clang-diagnostic-c++11-inline-namespace
* clang-diagnostic-c++11-long-long
* clang-diagnostic-c++11-narrowing
* clang-diagnostic-c++14-binary-literal
* clang-diagnostic-c++14-compat
* clang-diagnostic-c++14-compat-pedantic
* clang-diagnostic-c++14-extensions
* clang-diagnostic-c++17-compat
* clang-diagnostic-c++17-compat-mangling
* clang-diagnostic-c++17-compat-pedantic
* clang-diagnostic-c++17-extensions
* clang-diagnostic-c++1y-extensions
* clang-diagnostic-c++1z-compat
* clang-diagnostic-c++1z-compat-mangling
* clang-diagnostic-c++1z-extensions
* clang-diagnostic-c++2a-compat
* clang-diagnostic-c++2a-compat-pedantic
* clang-diagnostic-c++2a-extensions
* clang-diagnostic-c++98-c++11-c++14-c++17-compat
* clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic
* clang-diagnostic-c++98-c++11-c++14-compat
* clang-diagnostic-c++98-c++11-c++14-compat-pedantic
* clang-diagnostic-c++98-c++11-compat
* clang-diagnostic-c++98-c++11-compat-binary-literal
* clang-diagnostic-c++98-c++11-compat-pedantic
* clang-diagnostic-c++98-compat
* clang-diagnostic-c++98-compat-bind-to-temporary-copy
* clang-diagnostic-c++98-compat-extra-semi
* clang-diagnostic-c++98-compat-local-type-template-args
* clang-diagnostic-c++98-compat-pedantic
* clang-diagnostic-c++98-compat-unnamed-type-template-args
* clang-diagnostic-c11-extensions
* clang-diagnostic-c99-compat
* clang-diagnostic-c99-extensions
* clang-diagnostic-cast-align
* clang-diagnostic-cast-calling-convention
* clang-diagnostic-cast-of-sel-type
* clang-diagnostic-cast-qual
* clang-diagnostic-cast-qual-unrelated
* clang-diagnostic-char-subscripts
* clang-diagnostic-clang-cl-pch
* clang-diagnostic-class-varargs
* clang-diagnostic-comma
* clang-diagnostic-comment
* clang-diagnostic-comments
* clang-diagnostic-compare-distinct-pointer-types
* clang-diagnostic-complex-component-init
* clang-diagnostic-conditional-type-mismatch
* clang-diagnostic-conditional-uninitialized
* clang-diagnostic-config-macros
* clang-diagnostic-constant-conversion
* clang-diagnostic-constant-logical-operand
* clang-diagnostic-constexpr-not-const
* clang-diagnostic-consumed
* clang-diagnostic-conversion
* clang-diagnostic-conversion-null
* clang-diagnostic-coroutine
* clang-diagnostic-coroutine-missing-unhandled-exception
* clang-diagnostic-covered-switch-default
* clang-diagnostic-cpp
* clang-diagnostic-cstring-format-directive
* clang-diagnostic-cuda-compat
* clang-diagnostic-custom-atomic-properties
* clang-diagnostic-dangling
* clang-diagnostic-dangling-else
* clang-diagnostic-dangling-field
* clang-diagnostic-dangling-initializer-list
* clang-diagnostic-date-time
* clang-diagnostic-dealloc-in-category
* clang-diagnostic-debug-compression-unavailable
* clang-diagnostic-declaration-after-statement
* clang-diagnostic-defaulted-function-deleted
* clang-diagnostic-delegating-ctor-cycles
* clang-diagnostic-delete-incomplete
* clang-diagnostic-delete-non-virtual-dtor
* clang-diagnostic-deprecated
* clang-diagnostic-deprecated-attributes
* clang-diagnostic-deprecated-declarations
* clang-diagnostic-deprecated-dynamic-exception-spec
* clang-diagnostic-deprecated-implementations
* clang-diagnostic-deprecated-increment-bool
* clang-diagnostic-deprecated-objc-isa-usage
* clang-diagnostic-deprecated-objc-pointer-introspection
* clang-diagnostic-deprecated-objc-pointer-introspection-performSelector
* clang-diagnostic-deprecated-register
* clang-diagnostic-deprecated-this-capture
* clang-diagnostic-deprecated-writable-strings
* clang-diagnostic-direct-ivar-access
* clang-diagnostic-disabled-macro-expansion
* clang-diagnostic-distributed-object-modifiers
* clang-diagnostic-div-by-zero
* clang-diagnostic-division-by-zero
* clang-diagnostic-dll-attribute-on-redeclaration
* clang-diagnostic-dllexport-explicit-instantiation-decl
* clang-diagnostic-dllimport-static-field-def
* clang-diagnostic-documentation
* clang-diagnostic-documentation-deprecated-sync
* clang-diagnostic-documentation-html
* clang-diagnostic-documentation-pedantic
* clang-diagnostic-documentation-unknown-command
* clang-diagnostic-dollar-in-identifier-extension
* clang-diagnostic-double-promotion
* clang-diagnostic-duplicate-decl-specifier
* clang-diagnostic-duplicate-enum
* clang-diagnostic-duplicate-method-arg
* clang-diagnostic-duplicate-method-match
* clang-diagnostic-duplicate-protocol
* clang-diagnostic-dynamic-class-memaccess
* clang-diagnostic-dynamic-exception-spec
* clang-diagnostic-effc++
* clang-diagnostic-embedded-directive
* clang-diagnostic-empty-body
* clang-diagnostic-empty-decomposition
* clang-diagnostic-empty-translation-unit
* clang-diagnostic-encode-type
* clang-diagnostic-endif-labels
* clang-diagnostic-enum-compare
* clang-diagnostic-enum-compare-switch
* clang-diagnostic-enum-conversion
* clang-diagnostic-enum-too-large
* clang-diagnostic-exceptions
* clang-diagnostic-exit-time-destructors
* clang-diagnostic-expansion-to-defined
* clang-diagnostic-experimental-isel
* clang-diagnostic-explicit-initialize-call
* clang-diagnostic-explicit-ownership-type
* clang-diagnostic-extern-c-compat
* clang-diagnostic-extern-initializer
* clang-diagnostic-extra
* clang-diagnostic-extra-qualification
* clang-diagnostic-extra-semi
* clang-diagnostic-extra-tokens
* clang-diagnostic-fallback
* clang-diagnostic-fixed-enum-extension
* clang-diagnostic-flag-enum
* clang-diagnostic-flexible-array-extensions
* clang-diagnostic-float-conversion
* clang-diagnostic-float-equal
* clang-diagnostic-float-overflow-conversion
* clang-diagnostic-float-zero-conversion
* clang-diagnostic-for-loop-analysis
* clang-diagnostic-format
* clang-diagnostic-format-extra-args
* clang-diagnostic-format-invalid-specifier
* clang-diagnostic-format-non-iso
* clang-diagnostic-format-nonliteral
* clang-diagnostic-format-pedantic
* clang-diagnostic-format-security
* clang-diagnostic-format-zero-length
* clang-diagnostic-format=2
* clang-diagnostic-four-char-constants
* clang-diagnostic-frame-larger-than=
* clang-diagnostic-framework-include-private-from-public
* clang-diagnostic-function-def-in-objc-container
* clang-diagnostic-function-multiversion
* clang-diagnostic-gcc-compat
* clang-diagnostic-global-constructors
* clang-diagnostic-gnu
* clang-diagnostic-gnu-alignof-expression
* clang-diagnostic-gnu-anonymous-struct
* clang-diagnostic-gnu-array-member-paren-init
* clang-diagnostic-gnu-auto-type
* clang-diagnostic-gnu-binary-literal
* clang-diagnostic-gnu-case-range
* clang-diagnostic-gnu-complex-integer
* clang-diagnostic-gnu-compound-literal-initializer
* clang-diagnostic-gnu-conditional-omitted-operand
* clang-diagnostic-gnu-designator
* clang-diagnostic-gnu-empty-initializer
* clang-diagnostic-gnu-empty-struct
* clang-diagnostic-gnu-flexible-array-initializer
* clang-diagnostic-gnu-flexible-array-union-member
* clang-diagnostic-gnu-folding-constant
* clang-diagnostic-gnu-imaginary-constant
* clang-diagnostic-gnu-include-next
* clang-diagnostic-gnu-label-as-value
* clang-diagnostic-gnu-redeclared-enum
* clang-diagnostic-gnu-statement-expression
* clang-diagnostic-gnu-static-float-init
* clang-diagnostic-gnu-string-literal-operator-template
* clang-diagnostic-gnu-union-cast
* clang-diagnostic-gnu-variable-sized-type-not-at-end
* clang-diagnostic-gnu-zero-line-directive
* clang-diagnostic-gnu-zero-variadic-macro-arguments
* clang-diagnostic-header-guard
* clang-diagnostic-header-hygiene
* clang-diagnostic-idiomatic-parentheses
* clang-diagnostic-ignored-attributes
* clang-diagnostic-ignored-optimization-argument
* clang-diagnostic-ignored-pragma-intrinsic
* clang-diagnostic-ignored-pragma-optimize
* clang-diagnostic-ignored-pragmas
* clang-diagnostic-ignored-qualifiers
* clang-diagnostic-implicit
* clang-diagnostic-implicit-atomic-properties
* clang-diagnostic-implicit-conversion-floating-point-to-bool
* clang-diagnostic-implicit-exception-spec-mismatch
* clang-diagnostic-implicit-fallthrough
* clang-diagnostic-implicit-fallthrough-per-function
* clang-diagnostic-implicit-function-declaration
* clang-diagnostic-implicit-int
* clang-diagnostic-implicit-retain-self
* clang-diagnostic-implicitly-unsigned-literal
* clang-diagnostic-import-preprocessor-directive-pedantic
* clang-diagnostic-inaccessible-base
* clang-diagnostic-include-next-absolute-path
* clang-diagnostic-include-next-outside-header
* clang-diagnostic-incompatible-exception-spec
* clang-diagnostic-incompatible-function-pointer-types
* clang-diagnostic-incompatible-library-redeclaration
* clang-diagnostic-incompatible-ms-struct
* clang-diagnostic-incompatible-pointer-types
* clang-diagnostic-incompatible-pointer-types-discards-qualifiers
* clang-diagnostic-incompatible-property-type
* clang-diagnostic-incompatible-sysroot
* clang-diagnostic-incomplete-framework-module-declaration
* clang-diagnostic-incomplete-implementation
* clang-diagnostic-incomplete-module
* clang-diagnostic-incomplete-umbrella
* clang-diagnostic-inconsistent-dllimport
* clang-diagnostic-inconsistent-missing-destructor-override
* clang-diagnostic-inconsistent-missing-override
* clang-diagnostic-increment-bool
* clang-diagnostic-infinite-recursion
* clang-diagnostic-initializer-overrides
* clang-diagnostic-injected-class-name
* clang-diagnostic-inline-asm
* clang-diagnostic-inline-new-delete
* clang-diagnostic-instantiation-after-specialization
* clang-diagnostic-int-conversion
* clang-diagnostic-int-conversions
* clang-diagnostic-int-to-pointer-cast
* clang-diagnostic-int-to-void-pointer-cast
* clang-diagnostic-integer-overflow
* clang-diagnostic-invalid-command-line-argument
* clang-diagnostic-invalid-constexpr
* clang-diagnostic-invalid-iboutlet
* clang-diagnostic-invalid-initializer-from-system-header
* clang-diagnostic-invalid-ios-deployment-target
* clang-diagnostic-invalid-noreturn
* clang-diagnostic-invalid-offsetof
* clang-diagnostic-invalid-or-nonexistent-directory
* clang-diagnostic-invalid-partial-specialization
* clang-diagnostic-invalid-pp-token
* clang-diagnostic-invalid-source-encoding
* clang-diagnostic-invalid-token-paste
* clang-diagnostic-jump-seh-finally
* clang-diagnostic-keyword-compat
* clang-diagnostic-keyword-macro
* clang-diagnostic-knr-promoted-parameter
* clang-diagnostic-language-extension-token
* clang-diagnostic-large-by-value-copy
* clang-diagnostic-literal-conversion
* clang-diagnostic-literal-range
* clang-diagnostic-local-type-template-args
* clang-diagnostic-logical-not-parentheses
* clang-diagnostic-logical-op-parentheses
* clang-diagnostic-long-long
* clang-diagnostic-loop-analysis
* clang-diagnostic-macro-redefined
* clang-diagnostic-main
* clang-diagnostic-main-return-type
* clang-diagnostic-malformed-warning-check
* clang-diagnostic-many-braces-around-scalar-init
* clang-diagnostic-max-unsigned-zero
* clang-diagnostic-memset-transposed-args
* clang-diagnostic-memsize-comparison
* clang-diagnostic-method-signatures
* clang-diagnostic-microsoft
* clang-diagnostic-microsoft-anon-tag
* clang-diagnostic-microsoft-cast
* clang-diagnostic-microsoft-charize
* clang-diagnostic-microsoft-comment-paste
* clang-diagnostic-microsoft-const-init
* clang-diagnostic-microsoft-cpp-macro
* clang-diagnostic-microsoft-default-arg-redefinition
* clang-diagnostic-microsoft-end-of-file
* clang-diagnostic-microsoft-enum-forward-reference
* clang-diagnostic-microsoft-enum-value
* clang-diagnostic-microsoft-exception-spec
* clang-diagnostic-microsoft-exists
* clang-diagnostic-microsoft-explicit-constructor-call
* clang-diagnostic-microsoft-extra-qualification
* clang-diagnostic-microsoft-fixed-enum
* clang-diagnostic-microsoft-flexible-array
* clang-diagnostic-microsoft-goto
* clang-diagnostic-microsoft-inaccessible-base
* clang-diagnostic-microsoft-include
* clang-diagnostic-microsoft-mutable-reference
* clang-diagnostic-microsoft-pure-definition
* clang-diagnostic-microsoft-redeclare-static
* clang-diagnostic-microsoft-sealed
* clang-diagnostic-microsoft-template
* clang-diagnostic-microsoft-union-member-reference
* clang-diagnostic-microsoft-unqualified-friend
* clang-diagnostic-microsoft-using-decl
* clang-diagnostic-microsoft-void-pseudo-dtor
* clang-diagnostic-mismatched-new-delete
* clang-diagnostic-mismatched-parameter-types
* clang-diagnostic-mismatched-return-types
* clang-diagnostic-mismatched-tags
* clang-diagnostic-missing-braces
* clang-diagnostic-missing-declarations
* clang-diagnostic-missing-exception-spec
* clang-diagnostic-missing-field-initializers
* clang-diagnostic-missing-method-return-type
* clang-diagnostic-missing-noescape
* clang-diagnostic-missing-noreturn
* clang-diagnostic-missing-prototype-for-cc
* clang-diagnostic-missing-prototypes
* clang-diagnostic-missing-selector-name
* clang-diagnostic-missing-sysroot
* clang-diagnostic-missing-variable-declarations
* clang-diagnostic-module-build
* clang-diagnostic-module-conflict
* clang-diagnostic-module-file-config-mismatch
* clang-diagnostic-module-file-extension
* clang-diagnostic-module-import-in-extern-c
* clang-diagnostic-modules-ambiguous-internal-linkage
* clang-diagnostic-modules-import-nested-redundant
* clang-diagnostic-most
* clang-diagnostic-move
* clang-diagnostic-msvc-include
* clang-diagnostic-msvc-not-found
* clang-diagnostic-multichar
* clang-diagnostic-multiple-move-vbase
* clang-diagnostic-narrowing
* clang-diagnostic-nested-anon-types
* clang-diagnostic-new-returns-null
* clang-diagnostic-newline-eof
* clang-diagnostic-noexcept-type
* clang-diagnostic-non-gcc
* clang-diagnostic-non-literal-null-conversion
* clang-diagnostic-non-modular-include-in-framework-module
* clang-diagnostic-non-modular-include-in-module
* clang-diagnostic-non-pod-varargs
* clang-diagnostic-non-virtual-dtor
* clang-diagnostic-nonnull
* clang-diagnostic-nonportable-include-path
* clang-diagnostic-nonportable-system-include-path
* clang-diagnostic-nonportable-vector-initialization
* clang-diagnostic-nontrivial-memaccess
* clang-diagnostic-nsconsumed-mismatch
* clang-diagnostic-nsreturns-mismatch
* clang-diagnostic-null-arithmetic
* clang-diagnostic-null-character
* clang-diagnostic-null-conversion
* clang-diagnostic-null-dereference
* clang-diagnostic-null-pointer-arithmetic
* clang-diagnostic-nullability
* clang-diagnostic-nullability-completeness
* clang-diagnostic-nullability-completeness-on-arrays
* clang-diagnostic-nullability-declspec
* clang-diagnostic-nullability-extension
* clang-diagnostic-nullability-inferred-on-nested-type
* clang-diagnostic-nullable-to-nonnull-conversion
* clang-diagnostic-objc-autosynthesis-property-ivar-name-match
* clang-diagnostic-objc-circular-container
* clang-diagnostic-objc-cocoa-api
* clang-diagnostic-objc-designated-initializers
* clang-diagnostic-objc-flexible-array
* clang-diagnostic-objc-forward-class-redefinition
* clang-diagnostic-objc-interface-ivars
* clang-diagnostic-objc-literal-compare
* clang-diagnostic-objc-literal-conversion
* clang-diagnostic-objc-macro-redefinition
* clang-diagnostic-objc-messaging-id
* clang-diagnostic-objc-method-access
* clang-diagnostic-objc-missing-property-synthesis
* clang-diagnostic-objc-missing-super-calls
* clang-diagnostic-objc-multiple-method-names
* clang-diagnostic-objc-noncopy-retain-block-property
* clang-diagnostic-objc-nonunified-exceptions
* clang-diagnostic-objc-property-assign-on-object-type
* clang-diagnostic-objc-property-implementation
* clang-diagnostic-objc-property-implicit-mismatch
* clang-diagnostic-objc-property-matches-cocoa-ownership-rule
* clang-diagnostic-objc-property-no-attribute
* clang-diagnostic-objc-property-synthesis
* clang-diagnostic-objc-protocol-method-implementation
* clang-diagnostic-objc-protocol-property-synthesis
* clang-diagnostic-objc-protocol-qualifiers
* clang-diagnostic-objc-readonly-with-setter-property
* clang-diagnostic-objc-redundant-api-use
* clang-diagnostic-objc-redundant-literal-use
* clang-diagnostic-objc-root-class
* clang-diagnostic-objc-string-compare
* clang-diagnostic-objc-string-concatenation
* clang-diagnostic-objc-unsafe-perform-selector
* clang-diagnostic-odr
* clang-diagnostic-old-style-cast
* clang-diagnostic-opencl-unsupported-rgba
* clang-diagnostic-openmp-clauses
* clang-diagnostic-openmp-loop-form
* clang-diagnostic-openmp-target
* clang-diagnostic-option-ignored
* clang-diagnostic-ordered-compare-function-pointers
* clang-diagnostic-out-of-line-declaration
* clang-diagnostic-out-of-scope-function
* clang-diagnostic-over-aligned
* clang-diagnostic-overlength-strings
* clang-diagnostic-overloaded-shift-op-parentheses
* clang-diagnostic-overloaded-virtual
* clang-diagnostic-override-module
* clang-diagnostic-overriding-method-mismatch
* clang-diagnostic-overriding-t-option
* clang-diagnostic-packed
* clang-diagnostic-padded
* clang-diagnostic-parentheses
* clang-diagnostic-parentheses-equality
* clang-diagnostic-partial-availability
* clang-diagnostic-pass
* clang-diagnostic-pass-analysis
* clang-diagnostic-pass-failed
* clang-diagnostic-pass-missed
* clang-diagnostic-pch-date-time
* clang-diagnostic-pedantic-core-features
* clang-diagnostic-pessimizing-move
* clang-diagnostic-pointer-arith
* clang-diagnostic-pointer-bool-conversion
* clang-diagnostic-pointer-sign
* clang-diagnostic-pointer-type-mismatch
* clang-diagnostic-potentially-evaluated-expression
* clang-diagnostic-pragma-clang-attribute
* clang-diagnostic-pragma-once-outside-header
* clang-diagnostic-pragma-pack
* clang-diagnostic-pragma-pack-suspicious-include
* clang-diagnostic-pragma-system-header-outside-header
* clang-diagnostic-pragmas
* clang-diagnostic-predefined-identifier-outside-function
* clang-diagnostic-private-extern
* clang-diagnostic-private-header
* clang-diagnostic-private-module
* clang-diagnostic-profile-instr-missing
* clang-diagnostic-profile-instr-out-of-date
* clang-diagnostic-profile-instr-unprofiled
* clang-diagnostic-property-access-dot-syntax
* clang-diagnostic-property-attribute-mismatch
* clang-diagnostic-protocol
* clang-diagnostic-protocol-property-synthesis-ambiguity
* clang-diagnostic-qualified-void-return-type
* clang-diagnostic-quoted-include-in-framework-header
* clang-diagnostic-range-loop-analysis
* clang-diagnostic-readonly-iboutlet-property
* clang-diagnostic-receiver-expr
* clang-diagnostic-receiver-forward-class
* clang-diagnostic-redeclared-class-member
* clang-diagnostic-redundant-move
* clang-diagnostic-redundant-parens
* clang-diagnostic-register
* clang-diagnostic-reinterpret-base-class
* clang-diagnostic-remark-backend-plugin
* clang-diagnostic-reorder
* clang-diagnostic-requires-super-attribute
* clang-diagnostic-reserved-id-macro
* clang-diagnostic-reserved-user-defined-literal
* clang-diagnostic-retained-language-linkage
* clang-diagnostic-return-stack-address
* clang-diagnostic-return-std-move
* clang-diagnostic-return-std-move-in-c++11
* clang-diagnostic-return-type
* clang-diagnostic-return-type-c-linkage
* clang-diagnostic-sanitize-address
* clang-diagnostic-section
* clang-diagnostic-selector
* clang-diagnostic-selector-type-mismatch
* clang-diagnostic-self-assign
* clang-diagnostic-self-assign-field
* clang-diagnostic-self-assign-overloaded
* clang-diagnostic-self-move
* clang-diagnostic-semicolon-before-method-body
* clang-diagnostic-sentinel
* clang-diagnostic-sequence-point
* clang-diagnostic-serialized-diagnostics
* clang-diagnostic-shadow
* clang-diagnostic-shadow-all
* clang-diagnostic-shadow-field
* clang-diagnostic-shadow-field-in-constructor
* clang-diagnostic-shadow-field-in-constructor-modified
* clang-diagnostic-shadow-ivar
* clang-diagnostic-shadow-uncaptured-local
* clang-diagnostic-shift-count-negative
* clang-diagnostic-shift-count-overflow
* clang-diagnostic-shift-negative-value
* clang-diagnostic-shift-op-parentheses
* clang-diagnostic-shift-overflow
* clang-diagnostic-shift-sign-overflow
* clang-diagnostic-shorten-64-to-32
* clang-diagnostic-sign-compare
* clang-diagnostic-sign-conversion
* clang-diagnostic-signed-enum-bitfield
* clang-diagnostic-sizeof-array-argument
* clang-diagnostic-sizeof-array-decay
* clang-diagnostic-sizeof-pointer-memaccess
* clang-diagnostic-slash-u-filename
* clang-diagnostic-sometimes-uninitialized
* clang-diagnostic-source-uses-openmp
* clang-diagnostic-spir-compat
* clang-diagnostic-static-float-init
* clang-diagnostic-static-in-inline
* clang-diagnostic-static-inline-explicit-instantiation
* clang-diagnostic-static-local-in-inline
* clang-diagnostic-static-self-init
* clang-diagnostic-stdlibcxx-not-found
* clang-diagnostic-strict-prototypes
* clang-diagnostic-strict-selector-match
* clang-diagnostic-string-compare
* clang-diagnostic-string-conversion
* clang-diagnostic-string-plus-char
* clang-diagnostic-string-plus-int
* clang-diagnostic-strlcpy-strlcat-size
* clang-diagnostic-strncat-size
* clang-diagnostic-super-class-method-mismatch
* clang-diagnostic-suspicious-bzero
* clang-diagnostic-suspicious-memaccess
* clang-diagnostic-switch
* clang-diagnostic-switch-bool
* clang-diagnostic-switch-enum
* clang-diagnostic-sync-fetch-and-nand-semantics-changed
* clang-diagnostic-tautological-compare
* clang-diagnostic-tautological-constant-compare
* clang-diagnostic-tautological-constant-in-range-compare
* clang-diagnostic-tautological-constant-out-of-range-compare
* clang-diagnostic-tautological-overlap-compare
* clang-diagnostic-tautological-pointer-compare
* clang-diagnostic-tautological-type-limit-compare
* clang-diagnostic-tautological-undefined-compare
* clang-diagnostic-tautological-unsigned-enum-zero-compare
* clang-diagnostic-tautological-unsigned-zero-compare
* clang-diagnostic-tentative-definition-incomplete-type
* clang-diagnostic-thread-safety
* clang-diagnostic-thread-safety-analysis
* clang-diagnostic-thread-safety-attributes
* clang-diagnostic-thread-safety-beta
* clang-diagnostic-thread-safety-negative
* clang-diagnostic-thread-safety-precise
* clang-diagnostic-thread-safety-reference
* clang-diagnostic-thread-safety-verbose
* clang-diagnostic-trigraphs
* clang-diagnostic-type-safety
* clang-diagnostic-typedef-redefinition
* clang-diagnostic-typename-missing
* clang-diagnostic-unable-to-open-stats-file
* clang-diagnostic-unavailable-declarations
* clang-diagnostic-undeclared-selector
* clang-diagnostic-undef
* clang-diagnostic-undefined-bool-conversion
* clang-diagnostic-undefined-func-template
* clang-diagnostic-undefined-inline
* clang-diagnostic-undefined-internal
* clang-diagnostic-undefined-internal-type
* clang-diagnostic-undefined-reinterpret-cast
* clang-diagnostic-undefined-var-template
* clang-diagnostic-unevaluated-expression
* clang-diagnostic-unguarded-availability
* clang-diagnostic-unguarded-availability-new
* clang-diagnostic-unicode
* clang-diagnostic-unicode-homoglyph
* clang-diagnostic-unicode-whitespace
* clang-diagnostic-unicode-zero-width
* clang-diagnostic-uninitialized
* clang-diagnostic-unknown-argument
* clang-diagnostic-unknown-attributes
* clang-diagnostic-unknown-escape-sequence
* clang-diagnostic-unknown-pragmas
* clang-diagnostic-unknown-sanitizers
* clang-diagnostic-unknown-warning-option
* clang-diagnostic-unnamed-type-template-args
* clang-diagnostic-unneeded-internal-declaration
* clang-diagnostic-unneeded-member-function
* clang-diagnostic-unreachable-code
* clang-diagnostic-unreachable-code-aggressive
* clang-diagnostic-unreachable-code-break
* clang-diagnostic-unreachable-code-loop-increment
* clang-diagnostic-unreachable-code-return
* clang-diagnostic-unsequenced
* clang-diagnostic-unsupported-abs
* clang-diagnostic-unsupported-availability-guard
* clang-diagnostic-unsupported-cb
* clang-diagnostic-unsupported-dll-base-class-template
* clang-diagnostic-unsupported-friend
* clang-diagnostic-unsupported-gpopt
* clang-diagnostic-unsupported-nan
* clang-diagnostic-unsupported-target-opt
* clang-diagnostic-unsupported-visibility
* clang-diagnostic-unusable-partial-specialization
* clang-diagnostic-unused
* clang-diagnostic-unused-command-line-argument
* clang-diagnostic-unused-comparison
* clang-diagnostic-unused-const-variable
* clang-diagnostic-unused-exception-parameter
* clang-diagnostic-unused-function
* clang-diagnostic-unused-getter-return-value
* clang-diagnostic-unused-label
* clang-diagnostic-unused-lambda-capture
* clang-diagnostic-unused-local-typedef
* clang-diagnostic-unused-local-typedefs
* clang-diagnostic-unused-macros
* clang-diagnostic-unused-member-function
* clang-diagnostic-unused-parameter
* clang-diagnostic-unused-private-field
* clang-diagnostic-unused-property-ivar
* clang-diagnostic-unused-result
* clang-diagnostic-unused-template
* clang-diagnostic-unused-value
* clang-diagnostic-unused-variable
* clang-diagnostic-unused-volatile-lvalue
* clang-diagnostic-used-but-marked-unused
* clang-diagnostic-user-defined-literals
* clang-diagnostic-user-defined-warnings
* clang-diagnostic-varargs
* clang-diagnostic-variadic-macros
* clang-diagnostic-vec-elem-size
* clang-diagnostic-vector-conversion
* clang-diagnostic-vector-conversions
* clang-diagnostic-vexing-parse
* clang-diagnostic-visibility
* clang-diagnostic-vla
* clang-diagnostic-vla-extension
* clang-diagnostic-void-ptr-dereference
* clang-diagnostic-weak-template-vtables
* clang-diagnostic-weak-vtables
* clang-diagnostic-writable-strings
* clang-diagnostic-write-strings
* clang-diagnostic-zero-as-null-pointer-constant
* clang-diagnostic-zero-length-array

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1566)
<!-- Reviewable:end -->
