### PR TITLE
use StandardCharsets instead of Charset.forName()

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/ReservedNamesCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/ReservedNamesCheck.java
@@ -24,6 +24,7 @@ import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -52,7 +53,7 @@ import org.sonar.squidbridge.checks.SquidCheck;
 public class ReservedNamesCheck extends SquidCheck<Grammar> implements CxxCharsetAwareVisitor {
 
   private static final String[] keywords = CxxKeyword.keywordValues();
-  private Charset charset = Charset.forName("UTF-8");
+  private Charset charset = StandardCharsets.UTF_8;
   private static final Pattern DEFINE_DECLARATION_PATTERN = Pattern.compile("^\\s*#define\\s+([^\\s(]+).*$");
 
 

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectIncludeCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectIncludeCheck.java
@@ -24,6 +24,7 @@ import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.sonar.check.Priority;
@@ -49,7 +50,7 @@ public class UseCorrectIncludeCheck extends SquidCheck<Grammar> implements CxxCh
 
   private static final String REGULAR_EXPRESSION = "#include\\s+(?>\"|\\<)[\\\\/\\.]+";
   private Pattern pattern = null;
-  private Charset charset = Charset.forName("UTF-8");
+  private Charset charset = StandardCharsets.UTF_8;
 
   @Override
   public void init() {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/file/FileEncodingCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/file/FileEncodingCheck.java
@@ -23,6 +23,7 @@ import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
@@ -45,7 +46,7 @@ import org.sonar.squidbridge.checks.SquidCheck;
 public class FileEncodingCheck extends SquidCheck<Grammar> implements CxxCharsetAwareVisitor {
 
   private static final Logger LOG = Loggers.get(FileEncodingCheck.class);
-  private Charset charset = Charset.forName("UTF-8");
+  private Charset charset = StandardCharsets.UTF_8;
 
   @Override
   public void setCharset(Charset charset) {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/file/TabCharacterCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/file/TabCharacterCheck.java
@@ -24,6 +24,7 @@ import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
@@ -48,7 +49,7 @@ import org.sonar.squidbridge.checks.SquidCheck;
 public class TabCharacterCheck extends SquidCheck<Grammar> implements CxxCharsetAwareVisitor {
 
   private static final boolean DEFAULT_CREATE_LINE_VIOLATION = false;
-  private Charset charset = Charset.forName("UTF-8");
+  private Charset charset = StandardCharsets.UTF_8;
 
   /**
    * createLineViolation

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/TooLongLineCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/TooLongLineCheck.java
@@ -24,6 +24,7 @@ import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
@@ -68,7 +69,7 @@ public class TooLongLineCheck extends SquidCheck<Grammar> implements CxxCharsetA
     defaultValue = "" + DEFAULT_TAB_WIDTH)
   public int tabWidth = DEFAULT_TAB_WIDTH;
 
-  private Charset charset = Charset.forName("UTF-8");
+  private Charset charset = StandardCharsets.UTF_8;
 
   @Override
   public void setCharset(Charset charset) {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/regex/FileHeaderCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/regex/FileHeaderCheck.java
@@ -24,6 +24,7 @@ import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -72,7 +73,7 @@ public class FileHeaderCheck extends SquidCheck<Grammar> implements CxxCharsetAw
     defaultValue = "false")
   public boolean isRegularExpression;
 
-  private Charset charset = Charset.forName("UTF-8");
+  private Charset charset = StandardCharsets.UTF_8;
   private String[] expectedLines = null;
   private Pattern searchPattern = null;
 

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/regex/FileRegularExpressionCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/regex/FileRegularExpressionCheck.java
@@ -29,6 +29,7 @@ import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -60,7 +61,7 @@ public class FileRegularExpressionCheck extends SquidCheck<Grammar> implements C
   private static final boolean DEFAULT_INVERT_REGULAR_EXPRESSION = false;
   private static final String DEFAULT_MESSAGE = "The regular expression matches this file";
 
-  private Charset charset = Charset.forName("UTF-8");
+  private Charset charset = StandardCharsets.UTF_8;
   private CharsetDecoder decoder = null;
   private Pattern pattern = null;
 

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/regex/LineRegularExpressionCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/regex/LineRegularExpressionCheck.java
@@ -24,6 +24,7 @@ import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -56,7 +57,7 @@ public class LineRegularExpressionCheck extends SquidCheck<Grammar> implements C
   private static final boolean DEFAULT_INVERT_REGULAR_EXPRESSION = false;
   private static final String DEFAULT_MESSAGE = "The regular expression matches this line";
 
-  private Charset charset = Charset.forName("UTF-8");
+  private Charset charset = StandardCharsets.UTF_8;
   private Pattern pattern = null;
 
   /**

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/file/FileEncodingCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/file/FileEncodingCheckTest.java
@@ -22,6 +22,7 @@ package org.sonar.cxx.checks.file;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 import org.sonar.cxx.CxxAstScanner;
@@ -38,9 +39,9 @@ public class FileEncodingCheckTest {
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion
   public void testAsciiFileAsciiEncoding() throws UnsupportedEncodingException, IOException {
-    Charset charset = Charset.forName("US-ASCII");
+    Charset charset = StandardCharsets.US_ASCII;
     CxxConfiguration cxxConfig = new CxxConfiguration(charset);
-    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/checks/TabCharacter.cc", ".", Charset.forName("US-ASCII"));
+    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/checks/TabCharacter.cc", ".", StandardCharsets.US_ASCII);
     SourceFile file = CxxAstScanner.scanSingleFileConfig(CxxFileTesterHelper.mockCxxLanguage(), tester.cxxFile, cxxConfig, check);
 
     CheckMessagesVerifier.verify(file.getCheckMessages())
@@ -50,9 +51,9 @@ public class FileEncodingCheckTest {
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion
   public void testAsciiFileUtf8Encoding() throws UnsupportedEncodingException, IOException {
-    Charset charset = Charset.forName("UTF-8");
+    Charset charset = StandardCharsets.UTF_8;
     CxxConfiguration cxxConfig = new CxxConfiguration(charset);
-    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/checks/TabCharacter.cc", ".", Charset.forName("UTF-8"));
+    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/checks/TabCharacter.cc", ".", StandardCharsets.UTF_8);
     SourceFile file = CxxAstScanner.scanSingleFileConfig(CxxFileTesterHelper.mockCxxLanguage(), tester.cxxFile, cxxConfig, check);
 
     CheckMessagesVerifier.verify(file.getCheckMessages())
@@ -62,9 +63,9 @@ public class FileEncodingCheckTest {
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion
   public void testUnicodeFileUtf16Encoding() throws UnsupportedEncodingException, IOException {
-    Charset charset = Charset.forName("UTF-16");
+    Charset charset = StandardCharsets.UTF_16;
     CxxConfiguration cxxConfig = new CxxConfiguration(charset);
-    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/checks/Unicode.cc", ".", Charset.forName("UTF-16"));
+    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/checks/Unicode.cc", ".", StandardCharsets.UTF_16);
     SourceFile file = CxxAstScanner.scanSingleFileConfig(CxxFileTesterHelper.mockCxxLanguage(), tester.cxxFile, cxxConfig, check);
     CheckMessagesVerifier.verify(file.getCheckMessages())
       .noMore();
@@ -73,9 +74,9 @@ public class FileEncodingCheckTest {
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion
   public void testUnicodeFileAsciiEncoding() throws IOException {
-    Charset charset = Charset.forName("US-ASCII");
+    Charset charset = StandardCharsets.US_ASCII;
     CxxConfiguration cxxConfig = new CxxConfiguration(charset);
-    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/checks/Unicode.cc", ".", Charset.forName("US-ASCII"));
+    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/checks/Unicode.cc", ".", StandardCharsets.US_ASCII);
     SourceFile file = CxxAstScanner.scanSingleFileConfig(CxxFileTesterHelper.mockCxxLanguage(), tester.cxxFile, cxxConfig, check);
     CheckMessagesVerifier.verify(file.getCheckMessages())
       .next().withMessage("Not all characters of the file can be encoded with the predefined charset " + charset.name() + ".")

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/FileRegularExpressionCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/FileRegularExpressionCheckTest.java
@@ -22,6 +22,7 @@ package org.sonar.cxx.checks.regex;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 import org.sonar.cxx.CxxAstScanner;
@@ -51,7 +52,7 @@ public class FileRegularExpressionCheckTest {
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion
   public void fileRegExInvertWithoutFilePattern() throws UnsupportedEncodingException, IOException {
     FileRegularExpressionCheck check = new FileRegularExpressionCheck();
-    Charset charset = Charset.forName("UTF-8");
+    Charset charset = StandardCharsets.UTF_8;
     CxxConfiguration cxxConfig = new CxxConfiguration(charset);
     check.regularExpression = "stdafx\\.h";
     check.invertRegularExpression = true;
@@ -69,12 +70,12 @@ public class FileRegularExpressionCheckTest {
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion
   public void fileRegExCodingErrorActionReplace() throws UnsupportedEncodingException, IOException {
     FileRegularExpressionCheck check = new FileRegularExpressionCheck();
-    Charset charset = Charset.forName("US-ASCII");
+    Charset charset = StandardCharsets.US_ASCII;
     CxxConfiguration cxxConfig = new CxxConfiguration(charset);
     check.regularExpression = "stdafx\\.h";
     check.message = "Found 'stdafx.h' in file!";
 
-    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/checks/FileRegEx.cc", ".", Charset.forName("US-ASCII"));
+    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/checks/FileRegEx.cc", ".", StandardCharsets.US_ASCII);
 
     SourceFile file = CxxAstScanner.scanSingleFileConfig(CxxFileTesterHelper.mockCxxLanguage(), tester.cxxFile, cxxConfig, check);
     CheckMessagesVerifier.verify(file.getCheckMessages())
@@ -86,7 +87,7 @@ public class FileRegularExpressionCheckTest {
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion
   public void fileRegExWithFilePattern() throws UnsupportedEncodingException, IOException {
     FileRegularExpressionCheck check = new FileRegularExpressionCheck();
-    Charset charset = Charset.forName("UTF-8");
+    Charset charset = StandardCharsets.UTF_8;
     CxxConfiguration cxxConfig = new CxxConfiguration(charset);
     check.matchFilePattern = "/**/*.cc"; // all files with .cc file extension
     check.regularExpression = "#include\\s+\"stdafx\\.h\"";
@@ -104,7 +105,7 @@ public class FileRegularExpressionCheckTest {
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion
   public void fileRegExInvertWithFilePatternInvert() throws UnsupportedEncodingException, IOException {
     FileRegularExpressionCheck check = new FileRegularExpressionCheck();
-    Charset charset = Charset.forName("UTF-8");
+    Charset charset = StandardCharsets.UTF_8;
     CxxConfiguration cxxConfig = new CxxConfiguration(charset);
     check.matchFilePattern = "/**/*.h"; // all files with not .h file extension
     check.invertFilePattern = true;

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/CxxDrMemorySensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/CxxDrMemorySensorTest.java
@@ -20,6 +20,8 @@
 package org.sonar.cxx.sensors.drmemory;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.assertj.core.api.SoftAssertions;
@@ -50,7 +52,7 @@ public class CxxDrMemorySensorTest {
   public void shouldIgnoreAViolationWhenTheResourceCouldntBeFoundV1() {
 
     DefaultInputFile inputFile = TestInputFileBuilder.create("ProjectKey", "sources/utils/code_chunks.cpp")
-      .initMetadata("asd\nasdas\nasda\n").setCharset(Charset.forName("UTF-8")).build();
+      .initMetadata("asd\nasdas\nasda\n").setCharset(StandardCharsets.UTF_8).build();
 
     SensorContextTester context = SensorContextTester.create(fs.baseDir());
     context.settings().setProperty(language.getPluginProperty(CxxDrMemorySensor.REPORT_PATH_KEY),

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/TestUtils.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/TestUtils.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -89,7 +90,7 @@ public class TestUtils {
     List<File> sourceDirs,
     List<File> testDirs) {
     DefaultFileSystem fs = new DefaultFileSystem(baseDir);
-    fs.setEncoding(Charset.forName("UTF-8"));
+    fs.setEncoding(StandardCharsets.UTF_8);
     scanDirs(fs, sourceDirs, Type.MAIN);
     scanDirs(fs, testDirs, Type.TEST);
     return fs;

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxCpdVisitorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxCpdVisitorTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,7 +53,7 @@ public class CxxCpdVisitorTest {
 
     String content = new String(Files.readAllBytes(target.toPath()), "UTF-8");
     inputFile = TestInputFileBuilder.create("moduleKey", baseDir, target).setType(InputFile.Type.MAIN)
-      .setContents(content).setCharset(Charset.forName("UTF-8")).build();
+      .setContents(content).setCharset(StandardCharsets.UTF_8).build();
 
     context = SensorContextTester.create(baseDir);
     context.fileSystem().add(inputFile);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxFileLinesVisitorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxFileLinesVisitorTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Set;
@@ -76,7 +77,7 @@ public class CxxFileLinesVisitorTest {
   public void TestLinesOfCode() throws UnsupportedEncodingException, IOException {
     String content = new String(Files.readAllBytes(target.toPath()), "UTF-8");
     DefaultInputFile inputFile = TestInputFileBuilder.create("ProjectKey", baseDir, target).setContents(content)
-      .setCharset(Charset.forName("UTF-8")).setLanguage(language.getKey())
+      .setCharset(StandardCharsets.UTF_8).setLanguage(language.getKey())
       .setType(InputFile.Type.MAIN).build();
 
     SensorContextTester sensorContext = SensorContextTester.create(baseDir);
@@ -97,7 +98,7 @@ public class CxxFileLinesVisitorTest {
   public void TestLinesOfComments() throws UnsupportedEncodingException, IOException {
     String content = new String(Files.readAllBytes(target.toPath()), "UTF-8");
     DefaultInputFile inputFile = TestInputFileBuilder.create("ProjectKey", baseDir, target).setContents(content)
-      .setCharset(Charset.forName("UTF-8")).setLanguage(language.getKey())
+      .setCharset(StandardCharsets.UTF_8).setLanguage(language.getKey())
       .setType(InputFile.Type.MAIN).build();
 
     SensorContextTester sensorContext = SensorContextTester.create(baseDir);
@@ -117,7 +118,7 @@ public class CxxFileLinesVisitorTest {
 
     String content = new String(Files.readAllBytes(target.toPath()), "UTF-8");
     DefaultInputFile inputFile = TestInputFileBuilder.create("ProjectKey", baseDir, target).setContents(content)
-      .setCharset(Charset.forName("UTF-8")).setLanguage(language.getKey())
+      .setCharset(StandardCharsets.UTF_8).setLanguage(language.getKey())
       .setType(InputFile.Type.MAIN).build();
 
     SensorContextTester sensorContext = SensorContextTester.create(baseDir);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxHighlighterTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxHighlighterTest.java
@@ -22,6 +22,7 @@ package org.sonar.cxx.sensors.visitors;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,7 +48,7 @@ public class CxxHighlighterTest {
 
     String content = new String(Files.readAllBytes(target.toPath()), "UTF-8");
     DefaultInputFile inputFile = TestInputFileBuilder.create("ProjectKey", baseDir, target)
-      .setContents(content).setCharset(Charset.forName("UTF-8")).build();
+      .setContents(content).setCharset(StandardCharsets.UTF_8).build();
 
     context = SensorContextTester.create(baseDir);
     context.fileSystem().add(inputFile);

--- a/cxx-sensors/src/test/java/org/sonar/plugins/cxx/squid/CxxSquidSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/plugins/cxx/squid/CxxSquidSensorTest.java
@@ -22,6 +22,7 @@ package org.sonar.plugins.cxx.squid;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Optional;
 
@@ -78,7 +79,7 @@ public class CxxSquidSensorTest {
     File target = new File(baseDir, fileName);
     String content = new String(Files.readAllBytes(target.toPath()), "UTF-8");
     DefaultInputFile inputFile = TestInputFileBuilder.create("ProjectKey", baseDir, target).setContents(content)
-      .setCharset(Charset.forName("UTF-8")).setLanguage(language.getKey())
+      .setCharset(StandardCharsets.UTF_8).setLanguage(language.getKey())
       .setType(InputFile.Type.MAIN).build();
     return inputFile;
   }


### PR DESCRIPTION
* class `StandardCharsets` provides constants, which help to avoid typos
  (compile-time check vs run-time check) and reduce number
  of lookups

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1603)
<!-- Reviewable:end -->
