### PR TITLE
improve number lexer

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/lexer/CxxLexer.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/lexer/CxxLexer.java
@@ -55,7 +55,7 @@ public final class CxxLexer {
   private static final String HEXDIGIT_SEQUENCE = "[0-9a-fA-F]([']?+[0-9a-fA-F]++)*+";
   private static final String BINDIGIT_SEQUENCE = "[01]([']?+[01]++)*+";
   private static final String POINT = "\\.";
-  
+
   private CxxLexer() {
   }
 

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppLexer.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppLexer.java
@@ -25,8 +25,10 @@ import com.sonar.sslr.impl.channel.PunctuatorChannel;
 import static com.sonar.sslr.impl.channel.RegexpChannelBuilder.ANY_CHAR;
 import static com.sonar.sslr.impl.channel.RegexpChannelBuilder.and;
 import static com.sonar.sslr.impl.channel.RegexpChannelBuilder.commentRegexp;
+import static com.sonar.sslr.impl.channel.RegexpChannelBuilder.g;
 import static com.sonar.sslr.impl.channel.RegexpChannelBuilder.o2n;
 import static com.sonar.sslr.impl.channel.RegexpChannelBuilder.opt;
+import static com.sonar.sslr.impl.channel.RegexpChannelBuilder.or;
 import static com.sonar.sslr.impl.channel.RegexpChannelBuilder.regexp;
 import com.sonar.sslr.impl.channel.UnknownCharacterChannel;
 import org.sonar.cxx.CxxConfiguration;
@@ -39,13 +41,17 @@ import org.sonar.cxx.channels.StringLiteralsChannel;
 public final class CppLexer {
 
   private static final String HEX_PREFIX = "0[xX]";
-  private static final String EXPONENT = "([eE][+-]?+[0-9_]([']?+[0-9_]++)*+)";
-  private static final String BINARY_EXPONENT = "([pP][+-]?+[0-9]([']?+[0-9]++)*+)"; // since C++17
+  private static final String BIN_PREFIX = "0[bB]";
+  private static final String EXPONENT = "[eE][+-]?+[0-9_]([']?+[0-9_]++)*+";
+  private static final String BINARY_EXPONENT = "[pP][+-]?+[0-9]([']?+[0-9]++)*+"; // since C++17
   //private static final String INTEGER_SUFFIX = "(((U|u)(LL|ll|L|l)?)|((LL|ll|L|l)(u|U)?))";  
   //private static final String FLOAT_SUFFIX = "(f|l|F|L)";
   // ud-suffix: identifier (including INTEGER_SUFFIX, FLOAT_SUFFIX)
-  private static final String UD_SUFFIX = "([_a-zA-Z]([_a-zA-Z0-9]*+))";
-  private static final String HEXDIGIT_SEQUENCE = "([0-9a-fA-F]([']?+[0-9a-fA-F]++)*+)";
+  private static final String UD_SUFFIX = "[_a-zA-Z][_a-zA-Z0-9]*+";
+  private static final String DECDIGIT_SEQUENCE = "[0-9]([']?+[0-9]++)*+";
+  private static final String HEXDIGIT_SEQUENCE = "[0-9a-fA-F]([']?+[0-9a-fA-F]++)*+";
+  private static final String BINDIGIT_SEQUENCE = "[01]([']?+[01]++)*+";
+  private static final String POINT = "\\.";
 
   private CppLexer() {
   }
@@ -67,24 +73,22 @@ public final class CppLexer {
       .withChannel(commentRegexp("/\\*", ANY_CHAR + "*?", "\\*/"))
       .withChannel(new CharacterLiteralsChannel())
       .withChannel(new StringLiteralsChannel())
-      // C++ Standard, Section 2.14.4 "Floating literals"
-      .withChannel(regexp(CxxTokenType.NUMBER, "[0-9]([']?+[0-9]++)*+\\.([0-9]([']?+[0-9]++)*+)*+"
-        + opt(EXPONENT) + opt(UD_SUFFIX)))
-      .withChannel(regexp(CxxTokenType.NUMBER, "\\.[0-9]([']?+[0-9]++)*+"
-        + opt(EXPONENT) + opt(UD_SUFFIX)))
-      .withChannel(regexp(CxxTokenType.NUMBER, "[0-9]([']?+[0-9]++)*+" + EXPONENT + opt(UD_SUFFIX)))
-      .withChannel(regexp(CxxTokenType.NUMBER, HEX_PREFIX + HEXDIGIT_SEQUENCE
-        + BINARY_EXPONENT + opt(UD_SUFFIX))) // since C++17
-      .withChannel(regexp(CxxTokenType.NUMBER, HEX_PREFIX + HEXDIGIT_SEQUENCE + "."
-        + BINARY_EXPONENT + opt(UD_SUFFIX))) // since C++17
-      .withChannel(regexp(CxxTokenType.NUMBER, HEX_PREFIX + opt(HEXDIGIT_SEQUENCE) + "." + HEXDIGIT_SEQUENCE
-        + BINARY_EXPONENT + opt(UD_SUFFIX))) // since C++17
+
       // C++ Standard, Section 2.14.2 "Integer literals"
-      .withChannel(regexp(CxxTokenType.NUMBER, "[1-9]([']?+[0-9]++)*+" + opt(UD_SUFFIX))) // Decimal literals
-      .withChannel(regexp(CxxTokenType.NUMBER, "0[bB][01]([']?+[01]++)*+" + opt(UD_SUFFIX))) // Binary Literals
-      .withChannel(regexp(CxxTokenType.NUMBER, "0([']?+[0-7]++)++" + opt(UD_SUFFIX))) // Octal Literals
-      .withChannel(regexp(CxxTokenType.NUMBER, HEX_PREFIX + HEXDIGIT_SEQUENCE + opt(UD_SUFFIX))) // Hex Literals
-      .withChannel(regexp(CxxTokenType.NUMBER, "0" + opt(UD_SUFFIX))) // Decimal zero
+      // C++ Standard, Section 2.14.4 "Floating literals"
+      .withChannel(
+        regexp(CxxTokenType.NUMBER,
+          and(
+            or(
+              g(POINT, DECDIGIT_SEQUENCE, opt(g(EXPONENT))),
+              g(HEX_PREFIX, opt(g(HEXDIGIT_SEQUENCE)), opt(POINT), opt(g(HEXDIGIT_SEQUENCE)), opt(g(BINARY_EXPONENT))),
+              g(BIN_PREFIX, BINDIGIT_SEQUENCE),
+              g(DECDIGIT_SEQUENCE, opt(POINT), opt(g(DECDIGIT_SEQUENCE)), opt(g(EXPONENT)))
+            ),
+            opt(g(UD_SUFFIX))
+          )
+        )
+      )
 
       .withChannel(new KeywordChannel(and("#", o2n("\\s"), "[a-z]", o2n("\\w")), CppKeyword.values()))
       .withChannel(new IdentifierAndKeywordChannel(and("[a-zA-Z_]", o2n("\\w")), true))


### PR DESCRIPTION
- reduce the number of regex rules to detect a number
- use only one channel to detect numbers
- improve #1415

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1646)
<!-- Reviewable:end -->
