### PR TITLE
cleanup assertThat usage

### DIFF
--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/api/UndocumentedApiCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/api/UndocumentedApiCheckTest.java
@@ -111,7 +111,7 @@ public class UndocumentedApiCheckTest {
       errors.append(msg.formatDefaultMessage());
       errors.append("\r\n");
     }
-    assertThat(errors.length()).isEqualTo(0);
+    assertThat(errors.length()).isZero();
   }
 
   @Test
@@ -128,7 +128,7 @@ public class UndocumentedApiCheckTest {
       errors.append(msg.formatDefaultMessage());
       errors.append("\r\n");
     }
-    assertThat(errors.length()).isEqualTo(0);
+    assertThat(errors.length()).isZero();
   }
 
 }

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/FileHeaderCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/FileHeaderCheckTest.java
@@ -21,9 +21,9 @@ package org.sonar.cxx.checks.regex;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import org.junit.Rule;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.sonar.cxx.CxxAstScanner;
 import org.sonar.cxx.checks.CxxFileTester;
 import org.sonar.cxx.checks.CxxFileTesterHelper;
@@ -31,9 +31,6 @@ import org.sonar.squidbridge.api.SourceFile;
 import org.sonar.squidbridge.checks.CheckMessagesVerifier;
 
 public class FileHeaderCheckTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion
@@ -177,13 +174,12 @@ public class FileHeaderCheckTest {
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion
   public void should_fail_with_bad_regular_expression() {
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Unable to compile the regular expression: \"*\"");
-
     var check = new FileHeaderCheck();
     check.headerFormat = "*";
     check.isRegularExpression = true;
-    check.init();
+
+    IllegalStateException e = assertThrows(IllegalStateException.class, check::init);
+    assertThat(e).hasMessage("Unable to compile the regular expression: \"*\"");
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/prejobs/XlstSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/prejobs/XlstSensorTest.java
@@ -93,7 +93,7 @@ public class XlstSensorTest {
     logTester.clear();
     sensor.execute(context);
 
-    assertThat(context.allIssues()).hasSize(0);
+    assertThat(context.allIssues()).isEmpty();
   }
 
   @Test

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensorTest.java
@@ -58,7 +58,7 @@ public class CxxClangSASensorTest {
     var sensor = new CxxClangSASensor();
     sensor.execute(context);
 
-    assertThat(context.allIssues()).hasSize(0);
+    assertThat(context.allIssues()).isEmpty();
   }
 
   @Test
@@ -162,7 +162,7 @@ public class CxxClangSASensorTest {
     var sensor = new CxxClangSASensor();
     sensor.execute(context);
 
-    assertThat(context.allIssues()).hasSize(0);
+    assertThat(context.allIssues()).isEmpty();
   }
 
   @Test

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensorTest.java
@@ -56,7 +56,7 @@ public class CxxClangTidySensorTest {
     var sensor = new CxxClangTidySensor();
     sensor.execute(context);
 
-    assertThat(context.allIssues()).hasSize(0);
+    assertThat(context.allIssues()).isEmpty();
   }
 
   @Test
@@ -170,7 +170,7 @@ public class CxxClangTidySensorTest {
     var sensor = new CxxClangTidySensor();
     sensor.execute(context);
 
-    assertThat(context.allIssues()).hasSize(0);
+    assertThat(context.allIssues()).isEmpty();
   }
 
   @Test

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensorTest.java
@@ -59,7 +59,7 @@ public class CxxCompilerSensorTest {
     sensor.setRegex("(?<test>.*)");
     sensor.testExecuteReport(report);
     String log = logTester.logs().toString();
-    assertThat(log.contains("FileNotFoundException")).isTrue();
+    assertThat(log).contains("FileNotFoundException");
   }
 
   @Test
@@ -67,7 +67,7 @@ public class CxxCompilerSensorTest {
     var report = new File("");
     sensor.testExecuteReport(report);
     String log = logTester.logs().toString();
-    assertThat(log.contains("empty custom regular expression")).isTrue();
+    assertThat(log).contains("empty custom regular expression");
   }
 
   @Test
@@ -76,7 +76,7 @@ public class CxxCompilerSensorTest {
     sensor.setRegex("(?<test>*)");
     sensor.testExecuteReport(report);
     String log = logTester.logs().toString();
-    assertThat(log.contains("PatternSyntaxException")).isTrue();
+    assertThat(log).contains("PatternSyntaxException");
   }
 
   @Test
@@ -85,7 +85,7 @@ public class CxxCompilerSensorTest {
     sensor.setRegex(".*");
     sensor.testExecuteReport(report);
     String log = logTester.logs().toString();
-    assertThat(log.contains("contains no named-capturing group")).isTrue();
+    assertThat(log).contains("contains no named-capturing group");
   }
 
   private class CxxCompilerSensorMock extends CxxCompilerSensor {

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxBullseyeCoverageSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxBullseyeCoverageSensorTest.java
@@ -81,7 +81,7 @@ public class CxxBullseyeCoverageSensorTest {
       var zeroHitLines = new int[]{5, 10, 15, 17, 28, 32, 35, 40, 41, 44};
       for (var line : zeroHitLines) {
         LOG.debug("Check zero line coverage: {}", line);
-        assertThat(context.lineHits("ProjectKey:source_1.cpp", line)).isEqualTo(0);
+        assertThat(context.lineHits("ProjectKey:source_1.cpp", line)).isZero();
       }
 
       var oneHitlinesA = new int[]{7, 12, 17, 30};
@@ -219,9 +219,9 @@ public class CxxBullseyeCoverageSensorTest {
       assertThat(context.coveredConditions("ProjectKey:covfile/import/cereal/archives/json.hpp", 495)).isEqualTo(1);
 
       LOG.debug("Switch-label probe");
-      assertThat(context.lineHits("ProjectKey:covfile/import/cereal/archives/json.hpp", 474)).isEqualTo(0);
+      assertThat(context.lineHits("ProjectKey:covfile/import/cereal/archives/json.hpp", 474)).isZero();
       assertThat(context.conditions("ProjectKey:covfile/import/cereal/archives/json.hpp", 474)).isEqualTo(1);
-      assertThat(context.coveredConditions("ProjectKey:covfile/import/cereal/archives/json.hpp", 474)).isEqualTo(0);
+      assertThat(context.coveredConditions("ProjectKey:covfile/import/cereal/archives/json.hpp", 474)).isZero();
       assertThat(context.lineHits("ProjectKey:covfile/import/cereal/archives/json.hpp", 475)).isEqualTo(1);
       assertThat(context.conditions("ProjectKey:covfile/import/cereal/archives/json.hpp", 475)).isEqualTo(1);
       assertThat(context.coveredConditions("ProjectKey:covfile/import/cereal/archives/json.hpp", 475)).isEqualTo(1);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxCoberturaSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxCoberturaSensorTest.java
@@ -164,15 +164,15 @@ public class CxxCoberturaSensorTest {
 
     assertThat(context.lineHits("ProjectKey:sources/utils/code_chunks.cpp", 1)).isEqualTo(1);
     assertThat(context.lineHits("ProjectKey:sources/utils/code_chunks.cpp", 3)).isEqualTo(4);
-    assertThat(context.lineHits("ProjectKey:sources/utils/utils.cpp", 2)).isEqualTo(0);
+    assertThat(context.lineHits("ProjectKey:sources/utils/utils.cpp", 2)).isZero();
     assertThat(context.lineHits("ProjectKey:sources/application/main.cpp", 8)).isEqualTo(8);
     assertThat(context.lineHits("ProjectKey:sources/utils/code_chunks.cpp", 1)).isEqualTo(1);
     assertThat(context.lineHits("ProjectKey:sources/utils/code_chunks.cpp", 3)).isEqualTo(4);
-    assertThat(context.lineHits("ProjectKey:sources/utils/utils.cpp", 2)).isEqualTo(0);
+    assertThat(context.lineHits("ProjectKey:sources/utils/utils.cpp", 2)).isZero();
     assertThat(context.lineHits("ProjectKey:sources/application/main.cpp", 8)).isEqualTo(8);
     assertThat(context.lineHits("ProjectKey:sources/utils/code_chunks.cpp", 1)).isEqualTo(1);
     assertThat(context.lineHits("ProjectKey:sources/utils/code_chunks.cpp", 3)).isEqualTo(4);
-    assertThat(context.lineHits("ProjectKey:sources/utils/utils.cpp", 2)).isEqualTo(0);
+    assertThat(context.lineHits("ProjectKey:sources/utils/utils.cpp", 2)).isZero();
     assertThat(context.lineHits("ProjectKey:sources/application/main.cpp", 8)).isEqualTo(8);
   }
 
@@ -195,7 +195,7 @@ public class CxxCoberturaSensorTest {
 
     assertThat(context.lineHits("ProjectKey:sources/utils/code_chunks.cpp", 1)).isEqualTo(1);
     assertThat(context.lineHits("ProjectKey:sources/utils/code_chunks.cpp", 3)).isEqualTo(4);
-    assertThat(context.lineHits("ProjectKey:sources/utils/utils.cpp", 2)).isEqualTo(0);
+    assertThat(context.lineHits("ProjectKey:sources/utils/utils.cpp", 2)).isZero();
     assertThat(context.lineHits("ProjectKey:sources/application/main.cpp", 8)).isEqualTo(8);
   }
 
@@ -225,7 +225,7 @@ public class CxxCoberturaSensorTest {
     var sensor = new CxxCoverageCoberturaSensor();
     sensor.execute(context);
 
-    assertThat(linesOfCodeByFile.isEmpty()).isTrue();
+    assertThat(linesOfCodeByFile).isEmpty();
   }
 
   @Test

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxMSCoverageSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxMSCoverageSensorTest.java
@@ -91,7 +91,7 @@ public class CxxMSCoverageSensorTest {
     var oneHitlinesA = new int[]{4, 5, 6, 8, 13, 15, 16, 25};
     var zeroHitlinesA = new int[]{9, 10, 22, 23};
     for (var zeroHitline : zeroHitlinesA) {
-      assertThat(context.lineHits("ProjectKey:project2/source1.cpp", zeroHitline)).isEqualTo(0);
+      assertThat(context.lineHits("ProjectKey:project2/source1.cpp", zeroHitline)).isZero();
     }
     for (var oneHitline : oneHitlinesA) {
       assertThat(context.lineHits("ProjectKey:project2/source1.cpp", oneHitline)).isEqualTo(1);
@@ -100,7 +100,7 @@ public class CxxMSCoverageSensorTest {
     var oneHitlinesB = new int[]{4, 5, 6, 8, 9, 10, 13, 21, 25};
     var zeroHitlinesB = new int[]{15, 16, 22, 23};
     for (var zeroHitline : zeroHitlinesB) {
-      assertThat(context.lineHits("ProjectKey:project2/source2.cpp", zeroHitline)).isEqualTo(0);
+      assertThat(context.lineHits("ProjectKey:project2/source2.cpp", zeroHitline)).isZero();
     }
     for (var oneHitline : oneHitlinesB) {
       assertThat(context.lineHits("ProjectKey:project2/source2.cpp", oneHitline)).isEqualTo(1);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckSensorTest.java
@@ -89,7 +89,7 @@ public class CxxCppCheckSensorTest {
     var sensor = new CxxCppCheckSensor();
     sensor.execute(context);
 
-    assertThat(context.allIssues()).hasSize(0);
+    assertThat(context.allIssues()).isEmpty();
   }
 
   @Test
@@ -101,7 +101,7 @@ public class CxxCppCheckSensorTest {
     var sensor = new CxxCppCheckSensor();
     sensor.execute(context);
 
-    assertThat(context.allIssues()).hasSize(0);
+    assertThat(context.allIssues()).isEmpty();
   }
 
   @Test(expected = IllegalStateException.class)

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/infer/CxxInferSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/infer/CxxInferSensorTest.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.cxx.sensors.infer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,8 +30,6 @@ import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class CxxInferSensorTest {
 
@@ -97,7 +96,7 @@ public class CxxInferSensorTest {
     var sensor = new CxxInferSensor();
     sensor.execute(context);
 
-    assertThat(context.allIssues()).hasSize(0);
+    assertThat(context.allIssues()).isEmpty();
   }
 
   @Test(expected = IllegalStateException.class)

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherSensorTest.java
@@ -103,7 +103,7 @@ public class CxxOtherSensorTest {
     sensor = new CxxOtherSensor();
     sensor.execute(context);
 
-    assertThat(context.allIssues()).hasSize(0);
+    assertThat(context.allIssues()).isEmpty();
   }
 
   @Test
@@ -115,7 +115,7 @@ public class CxxOtherSensorTest {
     sensor = new CxxOtherSensor();
     sensor.execute(context);
 
-    assertThat(context.allIssues()).hasSize(0);
+    assertThat(context.allIssues()).isEmpty();
   }
 
   @Test(expected = IllegalStateException.class)

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensorTest.java
@@ -123,7 +123,7 @@ public class CxxPCLintSensorTest {
     CxxPCLintSensor sensor = new CxxPCLintSensor();
     sensor.execute(context);
 
-    assertThat(context.allIssues()).hasSize(0);
+    assertThat(context.allIssues()).isEmpty();
   }
 
   @Test
@@ -139,7 +139,7 @@ public class CxxPCLintSensorTest {
     var sensor = new CxxPCLintSensor();
     sensor.execute(context);
 
-    assertThat(context.allIssues()).hasSize(0);
+    assertThat(context.allIssues()).isEmpty();
   }
 
   @Test

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/CxxUnitTestResultsAggregatorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/CxxUnitTestResultsAggregatorTest.java
@@ -28,9 +28,7 @@ import static java.util.Arrays.asList;
 import java.util.Collections;
 import java.util.HashSet;
 import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -39,9 +37,6 @@ import org.sonar.api.config.Configuration;
 import org.sonar.api.config.internal.MapSettings;
 
 public class CxxUnitTestResultsAggregatorTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   private final String key1 = UnitTestConfiguration.VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY;
   private final String key2 = UnitTestConfiguration.XUNIT_TEST_RESULTS_PROPERTY_KEY;

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/NUnitTestResultsFileParserTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/NUnitTestResultsFileParserTest.java
@@ -25,9 +25,9 @@ package org.sonar.cxx.sensors.tests.dotnet;
 // mailto:info AT sonarsource DOT com
 import java.io.File;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import static org.mockito.Mockito.mock;
 import org.sonar.api.utils.log.LogTester;
 import org.sonar.api.utils.log.LoggerLevel;
@@ -35,27 +35,31 @@ import org.sonar.api.utils.log.LoggerLevel;
 public class NUnitTestResultsFileParserTest {
 
   private static final String REPORT_PATH
-                              = "src/test/resources/org/sonar/cxx/sensors/reports-project/xunit-reports/nunit/";
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
+                                = "src/test/resources/org/sonar/cxx/sensors/reports-project/xunit-reports/nunit/";
 
   @Rule
   public LogTester logTester = new LogTester();
 
   @Test
   public void no_counters() {
-    thrown.expect(ParseErrorException.class);
-    thrown.expectMessage("Missing attribute \"total\" in element <test-results> in ");
-    thrown.expectMessage(new File(REPORT_PATH + "no_counters.xml").getAbsolutePath());
-    new NUnitTestResultsFileParser().accept(new File(REPORT_PATH + "no_counters.xml"), mock(UnitTestResults.class));
+    ParseErrorException e = assertThrows(ParseErrorException.class, () -> {
+                                         new NUnitTestResultsFileParser().accept(new File(REPORT_PATH
+                                                                                            + "no_counters.xml"), mock(
+                                                                                 UnitTestResults.class));
+                                       });
+    assertThat(e).hasMessageContaining("Missing attribute \"total\" in element <test-results> in "
+                                         + new File(REPORT_PATH + "no_counters.xml").getAbsolutePath());
   }
 
   @Test
   public void wrong_passed_number() {
-    thrown.expect(ParseErrorException.class);
-    thrown.expectMessage("Expected an integer instead of \"invalid\" for the attribute \"total\" in ");
-    thrown.expectMessage(new File(REPORT_PATH + "invalid_total.xml").getAbsolutePath());
-    new NUnitTestResultsFileParser().accept(new File(REPORT_PATH + "invalid_total.xml"), mock(UnitTestResults.class));
+    ParseErrorException e = assertThrows(ParseErrorException.class, () -> {
+                                         new NUnitTestResultsFileParser().accept(new File(REPORT_PATH
+                                                                                            + "invalid_total.xml"),
+                                                                                 mock(UnitTestResults.class));
+                                       });
+    assertThat(e).hasMessageContaining("Expected an integer instead of \"invalid\" for the attribute \"total\" in "
+                                         + new File(REPORT_PATH + "invalid_total.xml").getAbsolutePath());
   }
 
   @Test
@@ -99,11 +103,11 @@ public class NUnitTestResultsFileParserTest {
 
     assertThat(logTester.logs(LoggerLevel.WARN)).contains(
       "One of the assemblies contains no test result, please make sure this is expected.");
-    assertThat(results.tests()).isEqualTo(0);
-    assertThat(results.passedPercentage()).isEqualTo(0);
-    assertThat(results.skipped()).isEqualTo(0);
-    assertThat(results.failures()).isEqualTo(0);
-    assertThat(results.errors()).isEqualTo(0);
+    assertThat(results.tests()).isZero();
+    assertThat(results.passedPercentage()).isZero();
+    assertThat(results.skipped()).isZero();
+    assertThat(results.failures()).isZero();
+    assertThat(results.errors()).isZero();
     assertThat(results.executionTime()).isNull();
   }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/VisualStudioTestResultsFileParserTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/VisualStudioTestResultsFileParserTest.java
@@ -25,34 +25,35 @@ package org.sonar.cxx.sensors.tests.dotnet;
 // mailto:info AT sonarsource DOT com
 import java.io.File;
 import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.Rule;
+import static org.junit.Assert.assertThrows;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import static org.mockito.Mockito.mock;
 
 public class VisualStudioTestResultsFileParserTest {
 
   private static final String REPORT_PATH = "src/test/resources/org/sonar/cxx/sensors/reports-project/MSTest-reports/";
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
   @Test
   public void no_counters() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("The mandatory <Counters> tag is missing in ");
-    thrown.expectMessage(new File(REPORT_PATH + "no_counters.trx").getAbsolutePath());
-    new VisualStudioTestResultsFileParser().accept(new File(REPORT_PATH + "no_counters.trx"),
-                                                   mock(UnitTestResults.class));
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+                                              new VisualStudioTestResultsFileParser().accept(new File(REPORT_PATH
+                                                                                                        + "no_counters.trx"),
+                                                                                             mock(UnitTestResults.class));
+                                            });
+    assertThat(e).hasMessageContaining("The mandatory <Counters> tag is missing in "
+                                         + new File(REPORT_PATH + "no_counters.trx").getAbsolutePath());
   }
 
   @Test
   public void wrong_passed_number() {
-    thrown.expect(ParseErrorException.class);
-    thrown.expectMessage("Expected an integer instead of \"foo\" for the attribute \"passed\" in ");
-    thrown.expectMessage(new File(REPORT_PATH + "wrong_passed_number.trx").getAbsolutePath());
-    new VisualStudioTestResultsFileParser().accept(new File(REPORT_PATH + "wrong_passed_number.trx"), mock(
-                                                   UnitTestResults.class));
+    ParseErrorException e = assertThrows(ParseErrorException.class, () -> {
+                                         new VisualStudioTestResultsFileParser().accept(new File(REPORT_PATH
+                                                                                                   + "wrong_passed_number.trx"),
+                                                                                        mock(
+                                                                                          UnitTestResults.class));
+                                       });
+    assertThat(e).hasMessageContaining("Expected an integer instead of \"foo\" for the attribute \"passed\" in "
+                                         + new File(REPORT_PATH + "wrong_passed_number.trx").getAbsolutePath());
   }
 
   @Test
@@ -75,9 +76,9 @@ public class VisualStudioTestResultsFileParserTest {
 
     assertThat(results.tests()).isEqualTo(3);
     assertThat(results.passedPercentage()).isEqualTo(3 * 100.0 / 3);
-    assertThat(results.skipped()).isEqualTo(0);
-    assertThat(results.failures()).isEqualTo(0);
-    assertThat(results.errors()).isEqualTo(0);
+    assertThat(results.skipped()).isZero();
+    assertThat(results.failures()).isZero();
+    assertThat(results.errors()).isZero();
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/WildcardPatternFileProviderTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/WildcardPatternFileProviderTest.java
@@ -26,18 +26,16 @@ package org.sonar.cxx.sensors.tests.dotnet;
 import java.io.File;
 import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 public class WildcardPatternFileProviderTest {
 
   @Rule
   public TemporaryFolder tmp = new TemporaryFolder();
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   private static String path(String... elements) {
     return String.join(File.separator, elements);
@@ -112,7 +110,8 @@ public class WildcardPatternFileProviderTest {
       .containsOnly(new File(tmp.getRoot(), path("c", "c22", "c31", "foo.txt")));
 
     assertThat(listFiles(new File(tmp.getRoot(), path("**", "c?1", "foo.txt")).getAbsolutePath()))
-      .containsOnly(new File(tmp.getRoot(), path("c", "c21", "foo.txt")), new File(tmp.getRoot(), path("c", "c22", "c31", "foo.txt")));
+      .containsOnly(new File(tmp.getRoot(), path("c", "c21", "foo.txt")), new File(tmp.getRoot(),
+                                                                                   path("c", "c22", "c31", "foo.txt")));
 
     assertThat(listFiles(new File(tmp.getRoot(), path("?", "**", "foo.txt")).getAbsolutePath()))
       .containsOnly(
@@ -168,7 +167,8 @@ public class WildcardPatternFileProviderTest {
       .containsOnly(new File(tmp.getRoot(), path("c", "c22", "c31", "foo.txt")));
 
     assertThat(listFiles(path("**", "c?1", "foo.txt"), tmp.getRoot()))
-      .containsOnly(new File(tmp.getRoot(), path("c", "c21", "foo.txt")), new File(tmp.getRoot(), path("c", "c22", "c31", "foo.txt")));
+      .containsOnly(new File(tmp.getRoot(), path("c", "c21", "foo.txt")), new File(tmp.getRoot(),
+                                                                                   path("c", "c22", "c31", "foo.txt")));
 
     assertThat(listFiles(path("?", "**", "foo.txt"), tmp.getRoot()))
       .containsOnly(
@@ -179,18 +179,19 @@ public class WildcardPatternFileProviderTest {
 
   @Test
   public void should_fail_with_current_folder_access_after_wildcard() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Cannot contain '.' or '..' after the first wildcard.");
-
-    listFiles(new File(tmp.getRoot(), path("?", ".", "foo.txt")).getAbsolutePath());
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+                                              listFiles(new File(tmp.getRoot(), path("?", ".", "foo.txt"))
+                                                .getAbsolutePath());
+                                            });
+    assertThat(e).hasMessage("Cannot contain '.' or '..' after the first wildcard.");
   }
 
   @Test
   public void should_fail_with_parent_folder_access_after_wildcard() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Cannot contain '.' or '..' after the first wildcard.");
-
-    listFiles(path("*", "..", "foo.txt"), tmp.getRoot());
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+                                              listFiles(path("*", "..", "foo.txt"), tmp.getRoot());
+                                            });
+    assertThat(e).hasMessage("Cannot contain '.' or '..' after the first wildcard.");
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/XUnitTestResultsFileParserTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/XUnitTestResultsFileParserTest.java
@@ -25,9 +25,9 @@ package org.sonar.cxx.sensors.tests.dotnet;
 // mailto:info AT sonarsource DOT com
 import java.io.File;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import static org.mockito.Mockito.mock;
 import org.sonar.api.utils.log.LogTester;
 import org.sonar.api.utils.log.LoggerLevel;
@@ -35,35 +35,45 @@ import org.sonar.api.utils.log.LoggerLevel;
 public class XUnitTestResultsFileParserTest {
 
   private static final String REPORT_PATH
-                              = "src/test/resources/org/sonar/cxx/sensors/reports-project/xunit-reports/xunit/";
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
+                                = "src/test/resources/org/sonar/cxx/sensors/reports-project/xunit-reports/xunit/";
 
   @Rule
   public LogTester logTester = new LogTester();
 
   @Test
   public void no_counters() {
-    thrown.expect(ParseErrorException.class);
-    thrown.expectMessage("Missing attribute \"total\" in element <assembly> in ");
-    thrown.expectMessage(new File(REPORT_PATH + "no_counters.xml").getAbsolutePath());
-    new XUnitTestResultsFileParser().accept(new File(REPORT_PATH + "no_counters.xml"), mock(UnitTestResults.class));
+    ParseErrorException e = assertThrows(ParseErrorException.class, () -> {
+                                         new XUnitTestResultsFileParser().accept(new File(REPORT_PATH
+                                                                                            + "no_counters.xml"), mock(
+                                                                                 UnitTestResults.class));
+                                       });
+    assertThat(e).hasMessageContaining("Missing attribute \"total\" in element <assembly> in "
+                                         + new File(REPORT_PATH + "no_counters.xml").getAbsolutePath());
   }
 
   @Test
   public void wrong_passed_number() {
-    thrown.expect(ParseErrorException.class);
-    thrown.expectMessage("Expected an integer instead of \"invalid\" for the attribute \"total\" in ");
-    thrown.expectMessage(new File(REPORT_PATH + "invalid_total.xml").getAbsolutePath());
-    new XUnitTestResultsFileParser().accept(new File(REPORT_PATH + "invalid_total.xml"), mock(UnitTestResults.class));
+    ParseErrorException e = assertThrows(ParseErrorException.class, () -> {
+                                         new XUnitTestResultsFileParser().accept(new File(REPORT_PATH
+                                                                                            + "invalid_total.xml"),
+                                                                                 mock(
+                                                                                   UnitTestResults.class));
+
+                                       });
+    assertThat(e).hasMessageContaining("Expected an integer instead of \"invalid\" for the attribute \"total\" in "
+                                         + new File(REPORT_PATH + "invalid_total.xml").getAbsolutePath());
   }
 
   @Test
   public void invalid_root() {
-    thrown.expect(ParseErrorException.class);
-    thrown.expectMessage("Expected either an <assemblies> or an <assembly> root tag, but got <foo> instead.");
-    thrown.expectMessage(new File(REPORT_PATH + "invalid_root.xml").getAbsolutePath());
-    new XUnitTestResultsFileParser().accept(new File(REPORT_PATH + "invalid_root.xml"), mock(UnitTestResults.class));
+    ParseErrorException e = assertThrows(ParseErrorException.class, () -> {
+                                         new XUnitTestResultsFileParser().accept(new File(REPORT_PATH
+                                                                                            + "invalid_root.xml"), mock(
+                                                                                 UnitTestResults.class));
+                                       });
+    assertThat(e).hasMessageContaining(
+      "Expected either an <assemblies> or an <assembly> root tag, but got <foo> instead. in "
+        + new File(REPORT_PATH + "invalid_root.xml").getAbsolutePath());
   }
 
   @Test
@@ -88,7 +98,7 @@ public class XUnitTestResultsFileParserTest {
     assertThat(results.passedPercentage()).isEqualTo(3 * 100.0 / 6);
     assertThat(results.skipped()).isEqualTo(2);
     assertThat(results.failures()).isEqualTo(1);
-    assertThat(results.errors()).isEqualTo(0);
+    assertThat(results.errors()).isZero();
   }
 
   @Test
@@ -111,11 +121,11 @@ public class XUnitTestResultsFileParserTest {
 
     assertThat(logTester.logs(LoggerLevel.WARN)).contains(
       "One of the assemblies contains no test result, please make sure this is expected.");
-    assertThat(results.tests()).isEqualTo(0);
-    assertThat(results.passedPercentage()).isEqualTo(0);
-    assertThat(results.skipped()).isEqualTo(0);
-    assertThat(results.failures()).isEqualTo(0);
-    assertThat(results.errors()).isEqualTo(0);
+    assertThat(results.tests()).isZero();
+    assertThat(results.passedPercentage()).isZero();
+    assertThat(results.skipped()).isZero();
+    assertThat(results.failures()).isZero();
+    assertThat(results.errors()).isZero();
     assertThat(results.executionTime()).isNull();
   }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/XmlParserHelperTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/XmlParserHelperTest.java
@@ -26,25 +26,23 @@ package org.sonar.cxx.sensors.tests.dotnet;
 import java.io.File;
 import java.io.IOException;
 import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.Rule;
+import static org.junit.Assert.assertThrows;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class XmlParserHelperTest {
 
   private static final String REPORT_PATH = "src/test/resources/org/sonar/cxx/sensors/reports-project/MSTest-reports/";
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
   @Test
   public void invalid_prolog() throws IOException {
-    thrown.expectMessage("Error while parsing the XML file: ");
-    thrown.expectMessage("invalid_prolog.txt");
-
-    try (var helper = new XmlParserHelper(new File(REPORT_PATH + "invalid_prolog.txt"))) {
-      helper.nextStartTag();
-    }
+    IllegalStateException e = assertThrows(IllegalStateException.class, () -> {
+                                           try ( var helper = new XmlParserHelper(new File(REPORT_PATH
+                                                                                         + "invalid_prolog.txt"))) {
+                                             helper.nextStartTag();
+                                           }
+                                         });
+    assertThat(e).hasMessageContaining("Error while parsing the XML file: "
+                                         + new File(REPORT_PATH + "invalid_prolog.txt").getAbsolutePath());
   }
 
   @Test
@@ -71,15 +69,11 @@ public class XmlParserHelperTest {
     assertThat(xml.getDoubleAttribute("myCommaDouble")).isEqualTo(1.234);
     assertThat(xml.getDoubleAttribute("nonExisting")).isNull();
 
-    thrown.expectMessage("valid.xml");
-    thrown.expectMessage("Expected an double instead of \"hello\" for the attribute \"myString\"");
-    xml.getDoubleAttribute("myString");
-    try {
-      xml.close();
-    } catch (IOException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    }
+    ParseErrorException e = assertThrows(ParseErrorException.class, () -> {
+                                         xml.getDoubleAttribute("myString");
+                                       });
+    assertThat(e).hasMessageContaining("Expected an double instead of \"hello\" for the attribute \"myString\" in "
+                                         + new File(REPORT_PATH + "valid.xml").getAbsolutePath());
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/xunit/CxxXunitSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/xunit/CxxXunitSensorTest.java
@@ -51,7 +51,7 @@ public class CxxXunitSensorTest {
     var sensor = new CxxXunitSensor();
     sensor.execute(context);
 
-    assertThat(context.measures(context.project().key())).hasSize(0);
+    assertThat(context.measures(context.project().key())).isEmpty();
   }
 
   @Test

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportSensorTest.java
@@ -89,8 +89,8 @@ public class CxxReportSensorTest {
     context.setSettings(settings);
     List<File> reports = CxxUtils.getFiles(context, REPORT_PATH_PROPERTY_KEY);
     assertThat(reports).isNotNull();
-    assertThat(reports.get(0).exists()).isTrue();
-    assertThat(reports.get(0).isAbsolute()).isTrue();
+    assertThat(reports.get(0)).exists();
+    assertThat(reports.get(0)).isAbsolute();
     assertThat(reports.size()).isEqualTo(3);
   }
 
@@ -101,8 +101,8 @@ public class CxxReportSensorTest {
     context.setSettings(settings);
     List<File> reports = CxxUtils.getFiles(context, REPORT_PATH_PROPERTY_KEY);
     assertThat(reports).isNotNull();
-    assertThat(reports.get(0).exists()).isTrue();
-    assertThat(reports.get(0).isAbsolute()).isTrue();
+    assertThat(reports.get(0)).exists();
+    assertThat(reports.get(0)).isAbsolute();
     assertThat(reports.size()).isEqualTo(3);
   }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportSensor_getReports_Test.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportSensor_getReports_Test.java
@@ -162,7 +162,7 @@ public class CxxReportSensor_getReports_Test {
     context.setSettings(settings);
 
     List<File> reports = CxxUtils.getFiles(context, REPORT_PATH_KEY);
-    assertThat(reports.size()).isEqualTo(0);
+    assertThat(reports.size()).isZero();
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/JsonCompilationDatabaseTest.java
@@ -43,9 +43,9 @@ public class JsonCompilationDatabaseTest {
 
     assertThat(cus).isNotNull();
     assertThat(cus.getDefines().containsKey("UNIT_DEFINE")).isFalse();
-    assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isTrue();
+    assertThat(cus.getDefines()).containsKey("GLOBAL_DEFINE");
     assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isFalse();
-    assertThat(cus.getIncludes().contains(Paths.get("/usr/include"))).isTrue();
+    assertThat(cus.getIncludes()).contains(Paths.get("/usr/include"));
   }
 
   @Test
@@ -61,9 +61,9 @@ public class JsonCompilationDatabaseTest {
     CxxCompilationUnitSettings cus = squidConfig.getCompilationUnitSettings(filename);
 
     assertThat(cus).isNotNull();
-    assertThat(cus.getDefines().containsKey("UNIT_DEFINE")).isTrue();
+    assertThat(cus.getDefines()).containsKey("UNIT_DEFINE");
     assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
-    assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isTrue();
+    assertThat(cus.getIncludes()).contains(Paths.get("/usr/local/include"));
     assertThat(cus.getIncludes().contains(Paths.get("/usr/include"))).isFalse();
   }
 
@@ -82,14 +82,14 @@ public class JsonCompilationDatabaseTest {
     CxxCompilationUnitSettings cus = squidConfig.getCompilationUnitSettings(filename);
 
     assertThat(cus).isNotNull();
-    assertThat(cus.getDefines().containsKey("COMMAND_DEFINE")).isTrue();
-    assertThat(cus.getDefines().containsKey("COMMAND_SPACE_DEFINE")).isTrue();
-    assertThat(cus.getDefines().get("COMMAND_SPACE_DEFINE")).isEqualTo("\" foo 'bar' zoo \"");
-    assertThat(cus.getDefines().containsKey("SIMPLE")).isTrue();
-    assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("1");
+    assertThat(cus.getDefines()).containsKey("COMMAND_DEFINE");
+    assertThat(cus.getDefines()).containsKey("COMMAND_SPACE_DEFINE");
+    assertThat(cus.getDefines()).containsEntry("COMMAND_SPACE_DEFINE", "\" foo 'bar' zoo \"");
+    assertThat(cus.getDefines()).containsKey("SIMPLE");
+    assertThat(cus.getDefines()).containsEntry("SIMPLE", "1");
     assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
-    assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isTrue();
-    assertThat(cus.getIncludes().contains(Paths.get("/another/include/dir"))).isTrue();
+    assertThat(cus.getIncludes()).contains(Paths.get("/usr/local/include"));
+    assertThat(cus.getIncludes()).contains(Paths.get("/another/include/dir"));
     assertThat(cus.getIncludes().contains(Paths.get("/usr/include"))).isFalse();
   }
 
@@ -109,21 +109,21 @@ public class JsonCompilationDatabaseTest {
 
     assertThat(cus).isNotNull();
 
-    assertThat(cus.getDefines().get("MACRO1")).isEqualTo("1");
-    assertThat(cus.getDefines().get("MACRO2")).isEqualTo("2");
-    assertThat(cus.getDefines().get("MACRO3")).isEqualTo("1");
-    assertThat(cus.getDefines().get("MACRO4")).isEqualTo("4");
-    assertThat(cus.getDefines().get("MACRO5")).isEqualTo("\" a 'b' c \"");
-    assertThat(cus.getDefines().get("MACRO6")).isEqualTo("\"With spaces, quotes and \\-es.\"");
+    assertThat(cus.getDefines()).containsEntry("MACRO1", "1");
+    assertThat(cus.getDefines()).containsEntry("MACRO2", "2");
+    assertThat(cus.getDefines()).containsEntry("MACRO3", "1");
+    assertThat(cus.getDefines()).containsEntry("MACRO4", "4");
+    assertThat(cus.getDefines()).containsEntry("MACRO5", "\" a 'b' c \"");
+    assertThat(cus.getDefines()).containsEntry("MACRO6", "\"With spaces, quotes and \\-es.\"");
 
-    assertThat(cus.getIncludes().contains(Paths.get("/aaa/bbb"))).isTrue();
-    assertThat(cus.getIncludes().contains(Paths.get("/ccc/ddd"))).isTrue();
-    assertThat(cus.getIncludes().contains(Paths.get("/eee/fff"))).isTrue();
-    assertThat(cus.getIncludes().contains(Paths.get("/ggg/hhh"))).isTrue();
-    assertThat(cus.getIncludes().contains(Paths.get("/iii/jjj"))).isTrue();
-    assertThat(cus.getIncludes().contains(Paths.get("/kkk/lll"))).isTrue();
-    assertThat(cus.getIncludes().contains(Paths.get("/mmm/nnn"))).isTrue();
-    assertThat(cus.getIncludes().contains(Paths.get("/ooo/ppp"))).isTrue();
+    assertThat(cus.getIncludes()).contains(Paths.get("/aaa/bbb"));
+    assertThat(cus.getIncludes()).contains(Paths.get("/ccc/ddd"));
+    assertThat(cus.getIncludes()).contains(Paths.get("/eee/fff"));
+    assertThat(cus.getIncludes()).contains(Paths.get("/ggg/hhh"));
+    assertThat(cus.getIncludes()).contains(Paths.get("/iii/jjj"));
+    assertThat(cus.getIncludes()).contains(Paths.get("/kkk/lll"));
+    assertThat(cus.getIncludes()).contains(Paths.get("/mmm/nnn"));
+    assertThat(cus.getIncludes()).contains(Paths.get("/ooo/ppp"));
   }
 
   @Test
@@ -141,14 +141,14 @@ public class JsonCompilationDatabaseTest {
     CxxCompilationUnitSettings cus = squidConfig.getCompilationUnitSettings(filename);
 
     assertThat(cus).isNotNull();
-    assertThat(cus.getDefines().containsKey("ARG_DEFINE")).isTrue();
-    assertThat(cus.getDefines().containsKey("ARG_SPACE_DEFINE")).isTrue();
-    assertThat(cus.getDefines().get("ARG_SPACE_DEFINE")).isEqualTo("\" foo 'bar' zoo \"");
-    assertThat(cus.getDefines().containsKey("SIMPLE")).isTrue();
-    assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("1");
+    assertThat(cus.getDefines()).containsKey("ARG_DEFINE");
+    assertThat(cus.getDefines()).containsKey("ARG_SPACE_DEFINE");
+    assertThat(cus.getDefines()).containsEntry("ARG_SPACE_DEFINE", "\" foo 'bar' zoo \"");
+    assertThat(cus.getDefines()).containsKey("SIMPLE");
+    assertThat(cus.getDefines()).containsEntry("SIMPLE", "1");
     assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
-    assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isTrue();
-    assertThat(cus.getIncludes().contains(Paths.get("/another/include/dir"))).isTrue();
+    assertThat(cus.getIncludes()).contains(Paths.get("/usr/local/include"));
+    assertThat(cus.getIncludes()).contains(Paths.get("/another/include/dir"));
     assertThat(cus.getIncludes().contains(Paths.get("/usr/include"))).isFalse();
   }
 
@@ -167,9 +167,9 @@ public class JsonCompilationDatabaseTest {
     CxxCompilationUnitSettings cus = squidConfig.getCompilationUnitSettings(filename);
 
     assertThat(cus).isNotNull();
-    assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isTrue();
-    assertThat(cus.getIncludes().contains(Paths.get("src/another/include/dir"))).isTrue();
-    assertThat(cus.getIncludes().contains(Paths.get("parent/include/dir"))).isTrue();
+    assertThat(cus.getIncludes()).contains(Paths.get("/usr/local/include"));
+    assertThat(cus.getIncludes()).contains(Paths.get("src/another/include/dir"));
+    assertThat(cus.getIncludes()).contains(Paths.get("parent/include/dir"));
     assertThat(cus.getIncludes().contains(Paths.get("/usr/include"))).isFalse();
   }
 
@@ -188,14 +188,14 @@ public class JsonCompilationDatabaseTest {
     CxxCompilationUnitSettings cus = squidConfig.getCompilationUnitSettings(filename);
 
     assertThat(cus).isNotNull();
-    assertThat(cus.getDefines().containsKey("ARG_DEFINE")).isTrue();
-    assertThat(cus.getDefines().containsKey("ARG_SPACE_DEFINE")).isTrue();
-    assertThat(cus.getDefines().get("ARG_SPACE_DEFINE")).isEqualTo("\" foo 'bar' zoo \"");
-    assertThat(cus.getDefines().containsKey("SIMPLE")).isTrue();
-    assertThat(cus.getDefines().get("SIMPLE")).isEqualTo("1");
+    assertThat(cus.getDefines()).containsKey("ARG_DEFINE");
+    assertThat(cus.getDefines()).containsKey("ARG_SPACE_DEFINE");
+    assertThat(cus.getDefines()).containsEntry("ARG_SPACE_DEFINE", "\" foo 'bar' zoo \"");
+    assertThat(cus.getDefines()).containsKey("SIMPLE");
+    assertThat(cus.getDefines()).containsEntry("SIMPLE", "1");
     assertThat(cus.getDefines().containsKey("GLOBAL_DEFINE")).isFalse();
-    assertThat(cus.getIncludes().contains(Paths.get("/usr/local/include"))).isTrue();
-    assertThat(cus.getIncludes().contains(Paths.get("/another/include/dir"))).isTrue();
+    assertThat(cus.getIncludes()).contains(Paths.get("/usr/local/include"));
+    assertThat(cus.getIncludes()).contains(Paths.get("/another/include/dir"));
     assertThat(cus.getIncludes().contains(Paths.get("/usr/include"))).isFalse();
   }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/CxxValgrindSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/CxxValgrindSensorTest.java
@@ -50,7 +50,7 @@ public class CxxValgrindSensorTest {
     SensorContextTester context = SensorContextTester.create(fs.baseDir());
     sensor.execute(context);
 
-    assertThat(context.allAnalysisErrors().isEmpty()).isTrue();
+    assertThat(context.allAnalysisErrors()).isEmpty();
   }
 
   @Test
@@ -77,7 +77,7 @@ public class CxxValgrindSensorTest {
     valgrindErrors.add(mockValgrindError(false));
     sensor.saveErrors(valgrindErrors);
 
-    assertThat(context.allIssues()).hasSize(0);
+    assertThat(context.allIssues()).isEmpty();
   }
 
   @Test

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/ValgrindErrorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/ValgrindErrorTest.java
@@ -63,8 +63,8 @@ public class ValgrindErrorTest {
 
   @Test
   public void errorHashWorksAsExpected() {
-    assertThat(error.hashCode() == equalError.hashCode()).isTrue();
-    assertThat(error.hashCode() != otherError.hashCode()).isTrue();
+    assertThat(error.hashCode()).isEqualTo(equalError.hashCode());
+    assertThat(error.hashCode()).isNotEqualTo(otherError.hashCode());
   }
 
   @Test

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/ValgrindFrameTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/ValgrindFrameTest.java
@@ -63,8 +63,8 @@ public class ValgrindFrameTest {
 
   @Test
   public void frameHashWorksAsExpected() {
-    assertThat(frame.hashCode() == equalFrame.hashCode()).isTrue();
-    assertThat(frame.hashCode() != otherFrame.hashCode()).isTrue();
+    assertThat(frame.hashCode()).isEqualTo(equalFrame.hashCode());
+    assertThat(frame.hashCode()).isNotEqualTo(otherFrame.hashCode());
   }
 
   @Test

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/ValgrindStackTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/ValgrindStackTest.java
@@ -73,8 +73,8 @@ public class ValgrindStackTest {
 
   @Test
   public void stackHashWorksAsExpected() {
-    assertThat(stack.hashCode() == equalStack.hashCode()).isTrue();
-    assertThat(stack.hashCode() != otherStack.hashCode()).isTrue();
+    assertThat(stack.hashCode()).isEqualTo(equalStack.hashCode());
+    assertThat(stack.hashCode()).isNotEqualTo(otherStack.hashCode());
   }
 
   @Test

--- a/cxx-squid/src/test/java/org/sonar/cxx/CxxSquidConfigurationTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/CxxSquidConfigurationTest.java
@@ -37,8 +37,8 @@ public class CxxSquidConfigurationTest {
     var squidConfig = new CxxSquidConfiguration();
     squidConfig.setCompilationPropertiesWithBuildLog(new ArrayList<>(), VC_KEY, VC_CHARSET);
     var softly = new SoftAssertions();
-    softly.assertThat(squidConfig.getIncludeDirectories().size()).isEqualTo(0);
-    softly.assertThat(squidConfig.getDefines().size()).isEqualTo(0);
+    softly.assertThat(squidConfig.getIncludeDirectories().size()).isZero();
+    softly.assertThat(squidConfig.getDefines().size()).isZero();
     softly.assertAll();
   }
 
@@ -47,8 +47,8 @@ public class CxxSquidConfigurationTest {
     var squidConfig = new CxxSquidConfiguration();
     squidConfig.setCompilationPropertiesWithBuildLog(null, VC_KEY, VC_CHARSET);
     var softly = new SoftAssertions();
-    softly.assertThat(squidConfig.getIncludeDirectories().size()).isEqualTo(0);
-    assertThat(squidConfig.getDefines().size()).isEqualTo(0);
+    softly.assertThat(squidConfig.getIncludeDirectories().size()).isZero();
+    assertThat(squidConfig.getDefines().size()).isZero();
     softly.assertAll();
   }
 
@@ -84,21 +84,21 @@ public class CxxSquidConfigurationTest {
     squidConfig.setCompilationPropertiesWithBuildLog(files, VC_KEY, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(squidConfig.getIncludeDirectories().size()).isEqualTo(0);
+    softly.assertThat(squidConfig.getIncludeDirectories().size()).isZero();
     List<String> defines = squidConfig.getDefines();
     softly.assertThat(defines.size()).isEqualTo(20 + 5);
     ValidateDefaultAsserts(softly, defines);
-    softly.assertThat(defines.contains("_OPENMP 200203")).isTrue();
-    softly.assertThat(defines.contains("_WIN32")).isTrue();
-    softly.assertThat(defines.contains("_M_IX86 600")).isTrue();
-    softly.assertThat(defines.contains("_M_IX86_FP 2")).isTrue();
-    softly.assertThat(defines.contains("_WCHAR_T_DEFINED 1")).isTrue();
-    softly.assertThat(defines.contains("_NATIVE_WCHAR_T_DEFINED 1")).isTrue();
-    softly.assertThat(defines.contains("_VC_NODEFAULTLIB")).isTrue();
-    softly.assertThat(defines.contains("_MT")).isTrue();
-    softly.assertThat(defines.contains("_DLL")).isTrue();
-    softly.assertThat(defines.contains("_DEBUG")).isTrue();
-    softly.assertThat(defines.contains("_VC_NODEFAULTLIB")).isTrue();
+    softly.assertThat(defines).contains("_OPENMP 200203");
+    softly.assertThat(defines).contains("_WIN32");
+    softly.assertThat(defines).contains("_M_IX86 600");
+    softly.assertThat(defines).contains("_M_IX86_FP 2");
+    softly.assertThat(defines).contains("_WCHAR_T_DEFINED 1");
+    softly.assertThat(defines).contains("_NATIVE_WCHAR_T_DEFINED 1");
+    softly.assertThat(defines).contains("_VC_NODEFAULTLIB");
+    softly.assertThat(defines).contains("_MT");
+    softly.assertThat(defines).contains("_DLL");
+    softly.assertThat(defines).contains("_DEBUG");
+    softly.assertThat(defines).contains("_VC_NODEFAULTLIB");
     softly.assertAll();
   }
 
@@ -109,11 +109,11 @@ public class CxxSquidConfigurationTest {
     squidConfig.setCompilationPropertiesWithBuildLog(files, VC_KEY, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(squidConfig.getIncludeDirectories().size()).isEqualTo(0);
+    softly.assertThat(squidConfig.getIncludeDirectories().size()).isZero();
     List<String> defines = squidConfig.getDefines();
     softly.assertThat(defines.size()).isEqualTo(3);
     ValidateDefaultAsserts(softly, defines);
-    softly.assertThat(defines.contains("_WIN32")).isTrue();
+    softly.assertThat(defines).contains("_WIN32");
     softly.assertAll();
   }
 
@@ -125,18 +125,18 @@ public class CxxSquidConfigurationTest {
     files.add(new File("src/test/resources/logfile/platformCommonX64.txt"));
     squidConfig.setCompilationPropertiesWithBuildLog(files, VC_KEY, VC_CHARSET);
 
-    assertThat(squidConfig.getIncludeDirectories().size()).isEqualTo(0);
+    assertThat(squidConfig.getIncludeDirectories().size()).isZero();
     List<String> defines = squidConfig.getDefines();
 
     var softly = new SoftAssertions();
     softly.assertThat(defines.size()).isEqualTo(15 + 5);
     ValidateDefaultAsserts(softly, defines);
-    softly.assertThat(defines.contains("_Wp64")).isTrue();
-    softly.assertThat(defines.contains("_WIN32")).isTrue();
-    softly.assertThat(defines.contains("_WIN64")).isTrue();
-    softly.assertThat(defines.contains("_M_X64 100")).isTrue();
+    softly.assertThat(defines).contains("_Wp64");
+    softly.assertThat(defines).contains("_WIN32");
+    softly.assertThat(defines).contains("_WIN64");
+    softly.assertThat(defines).contains("_M_X64 100");
     softly.assertThat(defines.contains("_M_IX86")).isFalse();
-    softly.assertThat(defines.contains("_M_IX86_FP 2")).isTrue();
+    softly.assertThat(defines).contains("_M_IX86_FP 2");
     softly.assertAll();
   }
 
@@ -149,14 +149,14 @@ public class CxxSquidConfigurationTest {
     squidConfig.setCompilationPropertiesWithBuildLog(files, VC_KEY, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(squidConfig.getIncludeDirectories().size()).isEqualTo(0);
+    softly.assertThat(squidConfig.getIncludeDirectories().size()).isZero();
     List<String> defines = squidConfig.getDefines();
     softly.assertThat(defines.size()).isEqualTo(12 + 6);
     ValidateDefaultAsserts(softly, defines);
-    softly.assertThat(defines.contains("_CPPUNWIND")).isTrue();
-    softly.assertThat(defines.contains("_M_IX86 600")).isTrue();
-    softly.assertThat(defines.contains("_WIN32")).isTrue();
-    softly.assertThat(defines.contains("_M_IX86_FP 2")).isTrue();
+    softly.assertThat(defines).contains("_CPPUNWIND");
+    softly.assertThat(defines).contains("_M_IX86 600");
+    softly.assertThat(defines).contains("_WIN32");
+    softly.assertThat(defines).contains("_M_IX86_FP 2");
     softly.assertAll();
   }
 
@@ -169,18 +169,18 @@ public class CxxSquidConfigurationTest {
     squidConfig.setCompilationPropertiesWithBuildLog(files, VC_KEY, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(squidConfig.getIncludeDirectories().size()).isEqualTo(0);
+    softly.assertThat(squidConfig.getIncludeDirectories().size()).isZero();
     List<String> defines = squidConfig.getDefines();
     softly.assertThat(defines.size()).isEqualTo(13 + 5);
     ValidateDefaultAsserts(softly, defines);
-    softly.assertThat(defines.contains("__cplusplus_winrt 201009")).isTrue();
-    softly.assertThat(defines.contains("_CPPUNWIND")).isTrue();
-    softly.assertThat(defines.contains("_M_IX86 600")).isTrue();
-    softly.assertThat(defines.contains("_WIN32")).isTrue();
-    softly.assertThat(defines.contains("_M_IX86_FP 2")).isTrue();
-    softly.assertThat(defines.contains("_MSC_VER 1700")).isTrue();
-    softly.assertThat(defines.contains("_MSC_FULL_VER 1700610301")).isTrue();
-    softly.assertThat(defines.contains("_ATL_VER 0x0B00")).isTrue();
+    softly.assertThat(defines).contains("__cplusplus_winrt 201009");
+    softly.assertThat(defines).contains("_CPPUNWIND");
+    softly.assertThat(defines).contains("_M_IX86 600");
+    softly.assertThat(defines).contains("_WIN32");
+    softly.assertThat(defines).contains("_M_IX86_FP 2");
+    softly.assertThat(defines).contains("_MSC_VER 1700");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 1700610301");
+    softly.assertThat(defines).contains("_ATL_VER 0x0B00");
     softly.assertAll();
   }
 
@@ -193,21 +193,21 @@ public class CxxSquidConfigurationTest {
     squidConfig.setCompilationPropertiesWithBuildLog(files, VC_KEY, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(squidConfig.getIncludeDirectories().size()).isEqualTo(0);
+    softly.assertThat(squidConfig.getIncludeDirectories().size()).isZero();
     List<String> defines = squidConfig.getDefines();
     softly.assertThat(defines.size()).isEqualTo(15 + 6);
     ValidateDefaultAsserts(softly, defines);
-    softly.assertThat(defines.contains("__AVX2__ 1")).isTrue();
-    softly.assertThat(defines.contains("__AVX__ 1")).isTrue();
-    softly.assertThat(defines.contains("__cplusplus_winrt 201009")).isTrue();
-    softly.assertThat(defines.contains("_CPPUNWIND")).isTrue();
-    softly.assertThat(defines.contains("_M_ARM_FP")).isTrue();
-    softly.assertThat(defines.contains("_WIN32")).isTrue();
-    softly.assertThat(defines.contains("_M_IX86 600")).isTrue();
-    softly.assertThat(defines.contains("_M_IX86_FP 2")).isTrue();
-    softly.assertThat(defines.contains("_MSC_VER 1800")).isTrue();
-    softly.assertThat(defines.contains("_MSC_FULL_VER 180031101")).isTrue();
-    softly.assertThat(defines.contains("_ATL_VER 0x0C00")).isTrue();
+    softly.assertThat(defines).contains("__AVX2__ 1");
+    softly.assertThat(defines).contains("__AVX__ 1");
+    softly.assertThat(defines).contains("__cplusplus_winrt 201009");
+    softly.assertThat(defines).contains("_CPPUNWIND");
+    softly.assertThat(defines).contains("_M_ARM_FP");
+    softly.assertThat(defines).contains("_WIN32");
+    softly.assertThat(defines).contains("_M_IX86 600");
+    softly.assertThat(defines).contains("_M_IX86_FP 2");
+    softly.assertThat(defines).contains("_MSC_VER 1800");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 180031101");
+    softly.assertThat(defines).contains("_ATL_VER 0x0C00");
     softly.assertAll();
   }
 
@@ -220,20 +220,20 @@ public class CxxSquidConfigurationTest {
     squidConfig.setCompilationPropertiesWithBuildLog(files, VC_KEY, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(squidConfig.getIncludeDirectories().size()).isEqualTo(0);
+    softly.assertThat(squidConfig.getIncludeDirectories().size()).isZero();
     List<String> defines = squidConfig.getDefines();
     assertThat(defines.size()).isEqualTo(15 + 6);
     ValidateDefaultAsserts(softly, defines);
-    softly.assertThat(defines.contains("__AVX2__ 1")).isTrue();
-    softly.assertThat(defines.contains("__AVX__ 1")).isTrue();
-    softly.assertThat(defines.contains("__cplusplus_winrt 201009")).isTrue();
-    softly.assertThat(defines.contains("_CPPUNWIND")).isTrue();
-    softly.assertThat(defines.contains("_M_ARM_FP")).isTrue();
-    softly.assertThat(defines.contains("_M_IX86 600")).isTrue();
-    softly.assertThat(defines.contains("_M_IX86_FP 2")).isTrue();
-    softly.assertThat(defines.contains("_MSC_VER 1900")).isTrue();
-    softly.assertThat(defines.contains("_MSC_FULL_VER 190024215")).isTrue();
-    softly.assertThat(defines.contains("_ATL_VER 0x0E00")).isTrue();
+    softly.assertThat(defines).contains("__AVX2__ 1");
+    softly.assertThat(defines).contains("__AVX__ 1");
+    softly.assertThat(defines).contains("__cplusplus_winrt 201009");
+    softly.assertThat(defines).contains("_CPPUNWIND");
+    softly.assertThat(defines).contains("_M_ARM_FP");
+    softly.assertThat(defines).contains("_M_IX86 600");
+    softly.assertThat(defines).contains("_M_IX86_FP 2");
+    softly.assertThat(defines).contains("_MSC_VER 1900");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 190024215");
+    softly.assertThat(defines).contains("_ATL_VER 0x0E00");
     softly.assertAll();
   }
 
@@ -250,12 +250,12 @@ public class CxxSquidConfigurationTest {
     List<String> defines = squidConfig.getDefines();
     assertThat(defines.size()).isEqualTo(34);
     ValidateDefaultAsserts(softly, defines);
-    softly.assertThat(defines.contains("_CPPUNWIND")).isTrue();
-    softly.assertThat(defines.contains("_M_IX86 600")).isTrue();
-    softly.assertThat(defines.contains("_M_IX86_FP 2")).isTrue();
-    softly.assertThat(defines.contains("_MSC_VER 1910")).isTrue();
-    softly.assertThat(defines.contains("_MSC_FULL_VER 191024629")).isTrue();
-    softly.assertThat(defines.contains("_ATL_VER 0x0E00")).isTrue();
+    softly.assertThat(defines).contains("_CPPUNWIND");
+    softly.assertThat(defines).contains("_M_IX86 600");
+    softly.assertThat(defines).contains("_M_IX86_FP 2");
+    softly.assertThat(defines).contains("_MSC_VER 1910");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 191024629");
+    softly.assertThat(defines).contains("_ATL_VER 0x0E00");
     softly.assertAll();
   }
 
@@ -272,12 +272,12 @@ public class CxxSquidConfigurationTest {
     List<String> defines = squidConfig.getDefines();
     assertThat(defines.size()).isEqualTo(34);
     ValidateDefaultAsserts(softly, defines);
-    softly.assertThat(defines.contains("_CPPUNWIND")).isTrue();
-    softly.assertThat(defines.contains("_M_IX86 600")).isTrue();
-    softly.assertThat(defines.contains("_M_IX86_FP 2")).isTrue();
-    softly.assertThat(defines.contains("_MSC_VER 1910")).isTrue();
-    softly.assertThat(defines.contains("_MSC_FULL_VER 191024629")).isTrue();
-    softly.assertThat(defines.contains("_ATL_VER 0x0E00")).isTrue();
+    softly.assertThat(defines).contains("_CPPUNWIND");
+    softly.assertThat(defines).contains("_M_IX86 600");
+    softly.assertThat(defines).contains("_M_IX86_FP 2");
+    softly.assertThat(defines).contains("_MSC_VER 1910");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 191024629");
+    softly.assertThat(defines).contains("_ATL_VER 0x0E00");
     softly.assertAll();
   }
 
@@ -290,16 +290,16 @@ public class CxxSquidConfigurationTest {
     squidConfig.setCompilationPropertiesWithBuildLog(files, VC_KEY, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(squidConfig.getIncludeDirectories().size()).isEqualTo(0);
+    softly.assertThat(squidConfig.getIncludeDirectories().size()).isZero();
     List<String> defines = squidConfig.getDefines();
     assertThat(defines.size()).isEqualTo(15 + 12);
     ValidateDefaultAsserts(softly, defines);
-    softly.assertThat(defines.contains("_M_IX86 600")).isTrue();
-    softly.assertThat(defines.contains("__cplusplus 199711L")).isTrue();
-    softly.assertThat(defines.contains("_MSC_VER 1910")).isTrue();
-    softly.assertThat(defines.contains("_MSC_FULL_VER 191024629")).isTrue();
+    softly.assertThat(defines).contains("_M_IX86 600");
+    softly.assertThat(defines).contains("__cplusplus 199711L");
+    softly.assertThat(defines).contains("_MSC_VER 1910");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 191024629");
     // check atldef.h for _ATL_VER
-    softly.assertThat(defines.contains("_ATL_VER 0x0E00")).isTrue();
+    softly.assertThat(defines).contains("_ATL_VER 0x0E00");
     softly.assertAll();
   }
 
@@ -312,16 +312,16 @@ public class CxxSquidConfigurationTest {
     squidConfig.setCompilationPropertiesWithBuildLog(files, VC_KEY, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(squidConfig.getIncludeDirectories().size()).isEqualTo(0);
+    softly.assertThat(squidConfig.getIncludeDirectories().size()).isZero();
     List<String> defines = squidConfig.getDefines();
     assertThat(defines.size()).isEqualTo(15 + 14);
     ValidateDefaultAsserts(softly, defines);
     softly.assertThat(defines.contains("_M_IX86 600")).isFalse();
-    softly.assertThat(defines.contains("__cplusplus 199711L")).isTrue();
-    softly.assertThat(defines.contains("_MSC_VER 1910")).isTrue();
-    softly.assertThat(defines.contains("_MSC_FULL_VER 191024629")).isTrue();
+    softly.assertThat(defines).contains("__cplusplus 199711L");
+    softly.assertThat(defines).contains("_MSC_VER 1910");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 191024629");
     // check atldef.h for _ATL_VER
-    softly.assertThat(defines.contains("_ATL_VER 0x0E00")).isTrue();
+    softly.assertThat(defines).contains("_ATL_VER 0x0E00");
     softly.assertAll();
   }
 
@@ -355,14 +355,14 @@ public class CxxSquidConfigurationTest {
   }
 
   private void ValidateDefaultAsserts(SoftAssertions softly, List<String> defines) {
-    softly.assertThat(defines.contains("_INTEGRAL_MAX_BITS 64")).isTrue();
-    softly.assertThat(defines.contains("_MSC_BUILD 1")).isTrue();
-    softly.assertThat(defines.contains("__COUNTER__ 0")).isTrue();
-    softly.assertThat(defines.contains("__DATE__ \"??? ?? ????\"")).isTrue();
-    softly.assertThat(defines.contains("__FILE__ \"file\"")).isTrue();
-    softly.assertThat(defines.contains("__LINE__ 1")).isTrue();
-    softly.assertThat(defines.contains("__TIME__ \"??:??:??\"")).isTrue();
-    softly.assertThat(defines.contains("__TIMESTAMP__ \"??? ?? ???? ??:??:??\"")).isTrue();
+    softly.assertThat(defines).contains("_INTEGRAL_MAX_BITS 64");
+    softly.assertThat(defines).contains("_MSC_BUILD 1");
+    softly.assertThat(defines).contains("__COUNTER__ 0");
+    softly.assertThat(defines).contains("__DATE__ \"??? ?? ????\"");
+    softly.assertThat(defines).contains("__FILE__ \"file\"");
+    softly.assertThat(defines).contains("__LINE__ 1");
+    softly.assertThat(defines).contains("__TIME__ \"??:??:??\"");
+    softly.assertThat(defines).contains("__TIMESTAMP__ \"??? ?? ???? ??:??:??\"");
     softly.assertAll();
   }
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppLexerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppLexerTest.java
@@ -24,7 +24,7 @@ import com.sonar.sslr.api.Token;
 import com.sonar.sslr.impl.Lexer;
 import static com.sonar.sslr.test.lexer.LexerMatchers.hasToken;
 import java.util.List;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 import org.sonar.cxx.api.CppKeyword;
 import org.sonar.cxx.api.CppPunctuator;
@@ -35,45 +35,46 @@ public class CppLexerTest {
 
   @Test
   public void cpp_keywords() {
-    assertThat(LEXER.lex("#define"), hasToken("#define", CppKeyword.DEFINE));
-    assertThat(LEXER.lex("#include"), hasToken("#include", CppKeyword.INCLUDE));
+    assertThat(LEXER.lex("#define").contains(hasToken("#define", CppKeyword.DEFINE)));
+    assertThat(LEXER.lex("#define").contains(hasToken("#define", CppKeyword.DEFINE)));
+    assertThat(LEXER.lex("#include").contains(hasToken("#include", CppKeyword.INCLUDE)));
   }
 
   @Test
   public void cpp_keywords_with_whitespaces() {
-    assertThat(LEXER.lex("#  define"), hasToken("#define", CppKeyword.DEFINE));
-    assertThat(LEXER.lex("#\tinclude"), hasToken("#include", CppKeyword.INCLUDE));
+    assertThat(LEXER.lex("#  define").contains(hasToken("#define", CppKeyword.DEFINE)));
+    assertThat(LEXER.lex("#\tinclude").contains(hasToken("#include", CppKeyword.INCLUDE)));
   }
 
   @Test
   public void cpp_keywords_indented() {
-    assertThat(LEXER.lex(" #define"), hasToken("#define", CppKeyword.DEFINE));
-    assertThat(LEXER.lex("\t#define"), hasToken("#define", CppKeyword.DEFINE));
+    assertThat(LEXER.lex(" #define").contains(hasToken("#define", CppKeyword.DEFINE)));
+    assertThat(LEXER.lex("\t#define").contains(hasToken("#define", CppKeyword.DEFINE)));
   }
 
   @Test
   public void cpp_identifiers() {
-    assertThat(LEXER.lex("lala"), hasToken("lala", IDENTIFIER));
+    assertThat(LEXER.lex("lala").contains(hasToken("lala", IDENTIFIER)));
   }
 
   @Test
   public void cpp_operators() {
-    assertThat(LEXER.lex("#"), hasToken("#", CppPunctuator.HASH));
-    assertThat(LEXER.lex("##"), hasToken("##", CppPunctuator.HASHHASH));
+    assertThat(LEXER.lex("#").contains(hasToken("#", CppPunctuator.HASH)));
+    assertThat(LEXER.lex("##").contains(hasToken("##", CppPunctuator.HASHHASH)));
   }
 
   @Test
   public void hashhash_followed_by_word() {
     List<Token> tokens = LEXER.lex("##a");
-    assertThat(tokens, hasToken("##", CppPunctuator.HASHHASH));
-    assertThat(tokens, hasToken("a", IDENTIFIER));
+    assertThat(tokens.contains(hasToken("##", CppPunctuator.HASHHASH)));
+    assertThat(tokens.contains(hasToken("a", IDENTIFIER)));
   }
 
   @Test
   public void hash_followed_by_word() {
     List<Token> tokens = LEXER.lex("#a");
-    assertThat(tokens, hasToken("#", CppPunctuator.HASH));
-    assertThat(tokens, hasToken("a", IDENTIFIER));
+    assertThat(tokens.contains(hasToken("#", CppPunctuator.HASH)));
+    assertThat(tokens.contains(hasToken("a", IDENTIFIER)));
   }
 
 }

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/IncludeLexerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/IncludeLexerTest.java
@@ -25,7 +25,6 @@ import com.sonar.sslr.impl.Lexer;
 import static com.sonar.sslr.test.lexer.LexerMatchers.hasToken;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.sonar.cxx.api.CxxTokenType;
 
@@ -35,15 +34,15 @@ public class IncludeLexerTest {
 
   @Test
   public void proper_preprocessor_directives_are_created() {
-    assertThat(LEXER.lex("#include <iostream>"), hasToken("#include <iostream>", CxxTokenType.PREPROCESSOR));
-    assertThat(LEXER.lex("#define lala"), hasToken("#define lala", CxxTokenType.PREPROCESSOR));
-    assertThat(LEXER.lex("#ifdef lala"), hasToken("#ifdef lala", CxxTokenType.PREPROCESSOR));
+    assertThat(LEXER.lex("#include <iostream>").contains(hasToken("#include <iostream>", CxxTokenType.PREPROCESSOR)));
+    assertThat(LEXER.lex("#define lala").contains(hasToken("#define lala", CxxTokenType.PREPROCESSOR)));
+    assertThat(LEXER.lex("#ifdef lala").contains(hasToken("#ifdef lala", CxxTokenType.PREPROCESSOR)));
   }
 
   @Test
   public void continued_lines_are_handled_correctly() {
     List<Token> tokens = LEXER.lex("#define\\\nname");
-    assertThat(tokens, hasToken("#define name", CxxTokenType.PREPROCESSOR));
+    assertThat(tokens.contains(hasToken("#define name", CxxTokenType.PREPROCESSOR)));
     assertThat(tokens).hasSize(2);
   }
 
@@ -51,14 +50,14 @@ public class IncludeLexerTest {
   public void multiline_comment_with_Include_is_swallowed() {
     List<Token> tokens = LEXER.lex("/* This is a multiline comment\n   #include should be swallowed\n */");
     assertThat(tokens).hasSize(1);
-    assertThat(tokens, hasToken("EOF", EOF));
+    assertThat(tokens.contains(hasToken("EOF", EOF)));
   }
 
   @Test
   public void singleline_comment_with_Include_is_swallowed() {
     List<Token> tokens = LEXER.lex("// #include should be swallowed\n");
     assertThat(tokens).hasSize(1);
-    assertThat(tokens, hasToken("EOF", EOF));
+    assertThat(tokens.contains(hasToken("EOF", EOF)));
   }
 
   @Test
@@ -67,7 +66,7 @@ public class IncludeLexerTest {
     // generating any tokens
     List<Token> tokens = LEXER.lex("void foo();");
     assertThat(tokens).hasSize(1);
-    assertThat(tokens, hasToken("EOF", EOF));
+    assertThat(tokens.contains(hasToken("EOF", EOF)));
   }
 
 }

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxFunctionComplexityVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxFunctionComplexityVisitorTest.java
@@ -54,8 +54,8 @@ public class CxxFunctionComplexityVisitorTest {
     SourceFile file = CxxAstScanner.scanSingleFile(tester.asFile());
 
     var softly = new SoftAssertions();
-    softly.assertThat(file.getInt(CxxMetric.COMPLEX_FUNCTIONS)).isEqualTo(0);
-    softly.assertThat(file.getInt(CxxMetric.COMPLEX_FUNCTIONS_LOC)).isEqualTo(0);
+    softly.assertThat(file.getInt(CxxMetric.COMPLEX_FUNCTIONS)).isZero();
+    softly.assertThat(file.getInt(CxxMetric.COMPLEX_FUNCTIONS_LOC)).isZero();
     softly.assertAll();
   }
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxFunctionSizeVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxFunctionSizeVisitorTest.java
@@ -54,8 +54,8 @@ public class CxxFunctionSizeVisitorTest {
     SourceFile file = CxxAstScanner.scanSingleFile(tester.asFile());
 
     var softly = new SoftAssertions();
-    softly.assertThat(file.getInt(CxxMetric.BIG_FUNCTIONS)).isEqualTo(0);
-    softly.assertThat(file.getInt(CxxMetric.BIG_FUNCTIONS_LOC)).isEqualTo(0);
+    softly.assertThat(file.getInt(CxxMetric.BIG_FUNCTIONS)).isZero();
+    softly.assertThat(file.getInt(CxxMetric.BIG_FUNCTIONS_LOC)).isZero();
     softly.assertAll();
   }
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
@@ -61,8 +61,8 @@ public class CxxPublicApiVisitorTest {
 
     SourceFile file = CxxAstScanner.scanSingleFileConfig(tester.asFile(), squidConfig);
 
-    assertThat(file.getInt(CxxMetric.PUBLIC_API)).isEqualTo(0);
-    assertThat(file.getInt(CxxMetric.PUBLIC_UNDOCUMENTED_API)).isEqualTo(0);
+    assertThat(file.getInt(CxxMetric.PUBLIC_API)).isZero();
+    assertThat(file.getInt(CxxMetric.PUBLIC_UNDOCUMENTED_API)).isZero();
   }
 
   @Test

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxChecksTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxChecksTest.java
@@ -95,7 +95,7 @@ public class CxxChecksTest {
   public void shouldWorkWithoutCustomChecks() {
     CxxChecks checks = CxxChecks.createCxxCheck(checkFactory);
     checks.addCustomChecks(null);
-    assertThat(checks.all()).hasSize(0);
+    assertThat(checks.all()).isEmpty();
   }
 
   @SuppressWarnings("rawtypes")

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxSonarWayProfileTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxSonarWayProfileTest.java
@@ -35,7 +35,7 @@ public class CxxSonarWayProfileTest {
     assertThat(profile.language()).isEqualTo(CxxLanguage.KEY);
     assertThat(profile.name()).isEqualTo("Sonar way");
     List<BuiltInQualityProfilesDefinition.BuiltInActiveRule> activeRules = profile.rules();
-    assertThat(activeRules.size()).as("Expected number of rules in profile").isGreaterThanOrEqualTo(0);
+    assertThat(activeRules.size()).as("Expected number of rules in profile").isNotNegative();
   }
 
 }

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxSquidSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxSquidSensorTest.java
@@ -71,7 +71,7 @@ public class CxxSquidSensorTest {
     softly.assertThat(context.measure(inputFile0.key(), CoreMetrics.NCLOC).value()).isEqualTo(54);
     softly.assertThat(context.measure(inputFile0.key(), CoreMetrics.STATEMENTS).value()).isEqualTo(50);
     softly.assertThat(context.measure(inputFile0.key(), CoreMetrics.FUNCTIONS).value()).isEqualTo(7);
-    softly.assertThat(context.measure(inputFile0.key(), CoreMetrics.CLASSES).value()).isEqualTo(0);
+    softly.assertThat(context.measure(inputFile0.key(), CoreMetrics.CLASSES).value()).isZero();
     softly.assertThat(context.measure(inputFile0.key(), CoreMetrics.COMPLEXITY).value()).isEqualTo(19);
     softly.assertThat(context.measure(inputFile0.key(), CoreMetrics.COGNITIVE_COMPLEXITY).value()).isEqualTo(8);
     softly.assertThat(context.measure(inputFile0.key(), CoreMetrics.COMMENT_LINES).value()).isEqualTo(15);
@@ -184,8 +184,8 @@ public class CxxSquidSensorTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(context.measure(inputFile.key(), CoreMetrics.NCLOC).value()).isEqualTo(1);
-    softly.assertThat(context.measure(inputFile.key(), CoreMetrics.STATEMENTS).value()).isEqualTo(0);
-    softly.assertThat(context.measure(inputFile.key(), CoreMetrics.FUNCTIONS).value()).isEqualTo(0);
+    softly.assertThat(context.measure(inputFile.key(), CoreMetrics.STATEMENTS).value()).isZero();
+    softly.assertThat(context.measure(inputFile.key(), CoreMetrics.FUNCTIONS).value()).isZero();
     softly.assertThat(context.measure(inputFile.key(), CoreMetrics.CLASSES).value()).isEqualTo(1);
     softly.assertAll();
   }
@@ -203,9 +203,9 @@ public class CxxSquidSensorTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(context.measure(inputFile.key(), CoreMetrics.NCLOC).value()).isEqualTo(9);
-    softly.assertThat(context.measure(inputFile.key(), CoreMetrics.STATEMENTS).value()).isEqualTo(0);
+    softly.assertThat(context.measure(inputFile.key(), CoreMetrics.STATEMENTS).value()).isZero();
     softly.assertThat(context.measure(inputFile.key(), CoreMetrics.FUNCTIONS).value()).isEqualTo(9);
-    softly.assertThat(context.measure(inputFile.key(), CoreMetrics.CLASSES).value()).isEqualTo(0);
+    softly.assertThat(context.measure(inputFile.key(), CoreMetrics.CLASSES).value()).isZero();
     softly.assertAll();
 
   }
@@ -227,7 +227,7 @@ public class CxxSquidSensorTest {
     softly.assertThat(context.measure(inputFile.key(), CoreMetrics.NCLOC).value()).isEqualTo(1);
     softly.assertThat(context.measure(inputFile.key(), CoreMetrics.STATEMENTS).value()).isEqualTo(2);
     softly.assertThat(context.measure(inputFile.key(), CoreMetrics.FUNCTIONS).value()).isEqualTo(1);
-    softly.assertThat(context.measure(inputFile.key(), CoreMetrics.CLASSES).value()).isEqualTo(0);
+    softly.assertThat(context.measure(inputFile.key(), CoreMetrics.CLASSES).value()).isZero();
     softly.assertAll();
   }
 


### PR DESCRIPTION
- reduce technical debt
- containsEntry, containsKey, contains, isEmpty, isZero
- remove deprecated ExpectedException.none()
- remove deprecated org.junit.Assert.assertThat

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1958)
<!-- Reviewable:end -->
