### PR TITLE
remove sensor.customRules support

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepository.java
@@ -29,7 +29,6 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxClangSARuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String CUSTOM_RULES_KEY = "clangsa.customRules";
   private static final String KEY = "ClangSA";
   private static final String NAME = "Clang-SA";
 
@@ -38,7 +37,7 @@ public class CxxClangSARuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxClangSARuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader,
     CxxLanguage language) {
-    super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+    super(fileSystem, xmlRuleLoader, KEY, NAME, language);
   }
 
   public static String getRepositoryKey(CxxLanguage lang) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepository.java
@@ -29,7 +29,6 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxClangTidyRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String CUSTOM_RULES_KEY = "clangtidy.customRules";
   private static final String KEY = "ClangTidy";
   private static final String NAME = "Clang-Tidy";
 
@@ -38,7 +37,7 @@ public class CxxClangTidyRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxClangTidyRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader,
     CxxLanguage language) {
-    super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+    super(fileSystem, xmlRuleLoader, KEY, NAME, language);
   }
 
   public static String getRepositoryKey(CxxLanguage lang) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccRuleRepository.java
@@ -29,7 +29,6 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxCompilerGccRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String CUSTOM_RULES_KEY = "compiler-gcc.customRules";
   private static final String KEY = "compiler-gcc";
   private static final String NAME = "Compiler-GCC";
 
@@ -38,7 +37,7 @@ public class CxxCompilerGccRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxCompilerGccRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader,
     CxxLanguage language) {
-    super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+    super(fileSystem, xmlRuleLoader, KEY, NAME, language);
   }
 
   public static String getRepositoryKey(CxxLanguage lang) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcRuleRepository.java
@@ -29,7 +29,6 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxCompilerVcRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String CUSTOM_RULES_KEY = "compiler-vc.customRules";
   private static final String KEY = "compiler-vc";
   private static final String NAME = "Compiler-VC";
 
@@ -38,7 +37,7 @@ public class CxxCompilerVcRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxCompilerVcRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader,
     CxxLanguage language) {
-    super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+    super(fileSystem, xmlRuleLoader, KEY, NAME, language);
   }
 
   public static String getRepositoryKey(CxxLanguage lang) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepository.java
@@ -29,7 +29,6 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxCppCheckRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String CUSTOM_RULES_KEY = "cppcheck.customRules";
   private static final String KEY = "cppcheck";
   private static final String NAME = "Cppcheck";
 
@@ -38,7 +37,7 @@ public class CxxCppCheckRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxCppCheckRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader,
     CxxLanguage language) {
-    super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+    super(fileSystem, xmlRuleLoader, KEY, NAME, language);
   }
 
   public static String getRepositoryKey(CxxLanguage lang) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/CxxDrMemoryRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/CxxDrMemoryRuleRepository.java
@@ -29,7 +29,6 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxDrMemoryRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String CUSTOM_RULES_KEY = "drmemory.customRules";
   private static final String KEY = "drmemory";
   private static final String NAME = "Dr Memory";
 
@@ -38,7 +37,7 @@ public class CxxDrMemoryRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxDrMemoryRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader,
     CxxLanguage language) {
-    super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+    super(fileSystem, xmlRuleLoader, KEY, NAME, language);
   }
 
   public static String getRepositoryKey(CxxLanguage lang) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/pclint/CxxPCLintRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/pclint/CxxPCLintRuleRepository.java
@@ -29,7 +29,6 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxPCLintRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String CUSTOM_RULES_KEY = "pclint.customRules";
   private static final String KEY = "pclint";
   private static final String NAME = "PC-lint";
 
@@ -38,7 +37,7 @@ public class CxxPCLintRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxPCLintRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader,
     CxxLanguage language) {
-    super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+    super(fileSystem, xmlRuleLoader, KEY, NAME, language);
   }
 
   public static String getRepositoryKey(CxxLanguage lang) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/rats/CxxRatsRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/rats/CxxRatsRuleRepository.java
@@ -29,7 +29,6 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxRatsRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String CUSTOM_RULES_KEY = "rats.customRules";
   private static final String KEY = "rats";
   private static final String NAME = "RATS";
 
@@ -38,7 +37,7 @@ public class CxxRatsRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxRatsRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader,
     CxxLanguage language) {
-    super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+    super(fileSystem, xmlRuleLoader, KEY, NAME, language);
   }
 
   public static String getRepositoryKey(CxxLanguage lang) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxAbstractRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxAbstractRuleRepository.java
@@ -22,7 +22,6 @@ package org.sonar.cxx.sensors.utils;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -48,7 +47,6 @@ public abstract class CxxAbstractRuleRepository implements RulesDefinition {
   private final CxxLanguage language;
   protected final String repositoryKey;
   protected final String repositoryName;
-  protected final String customRepositoryKey;
 
   /**
    * {@inheritDoc}
@@ -58,13 +56,11 @@ public abstract class CxxAbstractRuleRepository implements RulesDefinition {
     RulesDefinitionXmlLoader xmlRuleLoader,
     String key,
     String name,
-    String customKey,
     CxxLanguage language) {
     this.fileSystem = fileSystem;
     this.xmlRuleLoader = xmlRuleLoader;
     this.repositoryKey = getRepositoryKey(key, language);
     this.repositoryName = name;
-    this.customRepositoryKey = customKey;
     this.language = language;
   }
 
@@ -88,13 +84,6 @@ public abstract class CxxAbstractRuleRepository implements RulesDefinition {
         } catch (IOException | IllegalStateException ex) {
           LOG.info("Cannot Load XML '{}'", ex);
         }
-      }
-    }
-
-    if (language.getStringOption(this.customRepositoryKey).isPresent()) {
-      String customRules = language.getStringOption(this.customRepositoryKey).orElse(null);
-      if (customRules != null && !customRules.trim().isEmpty()) {
-        xmlRuleLoader.load(repository, new StringReader(customRules));
       }
     }
 

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/valgrind/CxxValgrindRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/valgrind/CxxValgrindRuleRepository.java
@@ -29,7 +29,6 @@ import org.sonar.cxx.sensors.utils.CxxAbstractRuleRepository;
  */
 public class CxxValgrindRuleRepository extends CxxAbstractRuleRepository {
 
-  public static final String CUSTOM_RULES_KEY = "valgrind.customRules";
   private static final String KEY = "valgrind";
   private static final String NAME = "Valgrind";
 
@@ -38,7 +37,7 @@ public class CxxValgrindRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxValgrindRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader,
     CxxLanguage language) {
-    super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+    super(fileSystem, xmlRuleLoader, KEY, NAME, language);
   }
 
   public static String getRepositoryKey(CxxLanguage lang) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxRuleRepository.java
@@ -38,7 +38,7 @@ public class CxxVeraxxRuleRepository extends CxxAbstractRuleRepository {
    */
   public CxxVeraxxRuleRepository(ServerFileSystem fileSystem, RulesDefinitionXmlLoader xmlRuleLoader,
     CxxLanguage language) {
-    super(fileSystem, xmlRuleLoader, KEY, NAME, CUSTOM_RULES_KEY, language);
+    super(fileSystem, xmlRuleLoader, KEY, NAME, language);
   }
 
   public static String getRepositoryKey(CxxLanguage lang) {

--- a/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
+++ b/sonar-c-plugin/src/main/java/org/sonar/plugins/c/CPlugin.java
@@ -202,14 +202,6 @@ public final class CPlugin implements Plugin {
       .multiValues(true)
       .index(1)
       .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCppCheckRuleRepository.CUSTOM_RULES_KEY)
-        .name("Cppcheck custom rules")
-        .description("XML definitions of custom Cppcheck rules, which are'nt builtin into the plugin."
-          + EXTENDING_THE_CODE_ANALYSIS)
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(2)
-        .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxValgrindSensor.REPORT_PATH_KEY)
         .name("Valgrind report(s)")
         .description("Path to <a href='http://valgrind.org/'>Valgrind</a> report(s), relative to projects root."
@@ -217,15 +209,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(3)
-        .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxValgrindRuleRepository.CUSTOM_RULES_KEY)
-        .name("Valgrind custom rules")
-        .description("XML definitions of custom Valgrind rules, which are'nt builtin into the plugin."
-          + EXTENDING_THE_CODE_ANALYSIS)
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(4)
+        .index(2)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxDrMemorySensor.REPORT_PATH_KEY)
         .name("Dr Memory report(s)")
@@ -234,7 +218,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(5)
+        .index(3)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxPCLintSensor.REPORT_PATH_KEY)
         .name("PC-lint report(s)")
@@ -243,15 +227,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(6)
-        .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxPCLintRuleRepository.CUSTOM_RULES_KEY)
-        .name("PC-lint custom rules")
-        .description("XML definitions of custom PC-lint rules, which are'nt builtin into the plugin."
-          + EXTENDING_THE_CODE_ANALYSIS)
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(7)
+        .index(4)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxRatsSensor.REPORT_PATH_KEY)
         .name("RATS report(s)")
@@ -260,15 +236,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(8)
-        .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxRatsRuleRepository.CUSTOM_RULES_KEY)
-        .name("RATS custom rules")
-        .description("XML definitions of custom RATS rules, which are'nt builtin into the plugin."
-          + EXTENDING_THE_CODE_ANALYSIS)
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(9)
+        .index(5)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxVeraxxSensor.REPORT_PATH_KEY)
         .name("Vera++ report(s)")
@@ -277,7 +245,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(10)
+        .index(6)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxVeraxxRuleRepository.CUSTOM_RULES_KEY)
         .name("Vera++ custom rules")
@@ -285,7 +253,7 @@ public final class CPlugin implements Plugin {
           + EXTENDING_THE_CODE_ANALYSIS)
         .type(PropertyType.TEXT)
         .subCategory(subcateg)
-        .index(11)
+        .index(7)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxOtherSensor.REPORT_PATH_KEY)
         .name("External checkers report(s)")
@@ -296,7 +264,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(12)
+        .index(8)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxOtherRepository.RULES_KEY)
         .name("External rules")
@@ -306,7 +274,7 @@ public final class CPlugin implements Plugin {
         .type(PropertyType.TEXT)
         .multiValues(true)
         .subCategory(subcateg)
-        .index(13)
+        .index(9)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidySensor.REPORT_PATH_KEY)
         .name("Clang-Tidy analyzer report(s)")
@@ -315,7 +283,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(14)
+        .index(10)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidySensor.REPORT_CHARSET_DEF)
         .defaultValue(CxxClangTidySensor.DEFAULT_CHARSET_DEF)
@@ -324,15 +292,7 @@ public final class CPlugin implements Plugin {
           + " Leave empty to use parser's default UTF-8.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .index(15)
-        .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidyRuleRepository.CUSTOM_RULES_KEY)
-        .name("Clang-Tidy custom rules")
-        .description("XML definitions of custom Clang-Tidy rules, which aren't builtin into the plugin."
-          + EXTENDING_THE_CODE_ANALYSIS)
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(16)
+        .index(11)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangSASensor.REPORT_PATH_KEY)
         .name("Clang Static analyzer analyzer report(s)")
@@ -341,14 +301,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(17)
-        .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangSARuleRepository.CUSTOM_RULES_KEY)
-        .name("Clang-SA custom rules")
-        .description("NO DESC")
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(18)
+        .index(12)
         .build()
     ));
   }
@@ -383,14 +336,6 @@ public final class CPlugin implements Plugin {
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .index(3)
         .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerVcRuleRepository.CUSTOM_RULES_KEY)
-        .name("VC Custom Rules")
-        .description("XML definitions of custom rules for Visual C++ warnings, which are'nt builtin into the plugin."
-          + EXTENDING_THE_CODE_ANALYSIS)
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(4)
-        .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerGccSensor.REPORT_PATH_KEY)
         .name("GCC Compiler Report(s)")
         .description("Path to compilers output (i.e. file(s) containg compiler warnings), relative to projects root."
@@ -398,7 +343,7 @@ public final class CPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(5)
+        .index(4)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerGccSensor.REPORT_CHARSET_DEF)
         .defaultValue(CxxCompilerVcSensor.DEFAULT_CHARSET_DEF)
@@ -406,7 +351,7 @@ public final class CPlugin implements Plugin {
         .description("The encoding to use when reading the compiler report. Leave empty to use parser's default UTF-8.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .index(6)
+        .index(5)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerGccSensor.REPORT_REGEX_DEF)
         .name("GCC Regular Expression")
@@ -416,15 +361,7 @@ public final class CPlugin implements Plugin {
           + "this page</a> for details regarding the different regular expression that can be use per compiler.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .index(7)
-        .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerGccRuleRepository.CUSTOM_RULES_KEY)
-        .name("GCC Custom Rules")
-        .description("XML definitions of custom rules for GCC's warnings, which are'nt builtin into the plugin."
-          + EXTENDING_THE_CODE_ANALYSIS)
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(8)
+        .index(6)
         .build()
     ));
   }

--- a/sonar-c-plugin/src/test/java/org/sonar/plugins/c/CPluginTest.java
+++ b/sonar-c-plugin/src/test/java/org/sonar/plugins/c/CPluginTest.java
@@ -35,7 +35,7 @@ public class CPluginTest {
     Plugin.Context context = new Plugin.Context(runtime);
     CPlugin plugin = new CPlugin();
     plugin.define(context);
-    assertThat(context.getExtensions()).hasSize(74);
+    assertThat(context.getExtensions()).hasSize(66);
   }
 
 }

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -210,14 +210,6 @@ public final class CxxPlugin implements Plugin {
       .multiValues(true)
       .index(1)
       .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCppCheckRuleRepository.CUSTOM_RULES_KEY)
-        .name("Cppcheck custom rules")
-        .description("XML definitions of custom Cppcheck rules, which are'nt builtin into the plugin."
-          + EXTENDING_THE_CODE_ANALYSIS)
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(2)
-        .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxValgrindSensor.REPORT_PATH_KEY)
         .name("Valgrind report(s)")
         .description("Path to <a href='http://valgrind.org/'>Valgrind</a> report(s), relative to projects root."
@@ -225,15 +217,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(3)
-        .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxValgrindRuleRepository.CUSTOM_RULES_KEY)
-        .name("Valgrind custom rules")
-        .description("XML definitions of custom Valgrind rules, which are'nt builtin into the plugin."
-          + EXTENDING_THE_CODE_ANALYSIS)
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(4)
+        .index(2)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxDrMemorySensor.REPORT_PATH_KEY)
         .name("Dr Memory report(s)")
@@ -242,7 +226,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(5)
+        .index(3)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxPCLintSensor.REPORT_PATH_KEY)
         .name("PC-lint report(s)")
@@ -251,15 +235,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(6)
-        .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxPCLintRuleRepository.CUSTOM_RULES_KEY)
-        .name("PC-lint custom rules")
-        .description("XML definitions of custom PC-lint rules, which are'nt builtin into the plugin."
-          + EXTENDING_THE_CODE_ANALYSIS)
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(7)
+        .index(4)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxRatsSensor.REPORT_PATH_KEY)
         .name("RATS report(s)")
@@ -268,15 +244,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(8)
-        .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxRatsRuleRepository.CUSTOM_RULES_KEY)
-        .name("RATS custom rules")
-        .description("XML definitions of custom RATS rules, which are'nt builtin into the plugin."
-          + EXTENDING_THE_CODE_ANALYSIS)
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(9)
+        .index(5)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxVeraxxSensor.REPORT_PATH_KEY)
         .name("Vera++ report(s)")
@@ -285,7 +253,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(10)
+        .index(6)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxVeraxxRuleRepository.CUSTOM_RULES_KEY)
         .name("Vera++ custom rules")
@@ -293,7 +261,7 @@ public final class CxxPlugin implements Plugin {
           + EXTENDING_THE_CODE_ANALYSIS)
         .type(PropertyType.TEXT)
         .subCategory(subcateg)
-        .index(11)
+        .index(7)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxOtherSensor.REPORT_PATH_KEY)
         .name("External checkers report(s)")
@@ -303,7 +271,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(12)
+        .index(8)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxOtherRepository.RULES_KEY)
         .name("External rules")
@@ -312,7 +280,7 @@ public final class CxxPlugin implements Plugin {
         .type(PropertyType.TEXT)
         .multiValues(true)
         .subCategory(subcateg)
-        .index(13)
+        .index(9)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidySensor.REPORT_PATH_KEY)
         .name("Clang-Tidy analyzer report(s)")
@@ -321,7 +289,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(14)
+        .index(10)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidySensor.REPORT_CHARSET_DEF)
         .defaultValue(CxxClangTidySensor.DEFAULT_CHARSET_DEF)
@@ -330,15 +298,7 @@ public final class CxxPlugin implements Plugin {
           + " Leave empty to use parser's default UTF-8.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .index(15)
-        .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangTidyRuleRepository.CUSTOM_RULES_KEY)
-        .name("Clang-Tidy custom rules")
-        .description("XML definitions of custom Clang-Tidy rules, which aren't builtin into the plugin."
-          + EXTENDING_THE_CODE_ANALYSIS)
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(16)
+        .index(11)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangSASensor.REPORT_PATH_KEY)
         .name("Clang Static analyzer analyzer report(s)")
@@ -347,14 +307,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(17)
-        .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxClangSARuleRepository.CUSTOM_RULES_KEY)
-        .name("Clang-SA custom rules")
-        .description("NO DESC")
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(18)
+        .index(12)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxFunctionComplexityVisitor.FUNCTION_COMPLEXITY_THRESHOLD_KEY)
         .defaultValue("10")
@@ -363,7 +316,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .type(PropertyType.INTEGER)
-        .index(19)
+        .index(13)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxFunctionSizeVisitor.FUNCTION_SIZE_THRESHOLD_KEY)
         .defaultValue("20")
@@ -372,7 +325,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .type(PropertyType.INTEGER)
-        .index(20)
+        .index(14)
         .build()
     ));
   }
@@ -407,14 +360,6 @@ public final class CxxPlugin implements Plugin {
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .index(3)
         .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerVcRuleRepository.CUSTOM_RULES_KEY)
-        .name("VC Custom Rules")
-        .description("XML definitions of custom rules for Visual C++ warnings, which are'nt builtin into the plugin."
-          + EXTENDING_THE_CODE_ANALYSIS)
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(4)
-        .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerGccSensor.REPORT_PATH_KEY)
         .name("GCC Compiler Report(s)")
         .description("Path to compilers output (i.e. file(s) containg compiler warnings), relative to projects root."
@@ -422,7 +367,7 @@ public final class CxxPlugin implements Plugin {
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .multiValues(true)
-        .index(5)
+        .index(4)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerGccSensor.REPORT_CHARSET_DEF)
         .defaultValue(CxxCompilerVcSensor.DEFAULT_CHARSET_DEF)
@@ -430,7 +375,7 @@ public final class CxxPlugin implements Plugin {
         .description("The encoding to use when reading the compiler report. Leave empty to use parser's default UTF-8.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .index(6)
+        .index(5)
         .build(),
       PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerGccSensor.REPORT_REGEX_DEF)
         .name("GCC Regular Expression")
@@ -440,15 +385,7 @@ public final class CxxPlugin implements Plugin {
           + "this page</a> for details regarding the different regular expression that can be use per compiler.")
         .subCategory(subcateg)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .index(7)
-        .build(),
-      PropertyDefinition.builder(LANG_PROP_PREFIX + CxxCompilerGccRuleRepository.CUSTOM_RULES_KEY)
-        .name("GCC Custom Rules")
-        .description("XML definitions of custom rules for GCC's warnings, which are'nt builtin into the plugin."
-          + EXTENDING_THE_CODE_ANALYSIS)
-        .type(PropertyType.TEXT)
-        .subCategory(subcateg)
-        .index(8)
+        .index(6)
         .build()
     ));
   }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -35,7 +35,7 @@ public class CxxPluginTest {
     Plugin.Context context = new Plugin.Context(runtime);
     CxxPlugin plugin = new CxxPlugin();
     plugin.define(context);
-    assertThat(context.getExtensions()).hasSize(81);
+    assertThat(context.getExtensions()).hasSize(73);
   }
 
 }


### PR DESCRIPTION
- it's better to keep the built-in repositories up to date
- after SQ core change support was limited to 4k XML data (close #1548)
- users can use cxx 'other' sensor or https://docs.sonarqube.org/latest/analysis/external-issues/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1781)
<!-- Reviewable:end -->
