### PR TITLE
fix coverage on SonarCloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ jdk:
   - openjdk11
 env:
   - SONARLABEL=sonarqube-6.7.7 SONARAPI=SqApi67
-  - SONARLABEL=sonarqube-7.9.1 SONARAPI=SqApi79
+  - SONARLABEL=sonarqube-7.9.2 SONARAPI=SqApi79
 matrix:
   exclude:
     - jdk: oraclejdk8
-      env: SONARLABEL=sonarqube-7.9.1 SONARAPI=SqApi79
+      env: SONARLABEL=sonarqube-7.9.2 SONARAPI=SqApi79
 
 branches:
   only:
@@ -51,8 +51,8 @@ install:
   - pushd /tmp
   - wget -nv --timeout=10 https://binaries.sonarsource.com/Distribution/sonarqube/$SONARLABEL.zip
   - unzip -qq $SONARLABEL.zip
-  - wget -nv --timeout=10 https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.0.0.1744.zip
-  - unzip -qq sonar-scanner-cli-4.0.0.1744.zip
+  - wget -nv --timeout=10 https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.2.0.1873.zip
+  - unzip -qq sonar-scanner-cli-4.2.0.1873.zip
   - wget -nv --timeout=10 https://github.com/htacg/tidy-html5/archive/5.6.0.zip --output-document=tidy-html5.zip
   - unzip -qq tidy-html5.zip
   - pushd tidy-html5-5.6.0/build/cmake/
@@ -70,7 +70,7 @@ script:
   - mvn install -B -e -V -DskipTests=true
   - mvn test -B -e -V
   - bash cxx-sensors/src/tools/check_rules.sh
-  - RAILS_ENV=production PATH=$PATH:/tmp/sonar-scanner-4.0.0.1744/bin TestDataFolder=~/build/SonarOpenCommunity/sonar-cxx/integration-tests/testdata behave --no-capture --tags=$SONARAPI
+  - RAILS_ENV=production PATH=$PATH:/tmp/sonar-scanner-4.2.0.1873/bin TestDataFolder=~/build/SonarOpenCommunity/sonar-cxx/integration-tests/testdata behave --no-capture --tags=$SONARAPI
 
 after_failure:
   - cat $SONARHOME/logs/sonar.log

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,17 +36,17 @@ install:
 
       if (!(Test-Path -Path "C:\sonar-scanner" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.3.0.1492.zip',
+          'https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.2.0.1873.zip',
           'C:\sonar-scanner-dist.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonar-scanner-dist.zip", "C:\sonar-scanner")
       }
       if (!(Test-Path -Path "C:\sonarqube" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.6.zip',
-          'C:\sonarqube-6.7.6.zip'
+          'https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-6.7.7.zip',
+          'C:\sonarqube-6.7.7.zip'
         )
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonarqube-6.7.6.zip", "C:\sonarqube")
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonarqube-6.7.7.zip", "C:\sonarqube")
       }
   - ps: |
       If ($env:Platform -Match "x86") {
@@ -62,10 +62,10 @@ install:
         $env:VCVARS_PLATFORM="amd64"
         $env:LANG_PLATFORM="-x64"
       }
-  - cmd: SET PATH=C:\maven\apache-maven-3.5.4\bin;%JAVA_HOME%\bin;C:\sonar-scanner\sonar-scanner-3.3.0.1492\bin;%PATH%
+  - cmd: SET PATH=C:\maven\apache-maven-3.5.4\bin;%JAVA_HOME%\bin;C:\sonar-scanner\sonar-scanner-4.2.0.1873\bin;%PATH%
   - cmd: SET M2_HOME=C:\maven\apache-maven-3.5.4
   - cmd: SET MAVEN_HOME=C:\maven\apache-maven-3.5.4
-  - cmd: SET SONARHOME=C:\sonarqube\sonarqube-6.7.6
+  - cmd: SET SONARHOME=C:\sonarqube\sonarqube-6.7.7
   - cmd: SET TestDataFolder=C:\projects\sonar-cxx\integration-tests\testdata
   - cmd: SET
 
@@ -108,4 +108,4 @@ on_failure:
   - ps: Get-ChildItem cxx-checks\target\surefire-reports\*.txt | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   - ps: Get-ChildItem sonar-cxx-plugin\target\surefire-reports\*.txt | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   - ps: Get-ChildItem *.log | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-  - ps: Get-ChildItem C:\sonarqube\sonarqube-6.7.6\logs\* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+  - ps: Get-ChildItem C:\sonarqube\sonarqube-6.7.7\logs\* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,7 +83,7 @@ build_script:
   - C:\Python27\Scripts\pip.exe install behave
   - C:\Python27\Scripts\pip.exe install colorama
   - mvn versions:set -DnewVersion=1.3.2.%APPVEYOR_BUILD_NUMBER%
-  - mvn org.jacoco:jacoco-maven-plugin:prepare-agent clean install -B -e -V -Pcoverage-per-test
+  - mvn clean install -B -e -V
   - IF "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" (mvn sonar:sonar -B -e -V -Dsonar.organization=sonaropencommunity -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=%sonarcloudtoken%)
   - REM IF NOT "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" (mvn sonar:sonar -B -e -X -V -Dsonar.verbose=true -Dsonar.pullrequest.base=master -Dsonar.pullrequest.branch=%APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH% -Dsonar.pullrequest.key=%APPVEYOR_PULL_REQUEST_NUMBER% -Dsonar.pullrequest.provider=GitHub -Dsonar.pullrequest.github.repository=%APPVEYOR_PROJECT_SLUG%)
   - C:\Python27\Scripts\behave.exe --no-capture --tags=SqApi67

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
       }
 
       (new-object System.Net.WebClient).DownloadFile(
-        'http://www.us.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.zip',
+        'https://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip',
         'C:\maven-bin.zip'
       )
       [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")

--- a/cxx-checks/pom.xml
+++ b/cxx-checks/pom.xml
@@ -12,6 +12,10 @@
 
   <name>Cxx :: Checks</name>
 
+  <properties>
+    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+  </properties>
+  
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/cxx-sensors/pom.xml
+++ b/cxx-sensors/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <sonar.artifact.path>target/${project.artifactId}-${project.version}.jar</sonar.artifact.path>
+    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <dependencies>

--- a/cxx-squid/pom.xml
+++ b/cxx-squid/pom.xml
@@ -12,6 +12,10 @@
 
   <name>Cxx :: Squid</name>
 
+  <properties>
+    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -15,9 +15,39 @@
     <cucumber.version>2.0.1</cucumber.version>
     <sonar.sources>features</sonar.sources>
     <sonar.inclusions>features/**</sonar.inclusions>
+    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <dependencies>
+    
+     <!-- set dependencies to aggregate coverage results -->
+     
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cxx-checks</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cxx-sensors</artifactId>
+      <version>${project.version}</version>
+    </dependency>         
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cxx-squid</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sonar-c-plugin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sonar-cxx-plugin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    
     <!-- https://mvnrepository.com/artifact/io.cucumber/cucumber-jvm-deps -->
 
     <!-- https://mvnrepository.com/artifact/io.cucumber/gherkin -->
@@ -133,6 +163,19 @@
               <goals>
                 <goal>python</goal>
               </goals>
+            </execution>
+          </executions>
+        </plugin>
+       <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>report</id>
+              <goals>
+                <goal>report-aggregate</goal>
+              </goals>
+              <phase>verify</phase>
             </execution>
           </executions>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -405,19 +405,24 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
-        </plugin>
-        <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>3.0</version>
+        </plugin> 
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
         </plugin>
         <plugin>
           <groupId>org.sonarsource.scanner.maven</groupId>
           <artifactId>sonar-maven-plugin</artifactId>
-          <version>3.5.0.1254</version>
+          <version>3.7.0.1746</version>
+        </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.5</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -430,52 +435,42 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.8.1</version>
         <configuration>
           <showDeprecation>true</showDeprecation>
         </configuration>
       </plugin>
     </plugins>
   </build>
-  <!-- BEGIN: Specific to mapping unit tests and covered code
-   Usage:
-1) Prepare jacoco agent to allow coverage report generation, build the project, and execute the unit tests:
-   mvn org.jacoco:jacoco-maven-plugin:prepare-agent clean install
-2) To get coverage per tests information, you will need to activate the profile when running the instrumented tests:
-   mvn org.jacoco:jacoco-maven-plugin:prepare-agent clean install -Pcoverage-per-test
-3) Analyze the project with SonarQube using Maven:
-   mvn sonar:sonar
-  -->
+  <!-- BEGIN: Specific to mapping unit tests and covered code -->
   <profiles>
     <profile>
-      <id>coverage-per-test</id>
+      <id>coverage</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <!-- Minimal supported version is 2.4 -->
-            <version>2.22.0</version>
-            <configuration>
-              <properties>
-                <property>
-                  <name>listener</name>
-                  <value>org.sonar.java.jacoco.JUnitListener</value>
-                </property>
-              </properties>
-            </configuration>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>report</id>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.sonarsource.java</groupId>
-          <artifactId>sonar-jacoco-listeners</artifactId>
-          <version>5.4.0.14284</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,7 @@
     <sonar.artifact.path>target/${project.artifactId}-${project.version}.jar</sonar.artifact.path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <animal.sniffer.skip>true</animal.sniffer.skip>
+    <aggregate.report.dir>integration-tests/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
   </properties>
 
   <dependencyManagement>

--- a/sonar-c-plugin/pom.xml
+++ b/sonar-c-plugin/pom.xml
@@ -21,8 +21,9 @@
     <sonar.pluginClass>org.sonar.plugins.c.CPlugin</sonar.pluginClass>
     <sonar.pluginName>C (Community)</sonar.pluginName>
     <sonar.artifact.path>target/${project.artifactId}-${project.version}.jar</sonar.artifact.path>
+    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
-
+  
   <dependencies>
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>

--- a/sonar-cxx-plugin/pom.xml
+++ b/sonar-cxx-plugin/pom.xml
@@ -20,6 +20,7 @@
     <sonar.artifact.path>target/${project.artifactId}-${project.version}.jar</sonar.artifact.path>
     <sonar.pluginClass>org.sonar.plugins.cxx.CxxPlugin</sonar.pluginClass>
     <sonar.pluginName>C++ (Community)</sonar.pluginName>
+    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Importing JaCoCo coverage report in XML format

Version 5.12 of SonarJava analyzer deprecated use JaCoCo’s binary format (.exec files) to import coverage. This binary format is internal to the JaCoCo project, and as such there are no guarantees for backward compatibility, so it should not be used for integration purposes. As a replacement the sonar-jacoco plugin, which imports JaCoCo’s XML coverage report, and this is the preferred option now.

In the guide below, is described how to import this XML report in some common scenarios.
https://community.sonarsource.com/t/coverage-test-data-importing-jacoco-coverage-report-in-xml-format/12151

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1804)
<!-- Reviewable:end -->
