### PR TITLE
Correction for expression used to check if a compiler warning is valid.

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensor.java
@@ -106,6 +106,10 @@ public abstract class CxxCompilerSensor extends CxxIssuesReportSensor {
 
   /**
    * Derived classes can overload this method
+   * 
+   * A valid issue must have an id 
+   * and, if it has a line number, a filename.
+   * 
    *
    * @param filename
    * @param line
@@ -113,9 +117,15 @@ public abstract class CxxCompilerSensor extends CxxIssuesReportSensor {
    * @param msg
    * @return true, if valid
    */
-  protected boolean isInputValid(String filename, String line, String id, String msg) {
-    return !filename.isEmpty() || !line.isEmpty() || !id.isEmpty() || !msg.isEmpty();
-  }
+	protected boolean isInputValid(String filename, String line, String id, String msg) {
+		if ((id == null) || id.isEmpty()) {
+			return false;
+		}
+		if ((line != null) && !line.isEmpty() && ((filename == null) || filename.isEmpty())) {
+			return false;
+		}
+		return true;
+	}
 
   /**
    * Derived classes can overload this method to align filename


### PR DESCRIPTION
I think there is a bug in the expression used to check if a compiler warning is valid (CxxCompilerSensor.java).

Currently a compiler warning is valid if there is either a filename,  a line number, an id or a warning message, I think it should be valid only if there are both a filename,  a line number, an id and a warning message..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1746)
<!-- Reviewable:end -->
