### PR TITLE
Correctly Handle relative paths in JSON Compilation Databases

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabase.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabase.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxCompilationUnitSettings;
@@ -63,7 +62,7 @@ public class JsonCompilationDatabase {
     mapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 
     JsonCompilationDatabaseCommandObject[] commandObjects = mapper.readValue(compileCommandsFile,
-      JsonCompilationDatabaseCommandObject[].class);
+            JsonCompilationDatabaseCommandObject[].class);
 
     for (JsonCompilationDatabaseCommandObject commandObject : commandObjects) {
 
@@ -92,8 +91,8 @@ public class JsonCompilationDatabase {
   }
 
   private static void parseCommandObject(CxxCompilationUnitSettings settings,
-    Path cwd,
-    JsonCompilationDatabaseCommandObject commandObject) {
+          Path cwd,
+          JsonCompilationDatabaseCommandObject commandObject) {
     settings.setDefines(commandObject.getDefines());
     settings.setIncludes(commandObject.getIncludes());
 
@@ -115,7 +114,7 @@ public class JsonCompilationDatabase {
     String[] args = tokenizeCommandLine(cmdLine);
     boolean nextInclude = false;
     boolean nextDefine = false;
-    List<String> includes = new ArrayList<>();
+    List<Path> includes = new ArrayList<>();
     HashMap<String, String> defines = new HashMap<>();
 
     // Capture defines and includes from command line
@@ -151,8 +150,8 @@ public class JsonCompilationDatabase {
     settings.setIncludes(includes);
   }
 
-  private static String makeRelativeToCwd(Path cwd, String include) {
-    return cwd.resolve(include).normalize().toString();
+  private static Path makeRelativeToCwd(Path cwd, String include) {
+    return cwd.resolve(include).normalize();
   }
 
   private static String[] tokenizeCommandLine(String cmdLine) {
@@ -176,7 +175,7 @@ public class JsonCompilationDatabase {
           } else if (ch == '\"') {
             stringOpen = '\"';
           } else if ((ch == ' ')
-            && (sb.length() > 0)) {
+                  && (sb.length() > 0)) {
             args.add(sb.toString());
             sb = new StringBuilder(512);
           }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseCommandObject.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseCommandObject.java
@@ -20,6 +20,7 @@
 package org.sonar.cxx.sensors.utils;
 
 import java.io.Serializable;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -46,7 +47,7 @@ public class JsonCompilationDatabaseCommandObject implements Serializable {
   /**
    * Extension to define include directories
    */
-  private ArrayList<String> includes;
+  private ArrayList<Path> includes;
 
   /**
    * Initialize members
@@ -62,8 +63,9 @@ public class JsonCompilationDatabaseCommandObject implements Serializable {
   }
 
   /**
-   * The working directory of the compilation. All paths specified in the command or file fields must be either absolute
-   * or relative to this directory.
+   * The working directory of the compilation. All paths specified in the
+   * command or file fields must be either absolute or relative to this
+   * directory.
    */
   public String getDirectory() {
     return directory;
@@ -74,9 +76,10 @@ public class JsonCompilationDatabaseCommandObject implements Serializable {
   }
 
   /**
-   * The main translation unit source processed by this compilation step. This is used by tools as the key into the
-   * compilation database. There can be multiple command objects for the same file, for example if the same source file
-   * is compiled with different configurations.
+   * The main translation unit source processed by this compilation step. This
+   * is used by tools as the key into the compilation database. There can be
+   * multiple command objects for the same file, for example if the same source
+   * file is compiled with different configurations.
    */
   public String getFile() {
     return file;
@@ -87,9 +90,11 @@ public class JsonCompilationDatabaseCommandObject implements Serializable {
   }
 
   /**
-   * The compile command executed. After JSON unescaping, this must be a valid command to rerun the exact compilation
-   * step for the translation unit in the environment the build system uses. Parameters use shell quoting and shell
-   * escaping of quotes, with ‘"‘ and ‘\‘ being the only special characters. Shell expansion is not supported.
+   * The compile command executed. After JSON unescaping, this must be a valid
+   * command to rerun the exact compilation step for the translation unit in the
+   * environment the build system uses. Parameters use shell quoting and shell
+   * escaping of quotes, with ‘"‘ and ‘\‘ being the only special characters.
+   * Shell expansion is not supported.
    */
   public String getCommand() {
     return command;
@@ -100,7 +105,8 @@ public class JsonCompilationDatabaseCommandObject implements Serializable {
   }
 
   /**
-   * The compile command executed as list of strings. Either arguments or command is required.
+   * The compile command executed as list of strings. Either arguments or
+   * command is required.
    */
   public List<String> getArguments() {
     return arguments;
@@ -111,8 +117,9 @@ public class JsonCompilationDatabaseCommandObject implements Serializable {
   }
 
   /**
-   * The name of the output created by this compilation step. This field is optional. It can be used to distinguish
-   * different processing modes of the same input file.
+   * The name of the output created by this compilation step. This field is
+   * optional. It can be used to distinguish different processing modes of the
+   * same input file.
    */
   public String getOutput() {
     return output;
@@ -136,11 +143,11 @@ public class JsonCompilationDatabaseCommandObject implements Serializable {
   /**
    * Extension to define include directories
    */
-  public List<String> getIncludes() {
+  public List<Path> getIncludes() {
     return Collections.unmodifiableList(includes);
   }
 
-  public void setIncludes(List<String> includes) {
+  public void setIncludes(List<Path> includes) {
     this.includes = new ArrayList<>(includes);
   }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseTest.java
@@ -44,8 +44,8 @@ public class JsonCompilationDatabaseTest {
     assertThat(cus).isNotNull();
     assertThat(cus.getDefines().containsKey("UNIT_DEFINE")).isFalse();
     assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isTrue();
-    assertThat(cus.getIncludes().contains("/usr/local/include")).isFalse();
-    assertThat(cus.getIncludes().contains("/usr/include")).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isFalse();
+    assertThat(cus.getIncludes().contains(Paths.get("/usr/include"))).isTrue();
   }
 
   @Test
@@ -63,8 +63,8 @@ public class JsonCompilationDatabaseTest {
     assertThat(cus).isNotNull();
     assertThat(cus.getDefines().containsKey("UNIT_DEFINE")).isTrue();
     assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
-    assertThat(cus.getIncludes().contains("/usr/local/include")).isTrue();
-    assertThat(cus.getIncludes().contains("/usr/include")).isFalse();
+    assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/usr/include"))).isFalse();
   }
 
   @Test
@@ -88,9 +88,9 @@ public class JsonCompilationDatabaseTest {
     assertThat(cus.getDefines().containsKey("SIMPLE")).isTrue();
     assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("");
     assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
-    assertThat(cus.getIncludes().contains("/usr/local/include")).isTrue();
-    assertThat(cus.getIncludes().contains("/another/include/dir")).isTrue();
-    assertThat(cus.getIncludes().contains("/usr/include")).isFalse();
+    assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/another/include/dir"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/usr/include"))).isFalse();
   }
 
   @Test
@@ -114,9 +114,9 @@ public class JsonCompilationDatabaseTest {
     assertThat(cus.getDefines().containsKey("SIMPLE")).isTrue();
     assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("");
     assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
-    assertThat(cus.getIncludes().contains("/usr/local/include")).isTrue();
-    assertThat(cus.getIncludes().contains("/another/include/dir")).isTrue();
-    assertThat(cus.getIncludes().contains("/usr/include")).isFalse();
+    assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/another/include/dir"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/usr/include"))).isFalse();
   }
 
   @Test
@@ -134,10 +134,10 @@ public class JsonCompilationDatabaseTest {
     CxxCompilationUnitSettings cus = conf.getCompilationUnitSettings(filename);
 
     assertThat(cus).isNotNull();
-    assertThat(cus.getIncludes().contains("/usr/local/include")).isTrue();
-    assertThat(cus.getIncludes().contains("src/another/include/dir")).isTrue();
-    assertThat(cus.getIncludes().contains("parent/include/dir")).isTrue();
-    assertThat(cus.getIncludes().contains("/usr/include")).isFalse();
+    assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("src/another/include/dir"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("parent/include/dir"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/usr/include"))).isFalse();
   }
 
   @Test
@@ -161,9 +161,9 @@ public class JsonCompilationDatabaseTest {
     assertThat(cus.getDefines().containsKey("SIMPLE")).isTrue();
     assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("");
     assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
-    assertThat(cus.getIncludes().contains("/usr/local/include")).isTrue();
-    assertThat(cus.getIncludes().contains("/another/include/dir")).isTrue();
-    assertThat(cus.getIncludes().contains("/usr/include")).isFalse();
+    assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/another/include/dir"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/usr/include"))).isFalse();
   }
 
   @Test

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseTest.java
@@ -120,6 +120,27 @@ public class JsonCompilationDatabaseTest {
   }
 
   @Test
+  public void testRelativeDirectorySettings() throws Exception {
+    CxxConfiguration conf = new CxxConfiguration();
+
+    File file = new File("src/test/resources/org/sonar/cxx/sensors/json-compilation-database-project/compile_commands.json");
+
+    JsonCompilationDatabase.parse(conf, file);
+
+    Path cwd = Paths.get("src");
+    Path absPath = cwd.resolve("test-with-relative-directory.cpp");
+    String filename = absPath.toAbsolutePath().normalize().toString();
+
+    CxxCompilationUnitSettings cus = conf.getCompilationUnitSettings(filename);
+
+    assertThat(cus).isNotNull();
+    assertThat(cus.getIncludes().contains("/usr/local/include")).isTrue();
+    assertThat(cus.getIncludes().contains("src/another/include/dir")).isTrue();
+    assertThat(cus.getIncludes().contains("parent/include/dir")).isTrue();
+    assertThat(cus.getIncludes().contains("/usr/include")).isFalse();
+  }
+
+  @Test
   public void testArgumentAsListSettings() throws Exception {
     CxxConfiguration conf = new CxxConfiguration();
 

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/json-compilation-database-project/compile_commands.json
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/json-compilation-database-project/compile_commands.json
@@ -31,6 +31,13 @@
         "output" : "test"
     },
 	{
+		"_comment_" : "example with using arguments as list",
+		"directory" : "./src",
+		"file" : "test-with-relative-directory.cpp",
+		"arguments" : ["-o", "test", "-I/usr/local/include", "-I", "another/include/dir", "-I", "../parent/include/dir", "test.cpp"],
+		"output" : "test"
+	},
+	{
 		"_comment_" : "example extension using defines and includes to define usage",
 		"directory" : ".",
 		"file" : "test-extension.cpp",

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxCompilationUnitSettings.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxCompilationUnitSettings.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.cxx;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -31,7 +32,7 @@ import javax.annotation.Nullable;
 public class CxxCompilationUnitSettings {
 
   private Map<String, String> defines = new HashMap<>();
-  private List<String> includes = new ArrayList<>();
+  private List<Path> includes = new ArrayList<>();
 
   public Map<String, String> getDefines() {
     return defines;
@@ -43,11 +44,11 @@ public class CxxCompilationUnitSettings {
     }
   }
 
-  public List<String> getIncludes() {
+  public List<Path> getIncludes() {
     return new ArrayList<>(includes);
   }
 
-  public void setIncludes(@Nullable List<String> includes) {
+  public void setIncludes(@Nullable List<Path> includes) {
     if (includes != null) {
       this.includes = new ArrayList<>(includes);
     }

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
@@ -21,6 +21,8 @@ package org.sonar.cxx;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,7 +31,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.Nullable;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.utils.log.Logger;
@@ -139,10 +140,12 @@ public class CxxConfiguration extends SquidConfiguration {
     }
   }
 
-  public List<String> getIncludeDirectories() {
-    Set<String> allIncludes = new HashSet<>();
+  public List<Path> getIncludeDirectories() {
+    Set<Path> allIncludes = new HashSet<>();
     for (List<String> elemList : uniqueIncludes.values()) {
-      allIncludes.addAll(elemList);
+      for (String elem : elemList) {
+        allIncludes.add(Paths.get(elem));
+      }
     }
     return new ArrayList<>(allIncludes);
   }
@@ -230,8 +233,8 @@ public class CxxConfiguration extends SquidConfiguration {
   }
 
   public void setCompilationPropertiesWithBuildLog(@Nullable List<File> reports,
-    String fileFormat,
-    String charsetName) {
+          String fileFormat,
+          String charsetName) {
 
     if (reports == null || reports.isEmpty()) {
       return;
@@ -242,8 +245,8 @@ public class CxxConfiguration extends SquidConfiguration {
         if ("Visual C++".equals(fileFormat)) {
           cxxVCppParser.parseVCppLog(buildLog, baseDir, charsetName);
           LOG.info("Parse build log '" + buildLog.getAbsolutePath()
-            + "' added includes: '" + getIncludeDirectories().size()
-            + "', added defines: '" + getDefines().size() + "'");
+                  + "' added includes: '" + getIncludeDirectories().size()
+                  + "', added defines: '" + getDefines().size() + "'");
           if (LOG.isDebugEnabled()) {
             for (List<String> allIncludes : uniqueIncludes.values()) {
               if (!allIncludes.isEmpty()) {

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -78,9 +78,9 @@ public class CxxPreprocessor extends Preprocessor {
 
   private static final String EVALUATED_TO_FALSE = "[{}:{}]: '{}' evaluated to false, skipping tokens that follow";
   private static final String MISSING_INCLUDE_MSG
-    = "Preprocessor: {} include directive error(s). This is only relevant if parser creates syntax errors."
-    + " The preprocessor searches for include files in the with 'sonar.cxx.includeDirectories'"
-    + " defined directories and order.";
+          = "Preprocessor: {} include directive error(s). This is only relevant if parser creates syntax errors."
+          + " The preprocessor searches for include files in the with 'sonar.cxx.includeDirectories'"
+          + " defined directories and order.";
   private static final Logger LOG = Loggers.get(CxxPreprocessor.class);
   private static final String VARIADICPARAMETER = "__VA_ARGS__";
   private static int missingIncludeFilesCounter = 0;
@@ -160,9 +160,9 @@ public class CxxPreprocessor extends Preprocessor {
   }
 
   public CxxPreprocessor(SquidAstVisitorContext<Grammar> context,
-    CxxConfiguration conf,
-    SourceCodeProvider sourceCodeProvider,
-    CxxLanguage language) {
+          CxxConfiguration conf,
+          SourceCodeProvider sourceCodeProvider,
+          CxxLanguage language) {
     this.context = context;
     this.cFilesPatterns = conf.getCFilesPatterns().stream().map(s -> s.replace("*", "")).collect(Collectors.toList());
     this.conf = conf;
@@ -306,8 +306,8 @@ public class CxxPreprocessor extends Preprocessor {
   private static List<Token> match(List<Token> tokens, String str) throws MismatchException {
     if (!tokens.get(0).getValue().equals(str)) {
       throw new MismatchException("Mismatch: expected '" + str + "' got: '"
-        + tokens.get(0).getValue() + "'" + " [" + tokens.get(0).getURI() + "("
-        + tokens.get(0).getLine() + "," + tokens.get(0).getColumn() + ")]");
+              + tokens.get(0).getValue() + "'" + " [" + tokens.get(0).getURI() + "("
+              + tokens.get(0).getLine() + "," + tokens.get(0).getColumn() + ")]");
     }
     return tokens.subList(1, tokens.size());
   }
@@ -325,12 +325,12 @@ public class CxxPreprocessor extends Preprocessor {
       if (nestingLevel == 0 && (",".equals(curr) || ")".equals(curr))) {
         if (tokensConsumed > 0) {
           arguments.add(Token.builder()
-            .setLine(firstToken.getLine())
-            .setColumn(firstToken.getColumn())
-            .setURI(firstToken.getURI())
-            .setValueAndOriginalValue(serialize(matchedTokens).trim())
-            .setType(STRING)
-            .build());
+                  .setLine(firstToken.getLine())
+                  .setColumn(firstToken.getColumn())
+                  .setURI(firstToken.getURI())
+                  .setValueAndOriginalValue(serialize(matchedTokens).trim())
+                  .setType(STRING)
+                  .build());
         }
         return tokens.subList(tokensConsumed, noTokens);
       }
@@ -363,13 +363,13 @@ public class CxxPreprocessor extends Preprocessor {
         Token succ = succConcatToken(it);
         if (pred != null && succ != null) {
           newTokens.add(Token.builder()
-            .setLine(pred.getLine())
-            .setColumn(pred.getColumn())
-            .setURI(pred.getURI())
-            .setValueAndOriginalValue(pred.getValue() + succ.getValue())
-            .setType(pred.getType())
-            .setGeneratedCode(true)
-            .build());
+                  .setLine(pred.getLine())
+                  .setColumn(pred.getColumn())
+                  .setURI(pred.getURI())
+                  .setValueAndOriginalValue(pred.getValue() + succ.getValue())
+                  .setType(pred.getType())
+                  .setGeneratedCode(true)
+                  .build());
         } else {
           LOG.error("Missing data : succ ='{}' or pred = '{}'", succ, pred);
         }
@@ -393,13 +393,13 @@ public class CxxPreprocessor extends Preprocessor {
             tokens.remove(tokens.size() - 1);
             String replacement = pred.getValue() + last.getValue();
             last = Token.builder()
-              .setLine(pred.getLine())
-              .setColumn(pred.getColumn())
-              .setURI(pred.getURI())
-              .setValueAndOriginalValue(replacement)
-              .setType(pred.getType())
-              .setGeneratedCode(true)
-              .build();
+                    .setLine(pred.getLine())
+                    .setColumn(pred.getColumn())
+                    .setURI(pred.getURI())
+                    .setValueAndOriginalValue(replacement)
+                    .setType(pred.getType())
+                    .setGeneratedCode(true)
+                    .build();
           }
         }
         return last;
@@ -473,13 +473,13 @@ public class CxxPreprocessor extends Preprocessor {
     int currColumn = token.getColumn();
     for (Token t : tokens) {
       reallocated.add(Token.builder()
-        .setLine(token.getLine())
-        .setColumn(currColumn)
-        .setURI(token.getURI())
-        .setValueAndOriginalValue(t.getValue())
-        .setType(t.getType())
-        .setGeneratedCode(true)
-        .build());
+              .setLine(token.getLine())
+              .setColumn(currColumn)
+              .setURI(token.getURI())
+              .setValueAndOriginalValue(t.getValue())
+              .setType(t.getType())
+              .setGeneratedCode(true)
+              .build());
       currColumn += t.getValue().length() + 1;
     }
 
@@ -493,26 +493,26 @@ public class CxxPreprocessor extends Preprocessor {
 
     AstNode paramList = ast.getFirstDescendant(CppGrammar.parameterList);
     List<Token> macroParams = paramList == null
-      ? "objectlikeMacroDefinition".equals(ast.getName()) ? null : new LinkedList<>() : getParams(paramList);
+            ? "objectlikeMacroDefinition".equals(ast.getName()) ? null : new LinkedList<>() : getParams(paramList);
 
     AstNode vaargs = ast.getFirstDescendant(CppGrammar.variadicparameter);
     if ((vaargs != null) && (macroParams != null)) {
       AstNode identifier = vaargs.getFirstChild(IDENTIFIER);
       macroParams.add(identifier == null
-        ? Token.builder()
-          .setLine(vaargs.getToken().getLine())
-          .setColumn(vaargs.getToken().getColumn())
-          .setURI(vaargs.getToken().getURI())
-          .setValueAndOriginalValue(VARIADICPARAMETER)
-          .setType(IDENTIFIER)
-          .setGeneratedCode(true)
-          .build()
-        : identifier.getToken());
+              ? Token.builder()
+                      .setLine(vaargs.getToken().getLine())
+                      .setColumn(vaargs.getToken().getColumn())
+                      .setURI(vaargs.getToken().getURI())
+                      .setValueAndOriginalValue(VARIADICPARAMETER)
+                      .setType(IDENTIFIER)
+                      .setGeneratedCode(true)
+                      .build()
+              : identifier.getToken());
     }
 
     AstNode replList = ast.getFirstDescendant(CppGrammar.replacementList);
     List<Token> macroBody = replList == null
-      ? new LinkedList<>() : replList.getTokens().subList(0, replList.getTokens().size() - 1);
+            ? new LinkedList<>() : replList.getTokens().subList(0, replList.getTokens().size() - 1);
 
     return new Macro(macroName, macroParams, macroBody, vaargs != null);
   }
@@ -616,7 +616,7 @@ public class CxxPreprocessor extends Preprocessor {
         LOG.warn("Cannot parse '{}', ignoring...", token.getValue());
         LOG.debug("Parser exception: '{}'", re);
         return new PreprocessorAction(1, Collections.singletonList(Trivia.createSkippedText(token)),
-          new ArrayList<>());
+                new ArrayList<>());
       }
 
       AstNodeType lineKind = lineAst.getType();
@@ -635,7 +635,7 @@ public class CxxPreprocessor extends Preprocessor {
 
       if (currentFileState.skipPreprocessorDirectives) {
         return new PreprocessorAction(1, Collections.singletonList(Trivia.createSkippedText(token)),
-          new ArrayList<>());
+                new ArrayList<>());
       }
 
       if (lineKind.equals(defineLine)) {
@@ -649,13 +649,13 @@ public class CxxPreprocessor extends Preprocessor {
       // Ignore all other preprocessor directives (which are not handled explicitly)
       // and strip them from the stream
       return new PreprocessorAction(1, Collections.singletonList(Trivia.createSkippedText(token)),
-        new ArrayList<>());
+              new ArrayList<>());
     }
 
     if (!ttype.equals(EOF)) {
       if (currentFileState.skipPreprocessorDirectives) {
         return new PreprocessorAction(1, Collections.singletonList(Trivia.createSkippedText(token)),
-          new ArrayList<>());
+                new ArrayList<>());
       }
 
       if (!ttype.equals(STRING) && !ttype.equals(NUMBER)) {
@@ -744,13 +744,13 @@ public class CxxPreprocessor extends Preprocessor {
     }
 
     return new PreprocessorAction(1, Collections.singletonList(Trivia.createSkippedText(token)),
-      new ArrayList<>());
+            new ArrayList<>());
   }
 
   private void parseIncludeLine(String includeLine, String filename, Charset charset) {
     AstNode includeAst = pplineParser.parse(includeLine);
     handleIncludeLine(includeAst, includeAst.getFirstDescendant(CppGrammar.includeBodyQuoted)
-      .getToken(), filename, charset);
+            .getToken(), filename, charset);
   }
 
   private int expandFunctionLikeMacro(String macroName, List<Token> restTokens, List<Token> expansion) {
@@ -765,12 +765,12 @@ public class CxxPreprocessor extends Preprocessor {
         Token firstToken = vaargs.get(0);
         arguments = arguments.subList(0, macro.params.size() - 1);
         arguments.add(Token.builder()
-          .setLine(firstToken.getLine())
-          .setColumn(firstToken.getColumn())
-          .setURI(firstToken.getURI())
-          .setValueAndOriginalValue(serialize(vaargs, ","))
-          .setType(STRING)
-          .build());
+                .setLine(firstToken.getLine())
+                .setColumn(firstToken.getColumn())
+                .setURI(firstToken.getURI())
+                .setValueAndOriginalValue(serialize(vaargs, ","))
+                .setType(STRING)
+                .build());
       }
       List<Token> replTokens = replaceParams(macro.body, macro.params, arguments);
       replTokens = evaluateHashhashOperators(replTokens);
@@ -790,7 +790,7 @@ public class CxxPreprocessor extends Preprocessor {
       if (!include.isEmpty()) {
         LOG.debug("parsing force include: '{}'", include);
         parseIncludeLine("#include \"" + include + "\"", "sonar." + this.language.getPropertiesKey() + ".forceIncludes",
-            conf.getEncoding());
+                conf.getEncoding());
       }
     }
   }
@@ -908,8 +908,8 @@ public class CxxPreprocessor extends Preprocessor {
             }
           } else {
             newTokens.add(Token.builder().setLine(replacement.getLine()).setColumn(replacement.getColumn())
-              .setURI(replacement.getURI()).setValueAndOriginalValue(newValue).setType(replacement.getType())
-              .setGeneratedCode(true).build());
+                    .setURI(replacement.getURI()).setValueAndOriginalValue(newValue).setType(replacement.getType())
+                    .setGeneratedCode(true).build());
           }
         }
       }
@@ -917,15 +917,15 @@ public class CxxPreprocessor extends Preprocessor {
 
     // replace # with "" if sequence HASH BR occurs for body HASH __VA_ARGS__
     if (newTokens.size() > 3 && newTokens.get(newTokens.size() - 2).getType().equals(HASH)
-      && newTokens.get(newTokens.size() - 1).getType().equals(BR_RIGHT)) {
+            && newTokens.get(newTokens.size() - 1).getType().equals(BR_RIGHT)) {
       for (int n = newTokens.size() - 2; n != 0; n--) {
         if (newTokens.get(n).getType().equals(WS)) {
           newTokens.remove(n);
         } else if (newTokens.get(n).getType().equals(HASH)) {
           newTokens.remove(n);
           newTokens.add(n, Token.builder().setLine(newTokens.get(n).getLine()).setColumn(newTokens.get(n).getColumn())
-            .setURI(newTokens.get(n).getURI()).setValueAndOriginalValue("\"\"").setType(STRING)
-            .setGeneratedCode(true).build());
+                  .setURI(newTokens.get(n).getURI()).setValueAndOriginalValue("\"\"").setType(STRING)
+                  .setGeneratedCode(true).build());
           break;
         } else {
           break;
@@ -937,7 +937,7 @@ public class CxxPreprocessor extends Preprocessor {
 
   private Macro parseMacroDefinition(String macroDef) {
     return parseMacroDefinition(pplineParser.parse(macroDef)
-      .getFirstDescendant(CppGrammar.defineLine));
+            .getFirstDescendant(CppGrammar.defineLine));
   }
 
   /**
@@ -946,7 +946,7 @@ public class CxxPreprocessor extends Preprocessor {
    */
   private Map<String, Macro> parseMacroDefinitions(Map<String, String> defines) {
     final List<String> margedDefines = defines.entrySet().stream().map(e -> e.getKey() + " " + e.getValue())
-        .collect(Collectors.toList());
+            .collect(Collectors.toList());
     return parseMacroDefinitions(margedDefines);
   }
 
@@ -1003,7 +1003,7 @@ public class CxxPreprocessor extends Preprocessor {
       String expandedIncludeBody = serialize(stripEOF(CxxLexer.create(this).lex(includeBody)), "");
       if (LOG.isTraceEnabled()) {
         LOG.trace("Include resolve macros: includeBody '{}' - expandedIncludeBody: '{}'",
-          includeBody, expandedIncludeBody);
+                includeBody, expandedIncludeBody);
       }
 
       boolean parseError = false;
@@ -1015,9 +1015,9 @@ public class CxxPreprocessor extends Preprocessor {
       }
 
       if (parseError || ((includeBodyAst != null)
-        && includeBodyAst.getFirstDescendant(CppGrammar.includeBodyFreeform) != null)) {
+              && includeBodyAst.getFirstDescendant(CppGrammar.includeBodyFreeform) != null)) {
         LOG.warn("[{}:{}]: cannot parse included filename: '{}'",
-          currFileName, token.getLine(), expandedIncludeBody);
+                currFileName, token.getLine(), expandedIncludeBody);
         if (LOG.isDebugEnabled()) {
           LOG.debug("Token : {}", token.toString());
         }
@@ -1063,15 +1063,15 @@ public class CxxPreprocessor extends Preprocessor {
       currentFileState.conditionWasTrue = false;
       if (LOG.isTraceEnabled()) {
         LOG.trace("[{}:{}]: handling #if line '{}'",
-          filename, token.getLine(), token.getValue());
+                filename, token.getLine(), token.getValue());
       }
       try {
         currentFileState.skipPreprocessorDirectives = false;
         currentFileState.skipPreprocessorDirectives = !ExpressionEvaluator.eval(conf, this,
-          ast.getFirstDescendant(CppGrammar.constantExpression));
+                ast.getFirstDescendant(CppGrammar.constantExpression));
       } catch (EvaluationException e) {
         LOG.error("[{}:{}]: error evaluating the expression {} assume 'true' ...",
-          filename, token.getLine(), token.getValue());
+                filename, token.getLine(), token.getValue());
         LOG.error("{}", e);
         currentFileState.skipPreprocessorDirectives = false;
       }
@@ -1088,7 +1088,7 @@ public class CxxPreprocessor extends Preprocessor {
     }
 
     return new PreprocessorAction(1, Collections.singletonList(Trivia.createSkippedText(token)),
-      new ArrayList<>());
+            new ArrayList<>());
   }
 
   PreprocessorAction handleElIfLine(AstNode ast, Token token, String filename) {
@@ -1099,14 +1099,14 @@ public class CxxPreprocessor extends Preprocessor {
         try {
           if (LOG.isTraceEnabled()) {
             LOG.trace("[{}:{}]: handling #elif line '{}'",
-              filename, token.getLine(), token.getValue());
+                    filename, token.getLine(), token.getValue());
           }
           currentFileState.skipPreprocessorDirectives = false;
           currentFileState.skipPreprocessorDirectives = !ExpressionEvaluator.eval(conf, this,
-            ast.getFirstDescendant(CppGrammar.constantExpression));
+                  ast.getFirstDescendant(CppGrammar.constantExpression));
         } catch (EvaluationException e) {
           LOG.error("[{}:{}]: error evaluating the expression {} assume 'true' ...",
-            filename, token.getLine(), token.getValue());
+                  filename, token.getLine(), token.getValue());
           LOG.error("{}", e);
           currentFileState.skipPreprocessorDirectives = false;
         }
@@ -1127,7 +1127,7 @@ public class CxxPreprocessor extends Preprocessor {
     }
 
     return new PreprocessorAction(1, Collections.singletonList(Trivia.createSkippedText(token)),
-      new ArrayList<>());
+            new ArrayList<>());
   }
 
   PreprocessorAction handleElseLine(Token token, String filename) {
@@ -1147,7 +1147,7 @@ public class CxxPreprocessor extends Preprocessor {
     }
 
     return new PreprocessorAction(1, Collections.singletonList(Trivia.createSkippedText(token)),
-      new ArrayList<>());
+            new ArrayList<>());
   }
 
   PreprocessorAction handleEndifLine(Token token, String filename) {
@@ -1164,7 +1164,7 @@ public class CxxPreprocessor extends Preprocessor {
     }
 
     return new PreprocessorAction(1, Collections.singletonList(Trivia.createSkippedText(token)),
-      new ArrayList<>());
+            new ArrayList<>());
   }
 
   PreprocessorAction handleDefineLine(AstNode ast, Token token, String filename) {
@@ -1177,7 +1177,7 @@ public class CxxPreprocessor extends Preprocessor {
     getMacros().put(macro.name, macro);
 
     return new PreprocessorAction(1, Collections.singletonList(Trivia.createSkippedText(token)),
-      new ArrayList<>());
+            new ArrayList<>());
   }
 
   PreprocessorAction handleIncludeLine(AstNode ast, Token token, String filename, Charset charset) {
@@ -1200,12 +1200,12 @@ public class CxxPreprocessor extends Preprocessor {
       if (conf.doCollectMissingIncludes()) {
         final File currentFile = this.getFileUnderAnalysis();
         missingIncludeFiles.computeIfAbsent(currentFile.getPath(), k -> new HashSet<>())
-          .add(new Include(token.getLine(), token.getValue()));
+                .add(new Include(token.getLine(), token.getValue()));
       }
     } else if (analysedFiles.add(includedFile.getAbsoluteFile())) {
       if (LOG.isTraceEnabled()) {
         LOG.trace("[{}:{}]: processing {}, resolved to file '{}'",
-          filename, token.getLine(), token.getValue(), includedFile.getAbsolutePath());
+                filename, token.getLine(), token.getValue(), includedFile.getAbsolutePath());
       }
 
       globalStateStack.push(currentFileState);
@@ -1221,14 +1221,14 @@ public class CxxPreprocessor extends Preprocessor {
     }
 
     return new PreprocessorAction(1, Collections.singletonList(Trivia.createSkippedText(token)),
-      new ArrayList<>());
+            new ArrayList<>());
   }
 
   PreprocessorAction handleUndefLine(AstNode ast, Token token) {
     String macroName = ast.getFirstDescendant(IDENTIFIER).getTokenValue();
     getMacros().removeLowPrio(macroName);
     return new PreprocessorAction(1, Collections.singletonList(Trivia.createSkippedText(token)),
-      new ArrayList<>());
+            new ArrayList<>());
   }
 
   PreprocessorAction handleIdentifiersAndKeywords(List<Token> tokens, Token curr, String filename) {
@@ -1249,8 +1249,8 @@ public class CxxPreprocessor extends Preprocessor {
         replTokens = new LinkedList<>(expandMacro(macro.name, serialize(evaluateHashhashOperators(macro.body))));
       } else {
         int tokensConsumedMatchingArgs = expandFunctionLikeMacro(macro.name,
-          tokens.subList(1, tokens.size()),
-          replTokens);
+                tokens.subList(1, tokens.size()),
+                replTokens);
         if (tokensConsumedMatchingArgs > 0) {
           tokensConsumed = 1 + tokensConsumedMatchingArgs;
         }
@@ -1290,16 +1290,16 @@ public class CxxPreprocessor extends Preprocessor {
 
         if (LOG.isTraceEnabled()) {
           LOG.trace("[{}:{}]: replacing '" + curr.getValue()
-            + (tokensConsumed == 1
-              ? ""
-              : serialize(tokens.subList(1, tokensConsumed))) + "' -> '" + serialize(replTokens) + '\'',
-            filename, curr.getLine());
+                  + (tokensConsumed == 1
+                          ? ""
+                          : serialize(tokens.subList(1, tokensConsumed))) + "' -> '" + serialize(replTokens) + '\'',
+                  filename, curr.getLine());
         }
 
         ppaction = new PreprocessorAction(
-          tokensConsumed,
-          Collections.singletonList(Trivia.createSkippedText(tokens.subList(0, tokensConsumed))),
-          replTokens);
+                tokensConsumed,
+                Collections.singletonList(Trivia.createSkippedText(tokens.subList(0, tokensConsumed))),
+                replTokens);
       }
     }
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/SourceCodeProviderTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/SourceCodeProviderTest.java
@@ -22,6 +22,8 @@ package org.sonar.cxx.preprocessor;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
@@ -62,7 +64,7 @@ public class SourceCodeProviderTest {
     String baseDir = new File("src/test").getAbsolutePath();
     String dummycwd = "/";
     String path = "source.hh";
-    String includeRoot = new File("src/test/resources/codeprovider").getAbsolutePath();
+    Path includeRoot = Paths.get("src/test/resources/codeprovider").toAbsolutePath();
 
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
     assertEquals(expected1, codeProvider.getSourceCodeFile(path, dummycwd, true));
@@ -74,7 +76,7 @@ public class SourceCodeProviderTest {
     String baseDir = new File("src/test").getAbsolutePath();
     String dummycwd = "/";
     String path = "source";
-    String includeRoot = new File("src/test/resources/codeprovider").getAbsolutePath();
+    Path includeRoot = Paths.get("src/test/resources/codeprovider").toAbsolutePath();
 
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
     assertEquals(expected2, codeProvider.getSourceCodeFile(path, dummycwd, true));
@@ -86,7 +88,7 @@ public class SourceCodeProviderTest {
     String baseDir = new File("src/test").getAbsolutePath();
     String dummycwd = "/";
     String path = "source.hh";
-    String includeRoot = "resources/codeprovider";
+    Path includeRoot = Paths.get("resources/codeprovider");
 
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
     assertEquals(expected1, codeProvider.getSourceCodeFile(path, dummycwd, true));
@@ -98,7 +100,7 @@ public class SourceCodeProviderTest {
     String baseDir = new File("src/test").getAbsolutePath();
     String dummycwd = "/";
     String path = "source";
-    String includeRoot = "resources/codeprovider";
+    Path includeRoot = Paths.get("resources/codeprovider");
 
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
     assertEquals(expected2, codeProvider.getSourceCodeFile(path, dummycwd, true));
@@ -110,7 +112,7 @@ public class SourceCodeProviderTest {
     String baseDir = new File("src/test").getAbsolutePath();
     String dummycwd = "/";
     String path = "codeprovider/source.hh";
-    String includeRoot = new File("src/test/resources").getAbsolutePath();
+    Path includeRoot = Paths.get("src/test/resources").toAbsolutePath();
 
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
     assertEquals(expected1, codeProvider.getSourceCodeFile(path, dummycwd, true));
@@ -122,7 +124,7 @@ public class SourceCodeProviderTest {
     String baseDir = new File("src/test").getAbsolutePath();
     String dummycwd = "/";
     String path = "codeprovider/source";
-    String includeRoot = new File("src/test/resources").getAbsolutePath();
+    Path includeRoot = Paths.get("src/test/resources").toAbsolutePath();
 
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
     assertEquals(expected2, codeProvider.getSourceCodeFile(path, dummycwd, true));
@@ -134,7 +136,7 @@ public class SourceCodeProviderTest {
     String baseDir = new File("src/test").getAbsolutePath();
     String dummycwd = "/";
     String path = "codeprovider/source.hh";
-    String includeRoot = "resources";
+    Path includeRoot = Paths.get("resources");
 
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
     assertEquals(expected1, codeProvider.getSourceCodeFile(path, dummycwd, true));
@@ -146,7 +148,7 @@ public class SourceCodeProviderTest {
     String baseDir = new File("src/test").getAbsolutePath();
     String dummycwd = "/";
     String path = "codeprovider/source";
-    String includeRoot = "resources";
+    Path includeRoot = Paths.get("resources");
 
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
     assertEquals(expected2, codeProvider.getSourceCodeFile(path, dummycwd, true));


### PR DESCRIPTION
According to the specification, all paths specified in a JSON Compilation
database must either be absolute, or relative to the location given
in the directory field.

Fixes #1790
Close #1791 & refactoring of include handling: using Path instead of String to be more platform independent

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1797)
<!-- Reviewable:end -->
