### PR TITLE
seperate cxx-lint tool

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -97,6 +97,7 @@ artifacts:
   - path: 'sonar-cxx-plugin\target\*.jar'
   - path: 'sonar-c-plugin\target\*.jar'
   - path: 'sslr-cxx-toolkit\target\*.jar'
+  - path: 'cxx-lint\target\*.jar'
 
 #---------------------------------#
 #        global handlers          #

--- a/sonar-cxx-plugin/pom.xml
+++ b/sonar-cxx-plugin/pom.xml
@@ -83,13 +83,6 @@
           <exclude>external/*</exclude>
         </excludes>
       </resource>
-      <resource>
-        <targetPath>static</targetPath>
-        <directory>../cxx-lint/target</directory>
-        <includes>
-          <include>cxx-lint-${project.version}.jar</include>
-        </includes>
-      </resource>
     </resources>
   </build>
 


### PR DESCRIPTION
- remove cxx-lint tool from cxx plugin
- cxx-lint tool is as seperate download available
- cxx plugin is no more doing static code analysis (#1704), so lint tool makes also no more sense

Seems that less people are using the cxx-lint tool. In a first step cxx-lint is available as seperate download to see if there is still interest. If no one is using it we remove it completely from the repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1705)
<!-- Reviewable:end -->
