### PR TITLE
make missing include less verbose

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/postjobs/FinalReport.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/postjobs/FinalReport.java
@@ -24,6 +24,7 @@ import org.sonar.api.batch.postjob.PostJobContext;
 import org.sonar.api.batch.postjob.PostJobDescriptor;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
+import org.sonar.cxx.preprocessor.CxxPreprocessor;
 import org.sonar.cxx.visitors.CxxParseErrorLoggerVisitor;
 
 public class FinalReport implements PostJob {
@@ -38,6 +39,7 @@ public class FinalReport implements PostJob {
 
   @Override
   public void execute(PostJobContext context) {
+    CxxPreprocessor.finalReport();
     CxxParseErrorLoggerVisitor.finalReport();
 
     if (!LOG.isDebugEnabled()) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
@@ -73,7 +73,6 @@ public class CxxSquidSensor implements Sensor {
   public static final String ERROR_RECOVERY_KEY = "errorRecoveryEnabled";
   public static final String FORCE_INCLUDE_FILES_KEY = "forceIncludes";
   public static final String C_FILES_PATTERNS_KEY = "cFilesPatterns";
-  public static final String MISSING_INCLUDE_WARN = "missingIncludeWarnings";
   public static final String JSON_COMPILATION_DATABASE_KEY = "jsonCompilationDatabase";
 
   /**
@@ -178,8 +177,6 @@ public class CxxSquidSensor implements Sensor {
     //    or createStringArray(settings.getStringArray(C_FILES_PATTERNS_KEY), DEFAULT_C_FILES)
     cxxConf.setCFilesPatterns(this.language.getStringArrayOption(C_FILES_PATTERNS_KEY));
     cxxConf.setHeaderFileSuffixes(this.language.getHeaderFileSuffixes());
-    cxxConf.setMissingIncludeWarningsEnabled(this.language.getBooleanOption(MISSING_INCLUDE_WARN)
-      .orElse(Boolean.FALSE));
     cxxConf.setJsonCompilationDatabaseFile(this.language.getStringOption(JSON_COMPILATION_DATABASE_KEY)
       .orElse(null));
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/postjobs/FinalReportTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/postjobs/FinalReportTest.java
@@ -55,8 +55,8 @@ public class FinalReportTest {
     SensorContextTester context = SensorContextTester.create(new File(dir));
     context.fileSystem().add(inputFile);
 
-    CxxParseErrorLoggerVisitor.errors = 0;
-    CxxPreprocessor.missingIncludeFilesCounter = 0;
+    CxxParseErrorLoggerVisitor.resetReport();
+    CxxPreprocessor.resetReport();
     CxxAstScanner.scanSingleFile(inputFile, context, TestUtils.mockCxxLanguage());
 
     FinalReport postjob = new FinalReport();

--- a/cxx-sensors/src/test/java/org/sonar/cxx/postjobs/FinalReportTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/postjobs/FinalReportTest.java
@@ -32,7 +32,9 @@ import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.utils.log.LogTester;
 import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.cxx.CxxAstScanner;
+import org.sonar.cxx.preprocessor.CxxPreprocessor;
 import org.sonar.cxx.sensors.utils.TestUtils;
+import org.sonar.cxx.visitors.CxxParseErrorLoggerVisitor;
 
 public class FinalReportTest {
 
@@ -53,13 +55,16 @@ public class FinalReportTest {
     SensorContextTester context = SensorContextTester.create(new File(dir));
     context.fileSystem().add(inputFile);
 
+    CxxParseErrorLoggerVisitor.errors = 0;
+    CxxPreprocessor.missingIncludeFilesCounter = 0;
     CxxAstScanner.scanSingleFile(inputFile, context, TestUtils.mockCxxLanguage());
 
     FinalReport postjob = new FinalReport();
     postjob.execute(postJobContext);
 
     List<String> log = logTester.logs(LoggerLevel.WARN);
-    assertThat(log.size()).isEqualTo(1);
-    assertThat(log.get(0)).contains("syntax error(s) detected");
+    assertThat(log.size()).isEqualTo(2);
+    assertThat(log.get(0)).contains("include directive error(s)");
+    assertThat(log.get(1)).contains("syntax error(s) detected");
   }
 }

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/postjobs/syntaxerror.cc
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/postjobs/syntaxerror.cc
@@ -1,3 +1,5 @@
+#include <invalid.h>
+
 namespace X {
    void test::f1() {
       int i = 0;

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
@@ -48,7 +48,6 @@ public class CxxConfiguration extends SquidConfiguration {
   private String baseDir;
   private boolean errorRecoveryEnabled = true;
   private List<String> cFilesPatterns = new ArrayList<>();
-  private boolean missingIncludeWarningsEnabled = true;
   private String jsonCompilationDatabaseFile;
   private CxxCompilationUnitSettings globalCompilationUnitSettings;
   private final Map<String, CxxCompilationUnitSettings> compilationUnitSettings = new HashMap<>();
@@ -207,14 +206,6 @@ public class CxxConfiguration extends SquidConfiguration {
 
   public List<String> getHeaderFileSuffixes() {
     return new ArrayList<>(this.headerFileSuffixes);
-  }
-
-  public void setMissingIncludeWarningsEnabled(boolean enabled) {
-    this.missingIncludeWarningsEnabled = enabled;
-  }
-
-  public boolean getMissingIncludeWarningsEnabled() {
-    return this.missingIncludeWarningsEnabled;
   }
 
   public String getJsonCompilationDatabaseFile() {

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.cxx.preprocessor;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.sonar.sslr.api.AstNode;
@@ -234,7 +235,7 @@ public class CxxPreprocessor extends Preprocessor {
   }
   private final Multimap<String, Include> includedFiles = HashMultimap.create();
   private final Multimap<String, Include> missingIncludeFiles = HashMultimap.create();
-  public static int missingIncludeFilesCounter = 0;
+  private static int missingIncludeFilesCounter = 0;
 
   private State currentFileState = new State(null);
   private final Deque<State> globalStateStack = new LinkedList<>();
@@ -295,7 +296,12 @@ public class CxxPreprocessor extends Preprocessor {
       LOG.warn(MISSING_INCLUDE_MSG, missingIncludeFilesCounter);
     }
   }
-  
+
+  @VisibleForTesting
+  public static void resetReport() {
+    missingIncludeFilesCounter = 0;
+  }
+
   private void registerMacros(Map<String, String> standardMacros) {
     for (Map.Entry<String, String> entry : standardMacros.entrySet()) {
       Token bodyToken;

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -675,10 +675,7 @@ public class CxxPreprocessor extends Preprocessor {
     }
 
     if (includedFile == null) {
-      if (conf.getMissingIncludeWarningsEnabled()) {
-        LOG.warn("[" + filename + ":" + token.getLine() + "]: cannot find the sources for '"
-          + token.getValue() + "'");
-      }
+      LOG.warn("[" + filename + ":" + token.getLine() + "]: cannot find the sources for '" + token.getValue() + "'");
       if (currentFile != null) {
         missingIncludeFiles.put(currentFile.getPath(), new Include(token.getLine(), token.getValue()));
       }

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitor.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.cxx.visitors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.AstVisitor;
 import com.sonar.sslr.api.GenericTokenType;
@@ -40,7 +41,7 @@ public class CxxParseErrorLoggerVisitor<GRAMMAR extends Grammar>
     + " Root cause are typically missing includes, missing macros or compiler specific extensions.";
   private static final Logger LOG = Loggers.get(CxxParseErrorLoggerVisitor.class);
   private final SquidAstVisitorContext<?> context;
-  public static int errors = 0;
+  private static int errors = 0;
 
   public CxxParseErrorLoggerVisitor(SquidAstVisitorContext<?> context) {
     this.context = context;
@@ -50,6 +51,11 @@ public class CxxParseErrorLoggerVisitor<GRAMMAR extends Grammar>
     if (errors != 0) {
       LOG.warn(SYNTAX_ERROR_MSG, errors);
     }
+  }
+
+  @VisibleForTesting
+  public static void resetReport() {
+    errors = 0;
   }
 
   @Override

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitor.java
@@ -40,7 +40,7 @@ public class CxxParseErrorLoggerVisitor<GRAMMAR extends Grammar>
     + " Root cause are typically missing includes, missing macros or compiler specific extensions.";
   private static final Logger LOG = Loggers.get(CxxParseErrorLoggerVisitor.class);
   private final SquidAstVisitorContext<?> context;
-  private static int errors = 0;
+  public static int errors = 0;
 
   public CxxParseErrorLoggerVisitor(SquidAstVisitorContext<?> context) {
     this.context = context;

--- a/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
+++ b/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
@@ -165,7 +165,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(9)
+        .index(8)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxSquidSensor.REPORT_CHARSET_DEF)
         .defaultValue(CxxSquidSensor.DEFAULT_CHARSET_DEF)
@@ -241,7 +241,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(5)
+        .index(6)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxPCLintRuleRepository.CUSTOM_RULES_KEY)
         .name("PC-lint custom rules")
@@ -249,7 +249,7 @@ public final class CPlugin implements Plugin {
           + EXTENDING_THE_CODE_ANALYSIS)
         .type(PropertyType.TEXT)
         .subCategory(subcateg)
-        .index(6)
+        .index(7)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxRatsSensor.REPORT_PATH_KEY)
         .name("RATS report(s)")
@@ -258,7 +258,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(7)
+        .index(8)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxRatsRuleRepository.CUSTOM_RULES_KEY)
         .name("RATS custom rules")
@@ -266,7 +266,7 @@ public final class CPlugin implements Plugin {
           + EXTENDING_THE_CODE_ANALYSIS)
         .type(PropertyType.TEXT)
         .subCategory(subcateg)
-        .index(8)
+        .index(9)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxVeraxxSensor.REPORT_PATH_KEY)
         .name("Vera++ report(s)")
@@ -275,7 +275,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(9)
+        .index(10)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxVeraxxRuleRepository.CUSTOM_RULES_KEY)
         .name("Vera++ custom rules")
@@ -283,7 +283,7 @@ public final class CPlugin implements Plugin {
           + EXTENDING_THE_CODE_ANALYSIS)
         .type(PropertyType.TEXT)
         .subCategory(subcateg)
-        .index(10)
+        .index(11)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxOtherSensor.REPORT_PATH_KEY)
         .name("External checkers report(s)")
@@ -294,7 +294,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(11)
+        .index(12)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxOtherRepository.RULES_KEY)
         .name("External rules")
@@ -304,7 +304,7 @@ public final class CPlugin implements Plugin {
         .type(PropertyType.TEXT)
         .multiValues(true)
         .subCategory(subcateg)
-        .index(12)
+        .index(13)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidySensor.REPORT_PATH_KEY)
         .name("Clang-Tidy analyzer report(s)")
@@ -313,7 +313,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(13)
+        .index(14)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidySensor.REPORT_CHARSET_DEF)
         .defaultValue(CxxClangTidySensor.DEFAULT_CHARSET_DEF)
@@ -321,7 +321,7 @@ public final class CPlugin implements Plugin {
         .description("The encoding to use when reading the clang-tidy report. Leave empty to use parser's default UTF-8.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .index(14)
+        .index(15)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidyRuleRepository.CUSTOM_RULES_KEY)
         .name("Clang-Tidy custom rules")
@@ -329,7 +329,7 @@ public final class CPlugin implements Plugin {
           + EXTENDING_THE_CODE_ANALYSIS)
         .type(PropertyType.TEXT)
         .subCategory(subcateg)
-        .index(15)
+        .index(16)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangSASensor.REPORT_PATH_KEY)
         .name("Clang Static analyzer analyzer report(s)")
@@ -338,14 +338,14 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(16)
+        .index(17)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangSARuleRepository.CUSTOM_RULES_KEY)
         .name("Clang-SA custom rules")
         .description("NO DESC")
         .type(PropertyType.TEXT)
         .subCategory(subcateg)
-        .index(17)
+        .index(18)
         .build()
     ));
   }
@@ -447,7 +447,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(6)
+        .index(2)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxXunitSensor.XSLT_URL_KEY)
         .name("XSLT transformer")
@@ -456,7 +456,7 @@ public final class CPlugin implements Plugin {
           + " to perform the according transformation.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .index(7)
+        .index(3)
         .build()
     ));
   }

--- a/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
+++ b/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
@@ -86,7 +86,6 @@ public final class CPlugin implements Plugin {
   public static final String ERROR_RECOVERY_KEY = LANG_PROP_PREFIX + "errorRecoveryEnabled";
   public static final String FORCE_INCLUDE_FILES_KEY = LANG_PROP_PREFIX + "forceIncludes";
   public static final String C_FILES_PATTERNS_KEY = LANG_PROP_PREFIX + "cFilesPatterns";
-  public static final String MISSING_INCLUDE_WARN = LANG_PROP_PREFIX + "missingIncludeWarnings";
   public static final String JSON_COMPILATION_DATABASE_KEY = LANG_PROP_PREFIX + "jsonCompilationDatabase";
   public static final String CPD_IGNORE_LITERALS_KEY = LANG_PROP_PREFIX + "cpd.ignoreLiterals";
   public static final String CPD_IGNORE_IDENTIFIERS_KEY = LANG_PROP_PREFIX + "cpd.ignoreIdentifiers";
@@ -157,15 +156,6 @@ public final class CPlugin implements Plugin {
         .type(PropertyType.BOOLEAN)
         .index(7)
         .build(),
-      PropertyDefinition.builder(CPlugin.MISSING_INCLUDE_WARN)
-        .defaultValue("True")
-        .name("Missing include warnings")
-        .description("Enables/disables the warnings when included files could not be found.")
-        .subCategory(subcateg)
-        .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .type(PropertyType.BOOLEAN)
-        .index(8)
-        .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxSquidSensor.REPORT_PATH_KEY)
         .name("MSBuild log(s)")
         .description("Extract includes, defines and compiler options from the build log. This works only"
@@ -183,7 +173,7 @@ public final class CPlugin implements Plugin {
         .description("The encoding to use when reading a MSBuild log. Leave empty to use default UTF-8.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .index(10)
+        .index(9)
         .build(),
       PropertyDefinition.builder(CPlugin.JSON_COMPILATION_DATABASE_KEY)
         .subCategory(subcateg)
@@ -191,7 +181,7 @@ public final class CPlugin implements Plugin {
         .description("JSON Compilation Database file to use as specification for what defines "
           + "and includes should be used for source files.")
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .index(11)
+        .index(10)
         .build()
     ));
   }

--- a/sonar-c-plugin/src/test/java/org/sonar/plugins/c/CPluginTest.java
+++ b/sonar-c-plugin/src/test/java/org/sonar/plugins/c/CPluginTest.java
@@ -35,6 +35,6 @@ public class CPluginTest {
     Plugin.Context context = new Plugin.Context(runtime);
     CPlugin plugin = new CPlugin();
     plugin.define(context);
-    assertThat(context.getExtensions()).hasSize(75);
+    assertThat(context.getExtensions()).hasSize(74);
   }
 }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -90,7 +90,6 @@ public final class CxxPlugin implements Plugin {
   public static final String ERROR_RECOVERY_KEY = LANG_PROP_PREFIX + "errorRecoveryEnabled";
   public static final String FORCE_INCLUDE_FILES_KEY = LANG_PROP_PREFIX + "forceIncludes";
   public static final String C_FILES_PATTERNS_KEY = LANG_PROP_PREFIX + "cFilesPatterns";
-  public static final String MISSING_INCLUDE_WARN = LANG_PROP_PREFIX + "missingIncludeWarnings";
   public static final String JSON_COMPILATION_DATABASE_KEY = LANG_PROP_PREFIX + "jsonCompilationDatabase";
   public static final String CPD_IGNORE_LITERALS_KEY = LANG_PROP_PREFIX + "cpd.ignoreLiterals";
   public static final String CPD_IGNORE_IDENTIFIERS_KEY = LANG_PROP_PREFIX + "cpd.ignoreIdentifiers";
@@ -166,15 +165,6 @@ public final class CxxPlugin implements Plugin {
         .type(PropertyType.BOOLEAN)
         .index(7)
         .build(),
-      PropertyDefinition.builder(CxxPlugin.MISSING_INCLUDE_WARN)
-        .defaultValue(Boolean.TRUE.toString())
-        .name("Missing include warnings")
-        .description("Enables/disables the warnings when included files could not be found.")
-        .subCategory(subcateg)
-        .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .type(PropertyType.BOOLEAN)
-        .index(8)
-        .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxSquidSensor.REPORT_PATH_KEY)
         .name("Path(s) to MSBuild log(s)")
         .description("Extract includes, defines and compiler options from the build log. This works only"
@@ -192,7 +182,7 @@ public final class CxxPlugin implements Plugin {
         .description("The encoding to use when reading a MSBuild log. Leave empty to use default UTF-8.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .index(10)
+        .index(9)
         .build(),
       PropertyDefinition.builder(CxxPlugin.JSON_COMPILATION_DATABASE_KEY)
         .subCategory(subcateg)
@@ -200,7 +190,7 @@ public final class CxxPlugin implements Plugin {
         .description("JSON Compilation Database file to use as specification for what defines and includes should be "
           + "used for source files.")
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .index(11)
+        .index(10)
         .build()
     ));
   }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -174,7 +174,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(9)
+        .index(8)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxSquidSensor.REPORT_CHARSET_DEF)
         .defaultValue(CxxSquidSensor.DEFAULT_CHARSET_DEF)
@@ -250,7 +250,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(5)
+        .index(6)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxPCLintRuleRepository.CUSTOM_RULES_KEY)
         .name("PC-lint custom rules")
@@ -258,7 +258,7 @@ public final class CxxPlugin implements Plugin {
           + EXTENDING_THE_CODE_ANALYSIS)
         .type(PropertyType.TEXT)
         .subCategory(subcateg)
-        .index(6)
+        .index(7)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxRatsSensor.REPORT_PATH_KEY)
         .name("RATS report(s)")
@@ -267,7 +267,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(7)
+        .index(8)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxRatsRuleRepository.CUSTOM_RULES_KEY)
         .name("RATS custom rules")
@@ -275,7 +275,7 @@ public final class CxxPlugin implements Plugin {
           + EXTENDING_THE_CODE_ANALYSIS)
         .type(PropertyType.TEXT)
         .subCategory(subcateg)
-        .index(8)
+        .index(9)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxVeraxxSensor.REPORT_PATH_KEY)
         .name("Vera++ report(s)")
@@ -284,7 +284,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(9)
+        .index(10)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxVeraxxRuleRepository.CUSTOM_RULES_KEY)
         .name("Vera++ custom rules")
@@ -292,7 +292,7 @@ public final class CxxPlugin implements Plugin {
           + EXTENDING_THE_CODE_ANALYSIS)
         .type(PropertyType.TEXT)
         .subCategory(subcateg)
-        .index(10)
+        .index(11)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxOtherSensor.REPORT_PATH_KEY)
         .name("External checkers report(s)")
@@ -302,7 +302,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(11)
+        .index(12)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxOtherRepository.RULES_KEY)
         .name("External rules")
@@ -311,7 +311,7 @@ public final class CxxPlugin implements Plugin {
         .type(PropertyType.TEXT)
         .multiValues(true)
         .subCategory(subcateg)
-        .index(12)
+        .index(13)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidySensor.REPORT_PATH_KEY)
         .name("Clang-Tidy analyzer report(s)")
@@ -320,7 +320,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(13)
+        .index(14)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidySensor.REPORT_CHARSET_DEF)
         .defaultValue(CxxClangTidySensor.DEFAULT_CHARSET_DEF)
@@ -328,7 +328,7 @@ public final class CxxPlugin implements Plugin {
         .description("The encoding to use when reading the clang-tidy report. Leave empty to use parser's default UTF-8.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .index(14)
+        .index(15)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidyRuleRepository.CUSTOM_RULES_KEY)
         .name("Clang-Tidy custom rules")
@@ -336,7 +336,7 @@ public final class CxxPlugin implements Plugin {
           + EXTENDING_THE_CODE_ANALYSIS)
         .type(PropertyType.TEXT)
         .subCategory(subcateg)
-        .index(15)
+        .index(16)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangSASensor.REPORT_PATH_KEY)
         .name("Clang Static analyzer analyzer report(s)")
@@ -345,14 +345,14 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(16)
+        .index(17)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangSARuleRepository.CUSTOM_RULES_KEY)
         .name("Clang-SA custom rules")
         .description("NO DESC")
         .type(PropertyType.TEXT)
         .subCategory(subcateg)
-        .index(17)
+        .index(18)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxFunctionComplexityVisitor.FUNCTION_COMPLEXITY_THRESHOLD_KEY)
         .defaultValue("10")
@@ -361,7 +361,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .type(PropertyType.INTEGER)
-        .index(18)
+        .index(19)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxFunctionSizeVisitor.FUNCTION_SIZE_THRESHOLD_KEY)
         .defaultValue("20")
@@ -370,7 +370,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .type(PropertyType.INTEGER)
-        .index(19)
+        .index(20)
         .build()
     ));
   }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -35,6 +35,6 @@ public class CxxPluginTest {
     Plugin.Context context = new Plugin.Context(runtime);
     CxxPlugin plugin = new CxxPlugin();
     plugin.define(context);
-    assertThat(context.getExtensions()).hasSize(82);
+    assertThat(context.getExtensions()).hasSize(81);
   }
 }


### PR DESCRIPTION
* remove 'sonar.cxx.missingIncludeWarnings' setting
* add warning only once in case include file(s) cannot be found
* add more details only if debug logging is enabled
* close #1230

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1567)
<!-- Reviewable:end -->
