### PR TITLE
path normalization / absolutization is not allowed to use File::getCanonicalPath()

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/BullseyeParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/BullseyeParser.java
@@ -28,7 +28,6 @@ import javax.annotation.Nullable;
 import javax.xml.stream.XMLStreamException;
 import org.codehaus.staxmate.in.SMHierarchicCursor;
 import org.codehaus.staxmate.in.SMInputCursor;
-import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.PathUtils;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
@@ -45,14 +44,14 @@ public class BullseyeParser extends CxxCoverageParser {
   private static int totalcoveredconditions;
 
   public BullseyeParser() {
-    // no operation but necessary for list of coverage parsers 
+    // no operation but necessary for list of coverage parsers
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public void processReport(final SensorContext context, File report, final Map<String, CoverageMeasures> coverageData)
+  public void processReport(File report, final Map<String, CoverageMeasures> coverageData)
     throws XMLStreamException {
     LOG.debug("Parsing 'Bullseye' format");
     StaxParser topLevelparser = new StaxParser(new StaxParser.XmlStreamHandler() {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CoberturaParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CoberturaParser.java
@@ -63,7 +63,7 @@ public class CoberturaParser extends CxxCoverageParser {
 
     StaxParser packageParser = new StaxParser((SMHierarchicCursor rootCursor) -> {
       rootCursor.advance();
-      collectPackageMeasures(baseDir, rootCursor.descendantElementCursor("package"), coverageData);
+      collectPackageMeasures(context, rootCursor.descendantElementCursor("package"), coverageData);
     });
     packageParser.parse(report);
   }
@@ -78,19 +78,19 @@ public class CoberturaParser extends CxxCoverageParser {
     }
   }
 
-  private static void collectPackageMeasures(final String baseDir, SMInputCursor pack,
+  private static void collectPackageMeasures(SensorContext sensorContext, SMInputCursor pack,
     Map<String, CoverageMeasures> coverageData)
     throws XMLStreamException {
     while (pack.getNext() != null) {
-      collectFileMeasures(baseDir, pack.descendantElementCursor("class"), coverageData);
+      collectFileMeasures(sensorContext, pack.descendantElementCursor("class"), coverageData);
     }
   }
 
-  private static void collectFileMeasures(final String baseDir, SMInputCursor clazz,
+  private static void collectFileMeasures(SensorContext sensorContext, SMInputCursor clazz,
     Map<String, CoverageMeasures> coverageData)
     throws XMLStreamException {
     while (clazz.getNext() != null) {
-      String normalPath = CxxUtils.normalizePathFull(clazz.getAttrValue("filename"), baseDir);
+      String normalPath = CxxUtils.normalizePathFull(sensorContext, clazz.getAttrValue("filename"));
       if (normalPath != null) {
         CoverageMeasures builder = coverageData.get(normalPath);
         if (builder == null) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CoberturaParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CoberturaParser.java
@@ -20,17 +20,17 @@
 package org.sonar.cxx.sensors.coverage;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.xml.stream.XMLStreamException;
 import org.codehaus.staxmate.in.SMHierarchicCursor;
 import org.codehaus.staxmate.in.SMInputCursor;
-import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
-import org.sonar.cxx.sensors.utils.CxxUtils;
 import org.sonar.cxx.sensors.utils.StaxParser;
 
 /**
@@ -39,7 +39,7 @@ import org.sonar.cxx.sensors.utils.StaxParser;
 public class CoberturaParser extends CxxCoverageParser {
 
   private static final Logger LOG = Loggers.get(CoberturaParser.class);
-  private String baseDir;
+  private Optional<Path> baseDir;
   private static final Pattern conditionsPattern = Pattern.compile("\\((.*?)\\)");
 
   public CoberturaParser() {
@@ -50,10 +50,10 @@ public class CoberturaParser extends CxxCoverageParser {
    * {@inheritDoc}
    */
   @Override
-  public void processReport(final SensorContext context, File report, final Map<String, CoverageMeasures> coverageData)
+  public void processReport(File report, final Map<String, CoverageMeasures> coverageData)
     throws XMLStreamException {
     LOG.debug("Parsing 'Cobertura' format");
-    baseDir = context.fileSystem().baseDir().getAbsolutePath();
+    baseDir = Optional.empty();
 
     StaxParser sourceParser = new StaxParser((SMHierarchicCursor rootCursor) -> {
       rootCursor.advance();
@@ -63,7 +63,7 @@ public class CoberturaParser extends CxxCoverageParser {
 
     StaxParser packageParser = new StaxParser((SMHierarchicCursor rootCursor) -> {
       rootCursor.advance();
-      collectPackageMeasures(context, rootCursor.descendantElementCursor("package"), coverageData);
+      collectPackageMeasures(rootCursor.descendantElementCursor("package"), coverageData);
     });
     packageParser.parse(report);
   }
@@ -72,33 +72,37 @@ public class CoberturaParser extends CxxCoverageParser {
     while (source.getNext() != null) {
       String sourceValue = source.getElemStringValue().trim();
       if (!sourceValue.isEmpty()) {
-        baseDir = Paths.get(baseDir).resolve(sourceValue).normalize().toString();
+        baseDir = Optional.of(Paths.get(sourceValue));
         break;
       }
     }
   }
 
-  private static void collectPackageMeasures(SensorContext sensorContext, SMInputCursor pack,
-    Map<String, CoverageMeasures> coverageData)
-    throws XMLStreamException {
+  private void collectPackageMeasures(SMInputCursor pack, Map<String, CoverageMeasures> coverageData)
+      throws XMLStreamException {
     while (pack.getNext() != null) {
-      collectFileMeasures(sensorContext, pack.descendantElementCursor("class"), coverageData);
+      collectFileMeasures(pack.descendantElementCursor("class"), coverageData);
     }
   }
 
-  private static void collectFileMeasures(SensorContext sensorContext, SMInputCursor clazz,
-    Map<String, CoverageMeasures> coverageData)
-    throws XMLStreamException {
+  private String buildPath(String filename) {
+    Path result = Paths.get(filename);
+    if (baseDir.isPresent()) {
+      result = baseDir.get().resolve(result);
+    }
+    return result.normalize().toString();
+  }
+
+  private void collectFileMeasures(SMInputCursor clazz, Map<String, CoverageMeasures> coverageData)
+      throws XMLStreamException {
     while (clazz.getNext() != null) {
-      String normalPath = CxxUtils.normalizePathFull(sensorContext, clazz.getAttrValue("filename"));
-      if (normalPath != null) {
-        CoverageMeasures builder = coverageData.get(normalPath);
-        if (builder == null) {
-          builder = CoverageMeasures.create();
-          coverageData.put(normalPath, builder);
-        }
-        collectFileData(clazz, builder);
+      String normalPath = buildPath(clazz.getAttrValue("filename"));
+      CoverageMeasures builder = coverageData.get(normalPath);
+      if (builder == null) {
+        builder = CoverageMeasures.create();
+        coverageData.put(normalPath, builder);
       }
+      collectFileData(clazz, builder);
     }
   }
 

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CoverageParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CoverageParser.java
@@ -21,11 +21,12 @@ package org.sonar.cxx.sensors.coverage;
 
 import java.io.File;
 import java.util.Map;
+
 import javax.xml.stream.XMLStreamException;
-import org.sonar.api.batch.sensor.SensorContext;
 
 /**
- * The interface a coverage report parser has to implement in order to be used by CxxCoverageSensor
+ * The interface a coverage report parser has to implement in order to be used
+ * by CxxCoverageSensor
  */
 public interface CoverageParser {
 
@@ -39,11 +40,14 @@ public interface CoverageParser {
    * @param coverageData
    *          A Map mapping source file names to coverage measures. Has to be
    *          used to store the results into. Source file names might be
-   *          relative. In such case they will be resolved agains the base
-   *          directory of SonarQube module/project.
+   *          relative. In such case they will be resolved against the base
+   *          directory of SonarQube module/project.<br>
+   *
+   *          <b>ATTENTION!</b> This map is shared between modules in
+   *          multi-module projects. Don't try to resolve paths against some
+   *          specific module!
    * @throws XMLStreamException
    *           javax.xml.stream.XMLStreamException
    */
-  void processReport(final SensorContext context, File report, Map<String, CoverageMeasures> coverageData)
-    throws XMLStreamException;
+  void processReport(File report, Map<String, CoverageMeasures> coverageData) throws XMLStreamException;
 }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CoverageParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CoverageParser.java
@@ -32,10 +32,17 @@ public interface CoverageParser {
   /**
    * Parses the given report and stores the results in the according builder
    *
-   * @param context of sensor
-   * @param report with coverage data
-   * @param coverageData A Map mapping source file names to coverage measures. Has to be used to store the results into.
-   * @throws XMLStreamException javax.xml.stream.XMLStreamException
+   * @param context
+   *          of sensor
+   * @param report
+   *          with coverage data
+   * @param coverageData
+   *          A Map mapping source file names to coverage measures. Has to be
+   *          used to store the results into. Source file names might be
+   *          relative. In such case they will be resolved agains the base
+   *          directory of SonarQube module/project.
+   * @throws XMLStreamException
+   *           javax.xml.stream.XMLStreamException
    */
   void processReport(final SensorContext context, File report, Map<String, CoverageMeasures> coverageData)
     throws XMLStreamException;

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
@@ -167,7 +167,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
     for (Map.Entry<String, CoverageMeasures> entry : coverageMeasures.entrySet()) {
       String filePath = PathUtils.sanitize(entry.getKey());
       if (filePath != null) {
-        filePath = CxxUtils.normalizePathFull(filePath, context.fileSystem().baseDir().getAbsolutePath());
+        filePath = CxxUtils.normalizePathFull(context, filePath);
         InputFile cxxFile = context.fileSystem().inputFile(context.fileSystem().predicates().hasPath(filePath));
         if (LOG.isDebugEnabled()) {
           LOG.debug("save coverage measure for file: '{}' cxxFile = '{}'", filePath, cxxFile);

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
@@ -100,20 +100,20 @@ public class CxxCoverageSensor extends CxxReportSensor {
       }
 
       List<File> reports = getReports(context.config(), context.fileSystem().baseDir(), getReportPathKey());
-      coverageMeasures = processReports(context, reports, this.cache.unitCoverageCache());
+      coverageMeasures = processReports(reports, this.cache.unitCoverageCache());
       saveMeasures(context, coverageMeasures);
     }
   }
 
-  private Map<String, CoverageMeasures> processReports(final SensorContext context, List<File> reports,
-    Map<String, Map<String, CoverageMeasures>> cacheCov) {
+  private Map<String, CoverageMeasures> processReports(List<File> reports,
+      Map<String, Map<String, CoverageMeasures>> cacheCov) {
     Map<String, CoverageMeasures> measuresTotal = new HashMap<>();
 
     for (File report : reports) {
       if (!cacheCov.containsKey(report.getAbsolutePath())) {
         for (CoverageParser parser : parsers) {
           try {
-            parseCoverageReport(parser, context, report, measuresTotal);
+            parseCoverageReport(parser, report, measuresTotal);
             if (LOG.isDebugEnabled()) {
               LOG.debug("cached measures for '{}' : current cache content data = '{}'", report.getAbsolutePath(),
                 cacheCov.size());
@@ -145,11 +145,11 @@ public class CxxCoverageSensor extends CxxReportSensor {
    * @param measuresTotal
    * @return true if report was parsed and results are available otherwise false
    */
-  private static void parseCoverageReport(CoverageParser parser, final SensorContext context, File report,
-    Map<String, CoverageMeasures> measuresTotal) {
+  private static void parseCoverageReport(CoverageParser parser, File report,
+      Map<String, CoverageMeasures> measuresTotal) {
     Map<String, CoverageMeasures> measuresForReport = new HashMap<>();
     try {
-      parser.processReport(context, report, measuresForReport);
+      parser.processReport(report, measuresForReport);
     } catch (XMLStreamException e) {
       throw new EmptyReportException("Coverage report" + report + "cannot be parsed by" + parser, e);
     }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
@@ -189,8 +189,12 @@ public class CxxCoverageSensor extends CxxReportSensor {
             CxxUtils.validateRecovery(ex, getLanguage());
           }
           LOG.info("Saved '{}' coverage measures for file '{}'", measures.size(), filePath);
-        } else  if (LOG.isDebugEnabled()) {
-          LOG.debug("Cannot find the file '{}', ignoring coverage measures", filePath);
+        } else {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Cannot find the file '{}', ignoring coverage measures", filePath);
+          } else if (filePath.startsWith(context.fileSystem().baseDir().getAbsolutePath())) {
+            LOG.warn("Cannot find the file '{}', ignoring coverage measures", filePath);
+          }
         }
       } else {
         if (LOG.isDebugEnabled()) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
@@ -165,9 +165,8 @@ public class CxxCoverageSensor extends CxxReportSensor {
   private void saveMeasures(SensorContext context,
     Map<String, CoverageMeasures> coverageMeasures) {
     for (Map.Entry<String, CoverageMeasures> entry : coverageMeasures.entrySet()) {
-      String filePath = PathUtils.sanitize(entry.getKey());
+      final String filePath = PathUtils.sanitize(entry.getKey());
       if (filePath != null) {
-        filePath = CxxUtils.normalizePathFull(context, filePath);
         InputFile cxxFile = context.fileSystem().inputFile(context.fileSystem().predicates().hasPath(filePath));
         if (LOG.isDebugEnabled()) {
           LOG.debug("save coverage measure for file: '{}' cxxFile = '{}'", filePath, cxxFile);
@@ -190,12 +189,8 @@ public class CxxCoverageSensor extends CxxReportSensor {
             CxxUtils.validateRecovery(ex, getLanguage());
           }
           LOG.info("Saved '{}' coverage measures for file '{}'", measures.size(), filePath);
-        } else {
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Cannot find the file '{}', ignoring coverage measures", filePath);
-          } else if (filePath.startsWith(context.fileSystem().baseDir().getAbsolutePath())) {
-            LOG.warn("Cannot find the file '{}', ignoring coverage measures", filePath);
-          }
+        } else  if (LOG.isDebugEnabled()) {
+          LOG.debug("Cannot find the file '{}', ignoring coverage measures", filePath);
         }
       } else {
         if (LOG.isDebugEnabled()) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/VisualStudioParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/VisualStudioParser.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import javax.xml.stream.XMLStreamException;
 import org.codehaus.staxmate.in.SMHierarchicCursor;
 import org.codehaus.staxmate.in.SMInputCursor;
-import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.sensors.utils.StaxParser;
@@ -37,14 +36,14 @@ public class VisualStudioParser extends CxxCoverageParser {
   private static final Logger LOG = Loggers.get(VisualStudioParser.class);
 
   public VisualStudioParser() {
-    // no operation but necessary for list of coverage parsers 
+    // no operation but necessary for list of coverage parsers
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public void processReport(final SensorContext context, File report, final Map<String, CoverageMeasures> coverageData)
+  public void processReport(File report, final Map<String, CoverageMeasures> coverageData)
     throws XMLStreamException {
     LOG.debug("Parsing 'Visual Studio' format");
     StaxParser parser = new StaxParser(new StaxParser.XmlStreamHandler() {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
@@ -77,6 +77,7 @@ public abstract class CxxIssuesReportSensor extends CxxReportSensor {
       LOG.info("Searching reports by relative path with basedir '{}' and search prop '{}'",
         context.fileSystem().baseDir(), getReportPathKey());
       List<File> reports = getReports(context.config(), context.fileSystem().baseDir(), getReportPathKey());
+      notFoundFiles.clear();
       violationsPerFileCount.clear();
       violationsPerModuleCount = 0;
 
@@ -158,15 +159,14 @@ public abstract class CxxIssuesReportSensor extends CxxReportSensor {
   }
 
   public InputFile getInputFileIfInProject(SensorContext sensorContext, String path) {
-    String root = sensorContext.fileSystem().baseDir().getAbsolutePath();
-    String normalPath = CxxUtils.normalizePathFull(path, root);
-    if (normalPath == null || notFoundFiles.contains(normalPath)) {
+    if (notFoundFiles.contains(path)) {
       return null;
     }
-    InputFile inputFile = sensorContext.fileSystem()
-        .inputFile(sensorContext.fileSystem().predicates().hasAbsolutePath(normalPath));
+    final InputFile inputFile = sensorContext.fileSystem().inputFile(sensorContext.fileSystem().predicates().hasPath(path));
     if (inputFile == null) {
-      notFoundFiles.add(normalPath);
+      LOG.debug("Path '{}' couldn't be found in module '{}' base dir '{}'", path, sensorContext.module().key(),
+          sensorContext.fileSystem().baseDir());
+      notFoundFiles.add(path);
     }
     return inputFile;
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxUtils.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxUtils.java
@@ -50,18 +50,12 @@ public final class CxxUtils {
   }
 
   /**
-   * @return returns canonical path if given file name could be resolved for the
-   *         given module, <code>null</code> otherwise
+   * @return absolute, resolved and normalized <code>path</code> against the
+   *         base directory of the given SonarQube module, represented by
+   *         <code>sensorContext</code>
    */
-  public static String normalizePathFull(SensorContext sensorContext, String filename) {
-    try {
-      return sensorContext.fileSystem().resolvePath(filename.trim()).getAbsolutePath();
-    } catch (Exception e) {
-      LOG.debug("path normalizing of '{}' failed with root cause '{}' (module '{}', base dir '{}')", filename,
-          ExceptionUtils.getRootCauseMessage(e), sensorContext.module().key(),
-          sensorContext.fileSystem().baseDir().getAbsolutePath());
-      return null;
-    }
+  public static String normalizePathFull(SensorContext sensorContext, String path) {
+    return sensorContext.fileSystem().baseDir().getAbsoluteFile().toPath().resolve(path.trim()).normalize().toString();
   }
 
   /**

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxUtils.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxUtils.java
@@ -31,7 +31,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
@@ -47,15 +46,6 @@ public final class CxxUtils {
 
   private CxxUtils() {
     // only static methods
-  }
-
-  /**
-   * @return absolute, resolved and normalized <code>path</code> against the
-   *         base directory of the given SonarQube module, represented by
-   *         <code>sensorContext</code>
-   */
-  public static String normalizePathFull(SensorContext sensorContext, String path) {
-    return sensorContext.fileSystem().baseDir().getAbsoluteFile().toPath().resolve(path.trim()).normalize().toString();
   }
 
   /**


### PR DESCRIPTION
Path normalization / absolutization is not allowed to use `File::getCanonicalPath()`. If performed on Linux (Unix), this method resolves the symbolic links. This fact might make the queries like "is this normalized path in SonarQube project" go wrong.

Fixed #1574

* review the SonarQube's filesystem queries
* no path absolutization is necessary; filesystem deals perfectly with relative paths

Fixes #1465 

* `CoberturaParser` used  `CxxUtils::normalizePathFull()`
* This made all file paths in parsed report to  absolute ones. Base directory of the first processed module was used in order to make paths absolute
* Since parsed reports were cached, this would lead to the wrong absolute paths in multi-module project
* Store original paths instead!

Misc:

* minor refactoring
* remove error-prone implementation of `CxxUtils::normalizePathFull()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1575)
<!-- Reviewable:end -->
