### PR TITLE
extern "C" { ... } public api detection

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
@@ -510,7 +510,12 @@ public abstract class AbstractCxxPublicApiVisitor<G extends Grammar> extends Squ
       AstNode linkageSpecification = declaration
         .getFirstAncestor(CxxGrammarImpl.linkageSpecification);
       if (linkageSpecification != null) {
-        docNode = linkageSpecification; // extern "C" ...
+        if( linkageSpecification.hasDirectChildren(CxxPunctuator.CURLBR_LEFT)) {
+          docNode = declaration; // extern "C" { ... }
+        }
+        else {
+          docNode = linkageSpecification; // extern "C" ...
+        }
       } else {
         docNode = declaration;
       }

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
@@ -73,7 +73,7 @@ public class CxxPublicApiVisitorTest {
 
   @Test
   public void to_delete() throws IOException {
-    assertThat(testFile("src/test/resources/metrics/public_api.h")).isEqualTo(tuple(44, 0));
+    assertThat(testFile("src/test/resources/metrics/public_api.h")).isEqualTo(tuple(47, 0));
 
   }
 
@@ -162,7 +162,10 @@ public class CxxPublicApiVisitorTest {
 //        expectedIdCommentMap.put("operator=", "operator=");
     expectedIdCommentMap.put("testUnnamedStructVar", "testUnnamedStructVar");
     expectedIdCommentMap.put("globalFuncDef", "globalFuncDef");
-    expectedIdCommentMap.put("linkageSpecification", "linkageSpecification");
+    expectedIdCommentMap.put("linkageSpecification1", "linkageSpecification1");
+    expectedIdCommentMap.put("linkageSpecification2", "linkageSpecification2");
+    expectedIdCommentMap.put("linkageSpecification3", "linkageSpecification3");
+    expectedIdCommentMap.put("linkageSpecification4", "linkageSpecification4");
 
     // check completeness
     for (var id : expectedIdCommentMap.keySet()) {

--- a/cxx-squid/src/test/resources/metrics/public_api.h
+++ b/cxx-squid/src/test/resources/metrics/public_api.h
@@ -29,11 +29,11 @@ public:
      */
     int publicAttribute;
 
-    int inlineCommentedAttr; //!< inlineCommentedAttr comment 
+    int inlineCommentedAttr; //!< inlineCommentedAttr comment
 
     void inlinePublicMethod(); //!< inlinePublicMethod comment
 
-    int attr1, //!< attr1 doc 
+    int attr1, //!< attr1 doc
         attr2; ///< attr2 doc
 
     // ignore friend declaration
@@ -71,7 +71,7 @@ protected:
      */
     struct protectedStruct {
         int protectedStructField; ///< protectedStructField doc
-        int protectedStructField2; ///< protectedStructField2 doc  
+        int protectedStructField2; ///< protectedStructField2 doc
     };
 
     /*!
@@ -139,7 +139,7 @@ private:
  */
 extern int globalVar;
 
-int globalVarInline; //!< globalVarInline doc 
+int globalVarInline; //!< globalVarInline doc
 
 int
 /**
@@ -203,7 +203,28 @@ void globalFuncDef() {}
 #define sint32 unsigned int
 #define bool char
 /**
- * linkageSpecification doc.
+ * linkageSpecification1 doc.
  * @return value doc
  */
-EXTERN_C EXPORT sint32 CALLCONV linkageSpecification(byte* params);
+EXTERN_C EXPORT sint32 CALLCONV linkageSpecification1(byte* params);
+
+extern "C" {
+
+   /**
+    * linkageSpecification2 doc.
+    */
+   extern void linkageSpecification2();
+}
+
+extern "C" {
+
+   /**
+    * linkageSpecification3 doc.
+    */
+   extern void linkageSpecification3();
+
+   /**
+    * linkageSpecification4 doc.
+    */
+   extern void linkageSpecification4();
+}


### PR DESCRIPTION
- support linkage specification extern "C" { ... }
- detect api documentation in function declarations inside extern "C" block
- close #1979

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1982)
<!-- Reviewable:end -->
