### PR TITLE
BUG? [sonar/cxx/api] NOT_EQ: "not_eq " to "not_eq"

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/api/CppPunctuator.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/api/CppPunctuator.java
@@ -102,7 +102,7 @@ public enum CppPunctuator implements TokenType {
   AL_BITOR("bitor"),
   AL_COMPL("compl"),
   AL_NOT("not"),
-  AL_NOT_EQ("not_eq "),
+  AL_NOT_EQ("not_eq"),
   AL_OR("or"),
   AL_OR_EQ("or_eq"),
   AL_AL_XOR("xor"),

--- a/cxx-squid/src/main/java/org/sonar/cxx/api/CxxKeyword.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/api/CxxKeyword.java
@@ -109,7 +109,7 @@ public enum CxxKeyword implements TokenType {
   BITOR("bitor"),
   COMPL("compl"),
   NOT("not"),
-  NOT_EQ("not_eq "),
+  NOT_EQ("not_eq"),
   OR("or"),
   OR_EQ("or_eq"),
   XOR("xor"),


### PR DESCRIPTION
I opened #1569 and then cloned the code to take a look, and thought this seems odd, and is possibly a bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1570)
<!-- Reviewable:end -->
