### PR TITLE
fix gcc warnings without rule id

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensor.java
@@ -32,7 +32,10 @@ public class CxxCompilerGccSensor extends CxxCompilerSensor {
   public static final String REPORT_REGEX_DEF = "gcc.regex";
   public static final String REPORT_CHARSET_DEF = "gcc.charset";
   public static final String DEFAULT_CHARSET_DEF = "UTF-8";
-  public static final String DEFAULT_ID = "enabled by default";
+  /**
+   * Default id used for gcc warnings not associated with any activation switch.
+   */
+  public static final String DEFAULT_ID = "default";
   public static final String DEFAULT_REGEX_DEF
     = "(?<file>.*):(?<line>[0-9]+):[0-9]+:\\x20warning:\\x20(?<message>.*?)(\\x20\\[(?<id>.*)\\])?\\s*$";
 
@@ -71,6 +74,9 @@ public class CxxCompilerGccSensor extends CxxCompilerSensor {
 
   @Override
   protected String alignId(String id) {
+	/* Some gcc warnings are not associated to any activation switch and don't have a matching id.
+	 * In these cases a default id is used. 
+	 */
 	if (id == null || "".equals(id)) {
 		id = DEFAULT_ID;
 	}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensor.java
@@ -32,8 +32,9 @@ public class CxxCompilerGccSensor extends CxxCompilerSensor {
   public static final String REPORT_REGEX_DEF = "gcc.regex";
   public static final String REPORT_CHARSET_DEF = "gcc.charset";
   public static final String DEFAULT_CHARSET_DEF = "UTF-8";
+  public static final String DEFAULT_ID = "enabled by default";
   public static final String DEFAULT_REGEX_DEF
-    = "(?<file>.*):(?<line>[0-9]+):[0-9]+:\\x20warning:\\x20(?<message>.*)\\x20\\[(?<id>.*)\\]";
+    = "(?<file>.*):(?<line>[0-9]+):[0-9]+:\\x20warning:\\x20(?<message>.*?)(\\x20\\[(?<id>.*)\\])?\\s*$";
 
   public CxxCompilerGccSensor(CxxLanguage language) {
     super(language, REPORT_PATH_KEY, CxxCompilerGccRuleRepository.getRepositoryKey(language));
@@ -70,6 +71,9 @@ public class CxxCompilerGccSensor extends CxxCompilerSensor {
 
   @Override
   protected String alignId(String id) {
+	if (id == null || "".equals(id)) {
+		id = DEFAULT_ID;
+	}
     return id.replaceAll("=$", "");
   }
 

--- a/cxx-sensors/src/main/resources/compiler-gcc.xml
+++ b/cxx-sensors/src/main/resources/compiler-gcc.xml
@@ -22,7 +22,7 @@ Follow these steps to make your custom Custom rules available in SonarQube:
     <severity>MAJOR</severity>
   </rule>
   <rule>
-    <key>enabled by default</key>
+    <key>default</key>
     <name>Default compiler warnings</name>
     <description>
     Default compiler warnings.

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/compiler-reports/build-warning-without-id.gcclog
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/compiler-reports/build-warning-without-id.gcclog
@@ -1,0 +1,7 @@
+main.c:7:1: warning: no semicolon at end of struct or union
+ } my_struct;
+ ^
+main.c: In function 'main':
+main.c:11:6: warning: unused variable 'i' [-Wunused-variable]
+  int i;
+      ^


### PR DESCRIPTION
close #1703

Problem:  
Some gcc warnings don't have anything to match with a id rule.  
In that case the default regex doesn't match and there is no id to match with a rule key

What I have done: 
- modified the regex to match gcc warnings with or without a rule is part
- when the matched warning don't have a id part, use a default one "enabled by default".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1708)
<!-- Reviewable:end -->
