### PR TITLE
clang-tidy: add 'clang-diagnostic-error' rule

### DIFF
--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -22,6 +22,15 @@
   <severity>MAJOR</severity>
 </rule>
 <rule>
+  <key>clang-diagnostic-error</key>
+  <name>clang-diagnostic-error</name>
+  <description><![CDATA[
+      <p>Diagnostic text: compiler error, e.g header file not found</p>
+      ]]></description>
+  <severity>INFO</severity>
+  <type>BUG</type>
+</rule>
+<rule>
   <key>clang-diagnostic-warning</key>
   <name>clang-diagnostic-warning</name>
   <description><![CDATA[

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
@@ -41,7 +41,7 @@ public class CxxClangTidyRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxClangTidyRuleRepository.getRepositoryKey(language));
-    assertEquals(1082, repo.rules().size());
+    assertEquals(1083, repo.rules().size());
   }
 
 }

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -300,6 +300,21 @@ def create_template_rules(rules):
     rules.append(rule)
 
 def create_clang_default_rules(rules):
+    # defaults clang error (not associated with any activation switch)
+    rule_key = "clang-diagnostic-error"
+    rule_name = "clang-diagnostic-error"
+    rule_type = DIAG_CLASS["CLASS_ERROR"]["sonarqube_type"]
+    rule_severity = SEVERITY["SEV_Remark"]["sonarqube_severity"] 
+    rule_description = "<p>Diagnostic text: compiler error, e.g header file not found</p>"
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = rule_key
+    et.SubElement(rule, 'name').text = rule_name
+    et.SubElement(rule, 'description').append(CDATA(rule_description))
+    et.SubElement(rule, 'severity').text = rule_severity
+    et.SubElement(rule, 'type').text = rule_type
+    rules.append(rule)
+  
     # defaults clang warning (not associated with any activation switch)
     rule_key = "clang-diagnostic-warning"
     rule_name = "clang-diagnostic-warning"


### PR DESCRIPTION
- type: BUG; severity: INFO
- parsing error, e.g. can't find header file
- it's not really a static code analysis finding more a diagnostic tool info
- close #1747

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1754)
<!-- Reviewable:end -->
