### PR TITLE
Alternative operator representations

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/api/CppPunctuator.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/api/CppPunctuator.java
@@ -102,7 +102,7 @@ public enum CppPunctuator implements TokenType {
   AL_BITOR("bitor"),
   AL_COMPL("compl"),
   AL_NOT("not"),
-  AL_NOT_EQ("not_eq "),
+  AL_NOT_EQ("not_eq"),
   AL_OR("or"),
   AL_OR_EQ("or_eq"),
   AL_AL_XOR("xor"),

--- a/cxx-squid/src/main/java/org/sonar/cxx/api/CxxKeyword.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/api/CxxKeyword.java
@@ -109,7 +109,7 @@ public enum CxxKeyword implements TokenType {
   BITOR("bitor"),
   COMPL("compl"),
   NOT("not"),
-  NOT_EQ("not_eq "),
+  NOT_EQ("not_eq"),
   OR("or"),
   OR_EQ("or_eq"),
   XOR("xor"),

--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -490,8 +490,8 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
 
     b.rule(binaryOperator).is( // todo
       b.firstOf(
-        "||", "&&", "&", "|", "^", "==", "!=", "<=", "<", ">=", ">",
-        "<<", ">>", "*", "/", "+", "-", assignmentOperator
+        "||", CxxKeyword.OR, "&&", CxxKeyword.AND, "&", CxxKeyword.BITAND, "|", CxxKeyword.BITOR, "^", CxxKeyword.XOR,
+        "==", "!=", CxxKeyword.NOT_EQ, "<=", "<", ">=", ">", "<<", ">>", "*", "/", "+", "-", assignmentOperator
       )
     );
 
@@ -575,9 +575,9 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
 
     b.rule(foldOperator).is(
       b.firstOf( // C++
-        "+", "-", "*", "/", "%", "ˆ", "&", "|", "<<", ">>",
-        "+=", "-=", "*=", "/=", "%=", "ˆ=", "&=", "|=", "<<=", ">>=", "=",
-        "==", "!=", "<", ">", "<=", ">=", "&&", "||", ",", ".*", "->*"
+        "+", "-", "*", "/", "%", "ˆ", CxxKeyword.XOR, "&", CxxKeyword.BITAND, "|", CxxKeyword.BITOR, "<<", ">>",
+        "+=", "-=", "*=", "/=", "%=", "ˆ=", CxxKeyword.XOR_EQ, "&=", CxxKeyword.AND_EQ, "|=", CxxKeyword.OR_EQ, "<<=", ">>=", "=",
+        "==", "!=", CxxKeyword.NOT_EQ, "<", ">", "<=", ">=", "&&", CxxKeyword.AND, "||", CxxKeyword.OR, ",", ".*", "->*"
       )
     );
 
@@ -658,7 +658,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
     ).skipIfOneChild();
 
     b.rule(unaryOperator).is(
-      b.firstOf("*", "&", "+", "-", "!", "~") // C++
+      b.firstOf("*", "&", "+", "-", "!", CxxKeyword.NOT, "~", CxxKeyword.COMPL) // C++
     );
 
     b.rule(newExpression).is(
@@ -773,7 +773,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
     ).skipIfOneChild();
 
     b.rule(assignmentOperator).is(
-      b.firstOf("=", "*=", "/=", "%=", "+=", "-=", ">>=", "<<=", "&=", "^=", "|=") // C++
+      b.firstOf("=", "*=", "/=", "%=", "+=", "-=", ">>=", "<<=", "&=", CxxKeyword.AND_EQ, "^=", CxxKeyword.XOR_EQ, "|=", CxxKeyword.OR_EQ) // C++
     );
 
     b.rule(expression).is(


### PR DESCRIPTION
Fix for #1569 

This is branched off of #1571 because I wanted the tests to be run... I'm not really familiar with the project or syntax... Setting up the testing etc was a bit of work, so I aim relaying on Travis and the code reviewers.

I found in #1570 that the alternative operators already existed, in two locations:
**sonar/cxx/api/CxxKeyword.java**
**sonar/cxx/api/CppPunctuator.java**

I used the ones from **CxxKeywords** and I just added them after where the regular ones were found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1572)
<!-- Reviewable:end -->
