### PR TITLE
CxxIssuesReportSensor: use realPath as part of path normalization

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
@@ -145,7 +145,7 @@ public abstract class CxxIssuesReportSensor extends CxxReportSensor {
       realPath = absolutePath.toRealPath(LinkOption.NOFOLLOW_LINKS);
     } catch (IOException e) {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Unable to get the real path: module '{}', baseDir '{}', path '{}', excepiton '{}'",
+        LOG.debug("Unable to get the real path: module '{}', baseDir '{}', path '{}', exception '{}'",
             sensorContext.module().key(), sensorContext.fileSystem().baseDir(), path, e);
       }
       return null;

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
@@ -151,10 +151,10 @@ public abstract class CxxIssuesReportSensor extends CxxReportSensor {
       return null;
     }
 
-    // if the real path is equals to the given one - skip search; we already
+    // if the real path is equal to the given one - skip search; we already
     // tried such path
     //
-    // IMPORTANT: don't use Path::equals(), since it's dependent on file-system
+    // IMPORTANT: don't use Path::equals(), since it's dependent on a file-system.
     // SonarQube plugin API works with string paths, so the equality of strings
     // is important
     final String realPathString = realPath.toString();

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
@@ -150,8 +150,20 @@ public abstract class CxxIssuesReportSensor extends CxxReportSensor {
       }
       return null;
     }
+
+    // if the real path is equals to the given one - skip search; we already
+    // tried such path
+    //
+    // IMPORTANT: don't use Path::equals(), since it's dependent on file-system
+    // SonarQube plugin API works with string paths, so the equality of strings
+    // is important
+    final String realPathString = realPath.toString();
+    if (absolutePath.toString().equals(realPathString)) {
+      return null;
+    }
+
     return sensorContext.fileSystem()
-        .inputFile(sensorContext.fileSystem().predicates().hasAbsolutePath(realPath.toString()));
+        .inputFile(sensorContext.fileSystem().predicates().hasAbsolutePath(realPathString));
   }
 
   public InputFile getInputFileIfInProject(SensorContext sensorContext, String path) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
@@ -20,6 +20,9 @@
 package org.sonar.cxx.sensors.utils;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -135,12 +138,56 @@ public abstract class CxxIssuesReportSensor extends CxxReportSensor {
     }
   }
 
+  private InputFile getInputFileTryRealPath(SensorContext sensorContext, String path) {
+    final Path absolutePath = sensorContext.fileSystem().baseDir().toPath().resolve(path);
+    Path realPath;
+    try {
+      realPath = absolutePath.toRealPath(LinkOption.NOFOLLOW_LINKS);
+    } catch (IOException e) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Unable to get the real path: module {}, baseDir {}, path {}", sensorContext.module().key(),
+            sensorContext.fileSystem().baseDir(), path);
+      }
+      return null;
+    }
+    return sensorContext.fileSystem()
+        .inputFile(sensorContext.fileSystem().predicates().hasAbsolutePath(realPath.toString()));
+  }
+
   public InputFile getInputFileIfInProject(SensorContext sensorContext, String path) {
     if (notFoundFiles.contains(path)) {
       return null;
     }
-    final InputFile inputFile = sensorContext.fileSystem().inputFile(sensorContext.
-      fileSystem().predicates().hasPath(path));
+
+    // 1. try the most generic search predicate first; usually it's the right
+    // one
+    InputFile inputFile = sensorContext.fileSystem()
+        .inputFile(sensorContext.fileSystem().predicates().hasPath(path));
+
+    // 2. if there was nothing found, try to normalize the path by means of
+    // Path::toRealPath(). This helps if some 3rd party tools obfuscate the
+    // paths. E.g. the MS VC compiler tends to transform file paths to the lower
+    // case in its logs.
+    //
+    // IMPORTANT: SQ plugin API allows creation of NewIssue only on locations,
+    // which belong to the module. This internal check is performed by means
+    // of comparison of the paths. The paths which are managed by the framework
+    // (the reference paths) are NOT stored in the canonical form.
+    // E.g. the plugin API neither resolves symbolic links nor performs
+    // case-insensitive path normalization (could be relevant on Windows)
+    //
+    // Normalization by means of File::getCanonicalFile() or Path::toRealPath()
+    // can produce paths, which don't pass the mentioned check. E.g. resolution
+    // of symbolic links or letter case transformation
+    // might lead to the paths, which don't belong to the module's base
+    // directory (at least not in terms of parent-child semantic). This is the
+    // reason why we should avoid the resolution of symbolic links and not use
+    // the Path::toRealPath() as the only search predicate.
+
+    if (inputFile == null) {
+      inputFile = getInputFileTryRealPath(sensorContext, path);
+    }
+
     if (inputFile == null) {
       LOG.warn("Cannot find the file '{}' in module '{}' base dir '{}', skipping violations.",
         path, sensorContext.module().key(), sensorContext.fileSystem().baseDir());

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
@@ -145,8 +145,8 @@ public abstract class CxxIssuesReportSensor extends CxxReportSensor {
       realPath = absolutePath.toRealPath(LinkOption.NOFOLLOW_LINKS);
     } catch (IOException e) {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Unable to get the real path: module {}, baseDir {}, path {}", sensorContext.module().key(),
-            sensorContext.fileSystem().baseDir(), path);
+        LOG.debug("Unable to get the real path: module '{}', baseDir '{}', path '{}', excepiton '{}'",
+            sensorContext.module().key(), sensorContext.fileSystem().baseDir(), path, e);
       }
       return null;
     }


### PR DESCRIPTION
* introduce the fallback for the lookup of `InputFile`s: if generic lookup was not successful, try it with the `Path::realPath()`

resolves #1651 

@rudolfgrauberger could you please test the snapshot on your local setup?
@guwirth how do we suppose to test things like that?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1653)
<!-- Reviewable:end -->
