### PR TITLE
JSON Compilation Database: support -isystem -iquote -isystem -idirafter

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabase.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabase.java
@@ -41,6 +41,10 @@ public class JsonCompilationDatabase {
 
   private static final Logger LOG = Loggers.get(JsonCompilationDatabase.class);
 
+  enum ArgNext {
+    NONE, DEFINE, INCLUDE, IQUOTE, ISYSTEM, IDIRAFTER;
+  }
+
   private JsonCompilationDatabase() {
     /* utility class is not meant to be instantiated */
   }
@@ -61,97 +65,109 @@ public class JsonCompilationDatabase {
     mapper.enable(DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY);
     mapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 
-    JsonCompilationDatabaseCommandObject[] commandObjects = mapper.readValue(compileCommandsFile,
-            JsonCompilationDatabaseCommandObject[].class);
+    JsonCompilationDatabaseCommandObject[] commandObjects
+            = mapper.readValue(compileCommandsFile, JsonCompilationDatabaseCommandObject[].class);
+    Path cwd;
 
     for (JsonCompilationDatabaseCommandObject commandObject : commandObjects) {
-
-      Path cwd = Paths.get(".");
-
       if (commandObject.getDirectory() != null) {
         cwd = Paths.get(commandObject.getDirectory());
+      } else {
+        cwd = Paths.get(".");
       }
 
       Path absPath = cwd.resolve(commandObject.getFile());
+      CxxCompilationUnitSettings settings = new CxxCompilationUnitSettings();
+      parseCommandObject(settings, cwd, commandObject);
 
       if ("__global__".equals(commandObject.getFile())) {
-        CxxCompilationUnitSettings globalSettings = new CxxCompilationUnitSettings();
-
-        parseCommandObject(globalSettings, cwd, commandObject);
-
-        config.setGlobalCompilationUnitSettings(globalSettings);
+        config.setGlobalCompilationUnitSettings(settings);
       } else {
-        CxxCompilationUnitSettings settings = new CxxCompilationUnitSettings();
-
-        parseCommandObject(settings, cwd, commandObject);
-
         config.addCompilationUnitSettings(absPath.toAbsolutePath().normalize().toString(), settings);
       }
     }
   }
 
   private static void parseCommandObject(CxxCompilationUnitSettings settings,
-          Path cwd,
-          JsonCompilationDatabaseCommandObject commandObject) {
+          Path cwd, JsonCompilationDatabaseCommandObject commandObject) {
+
     settings.setDefines(commandObject.getDefines());
     settings.setIncludes(commandObject.getIncludes());
 
     // No need to parse command lines as we have needed information
-    if (!commandObject.getDefines().isEmpty() || !commandObject.getIncludes().isEmpty()) {
+    if (commandObject.hasDefines() || commandObject.hasIncludes()) {
       return;
     }
 
     String cmdLine;
 
-    if (!commandObject.getArguments().isEmpty()) {
+    if (commandObject.hasArguments()) {
       cmdLine = commandObject.getArguments().stream().collect(Collectors.joining(" "));
-    } else if (!commandObject.getCommand().isEmpty()) {
+    } else if (commandObject.hasCommand()) {
       cmdLine = commandObject.getCommand();
     } else {
       return;
     }
 
     String[] args = tokenizeCommandLine(cmdLine);
-    boolean nextInclude = false;
-    boolean nextDefine = false;
-    List<Path> includes = new ArrayList<>();
-    HashMap<String, String> defines = new HashMap<>();
+    ArgNext next = ArgNext.NONE;
 
-    // Capture defines and includes from command line
+    HashMap<String, String> defines = new HashMap<>();
+    List<Path> includes = new ArrayList<>();
+    List<Path> iSystem = new ArrayList<>();
+    List<Path> iDirAfter = new ArrayList<>();
+
     for (String arg : args) {
-      if (nextInclude) {
-        nextInclude = false;
-        includes.add(makeRelativeToCwd(cwd, arg));
-      } else if (nextDefine) {
-        nextDefine = false;
-        String[] define = arg.split("=", 2);
-        if (define.length == 1) {
-          defines.put(define[0], "");
-        } else {
-          defines.put(define[0], define[1]);
-        }
-      } else if ("-I".equals(arg)) {
-        nextInclude = true;
-      } else if ("-isystem".equals(arg)) {
-        nextInclude = true;
+      if (arg.startsWith("-D")) {
+        arg = arg.substring(2);
+        next = ArgNext.DEFINE;
       } else if (arg.startsWith("-I")) {
-        includes.add(makeRelativeToCwd(cwd, arg.substring(2)));
+        arg = arg.substring(2);
+        next = ArgNext.INCLUDE;
+      } else if (arg.startsWith("-iquote")) {
+        arg = arg.substring(7);
+        next = ArgNext.INCLUDE;
       } else if (arg.startsWith("-isystem")) {
-        includes.add(makeRelativeToCwd(cwd, arg.substring(8)));
-      } else if ("-D".equals(arg)) {
-        nextDefine = true;
-      } else if (arg.startsWith("-D")) {
-        String[] define = arg.substring(2).split("=", 2);
-        if (define.length == 1) {
-          defines.put(define[0], "");
-        } else {
-          defines.put(define[0], define[1]);
+        arg = arg.substring(8);
+        next = ArgNext.ISYSTEM;
+      } else if (arg.startsWith("-idirafter")) {
+        arg = arg.substring(10);
+        next = ArgNext.IDIRAFTER;
+      }
+
+      if ((next != ArgNext.NONE) && !arg.isEmpty()) {
+        switch (next) {
+          case DEFINE:
+            addMacro(arg, defines);
+            break;
+          case INCLUDE:
+          case IQUOTE:
+            includes.add(makeRelativeToCwd(cwd, arg));
+            break;
+          case ISYSTEM:
+            iSystem.add(makeRelativeToCwd(cwd, arg));
+            break;
+          case IDIRAFTER:
+            iDirAfter.add(makeRelativeToCwd(cwd, arg));
+            break;
         }
+        next = ArgNext.NONE;
       }
     }
 
     settings.setDefines(defines);
+    includes.addAll(iSystem);
+    includes.addAll(iDirAfter);
     settings.setIncludes(includes);
+  }
+
+  private static void addMacro(String keyValue, HashMap<String, String> defines) {
+    String[] strings = keyValue.split("=", 2);
+    if (strings.length == 1) {
+      defines.put(strings[0], "1");
+    } else {
+      defines.put(strings[0], strings[1]);
+    }
   }
 
   private static Path makeRelativeToCwd(Path cwd, String include) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabase.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabase.java
@@ -132,8 +132,12 @@ public class JsonCompilationDatabase {
         }
       } else if ("-I".equals(arg)) {
         nextInclude = true;
+      } else if ("-isystem".equals(arg)) {
+        nextInclude = true;
       } else if (arg.startsWith("-I")) {
         includes.add(makeRelativeToCwd(cwd, arg.substring(2)));
+      } else if (arg.startsWith("-isystem")) {
+        includes.add(makeRelativeToCwd(cwd, arg.substring(8)));
       } else if ("-D".equals(arg)) {
         nextDefine = true;
       } else if (arg.startsWith("-D")) {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseCommandObject.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseCommandObject.java
@@ -96,24 +96,32 @@ public class JsonCompilationDatabaseCommandObject implements Serializable {
    * escaping of quotes, with ‘"‘ and ‘\‘ being the only special characters.
    * Shell expansion is not supported.
    */
-  public String getCommand() {
-    return command;
+  public boolean hasCommand() {
+    return !command.isEmpty();
   }
-
+  
   public void setCommand(String command) {
     this.command = command;
+  }
+  
+  public String getCommand() {
+    return command;
   }
 
   /**
    * The compile command executed as list of strings. Either arguments or
    * command is required.
    */
-  public List<String> getArguments() {
-    return arguments;
+  public boolean hasArguments() {
+    return !arguments.isEmpty();
   }
-
+  
   public void setArguments(List<String> arguments) {
     this.arguments = arguments;
+  }
+  
+  public List<String> getArguments() {
+    return arguments;
   }
 
   /**
@@ -132,23 +140,31 @@ public class JsonCompilationDatabaseCommandObject implements Serializable {
   /**
    * Extension to define defines
    */
-  public Map<String, String> getDefines() {
-    return defines;
+  public boolean hasDefines() {
+    return !defines.isEmpty();
   }
 
   public void setDefines(Map<String, String> defines) {
     this.defines = new HashMap<>(defines);
   }
 
+  public Map<String, String> getDefines() {
+    return defines;
+  }
+
   /**
    * Extension to define include directories
    */
-  public List<Path> getIncludes() {
-    return Collections.unmodifiableList(includes);
+  public boolean hasIncludes() {
+    return !includes.isEmpty();
   }
 
   public void setIncludes(List<Path> includes) {
     this.includes = new ArrayList<>(includes);
+  }
+
+  public List<Path> getIncludes() {
+    return Collections.unmodifiableList(includes);
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseTest.java
@@ -86,11 +86,44 @@ public class JsonCompilationDatabaseTest {
     assertThat(cus.getDefines().containsKey("COMMAND_SPACE_DEFINE")).isTrue();
     assertThat(cus.getDefines().get("COMMAND_SPACE_DEFINE")).isEqualTo("\" foo 'bar' zoo \"");
     assertThat(cus.getDefines().containsKey("SIMPLE")).isTrue();
-    assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("");
+    assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("1");
     assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
     assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isTrue();
     assertThat(cus.getIncludes().contains(Paths.get("/another/include/dir"))).isTrue();
     assertThat(cus.getIncludes().contains(Paths.get("/usr/include"))).isFalse();
+  }
+
+  @Test
+  public void testArgumentParser() throws Exception {
+    CxxConfiguration conf = new CxxConfiguration();
+
+    File file = new File("src/test/resources/org/sonar/cxx/sensors/json-compilation-database-project/compile_commands.json");
+
+    JsonCompilationDatabase.parse(conf, file);
+
+    Path cwd = Paths.get(".");
+    Path absPath = cwd.resolve("test-argument-parser.cpp");
+    String filename = absPath.toAbsolutePath().normalize().toString();
+
+    CxxCompilationUnitSettings cus = conf.getCompilationUnitSettings(filename);
+
+    assertThat(cus).isNotNull();
+
+    assertThat(cus.getDefines().get("MACRO1")).isEqualTo("1");
+    assertThat(cus.getDefines().get("MACRO2")).isEqualTo("2");
+    assertThat(cus.getDefines().get("MACRO3")).isEqualTo("1");
+    assertThat(cus.getDefines().get("MACRO4")).isEqualTo("4");
+    assertThat(cus.getDefines().get("MACRO5")).isEqualTo("\" a 'b' c \"");
+    assertThat(cus.getDefines().get("MACRO6")).isEqualTo("\"With spaces, quotes and \\-es.\"");
+
+    assertThat(cus.getIncludes().contains(Paths.get("/aaa/bbb"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/ccc/ddd"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/eee/fff"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/ggg/hhh"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/iii/jjj"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/kkk/lll"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/mmm/nnn"))).isTrue();
+    assertThat(cus.getIncludes().contains(Paths.get("/ooo/ppp"))).isTrue();
   }
 
   @Test
@@ -112,7 +145,7 @@ public class JsonCompilationDatabaseTest {
     assertThat(cus.getDefines().containsKey("ARG_SPACE_DEFINE")).isTrue();
     assertThat(cus.getDefines().get("ARG_SPACE_DEFINE")).isEqualTo("\" foo 'bar' zoo \"");
     assertThat(cus.getDefines().containsKey("SIMPLE")).isTrue();
-    assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("");
+    assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("1");
     assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
     assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isTrue();
     assertThat(cus.getIncludes().contains(Paths.get("/another/include/dir"))).isTrue();
@@ -159,7 +192,7 @@ public class JsonCompilationDatabaseTest {
     assertThat(cus.getDefines().containsKey("ARG_SPACE_DEFINE")).isTrue();
     assertThat(cus.getDefines().get("ARG_SPACE_DEFINE")).isEqualTo("\" foo 'bar' zoo \"");
     assertThat(cus.getDefines().containsKey("SIMPLE")).isTrue();
-    assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("");
+    assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("1");
     assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
     assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isTrue();
     assertThat(cus.getIncludes().contains(Paths.get("/another/include/dir"))).isTrue();

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/json-compilation-database-project/compile_commands.json
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/json-compilation-database-project/compile_commands.json
@@ -1,51 +1,67 @@
 [
-	{
-		"_comment_" : "example extension to define global defines and includes for headers and for files which are not compiled",
-		"file" : "__global__",
-		"defines" : {
-			"GLOBAL_DEFINE" : "1"
-			},
-		"includes" : [
-			"/usr/include"
-			]
-	},
-	{
-		"_comment_" : "example with command for compilation",
-		"directory" : ".",
-		"file" : "test-with-command.cpp",
-		"command" : "gcc -o test -I/usr/local/include -I /another/include/dir -DSIMPLE -DCOMMAND_DEFINE=1 -D COMMAND_SPACE_DEFINE=\" foo 'bar' zoo \" test.cpp",
-		"output" : "test"
-	},
-	{
-		"_comment_" : "example with using arguments",
-		"directory" : ".",
-		"file" : "test-with-arguments.cpp",
-		"arguments" : "-o test -I/usr/local/include -I /another/include/dir -DSIMPLE -DARG_DEFINE=1 -D ARG_SPACE_DEFINE=\" foo 'bar' zoo \" test.cpp",
-		"output" : "test"
-	},
-    {
-        "_comment_" : "example with using arguments as list",
-        "directory" : ".",
-        "file" : "test-with-arguments-as-list.cpp",
-        "arguments" : ["-o", "test", "-I/usr/local/include", "-I", "/another/include/dir", "-DSIMPLE", "-DARG_DEFINE=1", "-D", "ARG_SPACE_DEFINE=\" foo 'bar' zoo \"", "test.cpp"],
-        "output" : "test"
+  {
+    "_comment_": "example extension to define global defines and includes for headers and for files which are not compiled",
+    "file": "__global__",
+    "defines": {
+      "GLOBAL_DEFINE": "1"
     },
-	{
-		"_comment_" : "example with using arguments as list",
-		"directory" : "./src",
-		"file" : "test-with-relative-directory.cpp",
-		"arguments" : ["-o", "test", "-I/usr/local/include", "-I", "another/include/dir", "-I", "../parent/include/dir", "test.cpp"],
-		"output" : "test"
-	},
-	{
-		"_comment_" : "example extension using defines and includes to define usage",
-		"directory" : ".",
-		"file" : "test-extension.cpp",
-		"defines" : {
-			"UNIT_DEFINE" : "1"
-			},
-		"includes" : [
-			"/usr/local/include"
-			]
-	}
+    "includes": [
+      "/usr/include"
+    ]
+  },
+  {
+    "_comment_": "test argument parser",
+    "directory": ".",
+    "file": "test-argument-parser.cpp",
+    "arguments": [
+      "-DMACRO1", "-DMACRO2=2",
+      "-D", "MACRO3", "-D", "MACRO4=4",
+      "-DMACRO5=\" a 'b' c \"",
+      "-DMACRO6=\"With spaces, quotes and \\-es.\"",
+      "-I/aaa/bbb", "-I", "/ccc/ddd",
+      "-iquote/eee/fff", "-iquote", "/ggg/hhh",
+      "-isystem/iii/jjj", "-isystem", "/kkk/lll",
+      "-idirafter/mmm/nnn", "-idirafter", "/ooo/ppp"
+    ],
+    "output": "test"
+  },
+  {
+    "_comment_": "example with command for compilation",
+    "directory": ".",
+    "file": "test-with-command.cpp",
+    "command": "gcc -o test -I/usr/local/include -I /another/include/dir -DSIMPLE -DCOMMAND_DEFINE=1 -D COMMAND_SPACE_DEFINE=\" foo 'bar' zoo \" test.cpp",
+    "output": "test"
+  },
+  {
+    "_comment_": "example with using arguments",
+    "directory": ".",
+    "file": "test-with-arguments.cpp",
+    "arguments": "-o test -I/usr/local/include -I /another/include/dir -DSIMPLE -DARG_DEFINE=1 -D ARG_SPACE_DEFINE=\" foo 'bar' zoo \" test.cpp",
+    "output": "test"
+  },
+  {
+    "_comment_": "example with using arguments as list",
+    "directory": ".",
+    "file": "test-with-arguments-as-list.cpp",
+    "arguments": [ "-o", "test", "-I/usr/local/include", "-I", "/another/include/dir", "-DSIMPLE", "-DARG_DEFINE=1", "-D", "ARG_SPACE_DEFINE=\" foo 'bar' zoo \"", "test.cpp" ],
+    "output": "test"
+  },
+  {
+    "_comment_": "example with using arguments as list",
+    "directory": "./src",
+    "file": "test-with-relative-directory.cpp",
+    "arguments": [ "-o", "test", "-I/usr/local/include", "-I", "another/include/dir", "-I", "../parent/include/dir", "test.cpp" ],
+    "output": "test"
+  },
+  {
+    "_comment_": "example extension using defines and includes to define usage",
+    "directory": ".",
+    "file": "test-extension.cpp",
+    "defines": {
+      "UNIT_DEFINE": "1"
+    },
+    "includes": [
+      "/usr/local/include"
+    ]
+  }
 ]


### PR DESCRIPTION
support:
```
   -I dir
   -iquote dir
   -isystem dir
   -idirafter dir
```
define `<macro>` to `<value>` (or 1 if `<value>` omitted)

close #1799 
fixes #1215

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1802)
<!-- Reviewable:end -->
