### PR TITLE
preprocessor refactoring

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/MapChain.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/MapChain.java
@@ -32,11 +32,8 @@ import java.util.Map;
  */
 public class MapChain<K, V> {
 
-  private final Map<K, V> highPrioMap = new HashMap<>();
-  private final Map<K, V> lowPrioMap = new HashMap<>();
-  private final Map<K, V> highPrioDisabled = new HashMap<>();
-  private final Map<K, V> lowPrioDisabled = new HashMap<>();
-  private boolean isHighPrioEnabled = false;
+  private final Map<K, V> enabled = new HashMap<>();
+  private final Map<K, V> disabled = new HashMap<>();
 
   /**
    * get
@@ -45,12 +42,7 @@ public class MapChain<K, V> {
    * @return V
    */
   public V get(Object key) {
-    V value = highPrioMap.get(key);
-    return value != null ? value : lowPrioMap.get(key);
-  }
-
-  public void setHighPrio(boolean value) {
-    isHighPrioEnabled = value;
+    return enabled.get(key);
   }
 
   /**
@@ -61,37 +53,29 @@ public class MapChain<K, V> {
    * @return V
    */
   public V put(K key, V value) {
-    if (isHighPrioEnabled) {
-      return highPrioMap.put(key, value);
-    } else {
-      return lowPrioMap.put(key, value);
-    }
+    return enabled.put(key, value);
   }
 
   public void putAll(Map<K, V> m) {
-    if (isHighPrioEnabled) {
-      highPrioMap.putAll(m);
-    } else {
-      lowPrioMap.putAll(m);
-    }
+    enabled.putAll(m);
   }
 
   /**
-   * removeLowPrio
+   * remove
    *
    * @param key
    * @return V
    */
-  public V removeLowPrio(K key) {
-    return lowPrioMap.remove(key);
+  public V remove(K key) {
+    return enabled.remove(key);
   }
 
   /**
-   * clearLowPrio
+   * clear
    */
-  public void clearLowPrio() {
-    lowPrioMap.clear();
-    lowPrioDisabled.clear();
+  public void clear() {
+    enabled.clear();
+    disabled.clear();
   }
 
   /**
@@ -100,8 +84,7 @@ public class MapChain<K, V> {
    * @param key
    */
   public void disable(K key) {
-    move(key, lowPrioMap, lowPrioDisabled);
-    move(key, highPrioMap, highPrioDisabled);
+    move(key, enabled, disabled);
   }
 
   /**
@@ -110,12 +93,11 @@ public class MapChain<K, V> {
    * @param key
    */
   public void enable(K key) {
-    move(key, lowPrioDisabled, lowPrioMap);
-    move(key, highPrioDisabled, highPrioMap);
+    move(key, disabled, enabled);
   }
 
-  public Map<K, V> getHighPrioMap() {
-    return Collections.unmodifiableMap(highPrioMap);
+  public Map<K, V> getMap() {
+    return Collections.unmodifiableMap(enabled);
   }
 
   private void move(K key, Map<K, V> from, Map<K, V> to) {

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/SourceCodeProvider.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/SourceCodeProvider.java
@@ -26,9 +26,11 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
@@ -40,7 +42,13 @@ import org.sonar.api.utils.log.Loggers;
 public class SourceCodeProvider {
 
   private static final Logger LOG = Loggers.get(SourceCodeProvider.class);
+
   private final List<Path> includeRoots = new LinkedList<>();
+  private final Deque<State> ppState = new LinkedList<>();
+
+  public SourceCodeProvider() {
+    pushFileState(null);
+  }
 
   public void setIncludeRoots(List<String> roots, String baseDir) {
     for (var root : roots) {
@@ -63,38 +71,92 @@ public class SourceCodeProvider {
     }
   }
 
+  public void pushFileState(File currentFile) {
+    ppState.push(new State(currentFile));
+  }
+
+  public void popFileState() {
+    ppState.pop();
+  }
+
+  public void skipBlock(boolean state) {
+    ppState.peek().skipBlock = state;
+  }
+
+  public boolean doSkipBlock() {
+    return ppState.peek().skipBlock;
+  }
+
+  public boolean doNotSkipBlock() {
+    return !ppState.peek().skipBlock;
+  }
+
+  public void expressionWas(boolean state) {
+    ppState.peek().expression = state;
+  }
+
+  public boolean expressionWasTrue() {
+    return ppState.peek().expression;
+  }
+
+  public boolean expressionWasFalse() {
+    return !ppState.peek().expression;
+  }
+
+  public void nestedBlock(int dir) {
+    ppState.peek().nestedBlock += dir;
+  }
+
+  public boolean isNestedBlock() {
+    return ppState.peek().nestedBlock > 0;
+  }
+
+  public boolean isNotNestedBlock() {
+    return ppState.peek().nestedBlock <= 0;
+  }
+
+  public File getIncludeUnderAnalysis() {
+    return ppState.peek().includeUnderAnalysis;
+  }
+
   @CheckForNull
   public File getSourceCodeFile(String filename, String cwd, boolean quoted) {
     File result = null;
     var file = new File(filename);
 
-    // If the file name is fully specified for an include file that has a path that
-    // includes a colon (for example, F:\MSVC\SPECIAL\INCL\TEST.H), the preprocessor
-    // follows the path.
+    // If the file name is fully specified for an include file that has a path that includes a colon
+    // (for example F:\MSVC\SPECIAL\INCL\TEST.H) the preprocessor follows the path.
     if (file.isAbsolute()) {
       if (file.isFile()) {
         result = file;
       }
     } else {
       if (quoted) {
-
         // Quoted form: The preprocessor searches for include files in this order:
-        // 1) In the same directory as the file that contains the #include statement.
-        // 2) In the directories of the currently opened include files, in the reverse
-        // order in which they were opened. The search begins in the directory of the parent
-        // include file and continues upward through the directories of any grandparent include files.
         var abspath = new File(new File(cwd), file.getPath());
         if (abspath.isFile()) {
+          // 1) In the same directory as the file that contains the #include statement.
           result = abspath;
         } else {
-          // fall back to use include paths instead of local folder
-          result = null;
+          result = null; // 3) fallback to use include paths instead of local folder
+
+          // 2) In the directories of the currently opened include files, in the reverse order in which they were opened.
+          //    The search begins in the directory of the parent include file and continues upward through the
+          //    directories of any grandparent include files.
+          for (var parent : ppState) {
+            if (parent.includeUnderAnalysis != null) {
+              abspath = new File(parent.includeUnderAnalysis.getParentFile(), file.getPath());
+              if (abspath.exists()) {
+                result = abspath;
+                break;
+              }
+            }
+          }
         }
       }
 
       // Angle-bracket form: lookup relative to to the include roots.
-      // The quoted case falls back to this, if its special handling wasn't
-      // successful.
+      // The quoted case falls back to this, if its special handling wasn't successful.
       if (result == null) {
         for (var path : includeRoots) {
           Path abspath = path.resolve(filename);
@@ -120,6 +182,22 @@ public class SourceCodeProvider {
   public String getSourceCode(File file, Charset charset) throws IOException {
     byte[] encoded = Files.readAllBytes(Paths.get(file.getAbsolutePath()));
     return new String(encoded, charset);
+  }
+
+  private static class State {
+
+    private boolean skipBlock;
+    private boolean expression;
+    private int nestedBlock;
+    private File includeUnderAnalysis;
+
+    public State(@Nullable File includeUnderAnalysis) {
+      this.skipBlock = false;
+      this.expression = false;
+      this.nestedBlock = 0;
+      this.includeUnderAnalysis = includeUnderAnalysis;
+    }
+
   }
 
 }

--- a/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerIncludeTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerIncludeTest.java
@@ -1,0 +1,171 @@
+/*
+ * Sonar C++ Plugin (Community)
+ * Copyright (C) 2010-2020 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.lexer;
+
+import com.sonar.sslr.api.Grammar;
+import com.sonar.sslr.api.Token;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.sonar.cxx.config.CxxSquidConfiguration;
+import org.sonar.cxx.preprocessor.CxxPreprocessor;
+import org.sonar.cxx.preprocessor.JoinStringsPreprocessor;
+import org.sonar.cxx.utils.TestUtils;
+import org.sonar.squidbridge.SquidAstVisitorContext;
+
+public class CxxLexerIncludeTest {
+
+  @Test
+  public void quoted_include_without_IncludeDirectories() {
+    // Quoted form / preprocessor include file search order:
+    // 1) In the same directory as the file that contains the #include statement.
+
+    String result = tryInclude("\"a.h\"", "INCLUDE", absolute(""), null);
+    assertThat(result).isEqualTo("\"using: include/a.h\"");
+  }
+
+  @Test
+  public void quoted_include_with_IncludeDirectories1() {
+    // Quoted form / preprocessor include file search order:
+    // 1) In the same directory as the file that contains the #include statement.
+
+    String result = tryInclude("\"a.h\"", "INCLUDE", absolute("B", "C"), null);
+    assertThat(result).isEqualTo("\"using: include/a.h\"");
+  }
+
+  @Test
+  public void quoted_include_with_IncludeDirectories2() {
+    // Quoted form / preprocessor include file search order:
+    // 2) In the directories of the currently opened include files, in the reverse order in which they were opened.
+    // The search begins in the directory of the parent include file and continues upward through the directories of
+    // any grandparent include files.
+
+    String result = tryInclude("\"p.h\"", "INCLUDE", absolute(""), null);
+    assertThat(result).isEqualTo("\"using: include/a.h\"");
+  }
+
+  @Test
+  public void quoted_include_with_IncludeDirectories3a() {
+    // Quoted form / preprocessor include file search order:
+    // 3) Along the path that's specified by each /I compiler option.
+
+    String result = tryInclude("\"b.h\"", "INCLUDE", absolute("B", "C"), null);
+    assertThat(result).isEqualTo("\"using: include/B/b.h\"");
+  }
+
+  @Test
+  public void quoted_include_with_IncludeDirectories3b() {
+    // Quoted form / preprocessor include file search order:
+    // 3) Along the path that's specified by each /I compiler option.
+
+    String result = tryInclude("\"c.h\"", "INCLUDE", absolute("B", "C"), null);
+    assertThat(result).isEqualTo("\"using: include/C/c.h\"");
+  }
+
+  @Test
+  public void bracket_include_without_IncludeDirectories() {
+    // Angle-bracket form / preprocessor include file search order:
+    // 1) Along the path that's specified by each /I compiler option (IncludeDirectories).
+
+    String result = tryInclude("<a.h>", "INCLUDE", absolute(""), null);
+    assertThat(result).isEqualTo("INCLUDE"); // should not find the include
+  }
+
+  @Test
+  public void bracket_include_with_IncludeDirectories1a() {
+    // Angle-bracket form / preprocessor include file search order:
+    // 1) Along the path that's specified by each /I compiler option (IncludeDirectories).
+
+    String result = tryInclude("<a.h>", "INCLUDE", absolute("."), null);
+    assertThat(result).isEqualTo("\"using: include/a.h\"");
+  }
+
+  @Test
+  public void bracket_include_with_IncludeDirectories1b() {
+    // Angle-bracket form / preprocessor include file search order:
+    // 1) Along the path that's specified by each /I compiler option (IncludeDirectories).
+
+    String result = tryInclude("<b.h>", "INCLUDE", absolute("B", "C"), null);
+    assertThat(result).isEqualTo("\"using: include/B/b.h\"");
+  }
+
+  @Test
+  public void bracket_include_with_IncludeDirectories1c() {
+    // Angle-bracket form / preprocessor include file search order:
+    // 1) Along the path that's specified by each /I compiler option (IncludeDirectories).
+
+    String result = tryInclude("<a.h>", "INCLUDE", absolute("B", "C"), null);
+    assertThat(result).isEqualTo("\"using: include/B/a.h\"");
+  }
+
+  @Test
+  public void compilation_database_settings_propagated() {
+    // test: are compilation database settings propagated in case of nested includes
+
+    List<String> defines = Arrays.asList("GLOBAL 1");
+    String result = tryInclude("\"p.h\"", "PROPAGATED", absolute(""), defines);
+    assertThat(result).isEqualTo("\"propagated\"");
+  }
+
+  private File root() {
+    return TestUtils.loadResource("/preprocessor/include");
+  }
+
+  private List<String> absolute(String... path) {
+    var result = new ArrayList<String>();
+    for (String item : path) {
+      if (!item.isBlank()) {
+        result.add(new File(root(), item).getAbsolutePath());
+      }
+    }
+    return result;
+  }
+
+  private String tryInclude(String include, String macro,
+                            @Nullable List<String> includeDirectories,
+                            @Nullable List<String> defines) {
+    var squidConfig = new CxxSquidConfiguration();
+    if (includeDirectories != null) {
+      squidConfig.add(CxxSquidConfiguration.SONAR_PROJECT_PROPERTIES, CxxSquidConfiguration.INCLUDE_DIRECTORIES,
+                      includeDirectories);
+    }
+    if (defines != null) {
+      squidConfig.add(CxxSquidConfiguration.SONAR_PROJECT_PROPERTIES, CxxSquidConfiguration.DEFINES,
+                      defines);
+    }
+
+    var file = new File(root(), "root.cpp");
+    SquidAstVisitorContext<Grammar> context = mock(SquidAstVisitorContext.class);
+    when(context.getFile()).thenReturn(file);
+
+    var pp = new CxxPreprocessor(context, squidConfig);
+    var lexer = CxxLexer.create(squidConfig, pp, new JoinStringsPreprocessor());
+
+    String fileContent = "#include " + include + "\n" + macro;
+    List<Token> tokens = lexer.lex(fileContent);
+    return tokens.get(0).getValue();
+  }
+}

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/ExpressionEvaluatorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/ExpressionEvaluatorTest.java
@@ -19,6 +19,8 @@
  */
 package org.sonar.cxx.preprocessor;
 
+import com.sonar.sslr.api.Grammar;
+import java.io.File;
 import java.math.BigInteger;
 import org.assertj.core.api.SoftAssertions;
 import static org.junit.Assert.assertEquals;
@@ -395,7 +397,12 @@ public class ExpressionEvaluatorTest {
 
   @Test
   public void std_macro_evaluated_as_expected() {
-    var pp = new CxxPreprocessor(mock(SquidAstVisitorContext.class));
+    var file = new File("dummy.cpp");
+    SquidAstVisitorContext<Grammar> context = mock(SquidAstVisitorContext.class);
+    when(context.getFile()).thenReturn(file);
+
+    var pp = new CxxPreprocessor(context);
+    pp.init();
 
     assertTrue(eval("__LINE__", pp));
     assertTrue(eval("__STDC__", pp));

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/MapChainTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/MapChainTest.java
@@ -32,85 +32,43 @@ public class MapChainTest {
   }
 
   @Test
-  public void gettingHighPrioMapping() {
-    mc.setHighPrio(true);
+  public void getMapping() {
     mc.put("k", "v");
     assertEquals("v", mc.get("k"));
   }
 
   @Test
-  public void gettingLowPrioMapping() {
-    mc.setHighPrio(false);
+  public void removeMapping() {
     mc.put("k", "v");
-    assertEquals("v", mc.get("k"));
-  }
-
-  @Test
-  public void removeLowPrioMapping() {
-    mc.setHighPrio(false);
-    mc.put("k", "v");
-    mc.removeLowPrio("k");
+    mc.remove("k");
     assertNull(mc.get("k"));
   }
 
   @Test
-  public void gettingNotExistingMapping() {
-    mc.setHighPrio(false);
-    mc.put("k", "vlow");
-    mc.setHighPrio(true);
-    mc.put("k", "vhigh");
-    assertEquals("vhigh", mc.get("k"));
-  }
-
-  @Test
-  public void gettingOverwrittenMapping() {
+  public void noValueMapping() {
     assertNull(mc.get("k"));
   }
 
   @Test
-  public void clearingLowPrioDeletesLowPrioMappings() {
-    mc.setHighPrio(false);
+  public void clearMapping() {
     mc.put("k", "v");
-    mc.clearLowPrio();
+    mc.clear();
     assertNull(mc.get("k"));
-  }
-
-  @Test
-  public void clearingLowPrioDoesntAffectHighPrioMappings() {
-    mc.setHighPrio(true);
-    mc.put("k", "v");
-    mc.clearLowPrio();
-    assertEquals("v", mc.get("k"));
   }
 
   @Test
   public void disable() {
-    mc.setHighPrio(true);
-    mc.put("khigh", "vhigh");
-    mc.setHighPrio(false);
-    mc.put("klow", "vlow");
-
-    mc.disable("khigh");
-    mc.disable("klow");
-
-    assertNull(mc.get("khigh"));
-    assertNull(mc.get("klow"));
+    mc.put("k", "v");
+    mc.disable("k");
+    assertNull(mc.get("k"));
   }
 
   @Test
   public void enable() {
-    mc.setHighPrio(true);
-    mc.put("khigh", "vhigh");
-    mc.setHighPrio(false);
-    mc.put("klow", "vlow");
-    mc.disable("khigh");
-    mc.disable("klow");
-
-    mc.enable("khigh");
-    mc.enable("klow");
-
-    assertEquals("vhigh", mc.get("khigh"));
-    assertEquals("vlow", mc.get("klow"));
+    mc.put("k", "v");
+    mc.disable("k");
+    mc.enable("k");
+    assertEquals("v", mc.get("k"));
   }
 
 }

--- a/cxx-squid/src/test/resources/preprocessor/include/B/a.h
+++ b/cxx-squid/src/test/resources/preprocessor/include/B/a.h
@@ -1,0 +1,1 @@
+#define INCLUDE "using: include/B/a.h"

--- a/cxx-squid/src/test/resources/preprocessor/include/B/b.h
+++ b/cxx-squid/src/test/resources/preprocessor/include/B/b.h
@@ -1,0 +1,1 @@
+#define INCLUDE "using: include/B/b.h"

--- a/cxx-squid/src/test/resources/preprocessor/include/C/a.h
+++ b/cxx-squid/src/test/resources/preprocessor/include/C/a.h
@@ -1,0 +1,1 @@
+#define INCLUDE "using: include/C/a.h"

--- a/cxx-squid/src/test/resources/preprocessor/include/C/c.h
+++ b/cxx-squid/src/test/resources/preprocessor/include/C/c.h
@@ -1,0 +1,1 @@
+#define INCLUDE "using: include/C/c.h"

--- a/cxx-squid/src/test/resources/preprocessor/include/D/E/e.h
+++ b/cxx-squid/src/test/resources/preprocessor/include/D/E/e.h
@@ -1,0 +1,9 @@
+#define INCLUDE "using: include/D/E/e.h"
+#include "a.h"
+
+// test: are compilation database settings propagated
+#if GLOBAL
+#   define PROPAGATED "propagated"
+#else
+#   define PROPAGATED "not propagated"
+#endif

--- a/cxx-squid/src/test/resources/preprocessor/include/D/d.h
+++ b/cxx-squid/src/test/resources/preprocessor/include/D/d.h
@@ -1,0 +1,2 @@
+#define INCLUDE "using: include/D/d.h"
+#include "E/e.h"

--- a/cxx-squid/src/test/resources/preprocessor/include/a.h
+++ b/cxx-squid/src/test/resources/preprocessor/include/a.h
@@ -1,0 +1,1 @@
+#define INCLUDE "using: include/a.h"

--- a/cxx-squid/src/test/resources/preprocessor/include/p.h
+++ b/cxx-squid/src/test/resources/preprocessor/include/p.h
@@ -1,0 +1,2 @@
+#define INCLUDE "using: include/p.h"
+#include "D/d.h"


### PR DESCRIPTION
- support Microsoft Quoted form search (close #1225):
1) In the same directory as the file that contains the #include statement.
2) In the directories of the currently opened include files, in the reverse order in which they were opened. The search begins in the directory  of the parent include file and continues upward through the directories of any grandparent include files.
3) fallback to use include paths instead of local folder (same as Angle-bracket form)

- add #include unit tests
- test for compilation database settings propagation (close #1489)
- refactoring

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/1984)
<!-- Reviewable:end -->
