### PR TITLE
CxxPreprocessor: unitilize com.sonar.sslr.api.Preprocessor::init()

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -445,14 +445,10 @@ public class CxxPreprocessor extends Preprocessor {
   }
 
   @Override
-  public PreprocessorAction process(List<Token> tokens) { //TODO: deprecated PreprocessorAction
-    Token token = tokens.get(0);
-    TokenType ttype = token.getType();
-
-    final String rootFilePath = getFileUnderAnalysis().getAbsolutePath();
-
-    // CxxPreprocessor::process() can be called a) while construction,
-    // b) for a new "physical" file or c) for #include directive.
+  public void init() {
+    // CxxPreprocessor::init() can be called a) while construction,
+    // b) for a new "physical" file or c) while processing of
+    // #include directive.
     // Make sure, that the following code is executed for a new "physical" file
     // only.
     final boolean processingNewSourceFile = !ctorInProgress && (context.getFile() != currentContextFile);
@@ -465,12 +461,12 @@ public class CxxPreprocessor extends Preprocessor {
       compilationUnitSettings = conf.getCompilationUnitSettings(currentContextFile.getAbsolutePath());
 
       if (compilationUnitSettings != null) {
-        LOG.debug("compilation unit settings for: '{}'", rootFilePath);
+        LOG.debug("compilation unit settings for: '{}'", currentContextFile);
       } else {
         compilationUnitSettings = conf.getGlobalCompilationUnitSettings();
 
         if (compilationUnitSettings != null) {
-          LOG.debug("global compilation unit settings for: '{}'", rootFilePath);
+          LOG.debug("global compilation unit settings for: '{}'", currentContextFile);
         }
       }
 
@@ -526,7 +522,7 @@ public class CxxPreprocessor extends Preprocessor {
         }
       } else {
         // Use global settings
-        LOG.debug("global settings for: '{}'", rootFilePath);
+        LOG.debug("global settings for: '{}'", currentContextFile);
         if (isCFile(currentContextFile.getAbsolutePath())) {
           //Create macros to replace C++ keywords when parsing C files
           getMacros().putAll(Macro.COMPATIBILITY_MACROS);
@@ -536,6 +532,13 @@ public class CxxPreprocessor extends Preprocessor {
         }
       }
     }
+  }
+
+  @Override
+  public PreprocessorAction process(List<Token> tokens) { //TODO: deprecated PreprocessorAction
+    final Token token = tokens.get(0);
+    final TokenType ttype = token.getType();
+    final String rootFilePath = getFileUnderAnalysis().getAbsolutePath();
 
     if (ttype.equals(PREPROCESSOR)) {
 


### PR DESCRIPTION
* the check, if CxxPreprocessor was about to start preprocessing
  a new file, was previously done in CxxPreprocessor::process()
* Preprocessor::process() is called multiple time per file
* in the worst case it's called for each Token

* there is a special initialization method Preprocessor:init(),
  which is called once per file.
  See com.sonar.sslr.impl.Lexer::lex(Reader reader)
* override this method and put the is-new-file logic to
  CxxPreprocessor::init()

* we don't break any logic
  we still rely on the current context file, which is set in the
  proper order

  1. org.sonar.squidbridge.AstScanner::scanFiles() set the current
     context file
  2. parser.parse(file) -> lexer.lex(file) -> ... lex(reader)
  3. preprocessor.init();

* benefits: skip redundant checks, split the code in the more logical way

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1660)
<!-- Reviewable:end -->
