### PR TITLE
support `block` elements of BullsEye covxml 8.20.0 version

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/bullseye/BullseyeParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/bullseye/BullseyeParser.java
@@ -158,7 +158,7 @@ public class BullseyeParser implements CoverageParser {
   }
 
   private void funcWalk(SMInputCursor func, CoverageMeasures fileMeasuresBuilderIn) throws XMLStreamException {
-    SMInputCursor prob = func.childElementCursor();
+    SMInputCursor prob = func.childElementCursor("probe");
     while (prob.getNext() != null) {
       probWalk(prob, fileMeasuresBuilderIn);
     }
@@ -166,7 +166,7 @@ public class BullseyeParser implements CoverageParser {
   }
 
   private void fileWalk(SMInputCursor file, CoverageMeasures fileMeasuresBuilderIn) throws XMLStreamException {
-    SMInputCursor func = file.childElementCursor();
+    SMInputCursor func = file.childElementCursor("fn");
     while (func.getNext() != null) {
       funcWalk(func, fileMeasuresBuilderIn);
     }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxBullseyeCoverageSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxBullseyeCoverageSensorTest.java
@@ -233,4 +233,36 @@ public class CxxBullseyeCoverageSensorTest {
     }
   }
 
+  @Test
+  public void shouldIgnoreBlocks() {
+
+    // report contains a block tag => ignore
+    String coverageReport = "coverage-reports/bullseye/bullseye-coverage-Windows-V8.20.2.xml";
+    SensorContextTester context = SensorContextTester.create(fs.baseDir());
+
+    if (TestUtils.isWindows()) {
+      settings.setProperty(CxxCoverageBullseyeSensor.REPORT_PATH_KEY, coverageReport);
+      context.setSettings(settings);
+
+      context.fileSystem().add(TestInputFileBuilder.create("ProjectKey", "root/folder/test.cpp")
+        .setLanguage("cxx")
+        .initMetadata(
+          "namespace Core {\n"
+            + "    class TokenHandler {\n"
+            + "    public:\n"
+            + "        virtual ~TokenHandler() {}\n"
+            + "        virtual void OnHandle() = 0;\n"
+            + "    };\n"
+            + "}\n"
+        )
+        .build()
+      );
+
+      var sensor = new CxxCoverageBullseyeSensor();
+      sensor.execute(context);
+
+      assertThat(context.lineHits("ProjectKey:root/folder/test.cpp", 3)).isEqualTo(1);
+    }
+  }
+
 }

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/coverage-reports/bullseye/bullseye-coverage-Windows-V8.20.2.xml
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/coverage-reports/bullseye/bullseye-coverage-Windows-V8.20.2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- BullseyeCoverage XML 8.20.2 Windows x64 -->
+<BullseyeCoverage name="coverage.cov" dir="root" buildId="745ae38_2020-11-09_19:52:34" version="6" xmlns="https://www.bullseye.com/covxml"
+                  fn_cov="1" fn_total="1" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+  <folder name="folder" fn_cov="1" fn_total="1" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+    <src name="test.cpp" mtime="1604936026" fn_cov="1" fn_total="1" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+      <fn name="Core::TokenHandler::~TokenHandler()" fn_cov="1" fn_total="1" cd_cov="0" cd_total="0" d_cov="0" d_total="0">
+        <probe line="3" column="7" kind="function" event="full"/>
+        <block line="3" entered="1"/>
+      </fn>
+    </src>
+  </folder>
+</BullseyeCoverage>


### PR DESCRIPTION
- https://www.bullseye.com/help/ref-covxml.html
  - File Version: 6, Software Version: 8.20.0, Date: Oct 2020, Change: Add block element
- XML parser supports block tag
- ignore data of block tag
- close #1977

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1978)
<!-- Reviewable:end -->
