### PR TITLE
add 'cannot find the file...' only once

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
@@ -142,10 +142,8 @@ public abstract class CxxIssuesReportSensor extends CxxReportSensor {
     final InputFile inputFile = sensorContext.fileSystem().inputFile(sensorContext.
       fileSystem().predicates().hasPath(path));
     if (inputFile == null) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Path '{}' couldn't be found in module '{}' base dir '{}'", path, sensorContext.module().key(),
-          sensorContext.fileSystem().baseDir());
-      }
+      LOG.warn("Cannot find the file '{}' in module '{}' base dir '{}', skipping violations.",
+        path, sensorContext.module().key(), sensorContext.fileSystem().baseDir());
       notFoundFiles.add(path);
     }
     return inputFile;
@@ -182,10 +180,8 @@ public abstract class CxxIssuesReportSensor extends CxxReportSensor {
         .message(location.getInfo());
       affectedFiles.add(inputFile);
       return newIssueLocation;
-    } else {
-      LOG.warn("Cannot find the file '{}', skipping violations", location.getFile());
-      return null;
     }
+    return null;
   }
 
   /**


### PR DESCRIPTION
- reduce the noise in LOG file
- add 'cannot file the file...' only once per file in CxxIssuesReportSensor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1619)
<!-- Reviewable:end -->
