### PR TITLE
Don't mark @RuleProperty fields as final

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/HardcodedAccountCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/HardcodedAccountCheck.java
@@ -60,7 +60,7 @@ public class HardcodedAccountCheck extends SquidCheck<Grammar> {
     key = "regularExpression",
     description = "literal regular expression rule",
     defaultValue = DEFAULT_REGULAR_EXPRESSION)
-  private final String regularExpression = DEFAULT_REGULAR_EXPRESSION;
+  private String regularExpression = DEFAULT_REGULAR_EXPRESSION;
 
   private Pattern pattern;
 

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/HardcodedIpCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/HardcodedIpCheck.java
@@ -60,7 +60,7 @@ public class HardcodedIpCheck extends SquidCheck<Grammar> {
     key = "regularExpression",
     description = "The regular expression",
     defaultValue = DEFAULT_REGULAR_EXPRESSION)
-  private final String regularExpression = DEFAULT_REGULAR_EXPRESSION;
+  private String regularExpression = DEFAULT_REGULAR_EXPRESSION;
 
   @Override
   public void init() {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectIncludeCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectIncludeCheck.java
@@ -49,7 +49,7 @@ import org.sonar.squidbridge.checks.SquidCheck;
 public class UseCorrectIncludeCheck extends SquidCheck<Grammar> implements CxxCharsetAwareVisitor {
 
   private static final String REGULAR_EXPRESSION = "#include\\s+(?>\"|\\<)[\\\\/\\.]+";
-  private final static Pattern pattern = Pattern.compile(REGULAR_EXPRESSION, Pattern.DOTALL);
+  private static final Pattern PATTERN = Pattern.compile(REGULAR_EXPRESSION, Pattern.DOTALL);
   private Charset charset = StandardCharsets.UTF_8;
 
   @Override
@@ -62,7 +62,7 @@ public class UseCorrectIncludeCheck extends SquidCheck<Grammar> implements CxxCh
     }
     for (int i = 0; i < lines.size(); i++) {
       String line = lines.get(i);
-      if (pattern.matcher(line).find()) {
+      if (PATTERN.matcher(line).find()) {
         getContext().createLineViolation(this, "Do not use relative path for #include directive.", i + 1);
       }
     }

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectTypeCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/UseCorrectTypeCheck.java
@@ -65,7 +65,7 @@ public class UseCorrectTypeCheck extends SquidCheck<Grammar> {
     key = "regularExpression",
     description = "Type regular expression rule",
     defaultValue = DEFAULT_REGULAR_EXPRESSION)
-  private final String regularExpression = DEFAULT_REGULAR_EXPRESSION;
+  private String regularExpression = DEFAULT_REGULAR_EXPRESSION;
 
   /**
    * message
@@ -74,7 +74,7 @@ public class UseCorrectTypeCheck extends SquidCheck<Grammar> {
     key = "message",
     description = "The violation message",
     defaultValue = DEFAULT_MESSAGE)
-  private final String message = DEFAULT_MESSAGE;
+  private String message = DEFAULT_MESSAGE;
 
   @Override
   public void init() {

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/regex/CommentContainsPatternChecker.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/regex/CommentContainsPatternChecker.java
@@ -23,41 +23,14 @@ import com.sonar.sslr.api.Token;
 import com.sonar.sslr.api.Trivia;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.sonar.check.Priority;
-import org.sonar.check.Rule;
-import org.sonar.check.RuleProperty;
-import org.sonar.squidbridge.annotations.NoSqale;
-import org.sonar.squidbridge.annotations.RuleTemplate;
 import org.sonar.squidbridge.checks.SquidCheck;
 
-/**
- * CommentContainsPatternChecker
- */
-@Rule(
-  key = "CommentContainsPatternChecker",
-  name = "Regular expression on comment",
-  priority = Priority.MAJOR)
-@RuleTemplate
-@NoSqale
-public class CommentContainsPatternChecker {
+class CommentContainsPatternChecker {
 
   private static final Pattern EOL_PATTERN = Pattern.compile("\\R");
-
-  @RuleProperty(
-    key = "check",
-    description = "The Squid check")
   private final SquidCheck<?> check;
-
-  @RuleProperty(
-    key = "pattern",
-    description = "The regular expression")
   private final String pattern;
-
-  @RuleProperty(
-    key = "message",
-    description = "The violation message")
   private final String message;
-
   private final Pattern p;
 
   /**


### PR DESCRIPTION
1.

    Partial revert of "final" commit
    
    Some of the fields, which represent the user customization of SonarQube rules were marked as `final`.
    These are however changeable settings and are injected from SonarQube (see the `@RuleProperty` annotations).
    Besides the fact, that this change in not logical it also **actually** prevents the fields of being changed.
    
    E.g. I tried to create a custom quality profile with custom regular expression for `HardcodedIpCheck`.
    The associated C++ project doesn't react on the customized regexp. The default one is used instead.
    
    This reverts commit b92e83b1a13189395832da25a7db0ee16602e37e.

2.

    CommentContainsPatternChecker is not a SonarQube check
    
    The class `CommentContainsPatternChecker` is a utility class, which
    is used inside of the following checks
    
    * FixmeTagPresenceCheck
    * TodoTagPresenceCheck
    
    `CommentContainsPatternChecker` is however not a check by itself.
    All rules-related annotations are wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1617)
<!-- Reviewable:end -->
