### PR TITLE
support real paths in coverage sensor for C++/CLI

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
@@ -105,7 +105,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
    * {@inheritDoc}
    */
   @Override
-  public void execute(SensorContext context) {
+  public void executeImpl(SensorContext context) {
     Configuration conf = context.config();
     String[] reportsKey = conf.getStringArray(getReportPathKey());
     LOG.info("Searching coverage reports by path with basedir '{}' and search prop '{}'",
@@ -162,7 +162,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
     for (Map.Entry<String, CoverageMeasures> entry : coverageMeasures.entrySet()) {
       final String filePath = PathUtils.sanitize(entry.getKey());
       if (filePath != null) {
-        InputFile cxxFile = context.fileSystem().inputFile(context.fileSystem().predicates().hasPath(filePath));
+        InputFile cxxFile = getInputFileIfInProject(context, filePath);
         if (LOG.isDebugEnabled()) {
           LOG.debug("save coverage measure for file: '{}' cxxFile = '{}'", filePath, cxxFile);
         }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/other/CxxOtherSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/other/CxxOtherSensor.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.xml.stream.XMLStreamException;
@@ -79,9 +78,9 @@ public class CxxOtherSensor extends CxxIssuesReportSensor {
    * {@inheritDoc}
    */
   @Override
-  public void execute(SensorContext context) {
+  public void executeImpl(SensorContext context) {
     transformFiles(context.fileSystem().baseDir(), context);
-    super.execute(context);
+    super.executeImpl(context);
   }
 
   @Override

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/tests/xunit/CxxXunitSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/tests/xunit/CxxXunitSensor.java
@@ -73,7 +73,7 @@ public class CxxXunitSensor extends CxxReportSensor {
    * {@inheritDoc}
    */
   @Override
-  public void execute(SensorContext context) {
+  public void executeImpl(SensorContext context) {
     LOG.debug("Root module imports test metrics: Module Key = '{}'", context.module());
 
     try {

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportSensorTest.java
@@ -111,7 +111,7 @@ public class CxxReportSensorTest {
     }
 
     @Override
-    public void execute(SensorContext sc) {
+    public void executeImpl(SensorContext sc) {
     }
 
     @Override


### PR DESCRIPTION
- move getInputFileIfInProject to CxxReportSensor
- introduce executeImpl (template method pattern)

solution from @jmecosta #1688 with review comments from @ivangalkin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1701)
<!-- Reviewable:end -->
