### PR TITLE
fix: sslr-cxx-toolkit fails after #1645

### DIFF
--- a/sslr-cxx-toolkit/src/main/java/org/sonar/cxx/toolkit/CxxConfigurationModel.java
+++ b/sslr-cxx-toolkit/src/main/java/org/sonar/cxx/toolkit/CxxConfigurationModel.java
@@ -21,6 +21,8 @@ package org.sonar.cxx.toolkit;
 
 import com.sonar.sslr.api.Grammar;
 import com.sonar.sslr.impl.Parser;
+
+import java.io.File;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
@@ -37,8 +39,8 @@ import org.sonar.colorizer.Tokenizer;
 import org.sonar.cxx.CxxConfiguration;
 import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.api.CxxKeyword;
+import org.sonar.cxx.api.CxxMetric;
 import org.sonar.cxx.parser.CxxParser;
-import org.sonar.squidbridge.SquidAstVisitorContext;
 import org.sonar.squidbridge.SquidAstVisitorContextImpl;
 import org.sonar.squidbridge.api.SourceProject;
 import org.sonar.sslr.toolkit.AbstractConfigurationModel;
@@ -120,8 +122,9 @@ public class CxxConfigurationModel extends AbstractConfigurationModel {
 
   @Override
   public Parser<? extends Grammar> doGetParser() {
-    SquidAstVisitorContext<Grammar> context
+    SquidAstVisitorContextImpl<Grammar> context
       = new SquidAstVisitorContextImpl<>(new SourceProject(""));
+    context.setFile(new File("file.cpp").getAbsoluteFile(), CxxMetric.FILES);
     CppLanguage language = new CppLanguage(settings.asConfig());
     return CxxParser.create(context, getConfiguration(language), language);
   }


### PR DESCRIPTION
* org.sonar.sslr.toolkit.ConfigurationModel doesn't receive
  the file path of the processed file
* file path plays important role for the preprocessor
* pass a dummy path

fixes #1662

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1663)
<!-- Reviewable:end -->
