### PR TITLE
Add path/flow support for Clang Static Analyzer *.plist reports

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/utils/CxxReportIssue.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/utils/CxxReportIssue.java
@@ -33,17 +33,24 @@ public class CxxReportIssue {
 
   private final String ruleId;
   private final List<CxxReportLocation> locations;
+  private final List<CxxReportLocation> flow;
 
   public CxxReportIssue(String ruleId, @Nullable String file, @Nullable String line, String info) {
     super();
     this.ruleId = ruleId;
     this.locations = new ArrayList<>();
+    this.flow = new ArrayList<>();
     addLocation(file, line, info);
   }
 
   public final void addLocation(@Nullable String file, @Nullable String line, String info) {
     locations.add(new CxxReportLocation(file, line, info));
   }
+
+  public final void addFlowElement(@Nullable String file, @Nullable String line, String info) {
+    flow.add(0, new CxxReportLocation(file, line, info));
+  }
+
 
   public String getRuleId() {
     return ruleId;
@@ -53,15 +60,20 @@ public class CxxReportIssue {
     return Collections.unmodifiableList(locations);
   }
 
+  public List<CxxReportLocation> getFlow() {
+    return Collections.unmodifiableList(flow);
+  }
+
   @Override
   public String toString() {
     String locationsToString = locations.stream().map(Object::toString).collect(Collectors.joining(", "));
-    return "CxxReportIssue [ruleId=" + ruleId + ", locations=" + locationsToString + "]";
+    String flowToString = flow.stream().map(Object::toString).collect(Collectors.joining(", "));
+    return "CxxReportIssue [ruleId=" + ruleId + ", locations=" + locationsToString + ", flow=" + flowToString + "]";
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(locations, ruleId);
+    return Objects.hash(locations, flow, ruleId);
   }
 
   @Override
@@ -76,7 +88,8 @@ public class CxxReportIssue {
       return false;
     }
     CxxReportIssue other = (CxxReportIssue) obj;
-    return Objects.equals(locations, other.locations) && Objects.equals(ruleId, other.ruleId);
+    return Objects.equals(locations, other.locations) && Objects.equals(flow, other.flow)
+        && Objects.equals(ruleId, other.ruleId);
   }
 
 }

--- a/cxx-squid/src/test/java/org/sonar/cxx/utils/CxxReportIssueTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/utils/CxxReportIssueTest.java
@@ -21,6 +21,9 @@ package org.sonar.cxx.utils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+
+import java.util.List;
+
 import org.junit.Test;
 
 public class CxxReportIssueTest {
@@ -58,4 +61,47 @@ public class CxxReportIssueTest {
     assertNotEquals(issue0.hashCode(), issue2.hashCode());
   }
 
+  @Test
+  public void reportIssueEqualityConsideringFlow() {
+    CxxReportIssue issue0 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
+    issue0.addFlowElement("path0.cpp", "1", "a");
+    issue0.addFlowElement("path1.cpp", "1", "b");
+    issue0.addFlowElement("path2.cpp", "1", "c");
+
+    CxxReportIssue issue1 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
+    issue1.addFlowElement("path0.cpp", "1", "a");
+    issue1.addFlowElement("path1.cpp", "1", "b");
+    issue1.addFlowElement("path2.cpp", "1", "c");
+
+    CxxReportIssue issue2 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
+    issue2.addFlowElement("path1.cpp", "1", "b");
+    issue2.addFlowElement("path2.cpp", "1", "c");
+
+    CxxReportIssue issue3 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
+
+    assertEquals(issue0, issue1);
+    assertEquals(issue0.hashCode(), issue1.hashCode());
+
+    assertNotEquals(issue0, issue2);
+    assertNotEquals(issue0.hashCode(), issue2.hashCode());
+
+    assertNotEquals(issue1, issue2);
+    assertNotEquals(issue1.hashCode(), issue2.hashCode());
+
+    assertNotEquals(issue0, issue3);
+    assertNotEquals(issue0.hashCode(), issue3.hashCode());
+  }
+
+  @Test
+  public void reportIssueFlowOrder() {
+    CxxReportIssue issue0 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
+    issue0.addFlowElement("path0.cpp", "1", "a");
+    issue0.addFlowElement("path1.cpp", "2", "b");
+    issue0.addFlowElement("path2.cpp", "3", "c");
+
+    List<CxxReportLocation> flow = issue0.getFlow();
+    assertEquals(new CxxReportLocation("path2.cpp", "3", "c"), flow.get(0));
+    assertEquals(new CxxReportLocation("path1.cpp", "2", "b"), flow.get(1));
+    assertEquals(new CxxReportLocation("path0.cpp", "1", "a"), flow.get(2));
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,16 @@
     </developer>
   </developers>
 
+  <contributors>
+    <contributor>
+      <name>Adam Romanek</name>
+      <email>aromanek.contractor@libertyglobal.com</email>
+      <organization>Liberty Global B.V.</organization>
+      <organizationUrl>https://www.libertyglobal.com</organizationUrl>
+      <timezone>Europe/Warsaw</timezone>
+    </contributor>
+  </contributors>
+
   <modules>
     <module>cxx-squid</module>
     <module>cxx-checks</module>


### PR DESCRIPTION
ClangStaticAnalyzer is good at finding issues which involve a certain path in code, with given constraints and values of particular variables. Its HTML reports visualize the full path from the start to the final location, showing all the intermediate steps and the assumptions taken. The path and conditions are very often critical to understand why CSA reports a given issue. Without them one can easily judge CSA for reporting a false positive, while in fact the issue is there, but the conditions are non-obvious.

Currently sonar-cxx only reports the final location of a given issue. This PR addresses this shortcoming and closes the gap to CSA's HTML reports. With this PR SonarQube is now able to present the full path to a given issue, which provides similar UX to CSA's HTML reports.

Closes #1707.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1710)
<!-- Reviewable:end -->
