### PR TITLE
remove sonar.cxx.cFilesPatterns

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/squid/CxxSquidSensor.java
@@ -82,9 +82,6 @@ public class CxxSquidSensor implements ProjectSensor {
   public static final String FORCE_INCLUDE_FILES_KEY = "sonar.cxx.forceIncludes";
   public static final String JSON_COMPILATION_DATABASE_KEY = "sonar.cxx.jsonCompilationDatabase";
 
-  public static final String C_FILES_PATTERNS_KEY = "sonar.cxx.cFilesPatterns";
-  public static final String DEFAULT_C_FILES = "*.c,*.C";
-
   /**
    * the following settings are in use by the feature to read configuration settings from the VC compiler report
    */
@@ -158,15 +155,6 @@ public class CxxSquidSensor implements ProjectSensor {
         .subCategory(subcateg2)
         .onQualifiers(Qualifiers.PROJECT)
         .type(PropertyType.TEXT)
-        .build(),
-      PropertyDefinition.builder(C_FILES_PATTERNS_KEY)
-        .defaultValue(DEFAULT_C_FILES)
-        .multiValues(true)
-        .name("C source files patterns")
-        .description("Comma-separated list of wildcard patterns used to detect C files. When a file matches any of the"
-                       + "patterns, it is parsed in C-compatibility mode.")
-        .subCategory(subcateg1)
-        .onQualifiers(Qualifiers.PROJECT)
         .build(),
       PropertyDefinition.builder(ERROR_RECOVERY_KEY)
         .defaultValue(Boolean.TRUE.toString())
@@ -276,7 +264,6 @@ public class CxxSquidSensor implements ProjectSensor {
     //    default value instead
     //    For proper implemenation see CppLanguage::CppLanguage()
     //    or createStringArray(config.getStringArray(C_FILES_PATTERNS_KEY), DEFAULT_C_FILES)
-    cxxConf.setCFilesPatterns(this.config.getStringArray(C_FILES_PATTERNS_KEY));
     cxxConf.setJsonCompilationDatabaseFile(this.config.get(JSON_COMPILATION_DATABASE_KEY)
       .orElse(null));
 

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxConfiguration.java
@@ -49,7 +49,6 @@ public class CxxConfiguration extends SquidConfiguration {
   private List<String> forceIncludeFiles = new ArrayList<>();
   private String baseDir = "";
   private boolean errorRecoveryEnabled = true;
-  private List<String> cFilesPatterns = new ArrayList<>();
   private String jsonCompilationDatabaseFile;
   private CxxCompilationUnitSettings globalCompilationUnitSettings;
   private final Map<String, CxxCompilationUnitSettings> compilationUnitSettings = new HashMap<>();
@@ -166,16 +165,6 @@ public class CxxConfiguration extends SquidConfiguration {
 
   public boolean getErrorRecoveryEnabled() {
     return this.errorRecoveryEnabled;
-  }
-
-  public List<String> getCFilesPatterns() {
-    return new ArrayList<>(cFilesPatterns);
-  }
-
-  public void setCFilesPatterns(@Nullable String[] cFilesPatterns) {
-    if (cFilesPatterns != null && cFilesPatterns.length > 0) {
-      this.cFilesPatterns = Arrays.asList(cFilesPatterns);
-    }
   }
 
   public String getJsonCompilationDatabaseFile() {

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/Macro.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/Macro.java
@@ -45,11 +45,6 @@ public final class Macro {
    */
   public static final Map<String, Macro> UNIT_MACROS = initUnitMacros();
 
-  /**
-   * Macros to replace C++ keywords when parsing C files
-   */
-  public static final Map<String, Macro> COMPATIBILITY_MACROS = initCompatibilityMacros();
-
   public final String name;
   public final List<Token> params;
   public final List<Token> body;
@@ -111,46 +106,6 @@ public final class Macro {
     add(map, "__LINE__", "1");
     add(map, "__DATE__", "\"??? ?? ????\"");
     add(map, "__TIME__", "\"??:??:??\"");
-    return Collections.unmodifiableMap(map);
-  }
-
-  private static Map<String, Macro> initCompatibilityMacros() {
-    // This is a collection of macros used to let C code be parsed by C++ parser
-    Map<String, Macro> map = new HashMap<>();
-    add(map, "alignas", "__alignas");
-    add(map, "alignof", "__alignof");
-    add(map, "catch", "__catch");
-    add(map, "class", "__class");
-    add(map, "constexpr", "__constexpr");
-    add(map, "const_cast", "__const_cast");
-    add(map, "decltype", "__decltype");
-    add(map, "delete", "__delete");
-    add(map, "dynamic_cast", "__dynamic_cast");
-    add(map, "explicit", "__explicit");
-    add(map, "export", "__export");
-    add(map, "final", "__final");
-    add(map, "friend", "__friend");
-    add(map, "mutable", "__mutable");
-    add(map, "namespace", "__namespace");
-    add(map, "new", "__new");
-    add(map, "noexcept", "__noexcept");
-    add(map, "nullptr", "__nullptr");
-    add(map, "operator", "__operator");
-    add(map, "override", "__override");
-    add(map, "private", "__private");
-    add(map, "protected", "__protected");
-    add(map, "public", "__public");
-    add(map, "reinterpret_cast", "__reinterpret_cast");
-    add(map, "static_assert", "__static_assert");
-    add(map, "static_cast", "__static_cast");
-    add(map, "thread_local", "__thread_local");
-    add(map, "throw", "__throw");
-    add(map, "try", "__try");
-    add(map, "typeid", "__typeid");
-    add(map, "typename", "__typename");
-    add(map, "using", "__using");
-    add(map, "template", "__template");
-    add(map, "virtual", "__virtual");
     return Collections.unmodifiableMap(map);
   }
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/CxxParserTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/CxxParserTest.java
@@ -22,7 +22,6 @@ package org.sonar.cxx.parser;
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
 import com.sonar.sslr.impl.Parser;
-
 import java.io.File;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -88,7 +87,8 @@ public class CxxParserTest {
       AstNode root = p.parse(file);
       CxxParser.finishedParsing(file);
       if (map.containsKey(file.getName())) {
-        assertThat(root.getNumberOfChildren()).as("check number of nodes for file %s", file.getName()).isEqualTo(map.get(file.getName()));
+        assertThat(root.getNumberOfChildren()).as("check number of nodes for file %s", file.getName()).isEqualTo(map
+          .get(file.getName()));
       } else {
         assertThat(root.hasChildren()).isTrue();
       }
@@ -134,38 +134,12 @@ public class CxxParserTest {
       AstNode root = p.parse(file);
       CxxParser.finishedParsing(file);
       if (map.containsKey(file.getName())) {
-        assertThat(root.getNumberOfChildren()).as("check number of nodes for file %s", file.getName()).isEqualTo(map.get(file.getName()));
+        assertThat(root.getNumberOfChildren()).as("check number of nodes for file %s", file.getName()).isEqualTo(map
+          .get(file.getName()));
       } else {
         assertThat(root.hasChildren()).isTrue();
       }
     }
-  }
-
-  @SuppressWarnings("unchecked")
-  @Test
-  public void testParsingInCCompatMode() { //ToDo: Fix this compatibility test - currently it is useless
-    // The C-compatibility replaces c++ keywords, which aren't keywords in C,
-    // with non-keyword-strings via the preprocessor.
-    // This mode works if such a file causes parsing errors when the mode
-    // is switched off and doesn't, if the mode is switched on.
-
-    File cfile = listFiles(cCompatibilityFiles, new String[]{"c"}).get(0);
-
-    SquidAstVisitorContext<Grammar> context = mock(SquidAstVisitorContext.class);
-    when(context.getFile()).thenReturn(cfile);
-
-    CxxConfiguration conf = new CxxConfiguration();
-    conf.setErrorRecoveryEnabled(false);
-    conf.setCFilesPatterns(new String[]{""});
-    Parser<Grammar> p = CxxParser.create(context, conf);
-
-    AstNode root0 = p.parse(cfile);
-    assertThat(root0.getNumberOfChildren()).isEqualTo(2);
-
-    conf.setCFilesPatterns(new String[]{"*.c"});
-    p = CxxParser.create(context, conf);
-    AstNode root = p.parse(cfile);
-    assertThat(root.getNumberOfChildren()).isEqualTo(2);
   }
 
   @Test

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
@@ -36,7 +37,7 @@ public class CxxParseErrorLoggerVisitorTest {
 
   private final MapSettings settings = new MapSettings();
 
-  @org.junit.Rule
+  @Rule
   public LogTester logTester = new LogTester();
 
   @Before
@@ -53,12 +54,12 @@ public class CxxParseErrorLoggerVisitorTest {
   @Test
   public void handleParseErrorTest() throws Exception {
     List<String> log = logTester.logs(LoggerLevel.DEBUG);
-    assertThat(log).hasSize(12);
-    assertThat(log.get(7)).contains("skip declaration: namespace X {");
-    assertThat(log.get(8)).contains("skip declaration: void test :: f1 ( ) {");
-    assertThat(log.get(9)).contains("syntax error: i = unsigend int ( i + 1 )");
-    assertThat(log.get(10)).contains("skip declaration: void test :: f3 ( ) {");
-    assertThat(log.get(11)).contains("syntax error: int i = 0 i ++");
+    assertThat(log).hasSize(11);
+    assertThat(log.get(6)).contains("skip declaration: namespace X {");
+    assertThat(log.get(7)).contains("skip declaration: void test :: f1 ( ) {");
+    assertThat(log.get(8)).contains("syntax error: i = unsigend int ( i + 1 )");
+    assertThat(log.get(9)).contains("skip declaration: void test :: f3 ( ) {");
+    assertThat(log.get(10)).contains("syntax error: int i = 0 i ++");
   }
 
 }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -40,7 +40,7 @@ public class CxxPluginTest {
     Plugin.Context context = new Plugin.Context(runtime);
     CxxPlugin plugin = new CxxPlugin();
     plugin.define(context);
-    assertThat(context.getExtensions()).hasSize(72);
+    assertThat(context.getExtensions()).hasSize(71);
   }
 
 }


### PR DESCRIPTION
- we are using for all languages the same parser
- difference with `cFilesPatterns` was only to replace C++ keywords with placeholders to treat them different (use them for example as variable names)
- easier and more transparent solution is to create a header file and use `forceIncludes`
- `cFilesPatterns` support has been removed
- close #1105

Sample:
```C++
#define alignas __alignas
#define alignof __alignof
#define catch __catch
#define class __class
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1833)
<!-- Reviewable:end -->
