### PR TITLE
Mark static code analysis checks deprecated

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/BooleanEqualityComparisonCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/BooleanEqualityComparisonCheck.java
@@ -34,7 +34,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "BooleanEqualityComparison",
   name = "Literal boolean values should not be used in condition expressions",
   priority = Priority.MINOR,
-  tags = {Tag.CONVENTION})
+  tags = {Tag.CONVENTION},
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("5min")
 public class BooleanEqualityComparisonCheck extends SquidCheck<Grammar> {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/CollapsibleIfCandidateCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/CollapsibleIfCandidateCheck.java
@@ -36,7 +36,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "CollapsibleIfCandidate",
   name = "Collapsible 'if' statements should be merged",
   priority = Priority.MAJOR,
-  tags = {Tag.BRAIN_OVERLOAD})
+  tags = {Tag.BRAIN_OVERLOAD},
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("5min")
 public class CollapsibleIfCandidateCheck extends SquidCheck<Grammar> {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/CommentedCodeCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/CommentedCodeCheck.java
@@ -47,7 +47,9 @@ import org.sonar.squidbridge.recognizer.LanguageFootprint;
   key = "CommentedCode",
   name = "Sections of code should not be 'commented out'",
   tags = {Tag.BAD_PRACTICE},
-  priority = Priority.CRITICAL)
+  priority = Priority.CRITICAL,
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("5min")
 public class CommentedCodeCheck extends SquidCheck<Grammar> implements AstAndTokenVisitor {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/HardcodedAccountCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/HardcodedAccountCheck.java
@@ -41,7 +41,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "HardcodedAccount",
   name = "Do not hard code sensitive data in programs",
   tags = {Tag.CERT, Tag.SECURITY},
-  priority = Priority.BLOCKER)
+  priority = Priority.BLOCKER,
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("30min")
 public class HardcodedAccountCheck extends SquidCheck<Grammar> {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/HardcodedIpCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/HardcodedIpCheck.java
@@ -37,7 +37,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "HardcodedIp",
   name = "IP addresses should not be hardcoded",
   tags = {Tag.CERT, Tag.SECURITY},
-  priority = Priority.CRITICAL)
+  priority = Priority.CRITICAL,
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("30min")
 public class HardcodedIpCheck extends SquidCheck<Grammar> {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/MagicNumberCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/MagicNumberCheck.java
@@ -42,7 +42,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "MagicNumber",
   name = "Magic number should not be used",
   tags = {Tag.CONVENTION},
-  priority = Priority.MINOR)
+  priority = Priority.MINOR,
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("5min")
 public class MagicNumberCheck extends SquidCheck<Grammar> {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/MissingCurlyBracesCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/MissingCurlyBracesCheck.java
@@ -35,7 +35,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "MissingCurlyBraces",
   name = "if/else/for/while/do statements should always use curly braces",
   tags = {Tag.CONVENTION, Tag.PITFALL},
-  priority = Priority.MAJOR)
+  priority = Priority.MAJOR,
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("5min")
 public class MissingCurlyBracesCheck extends SquidCheck<Grammar> {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/NestedStatementsCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/NestedStatementsCheck.java
@@ -44,7 +44,8 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "NestedStatements",
   name = "Control flow statements \"if\", \"switch\", \"try\" and iterators should not be nested too deeply",
   tags = {Tag.BRAIN_OVERLOAD},
-  priority = Priority.MAJOR
+  priority = Priority.MAJOR,
+  status = "DEPRECATED"
 )
 @ActivatedByDefault
 @SqaleConstantRemediation("10min")

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/ReservedNamesCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/ReservedNamesCheck.java
@@ -46,7 +46,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "ReservedNames",
   name = "Reserved names should not be used for preprocessor macros",
   tags = {Tag.PREPROCESSOR},
-  priority = Priority.BLOCKER)
+  priority = Priority.BLOCKER,
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("5min")
 public class ReservedNamesCheck extends SquidCheck<Grammar> implements CxxCharsetAwareVisitor {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/SafetyTagCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/SafetyTagCheck.java
@@ -42,7 +42,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "SafetyTag",
   name = "Risk mitigation implementation shall be defined in separate file",
   priority = Priority.BLOCKER,
-  tags = {Tag.CONVENTION})
+  tags = {Tag.CONVENTION},
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("5min")
 public class SafetyTagCheck extends SquidCheck<Grammar> implements AstAndTokenVisitor {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/StringLiteralDuplicatedCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/StringLiteralDuplicatedCheck.java
@@ -37,7 +37,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "StringLiteralDuplicated",
   name = "String literals should not be duplicated",
   priority = Priority.MINOR,
-  tags = {Tag.BAD_PRACTICE})
+  tags = {Tag.BAD_PRACTICE},
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("5min")
 public class StringLiteralDuplicatedCheck extends SquidCheck<Grammar> {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/SwitchLastCaseIsDefaultCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/SwitchLastCaseIsDefaultCheck.java
@@ -38,7 +38,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "SwitchLastCaseIsDefault",
   name = "Switch statements should end with a default case",
   priority = Priority.MAJOR,
-  tags = {Tag.BAD_PRACTICE, Tag.PITFALL})
+  tags = {Tag.BAD_PRACTICE, Tag.PITFALL},
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("5min")
 public class SwitchLastCaseIsDefaultCheck extends SquidCheck<Grammar> {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/UnnamedNamespaceInHeaderCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/UnnamedNamespaceInHeaderCheck.java
@@ -33,7 +33,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "UnnamedNamespaceInHeader",
   name = "Unnamed namespaces are not allowed in header files",
   tags = {Tag.CONVENTION},
-  priority = Priority.BLOCKER)
+  priority = Priority.BLOCKER,
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("5min")
 //similar Vera++ rule T017

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectIncludeCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectIncludeCheck.java
@@ -43,7 +43,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "UseCorrectInclude",
   name = "#include directive shall not use relative path",
   tags = {Tag.PREPROCESSOR},
-  priority = Priority.BLOCKER)
+  priority = Priority.BLOCKER,
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("5min")
 public class UseCorrectIncludeCheck extends SquidCheck<Grammar> implements CxxCharsetAwareVisitor {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectTypeCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectTypeCheck.java
@@ -43,7 +43,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "UseCorrectType",
   name = "C++ type(s) shall be used",
   tags = {Tag.CONVENTION},
-  priority = Priority.MINOR)
+  priority = Priority.MINOR,
+  status = "DEPRECATED"
+)
 @RuleTemplate
 @NoSqale
 public class UseCorrectTypeCheck extends SquidCheck<Grammar> {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/UselessParenthesesCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/UselessParenthesesCheck.java
@@ -34,7 +34,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "UselessParentheses",
   name = "Useless parentheses around expressions should be removed to prevent any misunderstanding",
   priority = Priority.MAJOR,
-  tags = {Tag.CONFUSING})
+  tags = {Tag.CONFUSING},
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("1min")
 public class UselessParenthesesCheck extends SquidCheck<Grammar> {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/UsingNamespaceInHeaderCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/UsingNamespaceInHeaderCheck.java
@@ -34,7 +34,9 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "UsingNamespaceInHeader",
   name = "Using namespace directives are not allowed in header files",
   tags = {Tag.CONVENTION, Tag.PITFALL, Tag.BAD_PRACTICE},
-  priority = Priority.BLOCKER)
+  priority = Priority.BLOCKER,
+  status = "DEPRECATED"
+)
 @ActivatedByDefault
 @SqaleConstantRemediation("5min")
 //similar Vera++ rule T018

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/TooManyParametersCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/TooManyParametersCheck.java
@@ -34,7 +34,8 @@ import org.sonar.squidbridge.checks.SquidCheck;
   key = "TooManyParameters",
   priority = Priority.MAJOR,
   name = "Functions, methods and lambdas should not have too many parameters",
-  tags = {Tag.BRAIN_OVERLOAD}
+  tags = {Tag.BRAIN_OVERLOAD},
+  status = "DEPRECATED"
 )
 @SqaleConstantRemediation("20min")
 @ActivatedByDefault

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/BooleanEqualityComparison.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/BooleanEqualityComparison.html
@@ -2,7 +2,7 @@
 Boolean expressions should not be compared against boolean literals, as their value can be directly used.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>The following code:</p>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/BooleanEqualityComparison.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/BooleanEqualityComparison.html
@@ -1,6 +1,9 @@
 <p>
 Boolean expressions should not be compared against boolean literals, as their value can be directly used.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>The following code:</p>
 

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/CollapsibleIfCandidate.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/CollapsibleIfCandidate.html
@@ -1,6 +1,6 @@
 <p>Merging collapsible <code>if</code> statements increases the code's readability.</p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>The following code:</p>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/CollapsibleIfCandidate.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/CollapsibleIfCandidate.html
@@ -1,4 +1,7 @@
 <p>Merging collapsible <code>if</code> statements increases the code's readability.</p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>The following code:</p>
 

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/CommentedCode.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/CommentedCode.html
@@ -1,3 +1,8 @@
+<p>Remove commented code.</p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
+
 <p>Here are the main reasons why commented code is a code smell:</p>
 
 <ul>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/CommentedCode.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/CommentedCode.html
@@ -1,6 +1,6 @@
 <p>Remove commented code.</p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>Here are the main reasons why commented code is a code smell:</p>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/HardcodedAccount.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/HardcodedAccount.html
@@ -1,4 +1,7 @@
 <p>Be careful while handling sensitive data, such as passwords, in program code.</p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>Hard coding sensitive data is considered very bad programming practice because it enforces the requirement of the development environment to be secure.</p>
 

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/HardcodedAccount.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/HardcodedAccount.html
@@ -1,6 +1,6 @@
 <p>Be careful while handling sensitive data, such as passwords, in program code.</p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>Hard coding sensitive data is considered very bad programming practice because it enforces the requirement of the development environment to be secure.</p>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/HardcodedIp.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/HardcodedIp.html
@@ -1,3 +1,8 @@
+<p>Remove hardcoded IP addresses.</p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
+
 <p>Hardcoding an IP address into source code is a bad idea for several reasons:</p>
 
 <ul>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/HardcodedIp.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/HardcodedIp.html
@@ -1,6 +1,6 @@
 <p>Remove hardcoded IP addresses.</p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>Hardcoding an IP address into source code is a bad idea for several reasons:</p>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/MagicNumber.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/MagicNumber.html
@@ -2,6 +2,9 @@
 Numbers are not self-explanatory, they only are made of a value, which does not explain their purpose.
 Moreover, if the same number should be consistently used in multiple places, using a constant will ensure that all occurrences are updated at once.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>The following code:</p>
 

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/MagicNumber.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/MagicNumber.html
@@ -3,7 +3,7 @@ Numbers are not self-explanatory, they only are made of a value, which does not 
 Moreover, if the same number should be consistently used in multiple places, using a constant will ensure that all occurrences are updated at once.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>The following code:</p>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/MissingCurlyBraces.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/MissingCurlyBraces.html
@@ -1,6 +1,10 @@
 <p>
 Not using curly braces could be error-prone in some cases. For instance in the following example, the two statements seems to be attached to the if statement whereas this is the case only for the first one:
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
+
 <pre>
 if (condition) // Non-Compliant
   executeSomething();

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/MissingCurlyBraces.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/MissingCurlyBraces.html
@@ -2,7 +2,7 @@
 Not using curly braces could be error-prone in some cases. For instance in the following example, the two statements seems to be attached to the if statement whereas this is the case only for the first one:
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <pre>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/NestedStatements.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/NestedStatements.html
@@ -3,6 +3,9 @@ Nested <code>if</code>, <code>switch</code>, <code>try</code> and iterator (<cod
 <code>do</code>) statements are a key ingredient for making what's known as "Spaghetti code". Such code is hard to read,
 refactor and therefore maintain.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <h2>Noncompliant Code Example</h2>
 

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/NestedStatements.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/NestedStatements.html
@@ -4,7 +4,7 @@ Nested <code>if</code>, <code>switch</code>, <code>try</code> and iterator (<cod
 refactor and therefore maintain.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <h2>Noncompliant Code Example</h2>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/ReservedNames.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/ReservedNames.html
@@ -1,3 +1,8 @@
+<p>Don't use reserved names.</p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
+
 <p>   The C++ Standard reserves some forms of names for language
       implementations. One of the most frequent violations is a
       definition of preprocessor macro that begins with underscore

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/ReservedNames.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/ReservedNames.html
@@ -1,6 +1,6 @@
 <p>Don't use reserved names.</p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>   The C++ Standard reserves some forms of names for language

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/SafetyTag.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/SafetyTag.html
@@ -5,6 +5,6 @@ Safety critical implementation have to be managed in a special manner according 
 <p>Therefore separation of the source code makes it easier to monitor updates or test coverage.</p>
 
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/SafetyTag.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/SafetyTag.html
@@ -4,4 +4,7 @@ Safety critical implementation have to be managed in a special manner according 
 
 <p>Therefore separation of the source code makes it easier to monitor updates or test coverage.</p>
 
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/StringLiteralDuplicated.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/StringLiteralDuplicated.html
@@ -3,7 +3,7 @@ Duplicated string literals are error-prone to refactor, as one must pay attentio
 Constants can be referenced from many places, but there value is updated in a single place.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>The following code:</p>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/StringLiteralDuplicated.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/StringLiteralDuplicated.html
@@ -2,6 +2,9 @@
 Duplicated string literals are error-prone to refactor, as one must pay attention to update all occurrences.
 Constants can be referenced from many places, but there value is updated in a single place.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>The following code:</p>
 

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/SwitchLastCaseIsDefault.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/SwitchLastCaseIsDefault.html
@@ -3,7 +3,7 @@ The requirement for a final default clause is defensive programming.
 This clause should either take appropriate action or contain a suitable comment as to why no action is taken.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/SwitchLastCaseIsDefault.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/SwitchLastCaseIsDefault.html
@@ -2,6 +2,9 @@
 The requirement for a final default clause is defensive programming.
 This clause should either take appropriate action or contain a suitable comment as to why no action is taken.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>
 The following code snippet illustrates this rule:

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/TooManyParameters.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/TooManyParameters.html
@@ -3,7 +3,7 @@
   Functions with many parameters are hard to test, maintain and reuse.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/TooManyParameters.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/TooManyParameters.html
@@ -2,4 +2,8 @@
 <p>
   Functions with many parameters are hard to test, maintain and reuse.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
+
 

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UnnamedNamespaceInHeader.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UnnamedNamespaceInHeader.html
@@ -1,3 +1,8 @@
+<p>Unnamed namespaces in header files.</p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
+
 <p>The typical use of unnamed namespace is to hide module-internal
       names from the outside world. Header files are physically
       concatenated in a single translation unit, which logically

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UnnamedNamespaceInHeader.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UnnamedNamespaceInHeader.html
@@ -1,6 +1,6 @@
 <p>Unnamed namespaces in header files.</p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>The typical use of unnamed namespace is to hide module-internal

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UseCorrectInclude.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UseCorrectInclude.html
@@ -1,6 +1,9 @@
 <p>
 The #include directive shall only refer to predefined folders and therefore relative paths are not allowed.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>
 The following code snippet illustrates this rule:

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UseCorrectInclude.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UseCorrectInclude.html
@@ -2,7 +2,7 @@
 The #include directive shall only refer to predefined folders and therefore relative paths are not allowed.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UseCorrectType.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UseCorrectType.html
@@ -2,6 +2,9 @@
 Legacy code often use primitive types which shall be avoided or limited to platform APIs.
 C++ types shall be used instead.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>Avoid using the following types:</p>
 

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UseCorrectType.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UseCorrectType.html
@@ -3,7 +3,7 @@ Legacy code often use primitive types which shall be avoided or limited to platf
 C++ types shall be used instead.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>Avoid using the following types:</p>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UselessParentheses.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UselessParentheses.html
@@ -1,6 +1,9 @@
 <p>
 Useless parentheses can sometimes be misleading and so should be removed.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>
 The following code snippet illustrates this rule:

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UselessParentheses.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UselessParentheses.html
@@ -2,7 +2,7 @@
 Useless parentheses can sometimes be misleading and so should be removed.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UsingNamespaceInHeader.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UsingNamespaceInHeader.html
@@ -1,6 +1,6 @@
 <p>Namespace directive in header files.</p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>The using namespace directive imports names from the given

--- a/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UsingNamespaceInHeader.html
+++ b/sonar-c-plugin/src/main/resources/org/sonar/l10n/c/rules/c/UsingNamespaceInHeader.html
@@ -1,3 +1,8 @@
+<p>Namespace directive in header files.</p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
+
 <p>The using namespace directive imports names from the given
       namespace and when used in a header file influences the global
       namespace of all the files that directly or indirectly include

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/BooleanEqualityComparison.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/BooleanEqualityComparison.html
@@ -2,7 +2,7 @@
 Boolean expressions should not be compared against boolean literals, as their value can be directly used.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>The following code:</p>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/BooleanEqualityComparison.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/BooleanEqualityComparison.html
@@ -1,6 +1,9 @@
 <p>
 Boolean expressions should not be compared against boolean literals, as their value can be directly used.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>The following code:</p>
 

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/CollapsibleIfCandidate.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/CollapsibleIfCandidate.html
@@ -1,6 +1,6 @@
 <p>Merging collapsible <code>if</code> statements increases the code's readability.</p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>The following code:</p>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/CollapsibleIfCandidate.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/CollapsibleIfCandidate.html
@@ -1,4 +1,7 @@
 <p>Merging collapsible <code>if</code> statements increases the code's readability.</p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>The following code:</p>
 

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/CommentedCode.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/CommentedCode.html
@@ -1,3 +1,8 @@
+<p>Remove commented code.</p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
+
 <p>Here are the main reasons why commented code is a code smell:</p>
 
 <ul>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/CommentedCode.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/CommentedCode.html
@@ -1,6 +1,6 @@
 <p>Remove commented code.</p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>Here are the main reasons why commented code is a code smell:</p>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/HardcodedAccount.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/HardcodedAccount.html
@@ -1,4 +1,7 @@
 <p>Be careful while handling sensitive data, such as passwords, in program code.</p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>Hard coding sensitive data is considered very bad programming practice because it enforces the requirement of the development environment to be secure.</p>
 

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/HardcodedAccount.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/HardcodedAccount.html
@@ -1,6 +1,6 @@
 <p>Be careful while handling sensitive data, such as passwords, in program code.</p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>Hard coding sensitive data is considered very bad programming practice because it enforces the requirement of the development environment to be secure.</p>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/HardcodedIp.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/HardcodedIp.html
@@ -1,3 +1,8 @@
+<p>Remove hardcoded IP addresses.</p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
+
 <p>Hardcoding an IP address into source code is a bad idea for several reasons:</p>
 
 <ul>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/HardcodedIp.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/HardcodedIp.html
@@ -1,6 +1,6 @@
 <p>Remove hardcoded IP addresses.</p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>Hardcoding an IP address into source code is a bad idea for several reasons:</p>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/MagicNumber.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/MagicNumber.html
@@ -2,6 +2,9 @@
 Numbers are not self-explanatory, they only are made of a value, which does not explain their purpose.
 Moreover, if the same number should be consistently used in multiple places, using a constant will ensure that all occurrences are updated at once.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>The following code:</p>
 

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/MagicNumber.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/MagicNumber.html
@@ -3,7 +3,7 @@ Numbers are not self-explanatory, they only are made of a value, which does not 
 Moreover, if the same number should be consistently used in multiple places, using a constant will ensure that all occurrences are updated at once.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>The following code:</p>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/MissingCurlyBraces.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/MissingCurlyBraces.html
@@ -1,6 +1,10 @@
 <p>
 Not using curly braces could be error-prone in some cases. For instance in the following example, the two statements seems to be attached to the if statement whereas this is the case only for the first one:
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
+
 <pre>
 if (condition) // Non-Compliant
   executeSomething();

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/MissingCurlyBraces.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/MissingCurlyBraces.html
@@ -2,7 +2,7 @@
 Not using curly braces could be error-prone in some cases. For instance in the following example, the two statements seems to be attached to the if statement whereas this is the case only for the first one:
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <pre>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/NestedStatements.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/NestedStatements.html
@@ -3,6 +3,9 @@ Nested <code>if</code>, <code>switch</code>, <code>try</code> and iterator (<cod
 <code>do</code>) statements are a key ingredient for making what's known as "Spaghetti code". Such code is hard to read,
 refactor and therefore maintain.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <h2>Noncompliant Code Example</h2>
 

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/NestedStatements.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/NestedStatements.html
@@ -4,7 +4,7 @@ Nested <code>if</code>, <code>switch</code>, <code>try</code> and iterator (<cod
 refactor and therefore maintain.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <h2>Noncompliant Code Example</h2>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/ReservedNames.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/ReservedNames.html
@@ -1,3 +1,8 @@
+<p>Don't use reserved names.</p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
+
 <p>   The C++ Standard reserves some forms of names for language
       implementations. One of the most frequent violations is a
       definition of preprocessor macro that begins with underscore

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/ReservedNames.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/ReservedNames.html
@@ -1,6 +1,6 @@
 <p>Don't use reserved names.</p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>   The C++ Standard reserves some forms of names for language

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/SafetyTag.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/SafetyTag.html
@@ -5,6 +5,6 @@ Safety critical implementation have to be managed in a special manner according 
 <p>Therefore separation of the source code makes it easier to monitor updates or test coverage.</p>
 
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/SafetyTag.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/SafetyTag.html
@@ -4,4 +4,7 @@ Safety critical implementation have to be managed in a special manner according 
 
 <p>Therefore separation of the source code makes it easier to monitor updates or test coverage.</p>
 
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/StringLiteralDuplicated.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/StringLiteralDuplicated.html
@@ -3,7 +3,7 @@ Duplicated string literals are error-prone to refactor, as one must pay attentio
 Constants can be referenced from many places, but there value is updated in a single place.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>The following code:</p>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/StringLiteralDuplicated.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/StringLiteralDuplicated.html
@@ -2,6 +2,9 @@
 Duplicated string literals are error-prone to refactor, as one must pay attention to update all occurrences.
 Constants can be referenced from many places, but there value is updated in a single place.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>The following code:</p>
 

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/SwitchLastCaseIsDefault.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/SwitchLastCaseIsDefault.html
@@ -3,7 +3,7 @@ The requirement for a final default clause is defensive programming.
 This clause should either take appropriate action or contain a suitable comment as to why no action is taken.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/SwitchLastCaseIsDefault.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/SwitchLastCaseIsDefault.html
@@ -2,6 +2,9 @@
 The requirement for a final default clause is defensive programming.
 This clause should either take appropriate action or contain a suitable comment as to why no action is taken.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>
 The following code snippet illustrates this rule:

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/TooManyParameters.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/TooManyParameters.html
@@ -3,7 +3,7 @@
   Functions with many parameters are hard to test, maintain and reuse.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/TooManyParameters.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/TooManyParameters.html
@@ -2,4 +2,8 @@
 <p>
   Functions with many parameters are hard to test, maintain and reuse.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
+
 

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UnnamedNamespaceInHeader.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UnnamedNamespaceInHeader.html
@@ -1,3 +1,8 @@
+<p>Unnamed namespaces in header files.</p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
+
 <p>The typical use of unnamed namespace is to hide module-internal
       names from the outside world. Header files are physically
       concatenated in a single translation unit, which logically

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UnnamedNamespaceInHeader.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UnnamedNamespaceInHeader.html
@@ -1,6 +1,6 @@
 <p>Unnamed namespaces in header files.</p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>The typical use of unnamed namespace is to hide module-internal

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UseCorrectInclude.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UseCorrectInclude.html
@@ -1,6 +1,9 @@
 <p>
 The #include directive shall only refer to predefined folders and therefore relative paths are not allowed.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>
 The following code snippet illustrates this rule:

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UseCorrectInclude.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UseCorrectInclude.html
@@ -2,7 +2,7 @@
 The #include directive shall only refer to predefined folders and therefore relative paths are not allowed.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UseCorrectType.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UseCorrectType.html
@@ -2,6 +2,9 @@
 Legacy code often use primitive types which shall be avoided or limited to platform APIs.
 C++ types shall be used instead.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>Avoid using the following types:</p>
 

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UseCorrectType.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UseCorrectType.html
@@ -3,7 +3,7 @@ Legacy code often use primitive types which shall be avoided or limited to platf
 C++ types shall be used instead.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>Avoid using the following types:</p>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UselessParentheses.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UselessParentheses.html
@@ -1,6 +1,9 @@
 <p>
 Useless parentheses can sometimes be misleading and so should be removed.
 </p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
 
 <p>
 The following code snippet illustrates this rule:

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UselessParentheses.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UselessParentheses.html
@@ -2,7 +2,7 @@
 Useless parentheses can sometimes be misleading and so should be removed.
 </p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UsingNamespaceInHeader.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UsingNamespaceInHeader.html
@@ -1,6 +1,6 @@
 <p>Namespace directive in header files.</p>
 <ul>
-<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+<li><b>DEPRECATED</b>: Internal static code analysis checks will no longer be supported in future versions. Plug-in is able to import analysis reports from various external tools. Please consider using external code analyzers instead of deprecated internal ones.</li>
 </ul>
 
 <p>The using namespace directive imports names from the given

--- a/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UsingNamespaceInHeader.html
+++ b/sonar-cxx-plugin/src/main/resources/org/sonar/l10n/c++/rules/cxx/UsingNamespaceInHeader.html
@@ -1,3 +1,8 @@
+<p>Namespace directive in header files.</p>
+<ul>
+<li><b>DEPRECATED</b>: Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.</li>
+</ul>
+
 <p>The using namespace directive imports names from the given
       namespace and when used in a header file influences the global
       namespace of all the files that directly or indirectly include


### PR DESCRIPTION
- Static code analysis checks will no longer be supported in future versions. Use an external tool for static code analysis instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1613)
<!-- Reviewable:end -->
