### PR TITLE
make all sensors 'reportPath' properties multi-value

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
@@ -67,7 +67,7 @@ import org.sonar.squidbridge.indexer.QueryByType;
 public class CxxSquidSensor implements Sensor {
 
   private static final Logger LOG = Loggers.get(CxxSquidSensor.class);
-  
+
   public static final String DEFINES_KEY = "defines";
   public static final String INCLUDE_DIRECTORIES_KEY = "includeDirectories";
   public static final String ERROR_RECOVERY_KEY = "errorRecoveryEnabled";
@@ -82,7 +82,7 @@ public class CxxSquidSensor implements Sensor {
   public static final String REPORT_PATH_KEY = "msbuild.reportPath";
   public static final String REPORT_CHARSET_DEF = "msbuild.charset";
   public static final String DEFAULT_CHARSET_DEF = "UTF-8";
-  
+
   public static final String CPD_IGNORE_LITERALS_KEY = "cpd.ignoreLiterals";
   public static final String CPD_IGNORE_IDENTIFIERS_KEY = "cpd.ignoreIdentifiers";
 
@@ -191,14 +191,13 @@ public class CxxSquidSensor implements Sensor {
       }
     }
 
-    String filePaths = this.language.getStringOption(REPORT_PATH_KEY).orElse("");
-    if (filePaths != null && !"".equals(filePaths)) {
+    final String[] buildLogPaths = language.getStringArrayOption(REPORT_PATH_KEY);
+    final boolean buildLogPathsDefined = buildLogPaths != null && buildLogPaths.length != 0;
+    if (buildLogPathsDefined) {
       List<File> reports = CxxReportSensor.getReports(context.config(), fs.baseDir(),
-        this.language.getPluginProperty(REPORT_PATH_KEY));
-      cxxConf.setCompilationPropertiesWithBuildLog(reports,
-        "Visual C++",
-        this.language.getStringOption(REPORT_CHARSET_DEF)
-          .orElse(DEFAULT_CHARSET_DEF));
+          this.language.getPluginProperty(REPORT_PATH_KEY));
+      cxxConf.setCompilationPropertiesWithBuildLog(reports, "Visual C++",
+          this.language.getStringOption(REPORT_CHARSET_DEF).orElse(DEFAULT_CHARSET_DEF));
     }
 
     return cxxConf;

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxReportSensor.java
@@ -132,11 +132,11 @@ public abstract class CxxReportSensor implements Sensor {
       return reports;
     }
 
-    String reportPathString = settings.get(genericReportKeyData).orElse("");
-    if (reportPathString.isEmpty()) {
+    String[] reportPathString = settings.getStringArray(genericReportKeyData);
+    if (reportPathString.length == 0) {
       LOG.info("Undefined report path value for key '{}'", genericReportKeyData);
     } else {
-      List<String> reportPaths = Arrays.asList(splitProperty(reportPathString));
+      List<String> reportPaths = Arrays.asList(reportPathString);
 
       List<String> includes = normalizeReportPaths(moduleBaseDir, reportPaths);
       if (LOG.isDebugEnabled()) {

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxCoberturaSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxCoberturaSensorTest.java
@@ -19,11 +19,13 @@
  */
 package org.sonar.cxx.sensors.coverage;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Before;
 import org.junit.Test;
 import static org.mockito.Mockito.when;
@@ -113,14 +115,16 @@ public class CxxCoberturaSensorTest {
   public void shouldReportNoCoverageSaved() {
     SensorContextTester context = SensorContextTester.create(fs.baseDir());
 
-    settings.setProperty(language.getPluginProperty(CxxCoverageSensor.REPORT_PATH_KEY), "coverage-reports/cobertura/specific-cases/does-not-exist.xml");
+    final String reportPathValue = "coverage-reports/cobertura/specific-cases/does-not-exist.xml";
+    settings.setProperty(language.getPluginProperty(CxxCoverageSensor.REPORT_PATH_KEY), reportPathValue);
     context.setSettings(settings);
 
     sensor = new CxxCoverageSensor(new CxxCoverageCache(), language, context);
     sensor.execute(context);
 
     List<String> log = logTester.logs();
-    assertThat(log.contains("Scanner found '0' report files")).isTrue();
+    assertThat(log).contains("Property 'sonar.cxx.coverage.reportPath': cannot find any files matching the Ant pattern(s) '"
+        + new File(fs.baseDir(), reportPathValue).getAbsolutePath() + "'");
   }
 
   @Test

--- a/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
+++ b/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
@@ -174,6 +174,7 @@ public final class CPlugin implements Plugin {
           + USE_ANT_STYLE_WILDCARDS_1)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(9)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxSquidSensor.REPORT_CHARSET_DEF)
@@ -206,6 +207,7 @@ public final class CPlugin implements Plugin {
       )
       .subCategory(subcateg)
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+      .multiValues(true)
       .index(1)
       .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCppCheckRuleRepository.CUSTOM_RULES_KEY)
@@ -222,6 +224,7 @@ public final class CPlugin implements Plugin {
           + USE_ANT_STYLE_WILDCARDS_1)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(3)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxValgrindRuleRepository.CUSTOM_RULES_KEY)
@@ -238,6 +241,7 @@ public final class CPlugin implements Plugin {
           + USE_ANT_STYLE_WILDCARDS_1)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(5)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxPCLintSensor.REPORT_PATH_KEY)
@@ -246,6 +250,7 @@ public final class CPlugin implements Plugin {
           + "projects root." + USE_ANT_STYLE_WILDCARDS_1)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(5)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxPCLintRuleRepository.CUSTOM_RULES_KEY)
@@ -262,6 +267,7 @@ public final class CPlugin implements Plugin {
           + "relative to projects root." + USE_ANT_STYLE_WILDCARDS_1)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(7)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxRatsRuleRepository.CUSTOM_RULES_KEY)
@@ -278,6 +284,7 @@ public final class CPlugin implements Plugin {
           + USE_ANT_STYLE_WILDCARDS_1)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(9)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxVeraxxRuleRepository.CUSTOM_RULES_KEY)
@@ -296,6 +303,7 @@ public final class CPlugin implements Plugin {
           + "here</a> for details.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(11)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxOtherRepository.RULES_KEY)
@@ -314,6 +322,7 @@ public final class CPlugin implements Plugin {
           + USE_ANT_STYLE_WILDCARDS_2)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(13)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidySensor.REPORT_CHARSET_DEF)
@@ -338,6 +347,7 @@ public final class CPlugin implements Plugin {
           + USE_ANT_STYLE_WILDCARDS_2)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(16)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangSARuleRepository.CUSTOM_RULES_KEY)
@@ -359,6 +369,7 @@ public final class CPlugin implements Plugin {
           + USE_ANT_STYLE_WILDCARDS_1)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(1)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerVcSensor.REPORT_CHARSET_DEF)
@@ -393,6 +404,7 @@ public final class CPlugin implements Plugin {
           + USE_ANT_STYLE_WILDCARDS_1)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(5)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerGccSensor.REPORT_CHARSET_DEF)
@@ -434,6 +446,7 @@ public final class CPlugin implements Plugin {
           + "here</a> for supported formats." + USE_ANT_STYLE_WILDCARDS_1)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(1)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxXunitSensor.REPORT_PATH_KEY)
@@ -443,6 +456,7 @@ public final class CPlugin implements Plugin {
           + "here</a> for supported formats." + USE_ANT_STYLE_WILDCARDS_1)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(6)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxXunitSensor.XSLT_URL_KEY)

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -183,6 +183,7 @@ public final class CxxPlugin implements Plugin {
           + USE_ANT_STYLE_WILDCARDS)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(9)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxSquidSensor.REPORT_CHARSET_DEF)
@@ -215,6 +216,7 @@ public final class CxxPlugin implements Plugin {
       )
       .subCategory(subcateg)
       .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+      .multiValues(true)
       .index(1)
       .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCppCheckRuleRepository.CUSTOM_RULES_KEY)
@@ -231,6 +233,7 @@ public final class CxxPlugin implements Plugin {
           + USE_ANT_STYLE_WILDCARDS)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(3)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxValgrindRuleRepository.CUSTOM_RULES_KEY)
@@ -247,6 +250,7 @@ public final class CxxPlugin implements Plugin {
           + USE_ANT_STYLE_WILDCARDS)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(5)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxPCLintSensor.REPORT_PATH_KEY)
@@ -255,6 +259,7 @@ public final class CxxPlugin implements Plugin {
           + "  root." + USE_ANT_STYLE_WILDCARDS)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(5)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxPCLintRuleRepository.CUSTOM_RULES_KEY)
@@ -271,6 +276,7 @@ public final class CxxPlugin implements Plugin {
           + " relative to projects root." + USE_ANT_STYLE_WILDCARDS)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(7)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxRatsRuleRepository.CUSTOM_RULES_KEY)
@@ -287,6 +293,7 @@ public final class CxxPlugin implements Plugin {
           + USE_ANT_STYLE_WILDCARDS)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(9)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxVeraxxRuleRepository.CUSTOM_RULES_KEY)
@@ -304,6 +311,7 @@ public final class CxxPlugin implements Plugin {
           + "/wiki/Extending-the-code-analysis'>here</a> for details.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(11)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxOtherRepository.RULES_KEY)
@@ -321,6 +329,7 @@ public final class CxxPlugin implements Plugin {
           + "<a href='https://ant.apache.org/manual/dirtasks.html'>Ant-style wildcards</a> are at your service.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(13)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidySensor.REPORT_CHARSET_DEF)
@@ -345,6 +354,7 @@ public final class CxxPlugin implements Plugin {
           + "<a href='https://ant.apache.org/manual/dirtasks.html'>Ant-style wildcards</a> are at your service.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(16)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangSARuleRepository.CUSTOM_RULES_KEY)
@@ -384,6 +394,7 @@ public final class CxxPlugin implements Plugin {
           + USE_ANT_STYLE_WILDCARDS)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(1)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerVcSensor.REPORT_CHARSET_DEF)
@@ -418,6 +429,7 @@ public final class CxxPlugin implements Plugin {
           + USE_ANT_STYLE_WILDCARDS)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(5)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerGccSensor.REPORT_CHARSET_DEF)
@@ -455,7 +467,6 @@ public final class CxxPlugin implements Plugin {
 
     properties.add(
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCoverageSensor.REPORT_PATH_KEY)
-        .multiValues(true)
         .name("Unit test coverage report(s)")
         .description("List of paths to reports containing unit test coverage data, relative to projects root."
           + " The values are separated by commas."
@@ -463,6 +474,7 @@ public final class CxxPlugin implements Plugin {
           + "here</a> for supported formats.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(1)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxXunitSensor.REPORT_PATH_KEY)
@@ -472,6 +484,7 @@ public final class CxxPlugin implements Plugin {
           + "here</a> for supported formats." + USE_ANT_STYLE_WILDCARDS)
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .multiValues(true)
         .index(2)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxXunitSensor.XSLT_URL_KEY)
@@ -500,6 +513,15 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .index(5)
+        .build(),
+      PropertyDefinition.builder(LANG_PROP_PREFIX
+        + UnitTestConfiguration.NUNIT_TEST_RESULTS_PROPERTY_KEY)
+        .multiValues(true)
+        .name("NUnit Test Reports Paths")
+        .description("Example: \"TestResult.xml\", \"TestResult1.xml,TestResult2.xml\" or \"C:/TestResult.xml\"")
+        .subCategory(subcateg)
+        .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .index(6)
         .build()
     );
     return properties.build();

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -35,6 +35,6 @@ public class CxxPluginTest {
     Plugin.Context context = new Plugin.Context(runtime);
     CxxPlugin plugin = new CxxPlugin();
     plugin.define(context);
-    assertThat(context.getExtensions()).hasSize(81);
+    assertThat(context.getExtensions()).hasSize(82);
   }
 }


### PR DESCRIPTION
1. fixes #1384

Literaly all sensors derived from `CxxReportSensor` as well as `CxxSquidSensor`
use use the method `CxxReportSensor::getReports()` in order to access the
reporth paths. This method expects the `*.reportPath` property to be
a multi-value one. So fix the property access

* use `getStringArray()` method for parsing
* mark corresponding properties as multi-value

2. fixes #1376

While working on (1) I've found out, that the property
`UnitTestConfiguration.NUNIT_TEST_RESULTS_PROPERTY_KEY` is not public
accessible. This contradicts to the #1376.

On the other hand, if there should be no soupport for NUnit,
either the property must be marked as deprecated or the NUnit support
has to be removed completely. Please review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1568)
<!-- Reviewable:end -->
