### PR TITLE
unify checks for user-provided regular expressions + random refactoring

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/HardcodedAccountCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/HardcodedAccountCheck.java
@@ -21,13 +21,12 @@ package org.sonar.cxx.checks;
 
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
+import org.sonar.cxx.checks.utils.CheckUtils;
 import org.sonar.cxx.parser.CxxGrammarImpl;
 import org.sonar.cxx.tag.Tag;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
@@ -67,16 +66,8 @@ public class HardcodedAccountCheck extends SquidCheck<Grammar> {
 
   @Override
   public void init() {
-    Objects.requireNonNull(regularExpression, "getRegularExpression() should not return null");
-
-    if (!regularExpression.isEmpty()) {
-      try {
-        pattern = Pattern.compile(regularExpression);
-      } catch (PatternSyntaxException e) {
-        throw new IllegalStateException("Unable to compile regular expression: " + regularExpression, e);
-      }
-      subscribeTo(CxxGrammarImpl.LITERAL);
-    }
+    pattern = CheckUtils.compileUserRegexp(regularExpression);
+    subscribeTo(CxxGrammarImpl.LITERAL);
   }
 
   @Override

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/HardcodedIpCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/HardcodedIpCheck.java
@@ -24,10 +24,10 @@ import com.sonar.sslr.api.Grammar;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
+import org.sonar.cxx.checks.utils.CheckUtils;
 import org.sonar.cxx.parser.CxxGrammarImpl;
 import org.sonar.cxx.tag.Tag;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
@@ -65,16 +65,8 @@ public class HardcodedIpCheck extends SquidCheck<Grammar> {
 
   @Override
   public void init() {
-    Objects.requireNonNull(regularExpression, "getRegularExpression() should not return null");
-
-    if (!regularExpression.isEmpty()) {
-      try {
-        pattern = Pattern.compile(regularExpression);
-      } catch (PatternSyntaxException e) {
-        throw new IllegalStateException("Unable to compile regular expression: " + regularExpression, e);
-      }
-      subscribeTo(CxxGrammarImpl.LITERAL);
-    }
+    pattern = CheckUtils.compileUserRegexp(regularExpression);
+    subscribeTo(CxxGrammarImpl.LITERAL);
   }
 
   @Override

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/SwitchLastCaseIsDefaultCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/SwitchLastCaseIsDefaultCheck.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import static org.sonar.cxx.checks.utils.CheckUtils.isSwitchStatement;
+import org.sonar.cxx.api.CxxKeyword;
 import org.sonar.cxx.parser.CxxGrammarImpl;
 import org.sonar.cxx.tag.Tag;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
@@ -48,7 +49,6 @@ public class SwitchLastCaseIsDefaultCheck extends SquidCheck<Grammar> {
 
   private static final String MISSING_DEFAULT_CASE_MESSAGE = "Add a default case to this switch.";
   private static final String DEFAULT_CASE_IS_NOT_LAST_MESSAGE = "Move this default to the end of the switch.";
-  private static final String DEFAULT_CASE_TOKENVALUE = "default";
 
   private static void getSwitchCases(List<AstNode> result, AstNode node) {
     if (isSwitchStatement(node)) {
@@ -76,7 +76,7 @@ public class SwitchLastCaseIsDefaultCheck extends SquidCheck<Grammar> {
       AstNode defaultCase = null;
 
       for (AstNode switchCase : switchCases) {
-        if (switchCase.getTokenValue().equals(DEFAULT_CASE_TOKENVALUE)) {
+        if (CxxKeyword.DEFAULT.equals(switchCase.getToken().getType())) {
           defaultCase = switchCase;
           break;
         }

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectIncludeCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectIncludeCheck.java
@@ -49,17 +49,8 @@ import org.sonar.squidbridge.checks.SquidCheck;
 public class UseCorrectIncludeCheck extends SquidCheck<Grammar> implements CxxCharsetAwareVisitor {
 
   private static final String REGULAR_EXPRESSION = "#include\\s+(?>\"|\\<)[\\\\/\\.]+";
-  private Pattern pattern = null;
+  private static Pattern pattern = Pattern.compile(REGULAR_EXPRESSION, Pattern.DOTALL);
   private Charset charset = StandardCharsets.UTF_8;
-
-  @Override
-  public void init() {
-    try {
-      pattern = Pattern.compile(REGULAR_EXPRESSION, Pattern.DOTALL);
-    } catch (RuntimeException e) {
-      throw new IllegalStateException("Unable to compile regular expression: " + REGULAR_EXPRESSION, e);
-    }
-  }
 
   @Override
   public void visitFile(AstNode astNode) {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/UsingNamespaceInHeaderCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/UsingNamespaceInHeaderCheck.java
@@ -23,6 +23,7 @@ import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
+import org.sonar.cxx.api.CxxKeyword;
 import org.sonar.cxx.parser.CxxGrammarImpl;
 import org.sonar.cxx.tag.Tag;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
@@ -63,9 +64,12 @@ public class UsingNamespaceInHeaderCheck extends SquidCheck<Grammar> {
 
   @Override
   public void visitNode(AstNode node) {
-    if (isHeader
-      && "using".equals(node.getTokenValue()) && node.getFirstChild().getChildren().toString().contains("namespace")) {
-      getContext().createLineViolation(this, "Using namespace are not allowed in header files.", node);
+    if (isHeader && CxxKeyword.USING.equals(node.getToken().getType())) {
+      final boolean containsNamespace = node.getFirstChild().getChildren().stream()
+          .anyMatch(childNode -> CxxKeyword.NAMESPACE.equals(childNode.getToken().getType()));
+      if (containsNamespace) {
+        getContext().createLineViolation(this, "Using namespace are not allowed in header files.", node);
+      }
     }
   }
 

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/file/MissingNewLineAtEndOfFileCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/file/MissingNewLineAtEndOfFileCheck.java
@@ -23,7 +23,6 @@ import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.nio.charset.StandardCharsets;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.cxx.tag.Tag;
@@ -45,21 +44,15 @@ public class MissingNewLineAtEndOfFileCheck extends SquidCheck<Grammar> {
       return false;
     }
     randomAccessFile.seek(randomAccessFile.length() - 1);
-    byte[] chars = new byte[1];
-    if (randomAccessFile.read(chars) < 1) {
-      return false;
-    }
-    String ch = new String(chars, StandardCharsets.UTF_8);
-    return "\n".equals(ch) || "\r".equals(ch);
+    byte lastByte = randomAccessFile.readByte();
+    return lastByte == '\n' || lastByte == '\r';
   }
 
   @Override
   public void visitFile(AstNode astNode) {
-    try {
-      try (RandomAccessFile randomAccessFile = new RandomAccessFile(getContext().getFile(), "r")) {
-        if (!endsWithNewline(randomAccessFile)) {
-          getContext().createFileViolation(this, "Add a new line at the end of this file.");
-        }
+    try (RandomAccessFile randomAccessFile = new RandomAccessFile(getContext().getFile(), "r")) {
+      if (!endsWithNewline(randomAccessFile)) {
+        getContext().createFileViolation(this, "Add a new line at the end of this file.");
       }
     } catch (IOException e) {
       throw new IllegalStateException(e);

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/naming/ClassNameCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/naming/ClassNameCheck.java
@@ -25,6 +25,7 @@ import java.util.regex.Pattern;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
+import org.sonar.cxx.checks.utils.CheckUtils;
 import org.sonar.cxx.parser.CxxGrammarImpl;
 import org.sonar.cxx.tag.Tag;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
@@ -57,7 +58,7 @@ public class ClassNameCheck extends SquidCheck<Grammar> {
 
   @Override
   public void init() {
-    pattern = Pattern.compile(format);
+    pattern = CheckUtils.compileUserRegexp(format);
     subscribeTo(CxxGrammarImpl.classSpecifier);
   }
 

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/naming/FileNameCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/naming/FileNameCheck.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
+import org.sonar.cxx.checks.utils.CheckUtils;
 import org.sonar.cxx.tag.Tag;
 import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
 import org.sonar.squidbridge.checks.SquidCheck;
@@ -56,7 +57,7 @@ public class FileNameCheck extends SquidCheck<Grammar> {
 
   @Override
   public void init() {
-    pattern = Pattern.compile(format);
+    pattern = CheckUtils.compileUserRegexp(format);
   }
 
   @Override

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/naming/FunctionNameCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/naming/FunctionNameCheck.java
@@ -25,6 +25,7 @@ import java.util.regex.Pattern;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
+import org.sonar.cxx.checks.utils.CheckUtils;
 import org.sonar.cxx.parser.CxxGrammarImpl;
 import org.sonar.cxx.tag.Tag;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
@@ -69,7 +70,7 @@ public class FunctionNameCheck extends SquidCheck<Grammar> {
 
   @Override
   public void init() {
-    pattern = Pattern.compile(format);
+    pattern = CheckUtils.compileUserRegexp(format);
     subscribeTo(CxxGrammarImpl.functionDefinition);
   }
 

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/naming/MethodNameCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/naming/MethodNameCheck.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
+import org.sonar.cxx.checks.utils.CheckUtils;
 import org.sonar.cxx.parser.CxxGrammarImpl;
 import org.sonar.cxx.tag.Tag;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
@@ -128,7 +129,7 @@ public class MethodNameCheck extends SquidCheck<Grammar> {
 
   @Override
   public void init() {
-    pattern = Pattern.compile(format);
+    pattern = CheckUtils.compileUserRegexp(format);
     subscribeTo(CxxGrammarImpl.functionDefinition);
   }
 

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/regex/FileHeaderCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/regex/FileHeaderCheck.java
@@ -32,6 +32,7 @@ import java.util.regex.Pattern;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
+import org.sonar.cxx.checks.utils.CheckUtils;
 import org.sonar.cxx.visitors.CxxCharsetAwareVisitor;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
 import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
@@ -92,7 +93,7 @@ public class FileHeaderCheck extends SquidCheck<Grammar> implements CxxCharsetAw
     key = "isRegularExpression",
     description = "Whether the headerFormat is a regular expression",
     defaultValue = "false")
-  public boolean isRegularExpression;
+  public boolean isRegularExpression = false;
 
   private Charset charset = StandardCharsets.UTF_8;
   private String[] expectedLines = null;
@@ -106,17 +107,9 @@ public class FileHeaderCheck extends SquidCheck<Grammar> implements CxxCharsetAw
   @Override
   public void init() {
     if (isRegularExpression) {
-      if (searchPattern == null) {
-        try {
-          searchPattern = Pattern.compile(headerFormat, Pattern.DOTALL);
-        } catch (IllegalArgumentException e) {
-          throw new IllegalArgumentException("[" + getClass().getSimpleName()
-            + "] Unable to compile the regular expression: "
-            + headerFormat, e);
-        }
-      }
+      searchPattern = CheckUtils.compileUserRegexp(headerFormat, Pattern.DOTALL);
     } else {
-      expectedLines = headerFormat.split("(?:\r)?\n|\r");
+      expectedLines = headerFormat.split("\\R");
     }
   }
 

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/regex/LineRegularExpressionCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/regex/LineRegularExpressionCheck.java
@@ -28,12 +28,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 import org.sonar.api.utils.PathUtils;
 import org.sonar.api.utils.WildcardPattern;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
+import org.sonar.cxx.checks.utils.CheckUtils;
 import org.sonar.cxx.visitors.CxxCharsetAwareVisitor;
 import org.sonar.squidbridge.annotations.NoSqale;
 import org.sonar.squidbridge.annotations.RuleTemplate;
@@ -111,11 +111,7 @@ public class LineRegularExpressionCheck extends SquidCheck<Grammar> implements C
 
   @Override
   public void init() {
-    try {
-      pattern = Pattern.compile(regularExpression);
-    } catch (PatternSyntaxException e) {
-      throw new IllegalStateException(e);
-    }
+    pattern = CheckUtils.compileUserRegexp(regularExpression);
   }
 
   @Override

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/utils/CheckUtils.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/utils/CheckUtils.java
@@ -21,11 +21,31 @@ package org.sonar.cxx.checks.utils;
 
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.GenericTokenType;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
 import org.sonar.cxx.api.CxxKeyword;
 import org.sonar.cxx.api.CxxPunctuator;
 import org.sonar.cxx.parser.CxxGrammarImpl;
 
 public class CheckUtils {
+
+  public static Pattern compileUserRegexp(String regexp, int flags) {
+    Objects.requireNonNull(regexp, "regular expression has to be non null");
+    if (regexp.isEmpty()) {
+      throw new IllegalStateException("Empty regular expression");
+    }
+    try {
+      return Pattern.compile(regexp, flags);
+    } catch (PatternSyntaxException e) {
+      throw new IllegalStateException("Unable to compile the regular expression: \"" + regexp + "\"", e);
+    }
+  }
+
+  public static Pattern compileUserRegexp(String regexp) {
+    return compileUserRegexp(regexp, 0);
+  }
 
   public static boolean isIfStatement(AstNode node) {
     if (node.is(CxxGrammarImpl.selectionStatement)) {

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/FileHeaderCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/FileHeaderCheckTest.java
@@ -170,8 +170,8 @@ public class FileHeaderCheckTest {
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion
   public void should_fail_with_bad_regular_expression() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("[" + FileHeaderCheck.class.getSimpleName() + "] Unable to compile the regular expression: *");
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("Unable to compile the regular expression: \"*\"");
 
     FileHeaderCheck check = new FileHeaderCheck();
     check.headerFormat = "*";

--- a/cxx-lint/src/main/java/org/sonar/cxx/cxxlint/CxxCheckList.java
+++ b/cxx-lint/src/main/java/org/sonar/cxx/cxxlint/CxxCheckList.java
@@ -29,6 +29,13 @@ public final class CxxCheckList {
 
   public static final String DEFAULT_PROFILE = "Sonar way";
 
+  /**
+   * skip the following checks because they don't have reasonable defaults
+   * <ul>
+   * <li>org.sonar.cxx.checks.regex.FileRegularExpressionCheck.class</li>
+   * <li>org.sonar.cxx.checks.regex.LineRegularExpressionCheck.class</li>
+   * </ul>
+   */
   public static List<Class> getChecks() {
     return new ArrayList<>(Arrays.asList(
       org.sonar.cxx.checks.BooleanEqualityComparisonCheck.class,
@@ -70,9 +77,7 @@ public final class CxxCheckList {
       org.sonar.cxx.checks.naming.MethodNameCheck.class,
       org.sonar.cxx.checks.regex.CommentRegularExpressionCheck.class,
       org.sonar.cxx.checks.regex.FileHeaderCheck.class,
-      org.sonar.cxx.checks.regex.FileRegularExpressionCheck.class,
       org.sonar.cxx.checks.regex.FixmeTagPresenceCheck.class,
-      org.sonar.cxx.checks.regex.LineRegularExpressionCheck.class,
       org.sonar.cxx.checks.regex.NoSonarCheck.class,
       org.sonar.cxx.checks.regex.TodoTagPresenceCheck.class,
       org.sonar.cxx.checks.xpath.XPathCheck.class

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensor.java
@@ -43,6 +43,9 @@ public class CxxClangTidySensor extends CxxIssuesReportSensor {
   public static final String REPORT_CHARSET_DEF = "clangtidy.charset";
   public static final String DEFAULT_CHARSET_DEF = "UTF-8";
 
+  private static final String regex = "(.+|[a-zA-Z]:\\\\.+):([0-9]+):([0-9]+): ([^:]+): ([^]]+) \\[([^]]+)\\]";
+  private static final Pattern pattern = Pattern.compile(regex);
+
   /**
    * CxxClangTidySensor for clang-tidy Sensor
    *
@@ -74,8 +77,6 @@ public class CxxClangTidySensor extends CxxIssuesReportSensor {
       //   [clang-diagnostic-writable-strings]
       // <path>:<line>:<column>: <level>: <message> [<checkname>]
       // relative paths
-      final String regex = "(.+|[a-zA-Z]:\\\\.+):([0-9]+):([0-9]+): ([^:]+): ([^]]+) \\[([^]]+)\\]";
-      final Pattern pattern = Pattern.compile(regex);
 
       while (scanner.hasNextLine()) {
         String line = scanner.nextLine();

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensor.java
@@ -47,6 +47,12 @@ public abstract class CxxCompilerSensor extends CxxIssuesReportSensor {
     final String reportCharset = getCharset(context);
     final String reportRegEx = getRegex(context);
 
+    if (reportRegEx.isEmpty())
+    {
+      LOG.error("processReport terminated because of empty custom regular expression");
+      return;
+    }
+
     LOG.info("Parsing '{}' initialized with report '{}', Charset= '{}'", getCompilerKey(), report, reportCharset);
 
     try (Scanner scanner = new Scanner(report, reportCharset)) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/DrMemoryParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/DrMemoryParser.java
@@ -37,9 +37,9 @@ import org.sonar.cxx.sensors.utils.CxxUtils;
 public final class DrMemoryParser {
 
   private static final Logger LOG = Loggers.get(DrMemoryParser.class);
-  public static final Pattern RX_MESSAGE_FINDER = Pattern.compile("^Error #\\d+:(.*)");
-  public static final Pattern RX_FILE_FINDER = Pattern.compile("^.*\\[(.*):(\\d+)\\]$");
-  public static final int TOP_COUNT = 4;
+  private static final Pattern RX_MESSAGE_FINDER = Pattern.compile("^Error #\\d+:(.*)");
+  private static final Pattern RX_FILE_FINDER = Pattern.compile("^.*\\[(.*):(\\d+)\\]$");
+  private static final int TOP_COUNT = 4;
 
   /**
    * DrMemory parser

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensorTest.java
@@ -55,9 +55,18 @@ public class CxxCompilerSensorTest {
   @Test
   public void testFileNotFound() throws XMLStreamException {
     File report = new File("");
+    sensor.setRegex("*");
     sensor.testProcessReport(context, report);
     String log = logTester.logs().toString();
     assertThat(log.contains("FileNotFoundException")).isTrue();
+  }
+
+  @Test
+  public void testRegexEmpty() throws XMLStreamException {
+    File report = new File("");
+    sensor.testProcessReport(context, report);
+    String log = logTester.logs().toString();
+    assertThat(log.contains("empty custom regular expression")).isTrue();
   }
 
   @Test

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/XmlParserHelperTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/XmlParserHelperTest.java
@@ -38,11 +38,14 @@ public class XmlParserHelperTest {
   public ExpectedException thrown = ExpectedException.none();
 
   @Test
-  public void invalid_prolog() {
+  public void invalid_prolog() throws IOException {
     thrown.expectMessage("Error while parsing the XML file: ");
     thrown.expectMessage("invalid_prolog.txt");
 
-    new XmlParserHelper(new File(REPORT_PATH + "invalid_prolog.txt")).nextStartTag();
+    try ( XmlParserHelper helper = new XmlParserHelper(new File(REPORT_PATH + "invalid_prolog.txt")) )
+    {
+      helper.nextStartTag();
+    }
   }
 
   @Test

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxCpdVisitorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxCpdVisitorTest.java
@@ -23,9 +23,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
+import org.assertj.core.util.Files;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.batch.fs.InputFile;
@@ -44,13 +44,12 @@ public class CxxCpdVisitorTest {
   private CxxLanguage language;
 
   @Before
-  @SuppressWarnings("unchecked")
   public void scanFile() throws UnsupportedEncodingException, IOException {
     language = TestUtils.mockCxxLanguage();
     File baseDir = TestUtils.loadResource("/org/sonar/cxx/sensors");
     File target = new File(baseDir, "cpd.cc");
 
-    String content = new String(Files.readAllBytes(target.toPath()), "UTF-8");
+    String content = Files.contentOf(target, StandardCharsets.UTF_8);
     inputFile = TestInputFileBuilder.create("moduleKey", baseDir, target).setType(InputFile.Type.MAIN)
       .setContents(content).setCharset(StandardCharsets.UTF_8).build();
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxFileLinesVisitorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxFileLinesVisitorTest.java
@@ -23,13 +23,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.util.Files;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -76,7 +76,7 @@ public class CxxFileLinesVisitorTest {
 
   @Test
   public void TestLinesOfCode() throws UnsupportedEncodingException, IOException {
-    String content = new String(Files.readAllBytes(target.toPath()), "UTF-8");
+    String content = Files.contentOf(target, StandardCharsets.UTF_8);
     DefaultInputFile inputFile = TestInputFileBuilder.create("ProjectKey", baseDir, target).setContents(content)
       .setCharset(StandardCharsets.UTF_8).setLanguage(language.getKey())
       .setType(InputFile.Type.MAIN).build();
@@ -97,7 +97,7 @@ public class CxxFileLinesVisitorTest {
 
   @Test
   public void TestLinesOfComments() throws UnsupportedEncodingException, IOException {
-    String content = new String(Files.readAllBytes(target.toPath()), "UTF-8");
+    String content = Files.contentOf(target, StandardCharsets.UTF_8);
     DefaultInputFile inputFile = TestInputFileBuilder.create("ProjectKey", baseDir, target).setContents(content)
       .setCharset(StandardCharsets.UTF_8).setLanguage(language.getKey())
       .setType(InputFile.Type.MAIN).build();
@@ -117,7 +117,7 @@ public class CxxFileLinesVisitorTest {
   @Test
   public void TestExecutableLinesOfCode() throws UnsupportedEncodingException, IOException {
 
-    String content = new String(Files.readAllBytes(target.toPath()), "UTF-8");
+    String content = Files.contentOf(target, StandardCharsets.UTF_8);
     DefaultInputFile inputFile = TestInputFileBuilder.create("ProjectKey", baseDir, target).setContents(content)
       .setCharset(StandardCharsets.UTF_8).setLanguage(language.getKey())
       .setType(InputFile.Type.MAIN).build();

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxHighlighterTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/visitors/CxxHighlighterTest.java
@@ -22,9 +22,9 @@ package org.sonar.cxx.sensors.visitors;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
+import org.assertj.core.util.Files;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
@@ -45,7 +45,7 @@ public class CxxHighlighterTest {
     File baseDir = TestUtils.loadResource("/org/sonar/cxx/sensors");
     target = new File(baseDir, "highlighter.cc");
 
-    String content = new String(Files.readAllBytes(target.toPath()), "UTF-8");
+    String content = Files.contentOf(target, StandardCharsets.UTF_8);
     DefaultInputFile inputFile = TestInputFileBuilder.create("ProjectKey", baseDir, target)
       .setContents(content).setCharset(StandardCharsets.UTF_8).build();
 

--- a/cxx-sensors/src/test/java/org/sonar/plugins/cxx/squid/CxxSquidSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/plugins/cxx/squid/CxxSquidSensorTest.java
@@ -22,10 +22,10 @@ package org.sonar.plugins.cxx.squid;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.util.Files;
 import org.junit.Before;
 import org.junit.Test;
 import static org.mockito.ArgumentMatchers.same;
@@ -74,7 +74,7 @@ public class CxxSquidSensorTest {
 
   private DefaultInputFile buildTestInputFile(File baseDir, String fileName) throws IOException {
     File target = new File(baseDir, fileName);
-    String content = new String(Files.readAllBytes(target.toPath()), "UTF-8");
+    String content = Files.contentOf(target, StandardCharsets.UTF_8);
     DefaultInputFile inputFile = TestInputFileBuilder.create("ProjectKey", baseDir, target).setContents(content)
       .setCharset(StandardCharsets.UTF_8).setLanguage(language.getKey())
       .setType(InputFile.Type.MAIN).build();

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxAstScanner.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxAstScanner.java
@@ -204,7 +204,7 @@ public final class CxxAstScanner {
       .subscribeTo(CxxGrammarImpl.statement)
       .build());
 
-    builder.withSquidAstVisitor(new CxxCyclomaticComplexityVisitor(ComplexityVisitor.<Grammar>builder()
+    builder.withSquidAstVisitor(new CxxCyclomaticComplexityVisitor<Grammar>(ComplexityVisitor.<Grammar>builder()
       .setMetricDef(CxxMetric.COMPLEXITY)
       .subscribeTo(CxxComplexityConstants.getCyclomaticComplexityTypes())
       .build()));

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -914,7 +914,7 @@ public class CxxPreprocessor extends Preprocessor {
           Token c = replTokens.get(0);
           PreprocessorAction action = PreprocessorAction.NO_OPERATION;
           if (c.getType().equals(IDENTIFIER)) {
-            List<Token> rest = new ArrayList(replTokens);
+            List<Token> rest = new ArrayList<>(replTokens);
             rest.addAll(tokens.subList(tokensConsumed, tokens.size()));
             action = handleIdentifiersAndKeywords(rest, c, filename);
           }

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/CxxParserTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/CxxParserTest.java
@@ -22,6 +22,7 @@ package org.sonar.cxx.parser;
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
 import java.io.File;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -46,12 +47,9 @@ public class CxxParserTest extends ParserBaseTestHelper {
   String rootDir = "src/test/resources/parser";
   File erroneousSources = null;
 
-  public CxxParserTest() {
+  public CxxParserTest() throws URISyntaxException {
     super();
-    try {
-      erroneousSources = new File(CxxParserTest.class.getResource(errSources).toURI());
-    } catch (java.net.URISyntaxException e) {
-    }
+    erroneousSources = new File(CxxParserTest.class.getResource(errSources).toURI());
   }
 
   @Test
@@ -148,11 +146,9 @@ public class CxxParserTest extends ParserBaseTestHelper {
 
     conf.setCFilesPatterns(new String[]{""});
     p = CxxParser.create(context, conf, CxxFileTesterHelper.mockCxxLanguage());
-    try {
-      AstNode root = p.parse(cfile);
-      assertThat(root.getNumberOfChildren()).isEqualTo(2);
-    } catch (com.sonar.sslr.api.RecognitionException re) {
-    }
+
+    AstNode root0 = p.parse(cfile);
+    assertThat(root0.getNumberOfChildren()).isEqualTo(2);
 
     conf.setCFilesPatterns(new String[]{"*.c"});
     p = CxxParser.create(context, conf, CxxFileTesterHelper.mockCxxLanguage());


### PR DESCRIPTION
* check all user-provided regular expressions if they are empty
  -> throw if empty or not compilable
* avoid string comparisor for token value
  -> compare token types if possible
* unify and simplify the read functionality if content of entire file is required
* minor refactoring

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1607)
<!-- Reviewable:end -->
