### PR TITLE
add column information to issues

### DIFF
--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/CxxCyclomaticComplexityCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/CxxCyclomaticComplexityCheck.java
@@ -114,9 +114,9 @@ public abstract class CxxCyclomaticComplexityCheck<G extends Grammar> extends Mu
       msg.append("The Cyclomatic Complexity of this ").append(getScopeName()).append(" is ").append(currentComplexity)
         .append(" which is greater than ").append(maxComplexity).append(" authorized.");
 
-      var issue = new CxxReportIssue(getRuleKey(), null, scope.getStartingLine(), msg.toString());
+      var issue = new CxxReportIssue(getRuleKey(), null, scope.getStartingLine(), null, msg.toString());
       for (var source : scope.getSources()) {
-        issue.addLocation(null, source.getLine(), source.getExplanation());
+        issue.addLocation(null, source.getLine(), null, source.getExplanation());
       }
       createMultiLocationViolation(issue);
     }

--- a/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/FunctionCognitiveComplexityCheck.java
+++ b/cxx-checks/src/main/java/org/sonar/cxx/checks/metrics/FunctionCognitiveComplexityCheck.java
@@ -61,9 +61,9 @@ public class FunctionCognitiveComplexityCheck extends CxxCognitiveComplexityVisi
       msg.append("The Cognitive Complexity of this function is ").append(scope.getComplexity())
         .append(" which is greater than ").append(max).append(" authorized.");
 
-      var issue = new CxxReportIssue(getRuleKey(), null, scope.getStartingLine(), msg.toString());
+      var issue = new CxxReportIssue(getRuleKey(), null, scope.getStartingLine(), null, msg.toString());
       for (var source : scope.getSources()) {
-        issue.addLocation(null, source.getLine(), source.getExplanation());
+        issue.addLocation(null, source.getLine(), null, source.getExplanation());
       }
       createMultiLocationViolation(issue);
     }

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/ClassComplexityCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/ClassComplexityCheckTest.java
@@ -52,52 +52,52 @@ public class ClassComplexityCheckTest {
     CxxReportIssue issue0 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("9"))
       .findFirst().orElseThrow(() -> new AssertionError("No issue at line 9"));
     softly.assertThat(issue0.getLocations()).containsOnly(
-      new CxxReportLocation(null, "9",
+      new CxxReportLocation(null, "9", null,
                             "The Cyclomatic Complexity of this class is 12 which is greater than 5 authorized."),
-      new CxxReportLocation(null, "14", "+1: function definition"),
-      new CxxReportLocation(null, "16", "+1: function definition"),
-      new CxxReportLocation(null, "21", "+1: function definition"),
-      new CxxReportLocation(null, "22", "+1: function definition"),
-      new CxxReportLocation(null, "25", "+1: function definition"),
-      new CxxReportLocation(null, "26", "+1: if statement"),
-      new CxxReportLocation(null, "27", "+1: if statement"),
-      new CxxReportLocation(null, "28", "+1: conditional operator"),
-      new CxxReportLocation(null, "30", "+1: conditional operator"),
-      new CxxReportLocation(null, "33", "+1: if statement"),
-      new CxxReportLocation(null, "34", "+1: conditional operator"),
-      new CxxReportLocation(null, "36", "+1: conditional operator"));
+      new CxxReportLocation(null, "14", null, "+1: function definition"),
+      new CxxReportLocation(null, "16", null, "+1: function definition"),
+      new CxxReportLocation(null, "21", null, "+1: function definition"),
+      new CxxReportLocation(null, "22", null, "+1: function definition"),
+      new CxxReportLocation(null, "25", null, "+1: function definition"),
+      new CxxReportLocation(null, "26", null, "+1: if statement"),
+      new CxxReportLocation(null, "27", null, "+1: if statement"),
+      new CxxReportLocation(null, "28", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "30", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "33", null, "+1: if statement"),
+      new CxxReportLocation(null, "34", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "36", null, "+1: conditional operator"));
 
     CxxReportIssue issue1 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("42"))
       .findFirst().orElseThrow(() -> new AssertionError("No issue at line 42"));
     softly.assertThat(issue1.getLocations()).containsOnly(
-      new CxxReportLocation(null, "42",
+      new CxxReportLocation(null, "42", null,
                             "The Cyclomatic Complexity of this class is 10 which is greater than 5 authorized."),
-      new CxxReportLocation(null, "47", "+1: function definition"),
-      new CxxReportLocation(null, "49", "+1: function definition"),
-      new CxxReportLocation(null, "51", "+1: switch label"),
-      new CxxReportLocation(null, "53", "+1: switch label"),
-      new CxxReportLocation(null, "57", "+1: function definition"),
-      new CxxReportLocation(null, "58", "+1: for loop"),
-      new CxxReportLocation(null, "59", "+1: if statement"),
-      new CxxReportLocation(null, "59", "+1: logical operator"),
-      new CxxReportLocation(null, "59", "+1: logical operator"),
-      new CxxReportLocation(null, "65", "+1: function definition")
+      new CxxReportLocation(null, "47", null, "+1: function definition"),
+      new CxxReportLocation(null, "49", null, "+1: function definition"),
+      new CxxReportLocation(null, "51", null, "+1: switch label"),
+      new CxxReportLocation(null, "53", null, "+1: switch label"),
+      new CxxReportLocation(null, "57", null, "+1: function definition"),
+      new CxxReportLocation(null, "58", null, "+1: for loop"),
+      new CxxReportLocation(null, "59", null, "+1: if statement"),
+      new CxxReportLocation(null, "59", null, "+1: logical operator"),
+      new CxxReportLocation(null, "59", null, "+1: logical operator"),
+      new CxxReportLocation(null, "65", null, "+1: function definition")
     );
 
     CxxReportIssue issue2 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("45"))
       .findFirst().orElseThrow(() -> new AssertionError("No issue at line 45"));
     softly.assertThat(issue2.getLocations()).containsOnly(
-      new CxxReportLocation(null, "45",
+      new CxxReportLocation(null, "45", null,
                             "The Cyclomatic Complexity of this class is 9 which is greater than 5 authorized."),
-      new CxxReportLocation(null, "47", "+1: function definition"),
-      new CxxReportLocation(null, "49", "+1: function definition"),
-      new CxxReportLocation(null, "51", "+1: switch label"),
-      new CxxReportLocation(null, "53", "+1: switch label"),
-      new CxxReportLocation(null, "57", "+1: function definition"),
-      new CxxReportLocation(null, "58", "+1: for loop"),
-      new CxxReportLocation(null, "59", "+1: if statement"),
-      new CxxReportLocation(null, "59", "+1: logical operator"),
-      new CxxReportLocation(null, "59", "+1: logical operator"));
+      new CxxReportLocation(null, "47", null, "+1: function definition"),
+      new CxxReportLocation(null, "49", null, "+1: function definition"),
+      new CxxReportLocation(null, "51", null, "+1: switch label"),
+      new CxxReportLocation(null, "53", null, "+1: switch label"),
+      new CxxReportLocation(null, "57", null, "+1: function definition"),
+      new CxxReportLocation(null, "58", null, "+1: for loop"),
+      new CxxReportLocation(null, "59", null, "+1: if statement"),
+      new CxxReportLocation(null, "59", null, "+1: logical operator"),
+      new CxxReportLocation(null, "59", null, "+1: logical operator"));
 
     softly.assertAll();
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FileComplexityCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FileComplexityCheckTest.java
@@ -51,10 +51,11 @@ public class FileComplexityCheckTest {
     CxxReportIssue actualIssue = issues.iterator().next();
     softly.assertThat(actualIssue.getRuleId()).isEqualTo("FileComplexity");
     softly.assertThat(actualIssue.getLocations()).containsOnly(
-      new CxxReportLocation(null, "1",
+      new CxxReportLocation(null, "1", null,
                             "The Cyclomatic Complexity of this file is 2 which is greater than 1 authorized."),
-      new CxxReportLocation(null, "3", "+1: function definition"),
-      new CxxReportLocation(null, "5", "+1: function definition"));
+       new CxxReportLocation(null, "3", null, "+1: function definition"),
+       new CxxReportLocation(null, "5", null, "+1: function definition")
+    );
     softly.assertAll();
   }
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FunctionCognitiveComplexityCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FunctionCognitiveComplexityCheckTest.java
@@ -52,86 +52,86 @@ public class FunctionCognitiveComplexityCheckTest {
     CxxReportIssue issue0 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("13"))
       .findFirst().orElseThrow(() -> new AssertionError("No issue at line 13"));
     softly.assertThat(issue0.getLocations()).containsOnly(
-      new CxxReportLocation(null, "13",
+      new CxxReportLocation(null, "13", null,
                             "The Cognitive Complexity of this function is 20 which is greater than 5 authorized."),
-      new CxxReportLocation(null, "14", "+1: if statement"),
-      new CxxReportLocation(null, "15", "+2: if statement (incl 1 for nesting)"),
-      new CxxReportLocation(null, "16", "+3: conditional operator (incl 2 for nesting)"),
-      new CxxReportLocation(null, "17", "+1: else statement"),
-      new CxxReportLocation(null, "18", "+3: conditional operator (incl 2 for nesting)"),
-      new CxxReportLocation(null, "20", "+1: else statement"),
-      new CxxReportLocation(null, "21", "+2: if statement (incl 1 for nesting)"),
-      new CxxReportLocation(null, "22", "+3: conditional operator (incl 2 for nesting)"),
-      new CxxReportLocation(null, "23", "+1: else statement"),
-      new CxxReportLocation(null, "24", "+3: conditional operator (incl 2 for nesting)"));
+      new CxxReportLocation(null, "14", null, "+1: if statement"),
+      new CxxReportLocation(null, "15", null, "+2: if statement (incl 1 for nesting)"),
+      new CxxReportLocation(null, "16", null, "+3: conditional operator (incl 2 for nesting)"),
+      new CxxReportLocation(null, "17", null, "+1: else statement"),
+      new CxxReportLocation(null, "18", null, "+3: conditional operator (incl 2 for nesting)"),
+      new CxxReportLocation(null, "20", null, "+1: else statement"),
+      new CxxReportLocation(null, "21", null, "+2: if statement (incl 1 for nesting)"),
+      new CxxReportLocation(null, "22", null, "+3: conditional operator (incl 2 for nesting)"),
+      new CxxReportLocation(null, "23", null, "+1: else statement"),
+      new CxxReportLocation(null, "24", null, "+3: conditional operator (incl 2 for nesting)"));
 
     CxxReportIssue issue1 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("33"))
       .findFirst().orElseThrow(() -> new AssertionError("No issue at line 33"));
     softly.assertThat(issue1.getLocations()).containsOnly(
-      new CxxReportLocation(null, "33",
+      new CxxReportLocation(null, "33", null,
                             "The Cognitive Complexity of this function is 20 which is greater than 5 authorized."),
-      new CxxReportLocation(null, "34", "+1: if statement"),
-      new CxxReportLocation(null, "35", "+2: if statement (incl 1 for nesting)"),
-      new CxxReportLocation(null, "36", "+3: conditional operator (incl 2 for nesting)"),
-      new CxxReportLocation(null, "37", "+1: else statement"),
-      new CxxReportLocation(null, "38", "+3: conditional operator (incl 2 for nesting)"),
-      new CxxReportLocation(null, "40", "+1: else statement"),
-      new CxxReportLocation(null, "41", "+2: if statement (incl 1 for nesting)"),
-      new CxxReportLocation(null, "42", "+3: conditional operator (incl 2 for nesting)"),
-      new CxxReportLocation(null, "43", "+1: else statement"),
-      new CxxReportLocation(null, "44", "+3: conditional operator (incl 2 for nesting)"));
+      new CxxReportLocation(null, "34", null, "+1: if statement"),
+      new CxxReportLocation(null, "35", null, "+2: if statement (incl 1 for nesting)"),
+      new CxxReportLocation(null, "36", null, "+3: conditional operator (incl 2 for nesting)"),
+      new CxxReportLocation(null, "37", null, "+1: else statement"),
+      new CxxReportLocation(null, "38", null, "+3: conditional operator (incl 2 for nesting)"),
+      new CxxReportLocation(null, "40", null, "+1: else statement"),
+      new CxxReportLocation(null, "41", null, "+2: if statement (incl 1 for nesting)"),
+      new CxxReportLocation(null, "42", null, "+3: conditional operator (incl 2 for nesting)"),
+      new CxxReportLocation(null, "43", null, "+1: else statement"),
+      new CxxReportLocation(null, "44", null, "+3: conditional operator (incl 2 for nesting)"));
 
     CxxReportIssue issue2 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("51"))
       .findFirst().orElseThrow(() -> new AssertionError("No issue at line 51"));
     softly.assertThat(issue2.getLocations()).containsOnly(
-      new CxxReportLocation(null, "51",
+      new CxxReportLocation(null, "51", null,
                             "The Cognitive Complexity of this function is 20 which is greater than 5 authorized."),
-      new CxxReportLocation(null, "52", "+1: if statement"),
-      new CxxReportLocation(null, "53", "+2: if statement (incl 1 for nesting)"),
-      new CxxReportLocation(null, "54", "+3: conditional operator (incl 2 for nesting)"),
-      new CxxReportLocation(null, "55", "+1: else statement"),
-      new CxxReportLocation(null, "56", "+3: conditional operator (incl 2 for nesting)"),
-      new CxxReportLocation(null, "58", "+1: else statement"),
-      new CxxReportLocation(null, "59", "+2: if statement (incl 1 for nesting)"),
-      new CxxReportLocation(null, "60", "+3: conditional operator (incl 2 for nesting)"),
-      new CxxReportLocation(null, "61", "+1: else statement"),
-      new CxxReportLocation(null, "62", "+3: conditional operator (incl 2 for nesting)"));
+      new CxxReportLocation(null, "52", null, "+1: if statement"),
+      new CxxReportLocation(null, "53", null, "+2: if statement (incl 1 for nesting)"),
+      new CxxReportLocation(null, "54", null, "+3: conditional operator (incl 2 for nesting)"),
+      new CxxReportLocation(null, "55", null, "+1: else statement"),
+      new CxxReportLocation(null, "56", null, "+3: conditional operator (incl 2 for nesting)"),
+      new CxxReportLocation(null, "58", null, "+1: else statement"),
+      new CxxReportLocation(null, "59", null, "+2: if statement (incl 1 for nesting)"),
+      new CxxReportLocation(null, "60", null, "+3: conditional operator (incl 2 for nesting)"),
+      new CxxReportLocation(null, "61", null, "+1: else statement"),
+      new CxxReportLocation(null, "62", null, "+3: conditional operator (incl 2 for nesting)"));
 
     CxxReportIssue issue3 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("72"))
       .findFirst().orElseThrow(() -> new AssertionError("No issue at line 72"));
     softly.assertThat(issue3.getLocations()).containsOnly(
-      new CxxReportLocation(null, "72",
+      new CxxReportLocation(null, "72", null,
                             "The Cognitive Complexity of this function is 20 which is greater than 5 authorized."),
-      new CxxReportLocation(null, "73", "+1: if statement"),
-      new CxxReportLocation(null, "74", "+2: if statement (incl 1 for nesting)"),
-      new CxxReportLocation(null, "75", "+3: conditional operator (incl 2 for nesting)"),
-      new CxxReportLocation(null, "76", "+1: else statement"),
-      new CxxReportLocation(null, "77", "+3: conditional operator (incl 2 for nesting)"),
-      new CxxReportLocation(null, "79", "+1: else statement"),
-      new CxxReportLocation(null, "80", "+2: if statement (incl 1 for nesting)"),
-      new CxxReportLocation(null, "81", "+3: conditional operator (incl 2 for nesting)"),
-      new CxxReportLocation(null, "82", "+1: else statement"),
-      new CxxReportLocation(null, "83", "+3: conditional operator (incl 2 for nesting)"));
+      new CxxReportLocation(null, "73", null, "+1: if statement"),
+      new CxxReportLocation(null, "74", null, "+2: if statement (incl 1 for nesting)"),
+      new CxxReportLocation(null, "75", null, "+3: conditional operator (incl 2 for nesting)"),
+      new CxxReportLocation(null, "76", null, "+1: else statement"),
+      new CxxReportLocation(null, "77", null, "+3: conditional operator (incl 2 for nesting)"),
+      new CxxReportLocation(null, "79", null, "+1: else statement"),
+      new CxxReportLocation(null, "80", null, "+2: if statement (incl 1 for nesting)"),
+      new CxxReportLocation(null, "81", null, "+3: conditional operator (incl 2 for nesting)"),
+      new CxxReportLocation(null, "82", null, "+1: else statement"),
+      new CxxReportLocation(null, "83", null, "+3: conditional operator (incl 2 for nesting)"));
 
     CxxReportIssue issue4 = issues.stream().filter(issue -> issue.getLocations().get(0).getLine().equals("89"))
       .findFirst().orElseThrow(() -> new AssertionError("No issue at line 89"));
     softly.assertThat(issue4.getLocations()).containsOnly(
-      new CxxReportLocation(null, "89",
+      new CxxReportLocation(null, "89", null,
                             "The Cognitive Complexity of this function is 18 which is greater than 5 authorized."),
-      new CxxReportLocation(null, "91", "+1: if statement"),
-      new CxxReportLocation(null, "91", "+1: logical operator"),
-      new CxxReportLocation(null, "91", "+1: logical operator"),
-      new CxxReportLocation(null, "94", "+1: catch-clause"),
-      new CxxReportLocation(null, "96", "+1: catch-clause"),
-      new CxxReportLocation(null, "98", "+1: catch-clause"),
-      new CxxReportLocation(null, "100", "+1: catch-clause"),
-      new CxxReportLocation(null, "102", "+1: catch-clause"),
-      new CxxReportLocation(null, "104", "+1: catch-clause"),
-      new CxxReportLocation(null, "106", "+1: catch-clause"),
-      new CxxReportLocation(null, "107", "+2: iteration statement (incl 1 for nesting)"),
-      new CxxReportLocation(null, "108", "+3: conditional operator (incl 2 for nesting)"),
-      new CxxReportLocation(null, "110", "+2: conditional operator (incl 1 for nesting)"),
-      new CxxReportLocation(null, "113", "+1: switch statement"));
+      new CxxReportLocation(null, "91", null, "+1: if statement"),
+      new CxxReportLocation(null, "91", null, "+1: logical operator"),
+      new CxxReportLocation(null, "91", null, "+1: logical operator"),
+      new CxxReportLocation(null, "94", null, "+1: catch-clause"),
+      new CxxReportLocation(null, "96", null, "+1: catch-clause"),
+      new CxxReportLocation(null, "98", null, "+1: catch-clause"),
+      new CxxReportLocation(null, "100", null, "+1: catch-clause"),
+      new CxxReportLocation(null, "102", null, "+1: catch-clause"),
+      new CxxReportLocation(null, "104", null, "+1: catch-clause"),
+      new CxxReportLocation(null, "106", null, "+1: catch-clause"),
+      new CxxReportLocation(null, "107", null, "+2: iteration statement (incl 1 for nesting)"),
+      new CxxReportLocation(null, "108", null, "+3: conditional operator (incl 2 for nesting)"),
+      new CxxReportLocation(null, "110", null, "+2: conditional operator (incl 1 for nesting)"),
+      new CxxReportLocation(null, "113", null, "+1: switch statement"));
     softly.assertAll();
   }
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FunctionComplexityCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FunctionComplexityCheckTest.java
@@ -47,82 +47,82 @@ public class FunctionComplexityCheckTest {
       .filter(issue -> issue.getLocations().get(0).getLine().equals("13"))
       .findFirst().orElseThrow(() -> new AssertionError("No issue at line 13"));
     softly.assertThat(issue0.getLocations()).containsOnly(
-      new CxxReportLocation(null, "13",
+      new CxxReportLocation(null, "13", null,
                             "The Cyclomatic Complexity of this function is 8 which is greater than 5 authorized."),
-      new CxxReportLocation(null, "13", "+1: function definition"),
-      new CxxReportLocation(null, "14", "+1: if statement"),
-      new CxxReportLocation(null, "15", "+1: if statement"),
-      new CxxReportLocation(null, "16", "+1: conditional operator"),
-      new CxxReportLocation(null, "18", "+1: conditional operator"),
-      new CxxReportLocation(null, "21", "+1: if statement"),
-      new CxxReportLocation(null, "22", "+1: conditional operator"),
-      new CxxReportLocation(null, "24", "+1: conditional operator"));
+      new CxxReportLocation(null, "13", null, "+1: function definition"),
+      new CxxReportLocation(null, "14", null, "+1: if statement"),
+      new CxxReportLocation(null, "15", null, "+1: if statement"),
+      new CxxReportLocation(null, "16", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "18", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "21", null, "+1: if statement"),
+      new CxxReportLocation(null, "22", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "24", null, "+1: conditional operator"));
 
     var issue1 = issues.stream()
       .filter(issue -> issue.getLocations().get(0).getLine().equals("33"))
       .findFirst().orElseThrow(() -> new AssertionError("No issue at line 33"));
     softly.assertThat(issue1.getLocations()).containsOnly(
-      new CxxReportLocation(null, "33",
+      new CxxReportLocation(null, "33", null,
                             "The Cyclomatic Complexity of this function is 8 which is greater than 5 authorized."),
-      new CxxReportLocation(null, "33", "+1: function definition"),
-      new CxxReportLocation(null, "34", "+1: if statement"),
-      new CxxReportLocation(null, "35", "+1: if statement"),
-      new CxxReportLocation(null, "36", "+1: conditional operator"),
-      new CxxReportLocation(null, "38", "+1: conditional operator"),
-      new CxxReportLocation(null, "41", "+1: if statement"),
-      new CxxReportLocation(null, "42", "+1: conditional operator"),
-      new CxxReportLocation(null, "44", "+1: conditional operator"));
+      new CxxReportLocation(null, "33", null, "+1: function definition"),
+      new CxxReportLocation(null, "34", null, "+1: if statement"),
+      new CxxReportLocation(null, "35", null, "+1: if statement"),
+      new CxxReportLocation(null, "36", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "38", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "41", null, "+1: if statement"),
+      new CxxReportLocation(null, "42", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "44", null, "+1: conditional operator"));
 
     var issue2 = issues.stream()
       .filter(issue -> issue.getLocations().get(0).getLine().equals("51"))
       .findFirst().orElseThrow(() -> new AssertionError("No issue at line 51"));
     softly.assertThat(issue2.getLocations()).containsOnly(
-      new CxxReportLocation(null, "51",
+      new CxxReportLocation(null, "51", null,
                             "The Cyclomatic Complexity of this function is 8 which is greater than 5 authorized."),
-      new CxxReportLocation(null, "51", "+1: function definition"),
-      new CxxReportLocation(null, "52", "+1: if statement"),
-      new CxxReportLocation(null, "53", "+1: if statement"),
-      new CxxReportLocation(null, "54", "+1: conditional operator"),
-      new CxxReportLocation(null, "56", "+1: conditional operator"),
-      new CxxReportLocation(null, "59", "+1: if statement"),
-      new CxxReportLocation(null, "60", "+1: conditional operator"),
-      new CxxReportLocation(null, "62", "+1: conditional operator"));
+      new CxxReportLocation(null, "51", null, "+1: function definition"),
+      new CxxReportLocation(null, "52", null, "+1: if statement"),
+      new CxxReportLocation(null, "53", null, "+1: if statement"),
+      new CxxReportLocation(null, "54", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "56", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "59", null, "+1: if statement"),
+      new CxxReportLocation(null, "60", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "62", null, "+1: conditional operator"));
 
     var issue3 = issues.stream()
       .filter(issue -> issue.getLocations().get(0).getLine().equals("72"))
       .findFirst().orElseThrow(() -> new AssertionError("No issue at line 72"));
     softly.assertThat(issue3.getLocations()).containsOnly(
-      new CxxReportLocation(null, "72",
+      new CxxReportLocation(null, "72", null,
                             "The Cyclomatic Complexity of this function is 8 which is greater than 5 authorized."),
-      new CxxReportLocation(null, "72", "+1: function definition"),
-      new CxxReportLocation(null, "73", "+1: if statement"),
-      new CxxReportLocation(null, "74", "+1: if statement"),
-      new CxxReportLocation(null, "75", "+1: conditional operator"),
-      new CxxReportLocation(null, "77", "+1: conditional operator"),
-      new CxxReportLocation(null, "80", "+1: if statement"),
-      new CxxReportLocation(null, "81", "+1: conditional operator"),
-      new CxxReportLocation(null, "83", "+1: conditional operator"));
+      new CxxReportLocation(null, "72", null, "+1: function definition"),
+      new CxxReportLocation(null, "73", null, "+1: if statement"),
+      new CxxReportLocation(null, "74", null, "+1: if statement"),
+      new CxxReportLocation(null, "75", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "77", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "80", null, "+1: if statement"),
+      new CxxReportLocation(null, "81", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "83", null, "+1: conditional operator"));
 
     var issue4 = issues.stream()
       .filter(issue -> issue.getLocations().get(0).getLine().equals("89"))
       .findFirst().orElseThrow(() -> new AssertionError("No issue at line 89"));
     softly.assertThat(issue4.getLocations()).containsOnly(
-      new CxxReportLocation(null, "89",
+      new CxxReportLocation(null, "89", null,
                             "The Cyclomatic Complexity of this function is 14 which is greater than 5 authorized."),
-      new CxxReportLocation(null, "89", "+1: function definition"),
-      new CxxReportLocation(null, "91", "+1: if statement"),
-      new CxxReportLocation(null, "91", "+1: logical operator"),
-      new CxxReportLocation(null, "91", "+1: logical operator"),
-      new CxxReportLocation(null, "94", "+1: catch-clause"),
-      new CxxReportLocation(null, "96", "+1: catch-clause"),
-      new CxxReportLocation(null, "98", "+1: catch-clause"),
-      new CxxReportLocation(null, "100", "+1: catch-clause"),
-      new CxxReportLocation(null, "102", "+1: catch-clause"),
-      new CxxReportLocation(null, "104", "+1: catch-clause"),
-      new CxxReportLocation(null, "106", "+1: catch-clause"),
-      new CxxReportLocation(null, "107", "+1: while loop"),
-      new CxxReportLocation(null, "108", "+1: conditional operator"),
-      new CxxReportLocation(null, "110", "+1: conditional operator"));
+      new CxxReportLocation(null, "89", null, "+1: function definition"),
+      new CxxReportLocation(null, "91", null, "+1: if statement"),
+      new CxxReportLocation(null, "91", null, "+1: logical operator"),
+      new CxxReportLocation(null, "91", null, "+1: logical operator"),
+      new CxxReportLocation(null, "94", null, "+1: catch-clause"),
+      new CxxReportLocation(null, "96", null, "+1: catch-clause"),
+      new CxxReportLocation(null, "98", null, "+1: catch-clause"),
+      new CxxReportLocation(null, "100", null, "+1: catch-clause"),
+      new CxxReportLocation(null, "102", null, "+1: catch-clause"),
+      new CxxReportLocation(null, "104", null, "+1: catch-clause"),
+      new CxxReportLocation(null, "106", null, "+1: catch-clause"),
+      new CxxReportLocation(null, "107", null, "+1: while loop"),
+      new CxxReportLocation(null, "108", null, "+1: conditional operator"),
+      new CxxReportLocation(null, "110", null, "+1: conditional operator"));
     softly.assertAll();
   }
 

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensor.java
@@ -89,7 +89,7 @@ public class CxxClangSASensor extends CxxIssuesReportSensor {
       }
 
       var event = new PathEvent(pathObject, sourceFiles);
-      issue.addFlowElement(event.getFilePath(), event.getLineNumber(), event.getExtendedMessage());
+      issue.addFlowElement(event.getFilePath(), event.getLineNumber(), event.getColumnNumber(), event.getExtendedMessage());
     }
   }
 
@@ -118,6 +118,8 @@ public class CxxClangSASensor extends CxxIssuesReportSensor {
                                                        "Missing mandatory entry 'diagnostics/location'");
         int line = ((NSNumber) require(location.get("line"),
                                        "Missing mandatory entry 'diagnostics/location/line'")).intValue();
+        int column = ((NSNumber) require(location.get("col"),
+                                       "Missing mandatory entry 'diagnostics/location/col'")).intValue();
         int fileIndex = ((NSNumber) require(location.get("file"),
                                             "Missing mandatory entry 'diagnostics/location/file'")).intValue();
 
@@ -126,7 +128,7 @@ public class CxxClangSASensor extends CxxIssuesReportSensor {
         }
         String filePath = ((NSString) sourceFiles[fileIndex]).getContent();
 
-        var issue = new CxxReportIssue(checkerName, filePath, Integer.toString(line), description);
+        var issue = new CxxReportIssue(checkerName, filePath, Integer.toString(line), Integer.toString(column), description);
 
         addFlowToIssue(diag, sourceFiles, issue);
 
@@ -194,6 +196,11 @@ public class CxxClangSASensor extends CxxIssuesReportSensor {
     public String getLineNumber() {
       int lineNumber = ((NSNumber) require(getLocation().get("line"), "Missing mandatory entry 'line'")).intValue();
       return Integer.toString(lineNumber);
+    }
+
+    public String getColumnNumber() {
+      int columnNumber = ((NSNumber) require(getLocation().get("col"), "Missing mandatory entry 'col'")).intValue();
+      return Integer.toString(columnNumber);
     }
 
     public String getFilePath() {

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensor.java
@@ -105,7 +105,7 @@ public class CxxClangTidySensor extends CxxIssuesReportSensor {
           MatchResult m = matcher.toMatchResult();
           String path = m.group(1); // relative paths
           String line = m.group(2);
-          //String column = m.group(3);
+          String column = m.group(3);
           String level = m.group(4); // error, warning, note, ...
           String txt = m.group(5); // info( [ruleId])?
           String info = null;
@@ -132,9 +132,9 @@ public class CxxClangTidySensor extends CxxIssuesReportSensor {
             if (issue != null) {
               saveUniqueViolation(issue);
             }
-            issue = new CxxReportIssue(ruleId, path, line, info);
+            issue = new CxxReportIssue(ruleId, path, line, column, info);
           } else if ((issue != null) && "note".equals(level)) {
-            issue.addFlowElement(path, line, info);
+            issue.addFlowElement(path, line, column, info);
           }
         }
       }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensor.java
@@ -66,8 +66,8 @@ public class CxxCompilerGccSensor extends CxxCompilerSensor {
       PropertyDefinition.builder(REPORT_REGEX_DEF)
         .name("GCC Regular Expression")
         .description("Regular expression to identify the four named groups of the compiler warning message:"
-                       + " <file>, <line>, <id>, <message>. Leave empty to use parser's default."
-                       + " See <a href='https://github.com/SonarOpenCommunity/sonar-cxx/wiki/Compilers'>"
+                       + "  &lt;file&gt;,  &lt;line&gt;,  &lt;column&gt;,  &lt;id&gt;,  &lt;message&gt;. Leave empty to use parser's default."
+                     + " See <a href='https://github.com/SonarOpenCommunity/sonar-cxx/wiki/Compilers'>"
                        + "this page</a> for details regarding the different regular expression that can be use per compiler.")
         .category(category)
         .subCategory(subcateg)

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcSensor.java
@@ -62,7 +62,7 @@ public class CxxCompilerVcSensor extends CxxCompilerSensor {
       PropertyDefinition.builder(REPORT_REGEX_DEF)
         .name("VC Regular Expression")
         .description("Regular expression to identify the four named groups of the compiler warning message:"
-                       + " &lt;file&gt;, &lt;line&gt;, &lt;id&gt;, &lt;message&gt;. Leave empty to use parser's default."
+                       + " &lt;file&gt;, &lt;line&gt;, &lt;column&gt;, &lt;id&gt;, &lt;message&gt;. Leave empty to use parser's default."
                      + " See <a href='https://github.com/SonarOpenCommunity/sonar-cxx/wiki/Compilers'>"
                        + "this page</a> for details regarding the different regular expression that can be use per compiler.")
         .category(category)

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CppcheckParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CppcheckParser.java
@@ -129,11 +129,11 @@ public class CppcheckParser {
               return;
             }
 
-            issue = new CxxReportIssue(id, file, line, issueText);
+            issue = new CxxReportIssue(id, file, line, null, issueText);
             // add the same <file>:<line> second time if there is additional
             // information about the flow/analysis
             if (info != null && !msg.equals(info)) {
-              issue.addLocation(file, line, info);
+              issue.addLocation(file, line, null, info);
             }
           } else if (info != null) {
             // secondary location
@@ -142,7 +142,7 @@ public class CppcheckParser {
             // we'll use a primary location and move the affected path to the
             // info
             if (isLocationInProject) {
-              issue.addLocation(file, line, info);
+              issue.addLocation(file, line, null, info);
             } else {
               CxxReportLocation primaryLocation = issue.getLocations().get(0);
               String primaryFile = primaryLocation.getFile();
@@ -151,14 +151,14 @@ public class CppcheckParser {
               var extendedInfo = new StringBuilder(512);
               extendedInfo.append(makeRelativePath(file, primaryFile)).append(":").append(line).append(" ")
                 .append(info);
-              issue.addLocation(primaryFile, primaryLine, extendedInfo.toString());
+              issue.addLocation(primaryFile, primaryLine, null, extendedInfo.toString());
             }
           }
         }
 
         // no <location> tags: issue raised on the whole module/project
         if (issue == null) {
-          issue = new CxxReportIssue(id, null, null, issueText);
+          issue = new CxxReportIssue(id, null, null, null, issueText);
         }
         sensor.saveUniqueViolation(issue);
       }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/CxxDrMemorySensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/CxxDrMemorySensor.java
@@ -99,7 +99,7 @@ public class CxxDrMemorySensor extends CxxIssuesReportSensor {
 
     for (var error : DrMemoryParser.parse(report, DEFAULT_CHARSET_DEF)) {
       if (error.getStackTrace().isEmpty()) {
-        var moduleIssue = new CxxReportIssue(error.getType().getId(), null, null, error.getMessage());
+        var moduleIssue = new CxxReportIssue(error.getType().getId(), null, null, null, error.getMessage());
         saveUniqueViolation(moduleIssue);
       } else {
         Location lastOwnFrame = getLastOwnFrame(error);
@@ -108,8 +108,8 @@ public class CxxDrMemorySensor extends CxxIssuesReportSensor {
           continue;
         }
         var fileIssue = new CxxReportIssue(error.getType().getId(),
-                                       lastOwnFrame.getFile(), lastOwnFrame.getLine().toString(), error
-                                       .getMessage());
+                                       lastOwnFrame.getFile(), lastOwnFrame.getLine().toString(), null,
+                                       error.getMessage());
 
         // add all frames as secondary locations
         int frameNr = 0;
@@ -117,7 +117,7 @@ public class CxxDrMemorySensor extends CxxIssuesReportSensor {
           boolean frameIsInProject = frameIsInProject(frame);
           String mappedPath = (frameIsInProject) ? frame.getFile() : lastOwnFrame.getFile();
           Integer mappedLine = (frameIsInProject) ? frame.getLine() : lastOwnFrame.getLine();
-          fileIssue.addLocation(mappedPath, mappedLine.toString(), getFrameText(frame, frameNr));
+          fileIssue.addLocation(mappedPath, mappedLine.toString(), null, getFrameText(frame, frameNr));
           ++frameNr;
         }
         saveUniqueViolation(fileIssue);

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/infer/InferParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/infer/InferParser.java
@@ -65,8 +65,7 @@ public class InferParser {
       LOG.debug("Read: {}", issue.toString());
       if (issue.getFile() != null) {
         CxxReportIssue cxxReportIssue = new CxxReportIssue(
-          issue.getBugType(), issue.getFile(),
-          String.valueOf(issue.getLine()), issue.getQualifier());
+          issue.getBugType(), issue.getFile(), String.valueOf(issue.getLine()), null, issue.getQualifier());
         sensor.saveUniqueViolation(cxxReportIssue);
       } else {
         LOG.debug("Invalid infer issue '{}', skipping", issue.toString());

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/other/CxxOtherSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/other/CxxOtherSensor.java
@@ -40,8 +40,6 @@ import org.sonar.cxx.utils.CxxReportIssue;
 
 /**
  * Custom Rule Import, all static analysis are supported.
- *
- * @author jorge costa, stefan weiser
  */
 public class CxxOtherSensor extends CxxIssuesReportSensor {
 
@@ -97,10 +95,11 @@ public class CxxOtherSensor extends CxxIssuesReportSensor {
         while (errorCursor.getNext() != null) {
           String file = errorCursor.getAttrValue("file");
           String line = errorCursor.getAttrValue("line");
+          String column = errorCursor.getAttrValue("column");
           String id = errorCursor.getAttrValue("id");
           String msg = errorCursor.getAttrValue("msg");
 
-          var issue = new CxxReportIssue(id, file, line, msg);
+          var issue = new CxxReportIssue(id, file, line, column, msg);
           saveUniqueViolation(issue);
         }
       });

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensor.java
@@ -144,7 +144,7 @@ public class CxxPCLintSensor extends CxxIssuesReportSensor {
                 saveUniqueViolation(currentIssue);
               }
 
-              currentIssue = new CxxReportIssue(id, file, line, msg);
+              currentIssue = new CxxReportIssue(id, file, line, null, msg);
             } else {
               LOG.warn("PC-lint warning ignored: {}", msg);
               LOG.debug("File: {}, Line: {}, ID: {}, msg: {}", file, line, id, msg);
@@ -196,7 +196,7 @@ public class CxxPCLintSensor extends CxxIssuesReportSensor {
           line = primaryLocation.getLine();
         }
 
-        currentIssue.addFlowElement(file, line, msg);
+        currentIssue.addFlowElement(file, line, null, msg);
       }
 
       private boolean isInputValid(@Nullable String file, @Nullable String line,

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/rats/CxxRatsSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/rats/CxxRatsSensor.java
@@ -104,7 +104,7 @@ public class CxxRatsSensor extends CxxIssuesReportSensor {
           for (var lineElem : lines) {
             String line = lineElem.getTextTrim();
 
-            var issue = new CxxReportIssue(type, fileName, line, message);
+            var issue = new CxxReportIssue(type, fileName, line, null, message);
             saveUniqueViolation(issue);
           }
         }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/valgrind/CxxValgrindSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/valgrind/CxxValgrindSensor.java
@@ -92,13 +92,13 @@ public class CxxValgrindSensor extends CxxIssuesReportSensor {
 
     String errorMsg = createErrorMsg(error, stack, stackNr);
     // set the last own frame as a primary location
-    var issue = new CxxReportIssue(error.getKind(), lastOwnFrame.getPath(), lastOwnFrame.getLine(), errorMsg);
+    var issue = new CxxReportIssue(error.getKind(), lastOwnFrame.getPath(), lastOwnFrame.getLine(), null, errorMsg);
     // add all frames as secondary locations
     for (var frame : stack.getFrames()) {
       boolean frameIsInProject = frameIsInProject(frame);
       String mappedPath = (frameIsInProject) ? frame.getPath() : lastOwnFrame.getPath();
       String mappedLine = (frameIsInProject) ? frame.getLine() : lastOwnFrame.getLine();
-      issue.addLocation(mappedPath, mappedLine, frame.toString());
+      issue.addLocation(mappedPath, mappedLine, null, frame.toString());
     }
     return issue;
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxSensor.java
@@ -92,7 +92,7 @@ public class CxxVeraxxSensor extends CxxIssuesReportSensor {
               String message = errorCursor.getAttrValue("message");
               String source = errorCursor.getAttrValue("source");
 
-              var issue = new CxxReportIssue(source, name, line, message);
+              var issue = new CxxReportIssue(source, name, line, null, message);
               saveUniqueViolation(issue);
             } else {
               LOG.debug("Error in file '{}', with message '{}'",

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensorTest.java
@@ -71,12 +71,12 @@ public class CxxClangSASensorTest {
      * 2 issues
      */
     DefaultInputFile testFile0 = TestInputFileBuilder.create("ProjectKey", "src/lib/component0.cc").setLanguage("cxx")
-      .initMetadata("asd\nasdas\nasda\n").build();
+      .initMetadata("asd\nasdghzui\nasd\nasd\nasdghtlout\nasdghtkouilh\nasd\nasdkhgkjgkjhgjg\nasd\n").build();
     /*
      * 1 issue
      */
     DefaultInputFile testFile1 = TestInputFileBuilder.create("ProjectKey", "src/lib/component1.cc").setLanguage("cxx")
-      .initMetadata("asd\nasdas\nasda\n").build();
+      .initMetadata("asd\nasdas\nasdaghtzutiojklmg\n").build();
 
     context.fileSystem().add(testFile0);
     context.fileSystem().add(testFile1);
@@ -124,16 +124,16 @@ public class CxxClangSASensorTest {
         IssueLocation issueLocation = flow.locations().get(1);
         assertThat(issueLocation.inputComponent()).isEqualTo(testFile0);
         assertThat(issueLocation.message()).isEqualTo("'a' declared without an initial value");
-        assertThat(issueLocation.textRange().start().line()).isEqualTo(31);
-        assertThat(issueLocation.textRange().end().line()).isEqualTo(31);
+        assertThat(issueLocation.textRange().start().line()).isEqualTo(5);
+        assertThat(issueLocation.textRange().end().line()).isEqualTo(5);
       }
 
       {
         IssueLocation issueLocation = flow.locations().get(0);
         assertThat(issueLocation.inputComponent()).isEqualTo(testFile0);
         assertThat(issueLocation.message()).isEqualTo("Branch condition evaluates to a garbage value");
-        assertThat(issueLocation.textRange().start().line()).isEqualTo(32);
-        assertThat(issueLocation.textRange().end().line()).isEqualTo(32);
+        assertThat(issueLocation.textRange().start().line()).isEqualTo(6);
+        assertThat(issueLocation.textRange().end().line()).isEqualTo(6);
       }
     }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensorTest.java
@@ -70,8 +70,10 @@ public class CxxClangTidySensorTest {
 
     context.fileSystem().add(TestInputFileBuilder
       .create("ProjectKey", "sources/utils/code_chunks.cpp")
-      .setLanguage("cxx").initMetadata("asd\nasdas\nasda\n")
-      .build());
+      .setLanguage("cxx")
+      .initMetadata("asd\nasdasdgghs\nasda\n")
+      .build()
+    );
 
     var sensor = new CxxClangTidySensor();
     sensor.execute(context);
@@ -88,8 +90,12 @@ public class CxxClangTidySensorTest {
     );
     context.setSettings(settings);
 
-    context.fileSystem().add(TestInputFileBuilder.create("ProjectKey", "sources/utils/code_chunks.cpp")
-      .setLanguage("cxx").initMetadata("asd\nasdas\nasda\n").build());
+    context.fileSystem().add(TestInputFileBuilder
+      .create("ProjectKey", "sources/utils/code_chunks.cpp")
+      .setLanguage("cxx")
+      .initMetadata("asd\nasdasdfghtz\nasda\n")
+      .build()
+    );
 
     var sensor = new CxxClangTidySensor();
     sensor.execute(context);
@@ -106,8 +112,12 @@ public class CxxClangTidySensorTest {
     );
     context.setSettings(settings);
 
-    context.fileSystem().add(TestInputFileBuilder.create("ProjectKey", "sources/utils/code_chunks.cpp")
-      .setLanguage("cxx").initMetadata("asd\nasdas\nasda\n").build());
+    context.fileSystem().add(TestInputFileBuilder
+      .create("ProjectKey", "sources/utils/code_chunks.cpp")
+      .setLanguage("cxx")
+      .initMetadata("asd\nasdas\nasda\n")
+      .build()
+    );
 
     var sensor = new CxxClangTidySensor();
     sensor.execute(context);
@@ -126,8 +136,10 @@ public class CxxClangTidySensorTest {
 
     context.fileSystem().add(TestInputFileBuilder
       .create("ProjectKey", "sources/utils/code_chunks.cpp")
-      .setLanguage("cxx").initMetadata("asd\nasdas\nasda\n")
-      .build());
+      .setLanguage("cxx")
+      .initMetadata("ab\nab\nab\nab\nab\nab\nabcdefg\nabdefgrqwe\nab\nab\nabcdefghijklm\n")
+      .build()
+    );
 
     var sensor = new CxxClangTidySensor();
     sensor.execute(context);
@@ -150,8 +162,10 @@ public class CxxClangTidySensorTest {
 
     context.fileSystem().add(TestInputFileBuilder
       .create("ProjectKey", "sources/utils/code_chunks.cpp")
-      .setLanguage("cxx").initMetadata("asd\nasdas\nasda\n")
-      .build());
+      .setLanguage("cxx")
+      .initMetadata("asd\nasdas\nasda\n")
+      .build()
+    );
 
     var sensor = new CxxClangTidySensor();
     sensor.execute(context);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensorTest.java
@@ -56,7 +56,7 @@ public class CxxCompilerSensorTest {
   @Test
   public void testFileNotFound() {
     var report = new File("");
-    sensor.setRegex("*");
+    sensor.setRegex("(?<test>.*)");
     sensor.testExecuteReport(report);
     String log = logTester.logs().toString();
     assertThat(log.contains("FileNotFoundException")).isTrue();
@@ -73,7 +73,7 @@ public class CxxCompilerSensorTest {
   @Test
   public void testRegexInvalid() {
     var report = new File(fs.baseDir(), "compiler-reports/VC-report.vclog");
-    sensor.setRegex("*");
+    sensor.setRegex("(?<test>*)");
     sensor.testExecuteReport(report);
     String log = logTester.logs().toString();
     assertThat(log.contains("PatternSyntaxException")).isTrue();
@@ -85,7 +85,7 @@ public class CxxCompilerSensorTest {
     sensor.setRegex(".*");
     sensor.testExecuteReport(report);
     String log = logTester.logs().toString();
-    assertThat(log.contains("No group with name")).isTrue();
+    assertThat(log.contains("contains no named-capturing group")).isTrue();
   }
 
   private class CxxCompilerSensorMock extends CxxCompilerSensor {

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/cpd.report-error.txt
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/cpd.report-error.txt
@@ -1,3 +1,3 @@
-sources\utils\code_chunks.cpp:20:5: error: use of undeclared identifier 'gets' [clang-diagnostic-error]
+sources\utils\code_chunks.cpp:2:5: error: use of undeclared identifier 'gets' [clang-diagnostic-error]
     gets(buffer); //rats violation
     ^

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/cpd.report-note.txt
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/cpd.report-note.txt
@@ -1,5 +1,5 @@
 1 warning generated.
-sources\utils\code_chunks.cpp:11:18: warning: Dereference of null pointer (loaded from variable 'x') [clang-analyzer-core.NullDereference]
+sources\utils\code_chunks.cpp:11:9: warning: Dereference of null pointer (loaded from variable 'x') [clang-analyzer-core.NullDereference]
     printf("%d", *x);
                  ^
 sources\utils\code_chunks.cpp:7:5: note: 'x' initialized to a null pointer value
@@ -11,6 +11,6 @@ sources\utils\code_chunks.cpp:8:9: note: Assuming 'argc' is <= 1
 sources\utils\code_chunks.cpp:8:5: note: Taking false branch
     if (argc > 1) {
     ^
-sources\utils\code_chunks.cpp:11:18: note: Dereference of null pointer (loaded from variable 'x')
+sources\utils\code_chunks.cpp:11:9: note: Dereference of null pointer (loaded from variable 'x')
     printf("%d", *x);
                  ^

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clangsa-reports/clangsa-report.plist
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clangsa-reports/clangsa-report.plist
@@ -22,12 +22,12 @@
         <key>start</key>
          <array>
           <dict>
-           <key>line</key><integer>28</integer>
+           <key>line</key><integer>2</integer>
            <key>col</key><integer>5</integer>
            <key>file</key><integer>0</integer>
           </dict>
           <dict>
-           <key>line</key><integer>28</integer>
+           <key>line</key><integer>2</integer>
            <key>col</key><integer>7</integer>
            <key>file</key><integer>0</integer>
           </dict>
@@ -35,12 +35,12 @@
         <key>end</key>
          <array>
           <dict>
-           <key>line</key><integer>31</integer>
+           <key>line</key><integer>5</integer>
            <key>col</key><integer>5</integer>
            <key>file</key><integer>0</integer>
           </dict>
           <dict>
-           <key>line</key><integer>31</integer>
+           <key>line</key><integer>5</integer>
            <key>col</key><integer>7</integer>
            <key>file</key><integer>0</integer>
           </dict>
@@ -52,7 +52,7 @@
      <key>kind</key><string>event</string>
      <key>location</key>
      <dict>
-      <key>line</key><integer>31</integer>
+      <key>line</key><integer>5</integer>
       <key>col</key><integer>5</integer>
       <key>file</key><integer>0</integer>
      </dict>
@@ -60,12 +60,12 @@
      <array>
        <array>
         <dict>
-         <key>line</key><integer>31</integer>
+         <key>line</key><integer>5</integer>
          <key>col</key><integer>5</integer>
          <key>file</key><integer>0</integer>
         </dict>
         <dict>
-         <key>line</key><integer>31</integer>
+         <key>line</key><integer>5</integer>
          <key>col</key><integer>9</integer>
          <key>file</key><integer>0</integer>
         </dict>
@@ -85,12 +85,12 @@
         <key>start</key>
          <array>
           <dict>
-           <key>line</key><integer>31</integer>
+           <key>line</key><integer>5</integer>
            <key>col</key><integer>5</integer>
            <key>file</key><integer>0</integer>
           </dict>
           <dict>
-           <key>line</key><integer>31</integer>
+           <key>line</key><integer>5</integer>
            <key>col</key><integer>7</integer>
            <key>file</key><integer>0</integer>
           </dict>
@@ -98,12 +98,12 @@
         <key>end</key>
          <array>
           <dict>
-           <key>line</key><integer>32</integer>
+           <key>line</key><integer>6</integer>
            <key>col</key><integer>5</integer>
            <key>file</key><integer>0</integer>
           </dict>
           <dict>
-           <key>line</key><integer>32</integer>
+           <key>line</key><integer>6</integer>
            <key>col</key><integer>6</integer>
            <key>file</key><integer>0</integer>
           </dict>
@@ -119,12 +119,12 @@
         <key>start</key>
          <array>
           <dict>
-           <key>line</key><integer>32</integer>
+           <key>line</key><integer>6</integer>
            <key>col</key><integer>5</integer>
            <key>file</key><integer>0</integer>
           </dict>
           <dict>
-           <key>line</key><integer>32</integer>
+           <key>line</key><integer>6</integer>
            <key>col</key><integer>6</integer>
            <key>file</key><integer>0</integer>
           </dict>
@@ -132,12 +132,12 @@
         <key>end</key>
          <array>
           <dict>
-           <key>line</key><integer>32</integer>
+           <key>line</key><integer>6</integer>
            <key>col</key><integer>8</integer>
            <key>file</key><integer>0</integer>
           </dict>
           <dict>
-           <key>line</key><integer>32</integer>
+           <key>line</key><integer>6</integer>
            <key>col</key><integer>8</integer>
            <key>file</key><integer>0</integer>
           </dict>
@@ -149,7 +149,7 @@
      <key>kind</key><string>event</string>
      <key>location</key>
      <dict>
-      <key>line</key><integer>32</integer>
+      <key>line</key><integer>6</integer>
       <key>col</key><integer>8</integer>
       <key>file</key><integer>0</integer>
      </dict>
@@ -157,12 +157,12 @@
      <array>
        <array>
         <dict>
-         <key>line</key><integer>32</integer>
+         <key>line</key><integer>6</integer>
          <key>col</key><integer>8</integer>
          <key>file</key><integer>0</integer>
         </dict>
         <dict>
-         <key>line</key><integer>32</integer>
+         <key>line</key><integer>6</integer>
          <key>col</key><integer>8</integer>
          <key>file</key><integer>0</integer>
         </dict>
@@ -186,7 +186,7 @@
   <key>issue_hash_function_offset</key><string>8</string>
   <key>location</key>
   <dict>
-   <key>line</key><integer>32</integer>
+   <key>line</key><integer>6</integer>
    <key>col</key><integer>8</integer>
    <key>file</key><integer>0</integer>
   </dict>
@@ -198,7 +198,7 @@
      <key>kind</key><string>event</string>
      <key>location</key>
      <dict>
-      <key>line</key><integer>37</integer>
+      <key>line</key><integer>8</integer>
       <key>col</key><integer>9</integer>
       <key>file</key><integer>0</integer>
      </dict>
@@ -206,24 +206,24 @@
      <array>
        <array>
         <dict>
-         <key>line</key><integer>37</integer>
+         <key>line</key><integer>8</integer>
          <key>col</key><integer>9</integer>
          <key>file</key><integer>0</integer>
         </dict>
         <dict>
-         <key>line</key><integer>37</integer>
+         <key>line</key><integer>8</integer>
          <key>col</key><integer>9</integer>
          <key>file</key><integer>0</integer>
         </dict>
        </array>
        <array>
         <dict>
-         <key>line</key><integer>37</integer>
+         <key>line</key><integer>8</integer>
          <key>col</key><integer>13</integer>
          <key>file</key><integer>0</integer>
         </dict>
         <dict>
-         <key>line</key><integer>37</integer>
+         <key>line</key><integer>8</integer>
          <key>col</key><integer>15</integer>
          <key>file</key><integer>0</integer>
         </dict>
@@ -247,7 +247,7 @@
   <key>issue_hash_function_offset</key><string>13</string>
   <key>location</key>
   <dict>
-   <key>line</key><integer>37</integer>
+   <key>line</key><integer>8</integer>
    <key>col</key><integer>9</integer>
    <key>file</key><integer>0</integer>
   </dict>
@@ -259,7 +259,7 @@
      <key>kind</key><string>event</string>
      <key>location</key>
      <dict>
-      <key>line</key><integer>37</integer>
+      <key>line</key><integer>3</integer>
       <key>col</key><integer>9</integer>
       <key>file</key><integer>1</integer>
      </dict>
@@ -267,24 +267,24 @@
      <array>
        <array>
         <dict>
-         <key>line</key><integer>37</integer>
+         <key>line</key><integer>3</integer>
          <key>col</key><integer>9</integer>
          <key>file</key><integer>1</integer>
         </dict>
         <dict>
-         <key>line</key><integer>37</integer>
+         <key>line</key><integer>3</integer>
          <key>col</key><integer>9</integer>
          <key>file</key><integer>1</integer>
         </dict>
        </array>
        <array>
         <dict>
-         <key>line</key><integer>37</integer>
+         <key>line</key><integer>3</integer>
          <key>col</key><integer>13</integer>
          <key>file</key><integer>1</integer>
         </dict>
         <dict>
-         <key>line</key><integer>37</integer>
+         <key>line</key><integer>3</integer>
          <key>col</key><integer>15</integer>
          <key>file</key><integer>1</integer>
         </dict>
@@ -308,7 +308,7 @@
   <key>issue_hash_function_offset</key><string>13</string>
   <key>location</key>
   <dict>
-   <key>line</key><integer>37</integer>
+   <key>line</key><integer>3</integer>
    <key>col</key><integer>9</integer>
    <key>file</key><integer>1</integer>
   </dict>

--- a/cxx-squid/src/main/java/org/sonar/cxx/utils/CxxReportIssue.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/utils/CxxReportIssue.java
@@ -35,22 +35,22 @@ public class CxxReportIssue {
   private final List<CxxReportLocation> locations;
   private final List<CxxReportLocation> flow;
 
-  public CxxReportIssue(String ruleId, @Nullable String file, @Nullable String line, String info) {
+  public CxxReportIssue(String ruleId, @Nullable String file, @Nullable String line, @Nullable String column,
+                        String info) {
     super();
     this.ruleId = ruleId;
     this.locations = new ArrayList<>();
     this.flow = new ArrayList<>();
-    addLocation(file, line, info);
+    addLocation(file, line, column, info);
   }
 
-  public final void addLocation(@Nullable String file, @Nullable String line, String info) {
-    locations.add(new CxxReportLocation(file, line, info));
+  public final void addLocation(@Nullable String file, @Nullable String line, @Nullable String column, String info) {
+    locations.add(new CxxReportLocation(file, line, column, info));
   }
 
-  public final void addFlowElement(@Nullable String file, @Nullable String line, String info) {
-    flow.add(0, new CxxReportLocation(file, line, info));
+  public final void addFlowElement(@Nullable String file, @Nullable String line, @Nullable String column, String info) {
+    flow.add(0, new CxxReportLocation(file, line, column, info));
   }
-
 
   public String getRuleId() {
     return ruleId;
@@ -73,7 +73,7 @@ public class CxxReportIssue {
 
   @Override
   public int hashCode() {
-    return Objects.hash(locations, flow, ruleId);
+    return Objects.hash(ruleId, locations, flow);
   }
 
   @Override
@@ -88,8 +88,9 @@ public class CxxReportIssue {
       return false;
     }
     CxxReportIssue other = (CxxReportIssue) obj;
-    return Objects.equals(locations, other.locations) && Objects.equals(flow, other.flow)
-        && Objects.equals(ruleId, other.ruleId);
+    return Objects.equals(ruleId, other.ruleId)
+             && Objects.equals(locations, other.locations)
+             && Objects.equals(flow, other.flow);
   }
 
 }

--- a/cxx-squid/src/main/java/org/sonar/cxx/utils/CxxReportLocation.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/utils/CxxReportLocation.java
@@ -30,13 +30,15 @@ public class CxxReportLocation {
 
   private final String file;
   private final String line;
+  private final String column;
   private final String info;
 
-  public CxxReportLocation(@Nullable String file, @Nullable String line, String info) {
+  public CxxReportLocation(@Nullable String file, @Nullable String line, @Nullable String column, String info) {
     super();
     // normalize file, removing double and single dot path steps => avoids duplicates
     this.file = PathUtils.sanitize(file);
     this.line = line;
+    this.column = column;
     this.info = info;
   }
 
@@ -48,18 +50,27 @@ public class CxxReportLocation {
     return line;
   }
 
+  public String getColumn() {
+    return column;
+  }
+
   public String getInfo() {
     return info;
   }
 
   @Override
   public String toString() {
-    return "CxxReportLocation [file=" + file + ", line=" + line + ", info=" + info + "]";
+    return "CxxReportLocation ["
+             + "file=" + file
+             + ", line=" + line
+             + ", column=" + column
+             + ", info=" + info
+             + "]";
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(file, info, line);
+    return Objects.hash(file, line, column, info);
   }
 
   @Override
@@ -74,7 +85,10 @@ public class CxxReportLocation {
       return false;
     }
     CxxReportLocation other = (CxxReportLocation) obj;
-    return Objects.equals(file, other.file) && Objects.equals(info, other.info) && Objects.equals(line, other.line);
+    return Objects.equals(line, other.line)
+             && Objects.equals(column, other.column)
+             && Objects.equals(file, other.file)
+             && Objects.equals(info, other.info);
   }
 
 }

--- a/cxx-squid/src/test/java/org/sonar/cxx/utils/CxxReportIssueTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/utils/CxxReportIssueTest.java
@@ -28,12 +28,12 @@ public class CxxReportIssueTest {
 
   @Test
   public void reportLocationEquality() {
-    var location0 = new CxxReportLocation("path0.cpp", "1", "Boolean value assigned to pointer.");
-    var location1 = new CxxReportLocation("path0.cpp", "1", "Boolean value assigned to pointer.");
+    var location0 = new CxxReportLocation("path0.cpp", "1", null, "Boolean value assigned to pointer.");
+    var location1 = new CxxReportLocation("path0.cpp", "1", null, "Boolean value assigned to pointer.");
     assertEquals(location0, location1);
     assertEquals(location0.hashCode(), location1.hashCode());
 
-    var location2 = new CxxReportLocation("path2.cpp", "1", "Exception thrown in destructor.");
+    var location2 = new CxxReportLocation("path2.cpp", "1", null, "Exception thrown in destructor.");
     assertNotEquals(location2, location0);
     assertNotEquals(location2.hashCode(), location0.hashCode());
 
@@ -43,11 +43,11 @@ public class CxxReportIssueTest {
 
   @Test
   public void reportIssueEquality() {
-    var issue0 = new CxxReportIssue("nullPointer", "path0.cpp", "1", "Null pointer dereference: ptr");
-    issue0.addLocation("path0.cpp", "1", "Assignment &apos;ptr=nullptr&apos;, assigned value is 0");
+    var issue0 = new CxxReportIssue("nullPointer", "path0.cpp", "1", null, "Null pointer dereference: ptr");
+    issue0.addLocation("path0.cpp", "1", null, "Assignment &apos;ptr=nullptr&apos;, assigned value is 0");
 
-    var issue1 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
-    var issue2 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
+    var issue1 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", null, "Exception thrown in destructor.");
+    var issue2 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", null, "Exception thrown in destructor.");
 
     assertEquals(issue1, issue2);
     assertEquals(issue1.hashCode(), issue2.hashCode());
@@ -61,21 +61,21 @@ public class CxxReportIssueTest {
 
   @Test
   public void reportIssueEqualityConsideringFlow() {
-    var issue0 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
-    issue0.addFlowElement("path0.cpp", "1", "a");
-    issue0.addFlowElement("path1.cpp", "1", "b");
-    issue0.addFlowElement("path2.cpp", "1", "c");
+    var issue0 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", null, "Exception thrown in destructor.");
+    issue0.addFlowElement("path0.cpp", "1", null, "a");
+    issue0.addFlowElement("path1.cpp", "1", null, "b");
+    issue0.addFlowElement("path2.cpp", "1", null, "c");
 
-    var issue1 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
-    issue1.addFlowElement("path0.cpp", "1", "a");
-    issue1.addFlowElement("path1.cpp", "1", "b");
-    issue1.addFlowElement("path2.cpp", "1", "c");
+    var issue1 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", null, "Exception thrown in destructor.");
+    issue1.addFlowElement("path0.cpp", "1", null, "a");
+    issue1.addFlowElement("path1.cpp", "1", null, "b");
+    issue1.addFlowElement("path2.cpp", "1", null, "c");
 
-    var issue2 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
-    issue2.addFlowElement("path1.cpp", "1", "b");
-    issue2.addFlowElement("path2.cpp", "1", "c");
+    var issue2 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", null, "Exception thrown in destructor.");
+    issue2.addFlowElement("path1.cpp", "1", null, "b");
+    issue2.addFlowElement("path2.cpp", "1", null, "c");
 
-    var issue3 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
+    var issue3 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", null, "Exception thrown in destructor.");
 
     assertEquals(issue0, issue1);
     assertEquals(issue0.hashCode(), issue1.hashCode());
@@ -92,14 +92,14 @@ public class CxxReportIssueTest {
 
   @Test
   public void reportIssueFlowOrder() {
-    var issue0 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", "Exception thrown in destructor.");
-    issue0.addFlowElement("path0.cpp", "1", "a");
-    issue0.addFlowElement("path1.cpp", "2", "b");
-    issue0.addFlowElement("path2.cpp", "3", "c");
+    var issue0 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", null, "Exception thrown in destructor.");
+    issue0.addFlowElement("path0.cpp", "1", null, "a");
+    issue0.addFlowElement("path1.cpp", "2", null, "b");
+    issue0.addFlowElement("path2.cpp", "3", null, "c");
 
     List<CxxReportLocation> flow = issue0.getFlow();
-    assertEquals(new CxxReportLocation("path2.cpp", "3", "c"), flow.get(0));
-    assertEquals(new CxxReportLocation("path1.cpp", "2", "b"), flow.get(1));
-    assertEquals(new CxxReportLocation("path0.cpp", "1", "a"), flow.get(2));
+    assertEquals(new CxxReportLocation("path2.cpp", "3", null, "c"), flow.get(0));
+    assertEquals(new CxxReportLocation("path1.cpp", "2", null, "b"), flow.get(1));
+    assertEquals(new CxxReportLocation("path0.cpp", "1", null, "a"), flow.get(2));
   }
 }


### PR DESCRIPTION
- add column to CxxReportIssue and CxxReportLocation
- support column in base class CxxIssuesReportSensor
   - since we do not have more information, we select only one character
   - behaviour is designed to be different from Generic Issue Import (sonar.externalIssuesReportPaths), here column to end of line is marked

add column support to sensors:
- CxxOtherSensor: column tag
- CxxCompilerSensor: gcc/vc: 'column' named-capturing group
- CxxClangSASensor
- CxxClangTidySensor, close #1936

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1948)
<!-- Reviewable:end -->
