### PR TITLE
CxxCoverageSensor: fix typo in debug message

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/CxxCoverageSensor.java
@@ -95,7 +95,7 @@ public class CxxCoverageSensor extends CxxReportSensor {
     try {
       parser.parse(report, measuresForReport);
     } catch (XMLStreamException e) {
-      throw new EmptyReportException("Coverage report" + report + "cannot be parsed by" + parser, e);
+      throw new EmptyReportException("Coverage report " + report + " cannot be parsed by " + parser, e);
     }
 
     if (measuresForReport.isEmpty()) {


### PR DESCRIPTION
Add blanks in debug message between variable and static text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1918)
<!-- Reviewable:end -->
