### PR TITLE
Imrove compatibility of default warning regex

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensor.java
@@ -37,7 +37,7 @@ public class CxxCompilerGccSensor extends CxxCompilerSensor {
    */
   public static final String DEFAULT_ID = "default";
   public static final String DEFAULT_REGEX_DEF
-    = "(?<file>.*):(?<line>[0-9]+):[0-9]+:\\x20warning:\\x20(?<message>.*?)(\\x20\\[(?<id>.*)\\])?\\s*$";
+    = "(?<file>[^:]*):(?<line>[0-9]+):([0-9]+:)?\\x20warning:\\x20(?<message>.*?)(\\x20\\[(?<id>.*)\\])?\\s*$";
 
   public CxxCompilerGccSensor(CxxLanguage language) {
     super(language, REPORT_PATH_KEY, CxxCompilerGccRuleRepository.getRepositoryKey(language));


### PR DESCRIPTION
Some older GCC compilers (f.e. 4.3.2) don't print column per default in the warning message. This leads to problems detecting the reports. This fix would allow to detect both variants without the need to redefine the regex in the configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1801)
<!-- Reviewable:end -->
