### PR TITLE
Added a test for macros that shouldn't be substituted.

### DIFF
--- a/cxx-squid/src/test/resources/parser/preprocessor/variadic_macros.cpp
+++ b/cxx-squid/src/test/resources/parser/preprocessor/variadic_macros.cpp
@@ -7,6 +7,9 @@
 #define CHECK3(...) { printf(__VA_ARGS__); }
 #define MACRO(s, ...) printf(s, __VA_ARGS__)
 
+//Check macro substutiuon doesn't happen in the middle of a string.
+int mainMACRO();
+
 int main() {
     CHECK1(0, "here %s %s %s", "are", "some", "varargs1(1)\n");
     CHECK1(0, "here %s %s %s", "are", "some", "varargs1(2)\n");   // won't print


### PR DESCRIPTION
I suspect this is an issue, so just throwing it against the build system to see if it causes problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1913)
<!-- Reviewable:end -->
