### PR TITLE
Correctly Handle relative paths in JSON Compilation Databases

### DIFF
--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseTest.java
@@ -120,6 +120,27 @@ public class JsonCompilationDatabaseTest {
   }
 
   @Test
+  public void testRelativeDirectorySettings() throws Exception {
+    CxxConfiguration conf = new CxxConfiguration();
+
+    File file = new File("src/test/resources/org/sonar/cxx/sensors/json-compilation-database-project/compile_commands.json");
+
+    JsonCompilationDatabase.parse(conf, file);
+
+    Path cwd = Paths.get("src");
+    Path absPath = cwd.resolve("test-with-relative-directory.cpp");
+    String filename = absPath.toAbsolutePath().normalize().toString();
+
+    CxxCompilationUnitSettings cus = conf.getCompilationUnitSettings(filename);
+
+    assertThat(cus).isNotNull();
+    assertThat(cus.getIncludes().contains("/usr/local/include")).isTrue();
+    assertThat(cus.getIncludes().contains("src/another/include/dir")).isTrue();
+    assertThat(cus.getIncludes().contains("parent/include/dir")).isTrue();
+    assertThat(cus.getIncludes().contains("/usr/include")).isFalse();
+  }
+
+  @Test
   public void testArgumentAsListSettings() throws Exception {
     CxxConfiguration conf = new CxxConfiguration();
 

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/json-compilation-database-project/compile_commands.json
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/json-compilation-database-project/compile_commands.json
@@ -31,6 +31,13 @@
         "output" : "test"
     },
 	{
+		"_comment_" : "example with using arguments as list",
+		"directory" : "./src",
+		"file" : "test-with-relative-directory.cpp",
+		"arguments" : ["-o", "test", "-I/usr/local/include", "-I", "another/include/dir", "-I", "../parent/include/dir", "test.cpp"],
+		"output" : "test"
+	},
+	{
 		"_comment_" : "example extension using defines and includes to define usage",
 		"directory" : ".",
 		"file" : "test-extension.cpp",


### PR DESCRIPTION
According to the specification, all paths specified in a JSON Compilation
database must either be absolute, or relative to the location given
in the directory field.

Fixes #1790

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1791)
<!-- Reviewable:end -->
