### PR TITLE
clang-tidy refactoring

### DIFF
--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -25,7 +25,7 @@
   <key>clang-diagnostic-error</key>
   <name>clang-diagnostic-error</name>
   <description><![CDATA[
-      <p>Diagnostic text: compiler error, e.g header file not found</p>
+      <p>Default compiler diagnostic for errors without an explicit check name. Compiler error, e.g header file not found.</p>
       ]]></description>
   <severity>INFO</severity>
   <type>BUG</type>
@@ -34,9 +34,18 @@
   <key>clang-diagnostic-warning</key>
   <name>clang-diagnostic-warning</name>
   <description><![CDATA[
-      <p>Diagnostic text: default compiler warnings</p>
+      <p>Default compiler diagnostic for warnings without an explicit check name.</p>
       ]]></description>
   <severity>MAJOR</severity>
+  <type>CODE_SMELL</type>
+</rule>
+<rule>
+  <key>clang-diagnostic-unknown</key>
+  <name>clang-diagnostic-unknown</name>
+  <description><![CDATA[
+      <p>(Unkown) compiler diagnostic without an explicit check name.</p>
+      ]]></description>
+  <severity>INFO</severity>
   <type>CODE_SMELL</type>
 </rule>
 <rule>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
@@ -36,7 +36,7 @@ public class CxxClangTidyRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxClangTidyRuleRepository.KEY);
-    assertEquals(1083, repo.rules().size());
+    assertEquals(1084, repo.rules().size());
   }
 
 }

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/cpd.report-default-rule-id.txt
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/cpd.report-default-rule-id.txt
@@ -1,0 +1,15 @@
+sources\utils\code_chunks.cpp:2:10: fatal error: info without rule id
+    void foo(int bar);
+         ^
+
+sources\utils\code_chunks.cpp:2:11: error: info without rule id
+    void foo(int bar);
+          ^
+
+sources\utils\code_chunks.cpp:2:12: warning: info without rule id
+    void foo(int bar);
+           ^
+
+sources\utils\code_chunks.cpp:2:13: remark: info without rule id
+    void foo(int bar);
+            ^

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/cpd.report-fatal-error.txt
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/cpd.report-fatal-error.txt
@@ -1,0 +1,1 @@
+sources\utils\code_chunks.cpp:2:5: fatal error: 'wchar.h' file not found [clang-diagnostic-error]

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -300,12 +300,12 @@ def create_template_rules(rules):
     rules.append(rule)
 
 def create_clang_default_rules(rules):
-    # defaults clang error (not associated with any activation switch)
+    # defaults clang error (not associated with any activation switch): error, fatal error
     rule_key = "clang-diagnostic-error"
     rule_name = "clang-diagnostic-error"
     rule_type = DIAG_CLASS["CLASS_ERROR"]["sonarqube_type"]
     rule_severity = SEVERITY["SEV_Remark"]["sonarqube_severity"] 
-    rule_description = "<p>Diagnostic text: compiler error, e.g header file not found</p>"
+    rule_description = "<p>Default compiler diagnostic for errors without an explicit check name. Compiler error, e.g header file not found.</p>"
 
     rule = et.Element('rule')
     et.SubElement(rule, 'key').text = rule_key
@@ -315,12 +315,12 @@ def create_clang_default_rules(rules):
     et.SubElement(rule, 'type').text = rule_type
     rules.append(rule)
   
-    # defaults clang warning (not associated with any activation switch)
+    # defaults clang warning (not associated with any activation switch): warning
     rule_key = "clang-diagnostic-warning"
     rule_name = "clang-diagnostic-warning"
     rule_type = DIAG_CLASS["CLASS_WARNING"]["sonarqube_type"]
     rule_severity = SEVERITY["SEV_Warning"]["sonarqube_severity"] 
-    rule_description = "<p>Diagnostic text: default compiler warnings</p>"
+    rule_description = "<p>Default compiler diagnostic for warnings without an explicit check name.</p>"
 
     rule = et.Element('rule')
     et.SubElement(rule, 'key').text = rule_key
@@ -330,6 +330,21 @@ def create_clang_default_rules(rules):
     et.SubElement(rule, 'type').text = rule_type
     rules.append(rule)
 
+    # defaults clang issue (not associated with any activation switch): all other levels
+    rule_key = "clang-diagnostic-unknown"
+    rule_name = "clang-diagnostic-unknown"
+    rule_type = DIAG_CLASS["CLASS_REMARK"]["sonarqube_type"]
+    rule_severity = SEVERITY["SEV_Remark"]["sonarqube_severity"] 
+    rule_description = "<p>(Unkown) compiler diagnostic without an explicit check name.</p>"
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = rule_key
+    et.SubElement(rule, 'name').text = rule_name
+    et.SubElement(rule, 'description').append(CDATA(rule_description))
+    et.SubElement(rule, 'severity').text = rule_severity
+    et.SubElement(rule, 'type').text = rule_type
+    rules.append(rule)
+    
 def collect_warnings(data, diag_group_id, warnings_in_group):
     diag_group = data[diag_group_id]
 
@@ -365,6 +380,7 @@ DIAG_CLASS = {"CLASS_EXTENSION": {"weight": 0, "sonarqube_type": "CODE_SMELL", "
               "CLASS_REMARK": {"weight": 0, "sonarqube_type": "CODE_SMELL", "printable": "remark"},
               "CLASS_WARNING": {"weight": 0, "sonarqube_type": "CODE_SMELL", "printable": "warning"},
               "CLASS_ERROR": {"weight": 1, "sonarqube_type": "BUG", "printable": "error"}
+              "CLASS_FATAL_ERROR": {"weight": 1, "sonarqube_type": "BUG", "printable": "fatal error"}              
               }
 
 # see Severity in JSON


### PR DESCRIPTION
- support all diagnostic levels `"note", "remark", "warning", "error", "fatal error"`
- use default compiler diagnostic for issues without an explicit check name:
  - "error", "fatal error" => `"clang-diagnostic-error"`
  - "warning" => `"clang-diagnostic-warning"`
  - all other => `"clang-diagnostic-unknown"`
- close #1954

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1955)
<!-- Reviewable:end -->
