### PR TITLE
[Travis/AppVeyor] Updates sonarqube distribution URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,17 +43,17 @@ before_install:
 
 install:
         - pushd /tmp
-        - travis_retry wget -q https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-6.7.5.zip
+        - travis_retry wget -q https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.5.zip
         - unzip -qq sonarqube-6.7.5.zip
-        - travis_retry wget -q https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-7.0.zip
+        - travis_retry wget -q https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.0.zip
         - unzip -qq sonarqube-7.0.zip
-        - travis_retry wget -q https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-7.1.zip
+        - travis_retry wget -q https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.1.zip
         - unzip -qq sonarqube-7.1.zip
-        - travis_retry wget -q https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-7.2.zip
+        - travis_retry wget -q https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.2.zip
         - unzip -qq sonarqube-7.2.zip
-        - travis_retry wget -q https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-7.3.zip
+        - travis_retry wget -q https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.3.zip
         - unzip -qq sonarqube-7.3.zip     
-        - travis_retry wget -q https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.1.0.1141.zip
+        - travis_retry wget -q https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.1.0.1141.zip
         - unzip -qq sonar-scanner-cli-3.1.0.1141.zip
         - travis_retry wget -q https://github.com/htacg/tidy-html5/archive/5.6.0.zip --output-document=tidy-html5.zip
         - unzip -qq tidy-html5.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,14 +19,14 @@ install:
 
       if (!(Test-Path -Path "C:\sonar-scanner" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.1.0.1141.zip',
+          'https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.1.0.1141.zip',
           'C:\sonar-scanner-dist.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonar-scanner-dist.zip", "C:\sonar-scanner")
       }
       if (!(Test-Path -Path "C:\sonarqube" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-6.7.5.zip',
+          'https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.5.zip',
           'C:\sonarqube-6.7.5.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonarqube-6.7.5.zip", "C:\sonarqube")


### PR DESCRIPTION
looks like sonarqube is no longer distributed via bintray.com, and is hosted on their own site.

This is because I opened PR #1570 and it failed on Travis & AppVeyor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1571)
<!-- Reviewable:end -->
