### PR TITLE
Allow argument arrays in JsonCompilationDatabaseCommandObject

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabase.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabase.java
@@ -28,6 +28,8 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxCompilationUnitSettings;
@@ -58,6 +60,7 @@ public class JsonCompilationDatabase {
     ObjectMapper mapper = new ObjectMapper();
     mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     mapper.enable(DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY);
+    mapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 
     JsonCompilationDatabaseCommandObject[] commandObjects = mapper.readValue(compileCommandsFile,
       JsonCompilationDatabaseCommandObject[].class);
@@ -101,7 +104,7 @@ public class JsonCompilationDatabase {
     String cmdLine;
 
     if (!commandObject.getArguments().isEmpty()) {
-      cmdLine = commandObject.getArguments();
+      cmdLine = commandObject.getArguments().stream().collect(Collectors.joining(" "));
     } else if (!commandObject.getCommand().isEmpty()) {
       cmdLine = commandObject.getCommand();
     } else {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseCommandObject.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseCommandObject.java
@@ -35,7 +35,7 @@ public class JsonCompilationDatabaseCommandObject implements Serializable {
   private String directory;
   private String file;
   private String command;
-  private String arguments;
+  private List<String> arguments;
   private String output;
 
   /**
@@ -55,7 +55,7 @@ public class JsonCompilationDatabaseCommandObject implements Serializable {
     this.directory = "";
     this.file = "";
     this.command = "";
-    this.arguments = "";
+    this.arguments = new ArrayList<>();
     this.output = "";
     this.defines = new HashMap<>();
     this.includes = new ArrayList<>();
@@ -102,11 +102,11 @@ public class JsonCompilationDatabaseCommandObject implements Serializable {
   /**
    * The compile command executed as list of strings. Either arguments or command is required.
    */
-  public String getArguments() {
+  public List<String> getArguments() {
     return arguments;
   }
 
-  public void setArguments(String arguments) {
+  public void setArguments(List<String> arguments) {
     this.arguments = arguments;
   }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseTest.java
@@ -120,6 +120,32 @@ public class JsonCompilationDatabaseTest {
   }
 
   @Test
+  public void testArgumentAsListSettings() throws Exception {
+    CxxConfiguration conf = new CxxConfiguration();
+
+    File file = new File("src/test/resources/org/sonar/cxx/sensors/json-compilation-database-project/compile_commands.json");
+
+    JsonCompilationDatabase.parse(conf, file);
+
+    Path cwd = Paths.get(".");
+    Path absPath = cwd.resolve("test-with-arguments-as-list.cpp");
+    String filename = absPath.toAbsolutePath().normalize().toString();
+
+    CxxCompilationUnitSettings cus = conf.getCompilationUnitSettings(filename);
+
+    assertThat(cus).isNotNull();
+    assertThat(cus.getDefines().containsKey("ARG_DEFINE")).isTrue();
+    assertThat(cus.getDefines().containsKey("ARG_SPACE_DEFINE")).isTrue();
+    assertThat(cus.getDefines().get("ARG_SPACE_DEFINE")).isEqualTo("\" foo 'bar' zoo \"");
+    assertThat(cus.getDefines().containsKey("SIMPLE")).isTrue();
+    assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("");
+    assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
+    assertThat(cus.getIncludes().contains("/usr/local/include")).isTrue();
+    assertThat(cus.getIncludes().contains("/another/include/dir")).isTrue();
+    assertThat(cus.getIncludes().contains("/usr/include")).isFalse();
+  }
+
+  @Test
   public void testUnknownUnitSettings() throws Exception {
     CxxConfiguration conf = new CxxConfiguration();
 

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/json-compilation-database-project/compile_commands.json
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/json-compilation-database-project/compile_commands.json
@@ -23,6 +23,13 @@
 		"arguments" : "-o test -I/usr/local/include -I /another/include/dir -DSIMPLE -DARG_DEFINE=1 -D ARG_SPACE_DEFINE=\" foo 'bar' zoo \" test.cpp",
 		"output" : "test"
 	},
+    {
+        "_comment_" : "example with using arguments as list",
+        "directory" : ".",
+        "file" : "test-with-arguments-as-list.cpp",
+        "arguments" : ["-o", "test", "-I/usr/local/include", "-I", "/another/include/dir", "-DSIMPLE", "-DARG_DEFINE=1", "-D", "ARG_SPACE_DEFINE=\" foo 'bar' zoo \"", "test.cpp"],
+        "output" : "test"
+    },
 	{
 		"_comment_" : "example extension using defines and includes to define usage",
 		"directory" : ".",


### PR DESCRIPTION
according to the [spec](http://clang.llvm.org/docs/JSONCompilationDatabase.html) the arguments are a list of strings. [Bear](https://github.com/rizsotto/Bear) generates such files.

This change is backwards compatible.

Fixes #1745 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1789)
<!-- Reviewable:end -->
