### PR TITLE
use 'sonar.cxx.file.suffixes'

### DIFF
--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/CxxFileTesterHelper.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/CxxFileTesterHelper.java
@@ -35,22 +35,26 @@ import org.sonar.cxx.CxxLanguage;
  */
 public class CxxFileTesterHelper {
 
-  public static CxxFileTester CreateCxxFileTester(String fileName, String basePath) throws UnsupportedEncodingException, IOException {
+  public static CxxFileTester CreateCxxFileTester(String fileName, String basePath) throws UnsupportedEncodingException,
+                                                                                           IOException {
     CxxFileTester tester = new CxxFileTester();
     tester.sensorContext = SensorContextTester.create(new File(basePath));
 
     tester.sensorContext.fileSystem().add(TestInputFileBuilder.create("", fileName).build());
-    tester.cxxFile = tester.sensorContext.fileSystem().inputFile(tester.sensorContext.fileSystem().predicates().hasPath(fileName));
+    tester.cxxFile = tester.sensorContext.fileSystem().inputFile(tester.sensorContext.fileSystem().predicates().hasPath(
+      fileName));
 
     return tester;
   }
 
-  public static CxxFileTester CreateCxxFileTester(String fileName, String basePath, Charset charset) throws UnsupportedEncodingException, IOException {
+  public static CxxFileTester CreateCxxFileTester(String fileName, String basePath, Charset charset) throws
+    UnsupportedEncodingException, IOException {
     CxxFileTester tester = new CxxFileTester();
     tester.sensorContext = SensorContextTester.create(new File(basePath));
 
     tester.sensorContext.fileSystem().add(TestInputFileBuilder.create("", fileName).setCharset(charset).build());
-    tester.cxxFile = tester.sensorContext.fileSystem().inputFile(tester.sensorContext.fileSystem().predicates().hasPath(fileName));
+    tester.cxxFile = tester.sensorContext.fileSystem().inputFile(tester.sensorContext.fileSystem().predicates().hasPath(
+      fileName));
 
     return tester;
   }
@@ -61,7 +65,6 @@ public class CxxFileTesterHelper {
     when(language.getName()).thenReturn("c++");
     when(language.getFileSuffixes())
       .thenReturn(new String[]{".cpp", ".hpp", ".h", ".cxx", ".c", ".cc", ".hxx", ".hh"});
-    when(language.getHeaderFileSuffixes()).thenReturn(new String[]{".hpp", ".h", ".hxx", ".hh"});
 
     return language;
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
@@ -281,7 +281,6 @@ public class CxxSquidSensor implements ProjectSensor {
     //    For proper implemenation see CppLanguage::CppLanguage()
     //    or createStringArray(settings.getStringArray(C_FILES_PATTERNS_KEY), DEFAULT_C_FILES)
     cxxConf.setCFilesPatterns(this.settings.getStringArray(C_FILES_PATTERNS_KEY));
-    cxxConf.setHeaderFileSuffixes(this.language.getHeaderFileSuffixes());
     cxxConf.setJsonCompilationDatabaseFile(this.settings.get(JSON_COMPILATION_DATABASE_KEY)
       .orElse(null));
 

--- a/cxx-sensors/src/samples/SampleProject/pom.xml
+++ b/cxx-sensors/src/samples/SampleProject/pom.xml
@@ -541,9 +541,5 @@
     <sonar.cxx.defines>Q_OBJECT, Q_SLOTS</sonar.cxx.defines>
     <sonar.tests>sources/tests</sonar.tests>
 
-    <!-- <sonar.cxx.suffixes.sources></sonar.cxx.suffixes.sources> -->
-    <!-- <sonar.cxx.suffixes.headers></sonar.cxx.suffixes.headers> -->
-    <!-- <sonar.cxx.xunit.xsltURL></sonar.cxx.xunit.xsltURL> -->
-    <!-- <sonar.cxx.valgrind.reportPath></sonar.cxx.valgrind.reportPath> -->
   </properties>
 </project>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/TestUtils.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/TestUtils.java
@@ -96,7 +96,6 @@ public class TestUtils {
     when(language.getName()).thenReturn("c++");
     when(language.getFileSuffixes())
       .thenReturn(new String[]{".cpp", ".hpp", ".h", ".cxx", ".c", ".cc", ".hxx", ".hh"});
-    when(language.getHeaderFileSuffixes()).thenReturn(new String[]{".hpp", ".h", ".hxx", ".hh"});
 
     return language;
   }

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
@@ -188,20 +188,6 @@ public class CxxConfiguration extends SquidConfiguration {
     }
   }
 
-  public void setHeaderFileSuffixes(List<String> headerFileSuffixes) {
-    this.headerFileSuffixes = new ArrayList<>(headerFileSuffixes);
-  }
-
-  public void setHeaderFileSuffixes(@Nullable String[] headerFileSuffixes) {
-    if (headerFileSuffixes != null && headerFileSuffixes.length > 0) {
-      setHeaderFileSuffixes(Arrays.asList(headerFileSuffixes));
-    }
-  }
-
-  public List<String> getHeaderFileSuffixes() {
-    return new ArrayList<>(this.headerFileSuffixes);
-  }
-
   public String getJsonCompilationDatabaseFile() {
     return jsonCompilationDatabaseFile;
   }
@@ -231,8 +217,8 @@ public class CxxConfiguration extends SquidConfiguration {
   }
 
   public void setCompilationPropertiesWithBuildLog(@Nullable List<File> reports,
-          String fileFormat,
-          String charsetName) {
+                                                   String fileFormat,
+                                                   String charsetName) {
 
     if (reports == null || reports.isEmpty()) {
       return;
@@ -243,8 +229,8 @@ public class CxxConfiguration extends SquidConfiguration {
         if ("Visual C++".equals(fileFormat)) {
           cxxVCppParser.parseVCppLog(buildLog, baseDir, charsetName);
           LOG.info("Parse build log '" + buildLog.getAbsolutePath()
-                  + "' added includes: '" + getIncludeDirectories().size()
-                  + "', added defines: '" + getDefines().size() + "'");
+                     + "' added includes: '" + getIncludeDirectories().size()
+                     + "', added defines: '" + getDefines().size() + "'");
           if (LOG.isDebugEnabled()) {
             for (List<String> allIncludes : uniqueIncludes.values()) {
               if (!allIncludes.isEmpty()) {

--- a/cxx-squid/src/test/java/org/sonar/cxx/CxxFileTesterHelper.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/CxxFileTesterHelper.java
@@ -33,19 +33,23 @@ import org.sonar.api.batch.sensor.internal.SensorContextTester;
  */
 public class CxxFileTesterHelper {
 
-  public static CxxFileTester CreateCxxFileTester(String fileName, String basePath, String module) throws UnsupportedEncodingException, IOException {
+  public static CxxFileTester CreateCxxFileTester(String fileName, String basePath, String module) throws
+    UnsupportedEncodingException, IOException {
     CxxFileTester tester = new CxxFileTester();
     tester.sensorContext = SensorContextTester.create(new File(basePath));
 
     tester.sensorContext.fileSystem().add(TestInputFileBuilder.create(module, fileName).build());
-    tester.cxxFile = tester.sensorContext.fileSystem().inputFile(tester.sensorContext.fileSystem().predicates().hasPath(fileName));
+    tester.cxxFile = tester.sensorContext.fileSystem().inputFile(tester.sensorContext.fileSystem().predicates().hasPath(
+      fileName));
 
     return tester;
   }
 
-  public static CxxFileTester AddFileToContext(CxxFileTester tester, String fileName, String module) throws UnsupportedEncodingException, IOException {
+  public static CxxFileTester AddFileToContext(CxxFileTester tester, String fileName, String module) throws
+    UnsupportedEncodingException, IOException {
     tester.sensorContext.fileSystem().add(TestInputFileBuilder.create(module, fileName).build());
-    tester.cxxFile = tester.sensorContext.fileSystem().inputFile(tester.sensorContext.fileSystem().predicates().hasPath(fileName));
+    tester.cxxFile = tester.sensorContext.fileSystem().inputFile(tester.sensorContext.fileSystem().predicates().hasPath(
+      fileName));
     return tester;
   }
 
@@ -55,7 +59,6 @@ public class CxxFileTesterHelper {
     when(language.getName()).thenReturn("c++");
     when(language.getFileSuffixes())
       .thenReturn(new String[]{".cpp", ".hpp", ".h", ".cxx", ".c", ".cc", ".hxx", ".hh"});
-    when(language.getHeaderFileSuffixes()).thenReturn(new String[]{".hpp", ".h", ".hxx", ".hh"});
 
     return language;
   }

--- a/cxx-squid/src/test/java/org/sonar/cxx/CxxLanguageTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/CxxLanguageTest.java
@@ -27,91 +27,27 @@ import org.sonar.api.config.internal.MapSettings;
 
 public class CxxLanguageTest {
 
-  /**
-   * Default cxx header files suffixes
-   */
-  public static final String DEFAULT_HEADER_SUFFIXES = ".hxx,.hpp,.hh,.h";
-
-  private static final String KEY = "c++";
-  private static final String NAME = "c++";
-  private static final String PLUGIN_ID = "cxx";
-  private static final String SOURCE_SUFFIXES = ".cxx,.cpp,.cc,.c";
-  private static final String HEADER_SUFFIXES = ".hxx,.hpp,.hh,.h";
-
   private final MapSettings settings = new MapSettings();
 
   @Test
   public void testCxxLanguageStringConfiguration() throws Exception {
     CxxLanguage language = new CxxLanguage(settings.asConfig());
-    assertThat(language.getKey()).isEqualTo(KEY);
-  }
-
-  @Test
-  public void testGetSourceFileSuffixes() throws Exception {
-    CxxLanguage language = new CxxLanguage(settings.asConfig());
-    assertThat(language.getSourceFileSuffixes()).isEqualTo(SOURCE_SUFFIXES.split(","));
-  }
-
-  @Test
-  public void testGetHeaderFileSuffixes() throws Exception {
-    CxxLanguage language = new CxxLanguage(settings.asConfig());
-    assertThat(language.getHeaderFileSuffixes()).isEqualTo(HEADER_SUFFIXES.split(","));
+    assertThat(language.getKey()).isEqualTo("c++");
   }
 
   @Test
   public void shouldReturnConfiguredFileSuffixes() {
-    settings.setProperty(CxxLanguage.SOURCE_FILE_SUFFIXES_KEY, ".C,.c");
-    settings.setProperty(CxxLanguage.HEADER_FILE_SUFFIXES_KEY, ".H,.h");
+    settings.setProperty(CxxLanguage.FILE_SUFFIXES_KEY, ".C,.c,.H,.h");
     CxxLanguage cxx = new CxxLanguage(settings.asConfig());
-
     String[] expected = {".C", ".c", ".H", ".h"};
-    String[] expectedSources = {".C", ".c"};
-    String[] expectedHeaders = {".H", ".h"};
-
     assertThat(cxx.getFileSuffixes(), is(expected));
-    assertThat(cxx.getSourceFileSuffixes(), is(expectedSources));
-    assertThat(cxx.getHeaderFileSuffixes(), is(expectedHeaders));
   }
 
   @Test
   public void shouldReturnDefaultFileSuffixes() {
     CxxLanguage cxx = new CxxLanguage(settings.asConfig());
-
-    String[] expectedSources = {".cxx", ".cpp", ".cc", ".c"};
-    String[] expectedHeaders = {".hxx", ".hpp", ".hh", ".h"};
     String[] expectedAll = {".cxx", ".cpp", ".cc", ".c", ".hxx", ".hpp", ".hh", ".h"};
-
     assertThat(cxx.getFileSuffixes(), is(expectedAll));
-    assertThat(cxx.getSourceFileSuffixes(), is(expectedSources));
-    assertThat(cxx.getHeaderFileSuffixes(), is(expectedHeaders));
-  }
-
-  @Test
-  public void shouldReturnConfiguredSourceSuffixes() {
-    settings.setProperty(CxxLanguage.SOURCE_FILE_SUFFIXES_KEY, ".C,.c");
-    CxxLanguage cxx = new CxxLanguage(settings.asConfig());
-
-    String[] expectedSources = {".C", ".c"};
-    String[] expectedHeaders = {".hxx", ".hpp", ".hh", ".h"};
-    String[] expectedAll = {".C", ".c", ".hxx", ".hpp", ".hh", ".h"};
-
-    assertThat(cxx.getFileSuffixes(), is(expectedAll));
-    assertThat(cxx.getSourceFileSuffixes(), is(expectedSources));
-    assertThat(cxx.getHeaderFileSuffixes(), is(expectedHeaders));
-  }
-
-  @Test
-  public void shouldReturnConfiguredHeaderSuffixes() {
-    settings.setProperty(CxxLanguage.HEADER_FILE_SUFFIXES_KEY, ".H,.h");
-    CxxLanguage cxx = new CxxLanguage(settings.asConfig());
-
-    String[] expectedSources = {".cxx", ".cpp", ".cc", ".c"};
-    String[] expectedHeaders = {".H", ".h"};
-    String[] expectedAll = {".cxx", ".cpp", ".cc", ".c", ".H", ".h"};
-
-    assertThat(cxx.getFileSuffixes(), is(expectedAll));
-    assertThat(cxx.getSourceFileSuffixes(), is(expectedSources));
-    assertThat(cxx.getHeaderFileSuffixes(), is(expectedHeaders));
   }
 
 }

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
@@ -38,7 +38,6 @@ import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.CxxAstScanner;
 import org.sonar.cxx.CxxFileTester;
 import org.sonar.cxx.CxxFileTesterHelper;
-import org.sonar.cxx.CxxLanguage;
 import org.sonar.cxx.api.CxxMetric;
 import org.sonar.squidbridge.api.SourceFile;
 
@@ -47,7 +46,7 @@ public class CxxPublicApiVisitorTest {
   private final MapSettings settings = new MapSettings();
 
   private static final org.sonar.api.utils.log.Logger LOG
-    = Loggers.get(CxxPublicApiVisitorTest.class);
+                                                        = Loggers.get(CxxPublicApiVisitorTest.class);
 
   private static String getFileExtension(String fileName) {
     int lastIndexOf = fileName.lastIndexOf('.');
@@ -59,8 +58,9 @@ public class CxxPublicApiVisitorTest {
 
   @Test
   public void test_no_matching_suffix() throws IOException {
-    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/metrics/doxygen_example.h", ".", "");
-    settings.setProperty(CxxLanguage.HEADER_FILE_SUFFIXES_KEY, ".hpp");
+    CxxFileTester tester = CxxFileTesterHelper.CreateCxxFileTester("src/test/resources/metrics/doxygen_example.h", ".",
+                                                                   "");
+    settings.setProperty(CxxPublicApiVisitor.FILE_SUFFIXES_KEY, ".hpp");
 
     SourceFile file = CxxAstScanner.scanSingleFile(settings.asConfig(), tester.cxxFile, tester.sensorContext);
 
@@ -122,7 +122,7 @@ public class CxxPublicApiVisitorTest {
     expectedIdCommentMap.put("testUnion", "testUnion");
     expectedIdCommentMap.put("inlineCommentedAttr", "inlineCommentedAttr");
     expectedIdCommentMap.put("inlineCommentedLastAttr",
-      "inlineCommentedLastAttr");
+                             "inlineCommentedLastAttr");
     expectedIdCommentMap.put("enumVar", "classEnum"); // only one
     // declarator, then
     // doc should precede
@@ -155,7 +155,7 @@ public class CxxPublicApiVisitorTest {
     expectedIdCommentMap
       .put("protectedStructField", "protectedStructField");
     expectedIdCommentMap.put("protectedStructField2",
-      "protectedStructField2");
+                             "protectedStructField2");
     expectedIdCommentMap.put("protectedClass", "protectedClass");
     expectedIdCommentMap.put("operator[]", "operator");
     expectedIdCommentMap.put("bitfield", "bitfield");
@@ -208,8 +208,7 @@ public class CxxPublicApiVisitorTest {
    * @param fileName the file to use for test
    * @param expectedApi expected number of API
    * @param expectedUndoc expected number of undocumented API
-   * @param checkDouble if true, fails the test if two items with the same id
-   * are counted..
+   * @param checkDouble if true, fails the test if two items with the same id are counted..
    */
   private Tuple testFile(String fileName, boolean checkDouble)
     throws UnsupportedEncodingException, IOException {
@@ -223,7 +222,7 @@ public class CxxPublicApiVisitorTest {
     SourceFile file = CxxAstScanner.scanSingleFile(settings.asConfig(), tester.cxxFile, tester.sensorContext, visitor);
 
     LOG.debug("#API: {} UNDOC: {}",
-      file.getInt(CxxMetric.PUBLIC_API), file.getInt(CxxMetric.PUBLIC_UNDOCUMENTED_API));
+              file.getInt(CxxMetric.PUBLIC_API), file.getInt(CxxMetric.PUBLIC_UNDOCUMENTED_API));
 
     return new Tuple(file.getInt(CxxMetric.PUBLIC_API), file.getInt(CxxMetric.PUBLIC_UNDOCUMENTED_API));
   }

--- a/cxx-squid/src/test/resources/logfile/TFS-agent-msvc14-mp.txt
+++ b/cxx-squid/src/test/resources/logfile/TFS-agent-msvc14-mp.txt
@@ -146,8 +146,7 @@
 2017-12-18T17:13:10.3859498Z          sonar.cxx.vera.reportPath     = vera-report.xml
 2017-12-18T17:13:10.3859498Z          sonar.cxx.rats.reportPath     = rats-report.xml
 2017-12-18T17:13:10.3859498Z          sonar.cxx.coverage.reportPath = C:/agent/_work/1/s/TestResults/**/*.coveragexml
-2017-12-18T17:13:10.3859498Z          sonar.cxx.suffixes.sources    = .cc,.cpp,.c,.cu
-2017-12-18T17:13:10.3859498Z          sonar.cxx.suffixes.headers    = .h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
+2017-12-18T17:13:10.3859498Z          sonar.cxx.file.suffixes       = .cc,.cpp,.c,.cu,.h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
 2017-12-18T17:13:10.3859498Z          sonar.cxx.forceIncludes       = sonar-defines.h
 2017-12-18T17:13:10.3859498Z          sonar.cxx.includeDirectories  = C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/atlmfc/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/VS/include,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/ucrt,,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/um,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/shared,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/winrt,Include/um,C:/agent/_work/1/s/_Globals/Include,../../src/_Globals/Include
 2017-12-18T17:13:10.3859498Z      3>SQEnvCheck:
@@ -161,8 +160,7 @@
 2017-12-18T17:13:10.3859498Z          sonar.cxx.vera.reportPath     = vera-report.xml
 2017-12-18T17:13:10.3859498Z          sonar.cxx.rats.reportPath     = rats-report.xml
 2017-12-18T17:13:10.3859498Z          sonar.cxx.coverage.reportPath = C:/agent/_work/1/s/TestResults/**/*.coveragexml
-2017-12-18T17:13:10.3859498Z          sonar.cxx.suffixes.sources    = .cc,.cpp,.c,.cu
-2017-12-18T17:13:10.3859498Z          sonar.cxx.suffixes.headers    = .h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
+2017-12-18T17:13:10.3859498Z          sonar.cxx.file.suffixes       = .cc,.cpp,.c,.cu,.h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
 2017-12-18T17:13:10.3859498Z          sonar.cxx.forceIncludes       = sonar-defines.h
 2017-12-18T17:13:10.3859498Z          sonar.cxx.includeDirectories  = C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/atlmfc/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/VS/include,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/ucrt,,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/um,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/shared,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/winrt,Include/um,C:/agent/_work/1/s/_Globals/Include,../../src/_Globals/Include
 2017-12-18T17:13:10.3859498Z      5>CreateProjectSpecificDirs:
@@ -213,8 +211,7 @@
 2017-12-18T17:13:11.0578360Z          sonar.cxx.vera.reportPath     = vera-report.xml
 2017-12-18T17:13:11.0578360Z          sonar.cxx.rats.reportPath     = rats-report.xml
 2017-12-18T17:13:11.0578360Z          sonar.cxx.coverage.reportPath = C:/agent/_work/1/s/TestResults/**/*.coveragexml
-2017-12-18T17:13:11.0578360Z          sonar.cxx.suffixes.sources    = .cc,.cpp,.c,.cu
-2017-12-18T17:13:11.0578360Z          sonar.cxx.suffixes.headers    = .h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
+2017-12-18T17:13:11.0578360Z          sonar.cxx.file.suffixes       = .cc,.cpp,.c,.cu,.h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
 2017-12-18T17:13:11.0578360Z          sonar.cxx.forceIncludes       = sonar-defines.h
 2017-12-18T17:13:11.0578360Z          sonar.cxx.includeDirectories  = C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/atlmfc/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/VS/include,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/ucrt,,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/um,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/shared,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/winrt,Include/um,C:/agent/_work/1/s/_Globals/Include,../../src/_Globals/Include
 2017-12-18T17:13:11.0578360Z        CreateProjectSpecificDirs:
@@ -399,8 +396,7 @@
 2017-12-18T17:13:13.9797522Z          sonar.cxx.vera.reportPath     = vera-report.xml
 2017-12-18T17:13:13.9797522Z          sonar.cxx.rats.reportPath     = rats-report.xml
 2017-12-18T17:13:13.9797522Z          sonar.cxx.coverage.reportPath = C:/agent/_work/1/s/TestResults/**/*.coveragexml
-2017-12-18T17:13:13.9797522Z          sonar.cxx.suffixes.sources    = .cc,.cpp,.c,.cu
-2017-12-18T17:13:13.9797522Z          sonar.cxx.suffixes.headers    = .h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
+2017-12-18T17:13:13.9797522Z          sonar.cxx.file.suffixes       = .cc,.cpp,.c,.cu,.h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
 2017-12-18T17:13:13.9797522Z          sonar.cxx.forceIncludes       = sonar-defines.h
 2017-12-18T17:13:13.9797522Z          sonar.cxx.includeDirectories  = C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/atlmfc/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/VS/include,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/ucrt,,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/um,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/shared,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/winrt,Include/um,C:/agent/_work/1/s/_Globals/Include,../../src/_Globals/Include
 2017-12-18T17:13:13.9797522Z        CreateProjectSpecificDirs:
@@ -483,44 +479,44 @@
 2017-12-18T17:13:33.4020992Z          Creating directory "C:\agent\_work\1\.sonarqube\conf\CalculationTests_4020".
 2017-12-18T17:13:33.4020992Z      8>Done Building Project "C:\agent\_work\1\s\Tests\CalculationTests\CalculationTests.vcxproj" (default targets).
 2017-12-18T17:13:33.4177256Z      1>Done Building Project "C:\agent\_work\1\s\CppTesting.sln" (default targets).
-2017-12-18T17:13:33.4177256Z 
+2017-12-18T17:13:33.4177256Z
 2017-12-18T17:13:33.4177256Z Build succeeded.
-2017-12-18T17:13:33.4177256Z 
+2017-12-18T17:13:33.4177256Z
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj" (default target) (7) ->
-2017-12-18T17:13:33.4333520Z        (ClCompile target) -> 
+2017-12-18T17:13:33.4333520Z        (ClCompile target) ->
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\sqcxxtestdata\component2.cc(17): warning C4101: 'x': unreferenced local variable [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\sqcxxtestdata\component2.cc(36): warning C4189: 'i': local variable is initialized but not referenced [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\sqcxxtestdata\component1.cc(18): warning C4101: 'x': unreferenced local variable [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\sqcxxtestdata\component1.cc(37): warning C4189: 'i': local variable is initialized but not referenced [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\sqcxxtestdata\component2.cc(31): warning C4700: uninitialized local variable 'a' used [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\sqcxxtestdata\component1.cc(32): warning C4700: uninitialized local variable 'a' used [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
-2017-12-18T17:13:33.4333520Z 
-2017-12-18T17:13:33.4333520Z 
+2017-12-18T17:13:33.4333520Z
+2017-12-18T17:13:33.4333520Z
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\Source\MotorController\MotorController.vcxproj" (default target) (3) ->
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\motorcontroller\dllmain.cpp(7): warning C4100: 'lpReserved': unreferenced formal parameter [C:\agent\_work\1\s\Source\MotorController\MotorController.vcxproj]
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\motorcontroller\dllmain.cpp(4): warning C4100: 'hModule': unreferenced formal parameter [C:\agent\_work\1\s\Source\MotorController\MotorController.vcxproj]
-2017-12-18T17:13:33.4333520Z 
-2017-12-18T17:13:33.4333520Z 
+2017-12-18T17:13:33.4333520Z
+2017-12-18T17:13:33.4333520Z
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\Source\RootFinder\RootFinder.vcxproj" (default target) (2) ->
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\rootfinder\dllmain.cpp(7): warning C4100: 'lpReserved': unreferenced formal parameter [C:\agent\_work\1\s\Source\RootFinder\RootFinder.vcxproj]
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\rootfinder\dllmain.cpp(4): warning C4100: 'hModule': unreferenced formal parameter [C:\agent\_work\1\s\Source\RootFinder\RootFinder.vcxproj]
-2017-12-18T17:13:33.4333520Z 
-2017-12-18T17:13:33.4333520Z 
+2017-12-18T17:13:33.4333520Z
+2017-12-18T17:13:33.4333520Z
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\Source\Calculation\Calculation.vcxproj" (default target) (5) ->
-2017-12-18T17:13:33.4333520Z        (RunNativeCodeAnalysis target) -> 
+2017-12-18T17:13:33.4333520Z        (RunNativeCodeAnalysis target) ->
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\calculation\addition.cpp(11): warning C26497: This function CAddition::twoValues could be marked constexpr if compile-time evaluation is desired. (f.4: https://go.microsoft.com/fwlink/p/?LinkID=784970) [C:\agent\_work\1\s\Source\Calculation\Calculation.vcxproj]
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\calculation\multiply.cpp(11): warning C26497: This function CMultiply::twoValues could be marked constexpr if compile-time evaluation is desired. (f.4: https://go.microsoft.com/fwlink/p/?LinkID=784970) [C:\agent\_work\1\s\Source\Calculation\Calculation.vcxproj]
-2017-12-18T17:13:33.4333520Z 
-2017-12-18T17:13:33.4333520Z 
+2017-12-18T17:13:33.4333520Z
+2017-12-18T17:13:33.4333520Z
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\Source\MotorController\MotorController.vcxproj" (default target) (3) ->
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\motorcontroller\motorcontroller.cpp(63): warning C26498: This function call factorial can use constexpr if compile-time evaluation is desired. (con.5: https://go.microsoft.com/fwlink/p/?LinkID=784974) [C:\agent\_work\1\s\Source\MotorController\MotorController.vcxproj]
-2017-12-18T17:13:33.4333520Z 
-2017-12-18T17:13:33.4333520Z 
+2017-12-18T17:13:33.4333520Z
+2017-12-18T17:13:33.4333520Z
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj" (default target) (7) ->
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\sqcxxtestdata\component1.cc(18): warning C26494: Variable 'x' is uninitialized. Always initialize an object. (type.5: http://go.microsoft.com/fwlink/p/?LinkID=620421) [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
@@ -587,23 +583,23 @@
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\sqcxxtestdata\component2.cc(49): warning C26400: Do not assign the result of an allocation or a function call with an owner<T> return value to a raw pointer, use owner<T> instead. (i.11 http://go.microsoft.com/fwlink/?linkid=845474) [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\sqcxxtestdata\component2.cc(50): warning C26401: Do not delete a raw pointer that is not an owner<T>. (i.11: http://go.microsoft.com/fwlink/?linkid=845474) [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\source\sqcxxtestdata\component2.cc(50): warning C26409: Avoid calling new and delete explicitly, use std::make_unique<T> instead. (r.11 http://go.microsoft.com/fwlink/?linkid=845485) [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
-2017-12-18T17:13:33.4333520Z 
-2017-12-18T17:13:33.4333520Z 
+2017-12-18T17:13:33.4333520Z
+2017-12-18T17:13:33.4333520Z
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\Tests\MotorControllerTests\MotorControllerTests.vcxproj" (default target) (4) ->
-2017-12-18T17:13:33.4333520Z        (ClCompile target) -> 
+2017-12-18T17:13:33.4333520Z        (ClCompile target) ->
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\tests\motorcontrollertests\unittest1.cpp(15): warning C4505: 'Microsoft::VisualStudio::CppUnitTestFramework::ToString': unreferenced local function has been removed [C:\agent\_work\1\s\Tests\MotorControllerTests\MotorControllerTests.vcxproj]
-2017-12-18T17:13:33.4333520Z 
-2017-12-18T17:13:33.4333520Z 
+2017-12-18T17:13:33.4333520Z
+2017-12-18T17:13:33.4333520Z
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T17:13:33.4333520Z        "C:\agent\_work\1\s\Tests\RootFinderTests\RootFinderTests.vcxproj" (default target) (6) ->
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\tests\rootfindertests\unittest1.cpp(35): warning C4238: nonstandard extension used: class rvalue used as lvalue [C:\agent\_work\1\s\Tests\RootFinderTests\RootFinderTests.vcxproj]
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\tests\rootfindertests\unittest1.cpp(60): warning C4238: nonstandard extension used: class rvalue used as lvalue [C:\agent\_work\1\s\Tests\RootFinderTests\RootFinderTests.vcxproj]
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\tests\rootfindertests\unittest1.cpp(69): warning C4238: nonstandard extension used: class rvalue used as lvalue [C:\agent\_work\1\s\Tests\RootFinderTests\RootFinderTests.vcxproj]
 2017-12-18T17:13:33.4333520Z          c:\agent\_work\1\s\tests\rootfindertests\unittest1.cpp(57): warning C4189: 'result': local variable is initialized but not referenced [C:\agent\_work\1\s\Tests\RootFinderTests\RootFinderTests.vcxproj]
-2017-12-18T17:13:33.4333520Z 
+2017-12-18T17:13:33.4333520Z
 2017-12-18T17:13:33.4333520Z     82 Warning(s)
 2017-12-18T17:13:33.4333520Z     0 Error(s)
-2017-12-18T17:13:33.4333520Z 
+2017-12-18T17:13:33.4333520Z
 2017-12-18T17:13:33.4333520Z Time Elapsed 00:00:29.37
 2017-12-18T17:13:33.5271006Z ##[section]Finishing: Build solution CppTesting.sln

--- a/cxx-squid/src/test/resources/logfile/TFS-agent-msvc14.txt
+++ b/cxx-squid/src/test/resources/logfile/TFS-agent-msvc14.txt
@@ -56,8 +56,7 @@
 2017-12-18T08:06:58.6876002Z   sonar.cxx.vera.reportPath     = vera-report.xml
 2017-12-18T08:06:58.6876002Z   sonar.cxx.rats.reportPath     = rats-report.xml
 2017-12-18T08:06:58.6876002Z   sonar.cxx.coverage.reportPath = C:/agent/_work/1/s/TestResults/**/*.coveragexml
-2017-12-18T08:06:58.6876002Z   sonar.cxx.suffixes.sources    = .cc,.cpp,.c,.cu
-2017-12-18T08:06:58.6876002Z   sonar.cxx.suffixes.headers    = .h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
+2017-12-18T08:06:58.6876002Z   sonar.cxx.file.suffixes       = .cc,.cpp,.c,.cu,.h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
 2017-12-18T08:06:58.6876002Z   sonar.cxx.forceIncludes       = sonar-defines.h
 2017-12-18T08:06:58.6876002Z   sonar.cxx.includeDirectories  = C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/atlmfc/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/VS/include,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/ucrt,,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/um,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/shared,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/winrt,Include/um,C:/agent/_work/1/s/_Globals/Include,../../src/_Globals/Include
 2017-12-18T08:06:58.7813773Z CreateProjectSpecificDirs:
@@ -110,8 +109,7 @@
 2017-12-18T08:07:03.4148615Z   sonar.cxx.vera.reportPath     = vera-report.xml
 2017-12-18T08:07:03.4148615Z   sonar.cxx.rats.reportPath     = rats-report.xml
 2017-12-18T08:07:03.4148615Z   sonar.cxx.coverage.reportPath = C:/agent/_work/1/s/TestResults/**/*.coveragexml
-2017-12-18T08:07:03.4148615Z   sonar.cxx.suffixes.sources    = .cc,.cpp,.c,.cu
-2017-12-18T08:07:03.4148615Z   sonar.cxx.suffixes.headers    = .h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
+2017-12-18T08:07:03.4148615Z   sonar.cxx.file.suffixes       = .cc,.cpp,.c,.cu,.h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
 2017-12-18T08:07:03.4148615Z   sonar.cxx.forceIncludes       = sonar-defines.h
 2017-12-18T08:07:03.4148615Z   sonar.cxx.includeDirectories  = C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/atlmfc/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/VS/include,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/ucrt,,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/um,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/shared,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/winrt,Include/um,C:/agent/_work/1/s/_Globals/Include,../../src/_Globals/Include
 2017-12-18T08:07:03.4148615Z CreateProjectSpecificDirs:
@@ -193,8 +191,7 @@
 2017-12-18T08:07:12.2013619Z   sonar.cxx.vera.reportPath     = vera-report.xml
 2017-12-18T08:07:12.2013619Z   sonar.cxx.rats.reportPath     = rats-report.xml
 2017-12-18T08:07:12.2013619Z   sonar.cxx.coverage.reportPath = C:/agent/_work/1/s/TestResults/**/*.coveragexml
-2017-12-18T08:07:12.2013619Z   sonar.cxx.suffixes.sources    = .cc,.cpp,.c,.cu
-2017-12-18T08:07:12.2013619Z   sonar.cxx.suffixes.headers    = .h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
+2017-12-18T08:07:12.2013619Z   sonar.cxx.file.suffixes       = .cc,.cpp,.c,.cu,.h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
 2017-12-18T08:07:12.2013619Z   sonar.cxx.forceIncludes       = sonar-defines.h
 2017-12-18T08:07:12.2169834Z   sonar.cxx.includeDirectories  = C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/atlmfc/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/VS/include,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/ucrt,,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/um,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/shared,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/winrt,Include/um,C:/agent/_work/1/s/_Globals/Include,../../src/_Globals/Include
 2017-12-18T08:07:12.2169834Z CreateProjectSpecificDirs:
@@ -441,8 +438,7 @@
 2017-12-18T08:07:46.3541019Z   sonar.cxx.vera.reportPath     = vera-report.xml
 2017-12-18T08:07:46.3541019Z   sonar.cxx.rats.reportPath     = rats-report.xml
 2017-12-18T08:07:46.3541019Z   sonar.cxx.coverage.reportPath = C:/agent/_work/1/s/TestResults/**/*.coveragexml
-2017-12-18T08:07:46.3541019Z   sonar.cxx.suffixes.sources    = .cc,.cpp,.c,.cu
-2017-12-18T08:07:46.3541019Z   sonar.cxx.suffixes.headers    = .h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
+2017-12-18T08:07:46.3541019Z   sonar.cxx.file.suffixes       = .cc,.cpp,.c,.cu,.h,.hh,.hpp,.inl,.cuh,.inc,.cuinc
 2017-12-18T08:07:46.3541019Z   sonar.cxx.forceIncludes       = sonar-defines.h
 2017-12-18T08:07:46.3541019Z   sonar.cxx.includeDirectories  = C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.11.25503/atlmfc/include,,C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/VS/include,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/ucrt,,,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/um,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/shared,C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/winrt,Include/um,C:/agent/_work/1/s/_Globals/Include,../../src/_Globals/Include
 2017-12-18T08:07:46.3541019Z CreateProjectSpecificDirs:
@@ -452,50 +448,50 @@
 2017-12-18T08:07:46.3541019Z   Creating directory "C:\agent\_work\1\.sonarqube\conf\SQCxxTestData_3541".
 2017-12-18T08:07:46.3541019Z Done Building Project "C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj" (default targets).
 2017-12-18T08:07:46.3541019Z Done Building Project "C:\agent\_work\1\s\CppTesting.sln" (default targets).
-2017-12-18T08:07:46.3541019Z 
+2017-12-18T08:07:46.3541019Z
 2017-12-18T08:07:46.3541019Z Build succeeded.
-2017-12-18T08:07:46.3703906Z 
+2017-12-18T08:07:46.3703906Z
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\Source\RootFinder\RootFinder.vcxproj" (default target) (2) ->
-2017-12-18T08:07:46.3703906Z (ClCompile target) -> 
+2017-12-18T08:07:46.3703906Z (ClCompile target) ->
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\rootfinder\dllmain.cpp(7): warning C4100: 'lpReserved': unreferenced formal parameter [C:\agent\_work\1\s\Source\RootFinder\RootFinder.vcxproj]
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\rootfinder\dllmain.cpp(4): warning C4100: 'hModule': unreferenced formal parameter [C:\agent\_work\1\s\Source\RootFinder\RootFinder.vcxproj]
-2017-12-18T08:07:46.3703906Z 
-2017-12-18T08:07:46.3703906Z 
+2017-12-18T08:07:46.3703906Z
+2017-12-18T08:07:46.3703906Z
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\Source\MotorController\MotorController.vcxproj" (default target) (3) ->
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\motorcontroller\dllmain.cpp(7): warning C4100: 'lpReserved': unreferenced formal parameter [C:\agent\_work\1\s\Source\MotorController\MotorController.vcxproj]
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\motorcontroller\dllmain.cpp(4): warning C4100: 'hModule': unreferenced formal parameter [C:\agent\_work\1\s\Source\MotorController\MotorController.vcxproj]
-2017-12-18T08:07:46.3703906Z 
-2017-12-18T08:07:46.3703906Z 
+2017-12-18T08:07:46.3703906Z
+2017-12-18T08:07:46.3703906Z
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\Source\MotorController\MotorController.vcxproj" (default target) (3) ->
-2017-12-18T08:07:46.3703906Z (RunNativeCodeAnalysis target) -> 
+2017-12-18T08:07:46.3703906Z (RunNativeCodeAnalysis target) ->
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\motorcontroller\motorcontroller.cpp(63): warning C26498: This function call factorial can use constexpr if compile-time evaluation is desired. (con.5: https://go.microsoft.com/fwlink/p/?LinkID=784974) [C:\agent\_work\1\s\Source\MotorController\MotorController.vcxproj]
-2017-12-18T08:07:46.3703906Z 
-2017-12-18T08:07:46.3703906Z 
+2017-12-18T08:07:46.3703906Z
+2017-12-18T08:07:46.3703906Z
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\Tests\MotorControllerTests\MotorControllerTests.vcxproj" (default target) (4) ->
-2017-12-18T08:07:46.3703906Z (ClCompile target) -> 
+2017-12-18T08:07:46.3703906Z (ClCompile target) ->
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\tests\motorcontrollertests\unittest1.cpp(15): warning C4505: 'Microsoft::VisualStudio::CppUnitTestFramework::ToString': unreferenced local function has been removed [C:\agent\_work\1\s\Tests\MotorControllerTests\MotorControllerTests.vcxproj]
-2017-12-18T08:07:46.3703906Z 
-2017-12-18T08:07:46.3703906Z 
+2017-12-18T08:07:46.3703906Z
+2017-12-18T08:07:46.3703906Z
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\Source\Calculation\Calculation.vcxproj" (default target) (5) ->
-2017-12-18T08:07:46.3703906Z (RunNativeCodeAnalysis target) -> 
+2017-12-18T08:07:46.3703906Z (RunNativeCodeAnalysis target) ->
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\calculation\addition.cpp(11): warning C26497: This function CAddition::twoValues could be marked constexpr if compile-time evaluation is desired. (f.4: https://go.microsoft.com/fwlink/p/?LinkID=784970) [C:\agent\_work\1\s\Source\Calculation\Calculation.vcxproj]
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\calculation\multiply.cpp(11): warning C26497: This function CMultiply::twoValues could be marked constexpr if compile-time evaluation is desired. (f.4: https://go.microsoft.com/fwlink/p/?LinkID=784970) [C:\agent\_work\1\s\Source\Calculation\Calculation.vcxproj]
-2017-12-18T08:07:46.3703906Z 
-2017-12-18T08:07:46.3703906Z 
+2017-12-18T08:07:46.3703906Z
+2017-12-18T08:07:46.3703906Z
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\Tests\RootFinderTests\RootFinderTests.vcxproj" (default target) (7) ->
-2017-12-18T08:07:46.3703906Z (ClCompile target) -> 
+2017-12-18T08:07:46.3703906Z (ClCompile target) ->
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\tests\rootfindertests\unittest1.cpp(35): warning C4238: nonstandard extension used: class rvalue used as lvalue [C:\agent\_work\1\s\Tests\RootFinderTests\RootFinderTests.vcxproj]
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\tests\rootfindertests\unittest1.cpp(60): warning C4238: nonstandard extension used: class rvalue used as lvalue [C:\agent\_work\1\s\Tests\RootFinderTests\RootFinderTests.vcxproj]
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\tests\rootfindertests\unittest1.cpp(69): warning C4238: nonstandard extension used: class rvalue used as lvalue [C:\agent\_work\1\s\Tests\RootFinderTests\RootFinderTests.vcxproj]
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\tests\rootfindertests\unittest1.cpp(57): warning C4189: 'result': local variable is initialized but not referenced [C:\agent\_work\1\s\Tests\RootFinderTests\RootFinderTests.vcxproj]
-2017-12-18T08:07:46.3703906Z 
-2017-12-18T08:07:46.3703906Z 
+2017-12-18T08:07:46.3703906Z
+2017-12-18T08:07:46.3703906Z
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj" (default target) (8) ->
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\sqcxxtestdata\component2.cc(17): warning C4101: 'x': unreferenced local variable [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
@@ -504,11 +500,11 @@
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\sqcxxtestdata\component1.cc(37): warning C4189: 'i': local variable is initialized but not referenced [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\sqcxxtestdata\component2.cc(31): warning C4700: uninitialized local variable 'a' used [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\sqcxxtestdata\component1.cc(32): warning C4700: uninitialized local variable 'a' used [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
-2017-12-18T08:07:46.3703906Z 
-2017-12-18T08:07:46.3703906Z 
+2017-12-18T08:07:46.3703906Z
+2017-12-18T08:07:46.3703906Z
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\CppTesting.sln" (default target) (1) ->
 2017-12-18T08:07:46.3703906Z "C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj" (default target) (8) ->
-2017-12-18T08:07:46.3703906Z (RunNativeCodeAnalysis target) -> 
+2017-12-18T08:07:46.3703906Z (RunNativeCodeAnalysis target) ->
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\sqcxxtestdata\component1.cc(18): warning C26494: Variable 'x' is uninitialized. Always initialize an object. (type.5: http://go.microsoft.com/fwlink/p/?LinkID=620421) [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\sqcxxtestdata\component1.cc(51): warning C6279: 'ip' is allocated with scalar new, but deleted with array delete []. [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\sqcxxtestdata\component1.cc(32): warning C6001: Using uninitialized memory 'a'. [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
@@ -573,9 +569,9 @@
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\sqcxxtestdata\component2.cc(49): warning C26400: Do not assign the result of an allocation or a function call with an owner<T> return value to a raw pointer, use owner<T> instead. (i.11 http://go.microsoft.com/fwlink/?linkid=845474) [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\sqcxxtestdata\component2.cc(50): warning C26401: Do not delete a raw pointer that is not an owner<T>. (i.11: http://go.microsoft.com/fwlink/?linkid=845474) [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
 2017-12-18T08:07:46.3703906Z   c:\agent\_work\1\s\source\sqcxxtestdata\component2.cc(50): warning C26409: Avoid calling new and delete explicitly, use std::make_unique<T> instead. (r.11 http://go.microsoft.com/fwlink/?linkid=845485) [C:\agent\_work\1\s\Source\SQCxxTestData\SQCxxTestData.vcxproj]
-2017-12-18T08:07:46.3703906Z 
+2017-12-18T08:07:46.3703906Z
 2017-12-18T08:07:46.3703906Z     82 Warning(s)
 2017-12-18T08:07:46.3703906Z     0 Error(s)
-2017-12-18T08:07:46.3703906Z 
+2017-12-18T08:07:46.3703906Z
 2017-12-18T08:07:46.3703906Z Time Elapsed 00:00:55.11
 2017-12-18T08:07:46.4478516Z ##[section]Finishing: Build solution CppTesting.sln

--- a/integration-tests/features/steps/test_execution_statistics.py
+++ b/integration-tests/features/steps/test_execution_statistics.py
@@ -68,7 +68,7 @@ def step_impl(context, project):
     assert os.path.isdir(os.path.join(TESTDATADIR, project))
     context.project = project
     context.profile_key = None
- 
+
     url = (SONAR_URL + "/api/qualityprofiles/search")
     response = _rest_api_get(url)
     profiles = _get_json(response)["profiles"]
@@ -87,11 +87,11 @@ def step_impl(context, project):
         if name == "Sonar way copy - c++":
             copy_profile_key = key
 
-    if copy_profile_key:      
+    if copy_profile_key:
         url = (SONAR_URL + "/api/qualityprofiles/delete")
         payload = {'profileKey': copy_profile_key}
         _rest_api_set(url, payload)
-    
+
     url = (SONAR_URL + "/api/qualityprofiles/copy")
     payload = {'fromKey': default_profile_key, 'toName': 'Sonar way copy'}
     _rest_api_set(url, payload)
@@ -108,7 +108,7 @@ def step_impl(context, project):
     payload = {'profileKey': context.profile_key}
     _rest_api_set(url, payload)
 
-    
+
 @given(u'platform is not "{plat}"')
 def step_impl(context, plat):
     if platform.system() == plat:
@@ -121,32 +121,15 @@ def step_impl(context, plat):
         context.scenario.skip(reason='scenario meant to run only in specified platform')
 
 
-@given(u'declared source extensions of language c++ are "{extensions}"')
+@given(u'declared suffixes for c++ files to analyze are "{extensions}"')
 def step_impl(context, extensions):
     assert context.profile_key != "", "PROFILE KEY NOT FOUND: %s" % str(context.profile_key)
     url = (SONAR_URL + "/api/settings/reset")
-    _rest_api_set(url, {'keys': 'sonar.cxx.suffixes.sources'})
+    _rest_api_set(url, {'keys': 'sonar.cxx.file.suffixes'})
     url = (SONAR_URL + "/api/settings/set")
     extensionlist = extensions.split(",")
     payload = dict()
-    payload['key'] = 'sonar.cxx.suffixes.sources'
-    for extension in extensionlist:
-        if 'values' in payload:
-            payload['values'].append(extension)
-        else:
-            payload['values'] = [extension]
-    _rest_api_set(url, payload)
-
-
-@given(u'declared header extensions of language c++ are "{extensions}"')
-def step_impl(context, extensions):
-    assert context.profile_key != "", "PROFILE KEY NOT FOUND: %s" % str(context.profile_key)
-    url = (SONAR_URL + "/api/settings/reset")
-    _rest_api_set(url, {'keys': 'sonar.cxx.suffixes.headers'})
-    url = (SONAR_URL + "/api/settings/set")
-    extensionlist = extensions.split(",")
-    payload = dict()
-    payload['key'] = 'sonar.cxx.suffixes.headers'
+    payload['key'] = 'sonar.cxx.file.suffixes'
     for extension in extensionlist:
         if 'values' in payload:
             payload['values'].append(extension)

--- a/integration-tests/features/x_importing_cppcheck_reports_c_cpp.feature
+++ b/integration-tests/features/x_importing_cppcheck_reports_c_cpp.feature
@@ -3,14 +3,13 @@ Feature: Importing Cppcheck ANSI-C reports
 
   Scenario Outline: Importing cppcheck issues when c language issues are in report.
     Given the project "cppcheck_project_c_cpp"
-    And declared header extensions of language c++ are ".hpp,.hh"
-    And declared source extensions of language c++ are ".cpp,.cc"
+    And declared suffixes for c++ files to analyze are ".cpp,.cc,.hpp,.hh"
     And rule "cppcheck:unusedVariable" is enabled
     And rule "cppcheck:unreadVariable" is enabled
     And rule "cppcheck:deallocDealloc" is enabled
-    And rule "cppcheck:doubleFree" is enabled    
+    And rule "cppcheck:doubleFree" is enabled
     And rule "cppcheck:uninitvar" is enabled
-    And rule "cppcheck:unusedFunction" is enabled    
+    And rule "cppcheck:unusedFunction" is enabled
     When I run "sonar-scanner -X -Dsonar.cxx.cppcheck.reportPath=<reportpath>"
     Then the analysis finishes successfully
     And the analysis in server has completed

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -57,6 +57,7 @@ import org.sonar.cxx.sensors.veraxx.CxxVeraxxSensor;
 import org.sonar.cxx.sensors.visitors.CxxCpdVisitor;
 import org.sonar.cxx.visitors.CxxFunctionComplexityVisitor;
 import org.sonar.cxx.visitors.CxxFunctionSizeVisitor;
+import org.sonar.cxx.visitors.CxxPublicApiVisitor;
 
 /**
  * {@inheritDoc}
@@ -80,6 +81,7 @@ public final class CxxPlugin implements Plugin {
 
     // properties elements
     l.addAll(CxxLanguage.properties());
+    l.addAll(CxxPublicApiVisitor.properties());
     l.addAll(CxxSquidSensor.properties());
     l.addAll(CxxCppCheckSensor.properties());
     l.addAll(CxxValgrindSensor.properties());

--- a/sonar-cxx-plugin/src/samples/SampleProject/pom.xml
+++ b/sonar-cxx-plugin/src/samples/SampleProject/pom.xml
@@ -541,9 +541,5 @@
     <sonar.cxx.defines>Q_OBJECT, Q_SLOTS</sonar.cxx.defines>
     <sonar.tests>sources/tests</sonar.tests>
 
-    <!-- <sonar.cxx.suffixes.sources></sonar.cxx.suffixes.sources> -->
-    <!-- <sonar.cxx.suffixes.headers></sonar.cxx.suffixes.headers> -->
-    <!-- <sonar.cxx.xunit.xsltURL></sonar.cxx.xunit.xsltURL> -->
-    <!-- <sonar.cxx.valgrind.reportPath></sonar.cxx.valgrind.reportPath> -->
   </properties>
 </project>


### PR DESCRIPTION
align **file suffix configuration** with other plugins:
- use key `sonar.cxx.file.suffixes`
- instead of `sonar.cxx.suffixes.sources` and `sonar.cxx.suffixes.headers` (both deprecated)
- default cxx files suffixes are `.cxx,.cpp,.cc,.c,.hxx,.hpp,.hh,.h`

for **API** detection there is a new key now:
- `sonar.cxx.api.file.suffixes` instead of `sonar.cxx.suffixes.headers`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1829)
<!-- Reviewable:end -->
