### PR TITLE
NOSONAR support

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
@@ -35,6 +35,7 @@ import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.batch.sensor.issue.NewIssue;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
+import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.measures.Metric;
@@ -89,6 +90,7 @@ public class CxxSquidSensor implements Sensor {
 
   private final FileLinesContextFactory fileLinesContextFactory;
   private final CxxChecks checks;
+  private final NoSonarFilter noSonarFilter;
 
   private final CxxLanguage language;
 
@@ -97,8 +99,9 @@ public class CxxSquidSensor implements Sensor {
    */
   public CxxSquidSensor(CxxLanguage language,
     FileLinesContextFactory fileLinesContextFactory,
-    CheckFactory checkFactory) {
-    this(language, fileLinesContextFactory, checkFactory, null);
+    CheckFactory checkFactory,
+    NoSonarFilter noSonarFilter) {
+    this(language, fileLinesContextFactory, checkFactory, noSonarFilter, null);
   }
 
   /**
@@ -107,11 +110,13 @@ public class CxxSquidSensor implements Sensor {
   public CxxSquidSensor(CxxLanguage language,
     FileLinesContextFactory fileLinesContextFactory,
     CheckFactory checkFactory,
+    NoSonarFilter noSonarFilter,
     @Nullable CustomCxxRulesDefinition[] customRulesDefinition) {
     this.checks = CxxChecks.createCxxCheck(checkFactory)
       .addChecks(language.getRepositoryKey(), language.getChecks())
       .addCustomChecks(customRulesDefinition);
     this.fileLinesContextFactory = fileLinesContextFactory;
+    this.noSonarFilter = noSonarFilter;
     this.language = language;
   }
 

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
@@ -239,6 +239,10 @@ public class CxxSquidSensor implements Sensor {
   }
 
   private void saveMeasures(InputFile inputFile, SourceFile squidFile, SensorContext context) {
+    
+    // NOSONAR
+    noSonarFilter.noSonarInFile(inputFile, squidFile.getNoSonarTagLines());
+    
     // CORE METRICS
     context.<Integer>newMeasure().forMetric(CoreMetrics.NCLOC).on(inputFile)
       .withValue(squidFile.getInt(CxxMetric.LINES_OF_CODE)).save();

--- a/cxx-sensors/src/test/java/org/sonar/plugins/cxx/squid/CxxSquidSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/plugins/cxx/squid/CxxSquidSensorTest.java
@@ -37,6 +37,7 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
@@ -69,6 +70,7 @@ public class CxxSquidSensorTest {
       language,
       fileLinesContextFactory,
       checkFactory,
+      new NoSonarFilter(),
       null);
   }
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/CxxAstScannerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/CxxAstScannerTest.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.Test;
@@ -125,4 +127,11 @@ public class CxxAstScannerTest {
     assertThat(file.getInt(CxxMetric.FUNCTIONS)).isEqualTo(2);
   }
 
+  @Test
+  public void nosonar_comments() throws UnsupportedEncodingException, IOException {
+    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/metrics/nosonar.cc", ".", "");
+    SourceFile file = CxxAstScanner.scanSingleFile(tester.cxxFile, tester.sensorContext, CxxFileTesterHelper.mockCxxLanguage());
+    assertThat(file.getNoSonarTagLines()).containsOnlyElementsOf(Arrays.asList(3, 6, 9, 11));
+  }
+  
 }

--- a/cxx-squid/src/test/resources/metrics/nosonar.cc
+++ b/cxx-squid/src/test/resources/metrics/nosonar.cc
@@ -1,0 +1,13 @@
+/* Header */
+
+/* NOSONAR */
+int a;
+
+// NOSONAR
+int b;
+
+int c; /* NOSONAR */
+
+int d; // NOSONAR
+
+/* EOF '/

--- a/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
+++ b/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
@@ -30,6 +30,7 @@ import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.config.PropertyDefinition;
+import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.measures.Metric;
 import org.sonar.api.measures.Metrics;
@@ -688,15 +689,17 @@ public final class CPlugin implements Plugin {
 
     public CxxSquidSensorImpl(Configuration settings,
       FileLinesContextFactory fileLinesContextFactory,
-      CheckFactory checkFactory) {
-      super(new CLanguage(settings), fileLinesContextFactory, checkFactory);
+      CheckFactory checkFactory,
+      NoSonarFilter noSonarFilter) {
+      super(new CLanguage(settings), fileLinesContextFactory, checkFactory, noSonarFilter);
     }
 
     public CxxSquidSensorImpl(Configuration settings,
       FileLinesContextFactory fileLinesContextFactory,
       CheckFactory checkFactory,
+      NoSonarFilter noSonarFilter,
       @Nullable CustomCxxRulesDefinition[] customRulesDefinition) {
-      super(new CLanguage(settings), fileLinesContextFactory, checkFactory, customRulesDefinition);
+      super(new CLanguage(settings), fileLinesContextFactory, checkFactory, noSonarFilter, customRulesDefinition);
     }
   }
 

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -30,6 +30,7 @@ import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.config.PropertyDefinition;
+import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.measures.Metric;
 import org.sonar.api.measures.Metrics;
@@ -741,15 +742,17 @@ public final class CxxPlugin implements Plugin {
 
     public CxxSquidSensorImpl(Configuration settings,
       FileLinesContextFactory fileLinesContextFactory,
-      CheckFactory checkFactory) {
-      super(new CppLanguage(settings), fileLinesContextFactory, checkFactory);
+      CheckFactory checkFactory,
+      NoSonarFilter noSonarFilter) {
+      super(new CppLanguage(settings), fileLinesContextFactory, checkFactory, noSonarFilter);
     }
 
     public CxxSquidSensorImpl(Configuration settings,
       FileLinesContextFactory fileLinesContextFactory,
       CheckFactory checkFactory,
+      NoSonarFilter noSonarFilter,
       @Nullable CustomCxxRulesDefinition[] customRulesDefinition) {
-      super(new CppLanguage(settings), fileLinesContextFactory, checkFactory, customRulesDefinition);
+      super(new CppLanguage(settings), fileLinesContextFactory, checkFactory, noSonarFilter, customRulesDefinition);
     }
   }
 


### PR DESCRIPTION
support `//NOSONAR`

Most language analyzers support the use of the generic mechanism: //NOSONAR at the end of the line of the issue. This will suppress the all issues - now and in the future - that might be raised on the line.

This PR adds NOSONAR support.
- close #1300

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1758)
<!-- Reviewable:end -->
