### PR TITLE
CxxPreprocessor: cache forced includes, forced & global defines

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -217,8 +217,8 @@ public class CxxPreprocessor extends Preprocessor {
     }
 
     if (conf.getCompilationUnitSourceFiles().isEmpty() && (conf.getGlobalCompilationUnitSettings() == null)) {
-      // configuration doesn't contain any settings settings for compilation
-      // units. CxxPreprocessor will use fixedMacros only
+      // configuration doesn't contain any settings for compilation units.
+      // CxxPreprocessor will use fixedMacros only
       return Collections.emptyMap();
     }
 

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/Macro.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/Macro.java
@@ -96,6 +96,8 @@ public final class Macro {
     map.put(name, new Macro(name, body));
   }
 
+  public static final String CPLUSPLUS = "__cplusplus";
+
   /**
    * This is a collection of standard macros according to
    * http://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html
@@ -111,7 +113,7 @@ public final class Macro {
     add(STANDARD_MACROS_IMPL, "__TIME__", "\"??:??:??\"");
     add(STANDARD_MACROS_IMPL, "__STDC__", "1");
     add(STANDARD_MACROS_IMPL, "__STDC_HOSTED__", "1");
-    add(STANDARD_MACROS_IMPL, "__cplusplus", "201103L");
+    add(STANDARD_MACROS_IMPL, CPLUSPLUS, "201103L");
     // __has_include support (C++17)
     add(STANDARD_MACROS_IMPL, "__has_include", "1");
   }

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/Macro.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/Macro.java
@@ -61,7 +61,7 @@ public final class Macro {
    * @param name
    * @param body
    */
-  public Macro(String name, String body) {
+  private Macro(String name, String body) {
     this.name = name;
     this.params = null;
     this.body = Collections.singletonList(Token.builder()

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/MapChain.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/MapChain.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.cxx.preprocessor;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -118,6 +119,10 @@ public class MapChain<K, V> {
     if (value != null) {
       to.put(key, value);
     }
+  }
+
+  public Map<K, V> getHighPrioMap() {
+    return Collections.unmodifiableMap(highPrioMap);
   }
 
 }

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
@@ -53,12 +53,12 @@ public class CxxParseErrorLoggerVisitorTest {
   @Test
   public void handleParseErrorTest() throws Exception {
     List<String> log = logTester.logs(LoggerLevel.DEBUG);
-    assertThat(log).hasSize(12);
-    assertThat(log.get(7)).contains("skip declaration: namespace X {");
-    assertThat(log.get(8)).contains("skip declaration: void test :: f1 ( ) {");
-    assertThat(log.get(9)).contains("syntax error: i = unsigend int ( i + 1 )");
-    assertThat(log.get(10)).contains("skip declaration: void test :: f3 ( ) {");
-    assertThat(log.get(11)).contains("syntax error: int i = 0 i ++");
+    assertThat(log).hasSize(13);
+    assertThat(log.get(8)).contains("skip declaration: namespace X {");
+    assertThat(log.get(9)).contains("skip declaration: void test :: f1 ( ) {");
+    assertThat(log.get(10)).contains("syntax error: i = unsigend int ( i + 1 )");
+    assertThat(log.get(11)).contains("skip declaration: void test :: f3 ( ) {");
+    assertThat(log.get(12)).contains("syntax error: int i = 0 i ++");
   }
 
 }

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
@@ -53,12 +53,12 @@ public class CxxParseErrorLoggerVisitorTest {
   @Test
   public void handleParseErrorTest() throws Exception {
     List<String> log = logTester.logs(LoggerLevel.DEBUG);
-    assertThat(log).hasSize(13);
-    assertThat(log.get(8)).contains("skip declaration: namespace X {");
-    assertThat(log.get(9)).contains("skip declaration: void test :: f1 ( ) {");
-    assertThat(log.get(10)).contains("syntax error: i = unsigend int ( i + 1 )");
-    assertThat(log.get(11)).contains("skip declaration: void test :: f3 ( ) {");
-    assertThat(log.get(12)).contains("syntax error: int i = 0 i ++");
+    assertThat(log).hasSize(12);
+    assertThat(log.get(7)).contains("skip declaration: namespace X {");
+    assertThat(log.get(8)).contains("skip declaration: void test :: f1 ( ) {");
+    assertThat(log.get(9)).contains("syntax error: i = unsigend int ( i + 1 )");
+    assertThat(log.get(10)).contains("skip declaration: void test :: f3 ( ) {");
+    assertThat(log.get(11)).contains("syntax error: int i = 0 i ++");
   }
 
 }


### PR DESCRIPTION
Also:

apply correct order macro definitions
    
1. standard macro values (e.g.` __LINE__`)
2. configured defines (e.g. `-D__LINE__=123`)
3. forced include files (e.g. header contains `#define __LINE__ 456`)

-> 2 overrides 1
-> 3 overrides 2 and 1

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1665)
<!-- Reviewable:end -->
