### PR TITLE
test SQ 7.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
         - oraclejdk8
 
 env:
-        - SONARLABEL=sonarqube-6.7.6   SONARAPI=SqApi67
+        - SONARLABEL=sonarqube-6.7.7   SONARAPI=SqApi67
         - SONARLABEL=sonarqube-7.0     SONARAPI=SqApi67
         - SONARLABEL=sonarqube-7.1     SONARAPI=SqApi67
         - SONARLABEL=sonarqube-7.2     SONARAPI=SqApi67
@@ -16,7 +16,8 @@ env:
         - SONARLABEL=sonarqube-7.5     SONARAPI=SqApi75
         - SONARLABEL=sonarqube-7.6     SONARAPI=SqApi76
         - SONARLABEL=sonarqube-7.7     SONARAPI=SqApi76
-
+        - SONARLABEL=sonarqube-7.8     SONARAPI=SqApi78
+        
 matrix:
     fast_finish: true
 #    allow_failures:
@@ -52,8 +53,8 @@ install:
         - pushd /tmp
         - wget -nv --timeout=10 https://binaries.sonarsource.com/Distribution/sonarqube/$SONARLABEL.zip
         - unzip -qq $SONARLABEL.zip
-        - wget -nv --timeout=10 https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.3.0.1492.zip
-        - unzip -qq sonar-scanner-cli-3.3.0.1492.zip
+        - wget -nv --timeout=10 https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.0.0.1744.zip
+        - unzip -qq sonar-scanner-cli-4.0.0.1744.zip
         - wget -nv --timeout=10 https://github.com/htacg/tidy-html5/archive/5.6.0.zip --output-document=tidy-html5.zip
         - unzip -qq tidy-html5.zip
         - pushd tidy-html5-5.6.0/build/cmake/
@@ -71,8 +72,11 @@ script:
         - mvn install -B -e -V -DskipTests=true
         - mvn test -B -e -V
         - bash cxx-sensors/src/tools/check_rules.sh
-        - RAILS_ENV=production PATH=$PATH:/tmp/sonar-scanner-3.3.0.1492/bin TestDataFolder=~/build/SonarOpenCommunity/sonar-cxx/integration-tests/testdata behave --no-capture --tags=$SONARAPI
+        - RAILS_ENV=production PATH=$PATH:/tmp/sonar-scanner-4.0.0.1744/bin TestDataFolder=~/build/SonarOpenCommunity/sonar-cxx/integration-tests/testdata behave --no-capture --tags=$SONARAPI
 
 after_failure:
         - cat $SONARHOME/logs/sonar.log
+        - cat $SONARHOME/logs/web.log
+        - cat $SONARHOME/logs/ce.log
+        - cat $SONARHOME/logs/es.log
         - find . -name "*.log" | xargs cat

--- a/cxx-sensors/pom.xml
+++ b/cxx-sensors/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.plist</groupId>

--- a/integration-tests/features/importing_clangsa_reports.feature
+++ b/integration-tests/features/importing_clangsa_reports.feature
@@ -1,4 +1,4 @@
-@SqApi67 @SqApi75 @SqApi76
+@SqApi67 @SqApi75 @SqApi76 @SqApi78
 Feature: Importing Clang Static Analyzer reports
   As a SonarQube user,
   I want to import the Clang Static Analyzer reports into SonarQube.

--- a/integration-tests/features/importing_clangsa_scanbuild_reports.feature
+++ b/integration-tests/features/importing_clangsa_scanbuild_reports.feature
@@ -1,4 +1,4 @@
-@SqApi67 @SqApi75 @SqApi76
+@SqApi67 @SqApi75 @SqApi76 @SqApi78
 Feature: Importing Clang Static Analyzer scan-build reports
 
   As a SonarQube user,

--- a/integration-tests/features/importing_coverage.feature
+++ b/integration-tests/features/importing_coverage.feature
@@ -3,7 +3,7 @@ Feature: Importing coverage data
   I want to import my coverage metric values into SonarQube
   In order to be able to use relevant SonarQube features
 
-  @SqApi67 @SqApi75 @SqApi76
+  @SqApi67 @SqApi75 @SqApi76 @SqApi78
   Scenario: Importing coverage reports
     Given the project "coverage_project"
     When I run sonar-scanner with following options:
@@ -23,7 +23,7 @@ Feature: Importing coverage data
       | line_coverage           | 25.0  |
       | branch_coverage         | 50    |
 
-  @SqApi67 @SqApi75 @SqApi76
+  @SqApi67 @SqApi75 @SqApi76 @SqApi78
   Scenario: Zero coverage measures without coverage reports
     If we don't pass coverage reports all coverage measures, except the branch
     ones, should be 'zero'. The branch coverage measures remain 'None'

--- a/integration-tests/features/importing_cppcheck_reports.feature
+++ b/integration-tests/features/importing_cppcheck_reports.feature
@@ -4,7 +4,7 @@ Feature: Importing Cppcheck reports
   In order to have all static code checking results in one place,
   work with them, filter them etc. and derive metrics from them.
 
-  @SqApi67 @SqApi75 @SqApi76
+  @SqApi67 @SqApi75 @SqApi76 @SqApi78
   Scenario: The reports are missing
     Given the project "cppcheck_project"
     When I run "sonar-scanner -X -Dsonar.cxx.cppcheck.reportPath=empty.xml"
@@ -30,7 +30,7 @@ Feature: Importing Cppcheck reports
       """
     And the number of violations fed is 0
 
-  @SqApi67 @SqApi75 @SqApi76
+  @SqApi67 @SqApi75 @SqApi76 @SqApi78
   Scenario: The reports use paths relative to directories listed in sonar.sources
     Given the project "cppcheck_project"
     When I run "sonar-scanner -X -Dsonar.cxx.cppcheck.reportPath=relative-to-src.xml"
@@ -43,7 +43,7 @@ Feature: Importing Cppcheck reports
       """
     And the number of violations fed is 0
 
-  @SqApi67 @SqApi75 @SqApi76
+  @SqApi67 @SqApi75 @SqApi76 @SqApi78
   Scenario: The reports and issues in the reports have absolute paths
     Given the project "cppcheck_with_absolute_paths_project"
     And platform is not "Windows"
@@ -53,7 +53,7 @@ Feature: Importing Cppcheck reports
     And the server log (if locatable) contains no error/warning messages
     And the number of violations fed is 6
 
-  @SqApi67 @SqApi75 @SqApi76
+  @SqApi67 @SqApi75 @SqApi76 @SqApi78
   Scenario Outline: The reports are invalid
     Given the project "cppcheck_project"
     When I run "sonar-scanner -X -Dsonar.cxx.cppcheck.reportPath=<reportpath>"
@@ -70,7 +70,7 @@ Feature: Importing Cppcheck reports
       | unparsable.xml      | 0          |
       | wrongly_encoded.xml | 0          |
 
-  @SqApi67 @SqApi75 @SqApi76
+  @SqApi67 @SqApi75 @SqApi76 @SqApi78
   Scenario Outline: Importing Cppcheck reports
     Given the project "cppcheck_project"
     When I run "sonar-scanner -X -Dsonar.cxx.cppcheck.reportPath=<reportpath>"

--- a/integration-tests/features/multimodule_analysis.feature
+++ b/integration-tests/features/multimodule_analysis.feature
@@ -1,4 +1,4 @@
-@SqApi67 @SqApi75 @SqApi76
+@SqApi67 @SqApi75 @SqApi76 @SqApi78
 Feature: cpp-multimodule-project
   Test multimodule project with reports at root of the project
 

--- a/integration-tests/features/smoketest.feature
+++ b/integration-tests/features/smoketest.feature
@@ -119,3 +119,42 @@ Feature: Smoketest
       | test_failures            | 2     |
       | test_errors              | 0     |
       | tests                    | 4     |
+
+@SqApi78
+  Scenario: Smoketest
+    Given the project "smoketest_project"
+    When I run "sonar-scanner -X"
+    Then the analysis finishes successfully
+    And the analysis in server has completed
+    And the analysis log contains no error/warning messages except those matching:
+      """
+      .*WARN.*Unable to get a valid mac address, will use a dummy address
+      .*WARN.*cannot find the sources for '#include <gtest/gtest\.h>'
+      .*WARN.*cannot find the sources for '#include <iostream>'
+      .*WARN.*Cannot find the file '.*component_XXX.cc', skipping violations
+      .*WARN.*Cannot find a report for '.*'
+      .*WARN.*Already created edge from 'src/cli/main.cc'.*
+      """
+    And the following metrics have following values:
+      | metric                   | value |
+      | ncloc                    | 56    |
+      | lines                    | 151   |
+      | statements               | 36    |
+      | classes                  | 1     |
+      | files                    | 8     |
+      | functions                | 5     |
+      | comment_lines_density    | 30    |
+      | comment_lines            | 24    |
+      | duplicated_lines_density | 55.6  |
+      | duplicated_lines         | 84    |
+      | duplicated_blocks        | 2     |
+      | duplicated_files         | 2     |
+      | complexity               | 7     |
+      | file_complexity          | 0.9   |
+      | violations               | 12    |
+      | coverage                 | 53.8  |
+      | line_coverage            | 54.8  |
+      | branch_coverage          | 50    |
+      | test_failures            | 2     |
+      | test_errors              | 0     |
+      | tests                    | 4     |

--- a/integration-tests/features/test_create_rules_and_bullseye_import.feature
+++ b/integration-tests/features/test_create_rules_and_bullseye_import.feature
@@ -1,4 +1,4 @@
-@SqApi67 @SqApi75 @SqApi76
+@SqApi67 @SqApi75 @SqApi76 @SqApi78
 Feature: GoogleTestWithBullseyeAndVsProject
   This test verifies that analysis is able to import bullseye coverage reports and import custom rules reports.
   Custom rules are created using Rest API, after test ends rules are deleted.

--- a/integration-tests/features/test_execution_statistics.feature
+++ b/integration-tests/features/test_execution_statistics.feature
@@ -1,4 +1,4 @@
-@SqApi67 @SqApi75 @SqApi76
+@SqApi67 @SqApi75 @SqApi76 @SqApi78
 Feature: Providing test execution numbers
   As a SonarQube user,
   I want to import the test execution reports into SonarQube

--- a/integration-tests/features/x_importing_cppcheck_reports_c_cpp.feature
+++ b/integration-tests/features/x_importing_cppcheck_reports_c_cpp.feature
@@ -1,4 +1,4 @@
-@SqApi67 @SqApi75 @SqApi76
+@SqApi67 @SqApi75 @SqApi76 @SqApi78
 Feature: Importing Cppcheck ANSI-C reports
 
   Scenario Outline: Importing cppcheck issues when c language issues are in report.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>49</version>
+    <version>51</version>
   </parent>
 
   <groupId>org.sonarsource.sonarqube-plugins.cxx</groupId>


### PR DESCRIPTION
- SonarScanner 4.0.0.1744
- add all logs files in case of error
- fix project's duplication density value will likely rise (SONAR-12188)
 - use parent 51
- fix security alert com.fasterxml.jackson.core=2.9.9

- close #1731 
- close #1736 
- close #1737

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1738)
<!-- Reviewable:end -->
