### PR TITLE
Public API: ignore methods outside of class

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
@@ -26,7 +26,6 @@ import com.sonar.sslr.api.Token;
 import com.sonar.sslr.api.TokenType;
 import com.sonar.sslr.api.Trivia;
 import com.sonar.sslr.impl.ast.AstXmlPrinter;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.sonar.api.utils.log.Logger;
@@ -53,11 +52,10 @@ import org.sonar.squidbridge.checks.SquidCheck;
  * </ul>
  * <p>
  * Public API items are considered documented if they have Doxygen comments.<br>
- * Function arguments are not counted since they can be documented in function
- * documentation and this visitor does not parse Doxygen comments.<br>
+ * Function arguments are not counted since they can be documented in function documentation and this visitor does not
+ * parse Doxygen comments.<br>
  * This visitor should be applied only on header files.<br>
- * Currently, no filtering is applied using preprocessing directive, e.g
- * <code>#define DLLEXPORT</code>.<br>
+ * Currently, no filtering is applied using preprocessing directive, e.g <code>#define DLLEXPORT</code>.<br>
  * <p>
  * Limitation: only "in front of the declaration" comments are considered.
  *
@@ -91,12 +89,12 @@ public abstract class AbstractCxxPublicApiVisitor<G extends Grammar> extends Squ
   @Override
   public void init() {
     subscribeTo(
-        CxxGrammarImpl.classSpecifier,
-        CxxGrammarImpl.memberDeclaration,
-        CxxGrammarImpl.functionDefinition,
-        CxxGrammarImpl.enumSpecifier,
-        CxxGrammarImpl.initDeclaratorList,
-        CxxGrammarImpl.aliasDeclaration);
+      CxxGrammarImpl.classSpecifier,
+      CxxGrammarImpl.memberDeclaration,
+      CxxGrammarImpl.functionDefinition,
+      CxxGrammarImpl.enumSpecifier,
+      CxxGrammarImpl.initDeclaratorList,
+      CxxGrammarImpl.aliasDeclaration);
   }
 
   @Override
@@ -503,7 +501,7 @@ public abstract class AbstractCxxPublicApiVisitor<G extends Grammar> extends Squ
 
   private void visitFunctionDefinition(AstNode functionDef) {
     if (isPublicApiMember(functionDef)) {
-      
+
       // filter out deleted and defaulted methods
       AstNode functionBodyNode = functionDef
         .getFirstChild(CxxGrammarImpl.functionBody);
@@ -817,8 +815,8 @@ public abstract class AbstractCxxPublicApiVisitor<G extends Grammar> extends Squ
           return false;
         }
       }
-      
-      if (node.getType().equals(CxxGrammarImpl.functionDefinition)) {
+
+      if (node.is(CxxGrammarImpl.functionDefinition)) {
         // filter out function definitions with nested name specifier: should be documented inside of class
         AstNode declarator = node.getFirstChild(CxxGrammarImpl.declarator);
         if ((declarator != null) && declarator.hasDescendant(CxxGrammarImpl.nestedNameSpecifier)) {
@@ -831,8 +829,7 @@ public abstract class AbstractCxxPublicApiVisitor<G extends Grammar> extends Squ
   }
 
   /**
-   * Check if inline Doxygen documentation is attached to the given token at
-   * specified line
+   * Check if inline Doxygen documentation is attached to the given token at specified line
    *
    * @param token the token to inspect
    * @param line line of the inlined documentation

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
@@ -503,6 +503,7 @@ public abstract class AbstractCxxPublicApiVisitor<G extends Grammar> extends Squ
 
   private void visitFunctionDefinition(AstNode functionDef) {
     if (isPublicApiMember(functionDef)) {
+      
       // filter out deleted and defaulted methods
       AstNode functionBodyNode = functionDef
         .getFirstChild(CxxGrammarImpl.functionBody);
@@ -816,8 +817,15 @@ public abstract class AbstractCxxPublicApiVisitor<G extends Grammar> extends Squ
           return false;
         }
       }
+      
+      if (node.getType().equals(CxxGrammarImpl.functionDefinition)) {
+        // filter out function definitions with nested name specifier: should be documented inside of class
+        AstNode declarator = node.getFirstChild(CxxGrammarImpl.declarator);
+        if ((declarator != null) && declarator.hasDescendant(CxxGrammarImpl.nestedNameSpecifier)) {
+          return false;
+        }
+      }
 
-      // method or function outside of class
       return true;
     }
   }

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxPublicApiVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxPublicApiVisitor.java
@@ -19,18 +19,16 @@
  */
 package org.sonar.cxx.visitors;
 
+import com.sonar.sslr.api.AstNode;
+import com.sonar.sslr.api.Grammar;
+import com.sonar.sslr.api.Token;
 import java.util.Arrays;
 import java.util.List;
-
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.api.CxxMetric;
 import org.sonar.squidbridge.api.SourceFile;
-
-import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Grammar;
-import com.sonar.sslr.api.Token;
 
 /**
  * Visitor that counts documented and undocumented API items.<br>

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
@@ -31,10 +31,9 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.assertj.core.groups.Tuple;
 import static org.assertj.core.groups.Tuple.tuple;
-import static org.mockito.Mockito.when;
-
 import org.fest.assertions.Fail;
 import org.junit.Test;
+import static org.mockito.Mockito.when;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.cxx.CxxAstScanner;
@@ -58,6 +57,7 @@ public class CxxPublicApiVisitorTest {
   }
 
   private class TestPublicApiVisitor extends AbstractCxxPublicApiVisitor<Grammar> {
+
     final Map<String, List<Token>> idCommentMap = new HashMap<>();
     boolean checkDoubleIDs = false;
 
@@ -95,7 +95,7 @@ public class CxxPublicApiVisitorTest {
 
     if (LOG.isDebugEnabled()) {
       LOG.debug("#API: {} UNDOC: {}",
-          file.getInt(CxxMetric.PUBLIC_API), file.getInt(CxxMetric.PUBLIC_UNDOCUMENTED_API));
+        file.getInt(CxxMetric.PUBLIC_API), file.getInt(CxxMetric.PUBLIC_UNDOCUMENTED_API));
     }
 
     return new Tuple(file.getInt(CxxMetric.PUBLIC_API), file.getInt(CxxMetric.PUBLIC_UNDOCUMENTED_API));
@@ -104,9 +104,9 @@ public class CxxPublicApiVisitorTest {
   @Test
   public void test_no_matching_suffix() throws IOException {
     CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/metrics/doxygen_example.h", ".",
-        "");
+      "");
     CxxLanguage language = CxxFileTesterHelper.mockCxxLanguage();
-    when(language.getHeaderFileSuffixes()).thenReturn(new String[] { ".hpp" });
+    when(language.getHeaderFileSuffixes()).thenReturn(new String[]{".hpp"});
 
     SourceFile file = CxxAstScanner.scanSingleFile(tester.cxxFile, tester.sensorContext, language);
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
@@ -121,7 +121,7 @@ public class CxxPublicApiVisitorTest {
 
   @Test
   public void to_delete() throws IOException {
-    assertThat(testFile("src/test/resources/metrics/public_api.h", true)).isEqualTo(tuple(43, 0));
+    assertThat(testFile("src/test/resources/metrics/public_api.h", true)).isEqualTo(tuple(44, 0));
 
   }
 
@@ -132,7 +132,7 @@ public class CxxPublicApiVisitorTest {
 
   @Test
   public void template() throws IOException {
-    assertThat(testFile("src/test/resources/metrics/template.h", false)).isEqualTo(tuple(14, 4));
+    assertThat(testFile("src/test/resources/metrics/template.h", false)).isEqualTo(tuple(13, 4));
   }
 
   @Test
@@ -161,6 +161,7 @@ public class CxxPublicApiVisitorTest {
     final Map<String, String> expectedIdCommentMap = new HashMap<>();
 
     expectedIdCommentMap.put("publicDefinedMethod", "publicDefinedMethod");
+    expectedIdCommentMap.put("publicDeclaredMethod", "publicDeclaredMethod");
     expectedIdCommentMap.put("aliasDeclaration", "aliasDeclaration");
     expectedIdCommentMap.put("publicMethod", "publicMethod");
     expectedIdCommentMap.put("testStruct", "testStruct");

--- a/cxx-squid/src/test/resources/metrics/public_api.h
+++ b/cxx-squid/src/test/resources/metrics/public_api.h
@@ -1,136 +1,150 @@
 #define TEST_MACRO() \
-	macro
+    macro
 
 /**
  testClass doc
  */
 class testClass
 {
-	void defaultMethod();
+    void defaultMethod();
 
 public:
-	// comment
-	
-	/// aliasDeclaration
-	using aliasDeclaration = int;
+    // comment
 
-	/** publicMethod doc */
-	void publicMethod();
-	
-	/// classEnum doc
-	enum classEnum {
-		classEnumValue ///< classEnumValue doc
-	}
-	/// block enumVar doc
-	enumVar; ///< inline enumVar doc, invalid ?
-	 
-	 /**
-	 publicAttribute doc
-	 */
-	int publicAttribute;
-	 
-	int inlineCommentedAttr; //!< inlineCommentedAttr comment 
+    /// aliasDeclaration
+    using aliasDeclaration = int;
 
-	void inlinePublicMethod(); //!< inlinePublicMethod comment
-	
-	int attr1, //!< attr1 doc 
-	attr2; ///< attr2 doc
+    /** publicMethod doc */
+    void publicMethod();
 
-	// ignore friend declaration
-	template<typename S> friend S& operator<<(S&, A const&);
+    /// classEnum doc
+    enum classEnum {
+        classEnumValue ///< classEnumValue doc
+    }
+    /// block enumVar doc
+    enumVar; ///< inline enumVar doc, invalid ?
 
-	friend class friendClass;
+    /**
+     publicAttribute doc
+     */
+    int publicAttribute;
 
-  // ignore deleted methods
-	A(A const&) = delete;
+    int inlineCommentedAttr; //!< inlineCommentedAttr comment 
 
-  // ignore defaulted methods
-	A& operator=(A const&) = default;
+    void inlinePublicMethod(); //!< inlinePublicMethod comment
 
-	/**
-	 * publicDefinedMethod comment
-	 */
-	void publicDefinedMethod() { }
+    int attr1, //!< attr1 doc 
+        attr2; ///< attr2 doc
+
+    // ignore friend declaration
+    template<typename S> friend S& operator<<(S&, A const&);
+
+    friend class friendClass;
+
+    // ignore deleted methods
+    A(A const&) = delete;
+
+    // ignore defaulted methods
+    A& operator=(A const&) = default;
+
+    /**
+     * publicDefinedMethod comment
+     */
+    void publicDefinedMethod() { }
+
+    /**
+     * publicDeclaredMethod comment
+     */
+    void publicDeclaredMethod();
+
 protected:
-	/**
-	 protectedMethod doc
-	 */
-	virtual void protectedMethod();
 
-	virtual void overriddenMethod() override; // no doc is OK, it could come from ancestor
+    /**
+     protectedMethod doc
+     */
+    virtual void protectedMethod();
 
-	/**
-	  protectedStruct doc
-	*/
-	struct protectedStruct {
-	   int protectedStructField; ///< protectedStructField doc
-	   int protectedStructField2; ///< protectedStructField2 doc  
-	};
-	 
-	/*!
-	  protectedClass doc
-	*/
-	class protectedClass {
-	};
-	 
-	/**
-	  operator doc
-	*/
-	value_t& operator[](std::size_t idx);
-	 
+    virtual void overriddenMethod() override; // no doc is OK, it could come from ancestor
+
+    /**
+     protectedStruct doc
+     */
+    struct protectedStruct {
+        int protectedStructField; ///< protectedStructField doc
+        int protectedStructField2; ///< protectedStructField2 doc  
+    };
+
+    /*!
+     protectedClass doc
+     */
+    class protectedClass {
+    };
+
+    /**
+     operator doc
+     */
+    value_t& operator[](std::size_t idx);
+
 private:
-	void privateMethod();
-	
-	enum privateEnum {
-		privateEnumVal
-	};
-	
-	struct privateStruct {
-		int privateStructField;
-	};
-	
-	class privateClass {
-		int i;
-	};
-	
-	union privateUnion {
-		int u;
-	};
-	
-	using privateAliasDeclaration = int;
+
+    void privateMethod();
+
+    enum privateEnum {
+        privateEnumVal
+    };
+
+    struct privateStruct {
+        int privateStructField;
+    };
+
+    class privateClass {
+        int i;
+    };
+
+    union privateUnion {
+        int u;
+    };
+
+    using privateAliasDeclaration = int;
 
 public:
-	int inlineCommentedLastAttr; //!< inlineCommentedLastAttr comment
+
+    int inlineCommentedLastAttr; //!< inlineCommentedLastAttr comment
 };
+
+inline void testClass::publicDeclaredMethod() {
+   // This method is defined and documented inside testClass
+   // and should not be marked as undocumented here.
+}
 
 /// testStruct doc
 struct testStruct {
-	int testField; /**< inline testField comment */
-	
-	/// testTypeDef
-	///
+    int testField; /**< inline testField comment */
+
+    /// testTypeDef
+    ///
     typedef toto<T> testTypeDef;
 
     /**
      * bitfield doc
      */
-    unsigned int bitfield:1;
+    unsigned int bitfield : 1;
 
 private:
-    void private_def(){}
+    void private_def() {}
 };
 
 /**
  globalVar doc
-*/
-extern int globalVar; 
+ */
+extern int globalVar;
 
 int globalVarInline; //!< globalVarInline doc 
 
 int
 /**
-globalVar1 doc
-*/
+ globalVar1 doc
+ */
 globalVar1,
 globalVar2, ///< globalVar2 doc
 globalVar3; /*!< globalVar3 doc */
@@ -146,24 +160,24 @@ typedef int testType; ///< testType doc
 
 /**
  testEnum doc
-*/
+ */
 enum testEnum
 {
-  /**
-  enum_val doc
-  */
-  enum_val
+    /**
+     enum_val doc
+     */
+    enum_val
 };
 
 enum testEnum enumVar1, ///< enumVar1 doc
-/**
- enumVar2 doc
-*/ 
-enumVar2;
+   /**
+    enumVar2 doc
+    */
+    enumVar2;
 
 /*!
  testUnion doc
-*/
+ */
 union testUnion
 {
 
@@ -173,7 +187,7 @@ union testUnion
  * <unnamed> doc
  */
 struct {
-	int testField2; /**< inline testField2 comment */
+    int testField2; /**< inline testField2 comment */
 } testUnnamedStructVar; ///< testUnnamedStructVar doc
 
 int lastVar; ///< lastVar doc

--- a/cxx-squid/src/test/resources/metrics/template.h
+++ b/cxx-squid/src/test/resources/metrics/template.h
@@ -56,13 +56,12 @@ public:
    void functionTest2();
 };
 
-/**
- * @brief DOCUMENTATION
- */
 template <class U>
 template <class T>
 void TestClass2::functionTest2()
 {
+   // This method is defined and documented inside TestClass2
+   // and should not be marked as undocumented here.
 }
 
 /**

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UndocumentedApi.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UndocumentedApi.html
@@ -34,7 +34,7 @@ class DocumentedClass {
   public:
 
     DocumentedClass() = default;
-    DocumentedClass& operator(const DocumentedClass&) = delete;
+    DocumentedClass&amp; operator(const DocumentedClass&amp;) = delete;
 
     int commentedVar; ///< documentation
 
@@ -51,6 +51,6 @@ class DocumentedClass {
 
 void DocumentedClass::apiMethod()
 {
-   // documentation should be inside of the class
+   // documentation should be within the class definition
 }
 </pre>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UndocumentedApi.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UndocumentedApi.html
@@ -7,21 +7,19 @@
 <ul>
   <li>Member functions marked with identifier <b>override</b>. Assumption is that they are documented in the base class.</li>
   <li>Member functions marked with specifier <b>delete</b> or <b>default</b>.</li>
-  <li>Function definitions with a qualified name outside of a class. Assumption is that they are already documented inside of the class.</li>
+  <li>Member functions defined outside of a class/struct. Assumption is that they are already documented inside of the class.</li>
 </ul>
 
 <p>Following items are considered as public API:</p>
 <ul>
-  <li>classes/structures/templates</li>
-  <li>class members (public and protected)</li>
-  <li>structure members</li>
-  <li>union members</li>
-  <li>enumerations</li>
-  <li>enumeration values</li>
-  <li>typedefs</li>
-  <li>alias declaration (<code>using MyAlias = int;</code>)</li>
-  <li>functions</li>
-  <li>variables</li>
+  <li>classes/structures/unions</li>
+  <li>class/structure/union members (public and protected only)</li>
+  <li>template declarations</li>
+  <li>enumeration declarations</li>
+  <li>enumeration definitions</li>
+  <li>typedef/alias declarations</li>  
+  <li>functions (global scope)</li>
+  <li>variables (global scope)</li>  
 </ul>
 
 <p>The following code illustrates a well documented class:</p>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UndocumentedApi.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UndocumentedApi.html
@@ -1,17 +1,44 @@
 <p>
-Public APIs have to be documented in order to be used by customers.<br>
-APIs documentation is typically generated using a tool, such as <a href="http://www.stack.nl/~dimitri/doxygen/index.html">Doxygen</a>.
+  Public APIs have to be documented in order to be used by customers.<br>
+  APIs documentation is typically generated using a tool, such as <a href="http://www.stack.nl/~dimitri/doxygen/index.html">Doxygen</a>.
 </p>
+
+<p>Exceptions that do not require documentation:</p>
+<ul>
+  <li>Member functions marked with identifier <b>override</b>. Assumption is that they are documented in the base class.</li>
+  <li>Member functions marked with specifier <b>delete</b> or <b>default</b>.</li>
+  <li>Function definitions with a qualified name outside of a class. Assumption is that they are already documented inside of the class.</li>
+</ul>
+
+<p>Following items are considered as public API:</p>
+<ul>
+  <li>classes/structures/templates</li>
+  <li>class members (public and protected)</li>
+  <li>structure members</li>
+  <li>union members</li>
+  <li>enumerations</li>
+  <li>enumeration values</li>
+  <li>typedefs</li>
+  <li>alias declaration (<code>using MyAlias = int;</code>)</li>
+  <li>functions</li>
+  <li>variables</li>
+</ul>
 
 <p>The following code illustrates a well documented class:</p>
 
 <pre>
 /**
   class documentation
-/*
+ */
 class DocumentedClass {
   public:
+
+    DocumentedClass() = default;
+    DocumentedClass& operator(const DocumentedClass&) = delete;
+
     int commentedVar; ///< documentation
+
+    void apiFromBaseClass() = override;
 
     /**
       apiMethod documentation
@@ -21,4 +48,9 @@ class DocumentedClass {
   private:
     void notInApiMethod();
 };
+
+void DocumentedClass::apiMethod()
+{
+   // documentation should be inside of the class
+}
 </pre>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UndocumentedApi.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UndocumentedApi.html
@@ -34,7 +34,7 @@ class DocumentedClass {
   public:
 
     DocumentedClass() = default;
-    DocumentedClass& operator(const DocumentedClass&) = delete;
+    DocumentedClass&amp; operator(const DocumentedClass&amp;) = delete;
 
     int commentedVar; ///< documentation
 
@@ -51,6 +51,6 @@ class DocumentedClass {
 
 void DocumentedClass::apiMethod()
 {
-   // documentation should be inside of the class
+   // documentation should be within the class definition
 }
 </pre>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UndocumentedApi.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UndocumentedApi.html
@@ -7,21 +7,19 @@
 <ul>
   <li>Member functions marked with identifier <b>override</b>. Assumption is that they are documented in the base class.</li>
   <li>Member functions marked with specifier <b>delete</b> or <b>default</b>.</li>
-  <li>Function definitions with a qualified name outside of a class. Assumption is that they are already documented inside of the class.</li>
+  <li>Member functions defined outside of a class/struct. Assumption is that they are already documented inside of the class.</li>
 </ul>
 
 <p>Following items are considered as public API:</p>
 <ul>
-  <li>classes/structures/templates</li>
-  <li>class members (public and protected)</li>
-  <li>structure members</li>
-  <li>union members</li>
-  <li>enumerations</li>
-  <li>enumeration values</li>
-  <li>typedefs</li>
-  <li>alias declaration (<code>using MyAlias = int;</code>)</li>
-  <li>functions</li>
-  <li>variables</li>
+  <li>classes/structures/unions</li>
+  <li>class/structure/union members (public and protected only)</li>
+  <li>template declarations</li>
+  <li>enumeration declarations</li>
+  <li>enumeration definitions</li>
+  <li>typedef/alias declarations</li>  
+  <li>functions (global scope)</li>
+  <li>variables (global scope)</li>  
 </ul>
 
 <p>The following code illustrates a well documented class:</p>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UndocumentedApi.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UndocumentedApi.html
@@ -1,17 +1,44 @@
 <p>
-Public APIs have to be documented in order to be used by customers.<br>
-APIs documentation is typically generated using a tool, such as <a href="http://www.stack.nl/~dimitri/doxygen/index.html">Doxygen</a>.
+  Public APIs have to be documented in order to be used by customers.<br>
+  APIs documentation is typically generated using a tool, such as <a href="http://www.stack.nl/~dimitri/doxygen/index.html">Doxygen</a>.
 </p>
+
+<p>Exceptions that do not require documentation:</p>
+<ul>
+  <li>Member functions marked with identifier <b>override</b>. Assumption is that they are documented in the base class.</li>
+  <li>Member functions marked with specifier <b>delete</b> or <b>default</b>.</li>
+  <li>Function definitions with a qualified name outside of a class. Assumption is that they are already documented inside of the class.</li>
+</ul>
+
+<p>Following items are considered as public API:</p>
+<ul>
+  <li>classes/structures/templates</li>
+  <li>class members (public and protected)</li>
+  <li>structure members</li>
+  <li>union members</li>
+  <li>enumerations</li>
+  <li>enumeration values</li>
+  <li>typedefs</li>
+  <li>alias declaration (<code>using MyAlias = int;</code>)</li>
+  <li>functions</li>
+  <li>variables</li>
+</ul>
 
 <p>The following code illustrates a well documented class:</p>
 
 <pre>
 /**
   class documentation
-/*
+ */
 class DocumentedClass {
   public:
+
+    DocumentedClass() = default;
+    DocumentedClass& operator(const DocumentedClass&) = delete;
+
     int commentedVar; ///< documentation
+
+    void apiFromBaseClass() = override;
 
     /**
       apiMethod documentation
@@ -21,4 +48,9 @@ class DocumentedClass {
   private:
     void notInApiMethod();
 };
+
+void DocumentedClass::apiMethod()
+{
+   // documentation should be inside of the class
+}
 </pre>


### PR DESCRIPTION
* add exception: Function definitions with a qualified name outside of a class. Assumption is that they are already documented inside of the class.
* close #1543, #1544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1580)
<!-- Reviewable:end -->
