### PR TITLE
rename CxxLanguage.NAME to CXX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ jdk:
 env:
   - SONARLABEL=sonarqube-7.9.2 SONARAPI=SqApi79
 
-branches:
-  only:
-    - master
-
 # shorten the VM hostname with the new workaround
 # https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
 addons:

--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxLanguage.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxLanguage.java
@@ -42,7 +42,7 @@ public class CxxLanguage extends AbstractLanguage {
   /**
    * cxx language name
    */
-  public static final String NAME = "C++ (Community)";
+  public static final String NAME = "CXX";
 
   /**
    * Key of the file suffix parameter


### PR DESCRIPTION
- language name: "C++ (Community)" => "CXX"
- in Issues / Rules there is the language name in brackets before the rule; old name was too long

![image](https://user-images.githubusercontent.com/6077367/78293565-0834ac00-7529-11ea-9d98-1cba926bf782.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1839)
<!-- Reviewable:end -->
