### PR TITLE
CxxPreprocessor: collect missing includes conditionally

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
@@ -46,6 +46,7 @@ import org.sonar.cxx.CxxConfiguration;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.CxxMetricsFactory;
 import org.sonar.cxx.api.CxxMetric;
+import org.sonar.cxx.checks.error.MissingIncludeFileCheck;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.JsonCompilationDatabase;
 import org.sonar.cxx.sensors.visitors.CxxCpdVisitor;
@@ -139,6 +140,7 @@ public class CxxSquidSensor implements Sensor {
         this.language.getBooleanOption(CPD_IGNORE_IDENTIFIERS_KEY).orElse(Boolean.FALSE)));
 
     CxxConfiguration cxxConf = createConfiguration(context.fileSystem(), context);
+    cxxConf.setCollectMissingIncludes(visitors.stream().anyMatch(v -> v instanceof MissingIncludeFileCheck));
     AstScanner<Grammar> scanner = CxxAstScanner.create(this.language, cxxConf,
       visitors.toArray(new SquidAstVisitor[visitors.size()]));
 

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
@@ -53,6 +53,7 @@ public class CxxConfiguration extends SquidConfiguration {
   private String jsonCompilationDatabaseFile;
   private CxxCompilationUnitSettings globalCompilationUnitSettings;
   private final Map<String, CxxCompilationUnitSettings> compilationUnitSettings = new HashMap<>();
+  private boolean collectMissingIncludes = false;
 
   private final CxxVCppBuildLogParser cxxVCppParser;
 
@@ -82,6 +83,14 @@ public class CxxConfiguration extends SquidConfiguration {
 
   public boolean getIgnoreHeaderComments() {
     return ignoreHeaderComments;
+  }
+
+  public boolean doCollectMissingIncludes() {
+    return collectMissingIncludes;
+  }
+
+  public void setCollectMissingIncludes(boolean collectMissingIncludes) {
+    this.collectMissingIncludes = collectMissingIncludes;
   }
 
   public void setDefines(@Nullable String[] defines) {


### PR DESCRIPTION
* collect missing includes only if MissingIncludeFileCheck was activated
* don't collect successful includes - nobody uses them
* avoid memory run-time overhead and reduce memory footprint
* CxxParser::cxxpp - don't extend the lifetime of CxxPreprocessor artificially

Alternative (more radical) solution: #1638

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1650)
<!-- Reviewable:end -->
