### PR TITLE
C++20 initialization

### DIFF
--- a/cxx-squid/dox/2020-04-01_cpp20_grammar.txt
+++ b/cxx-squid/dox/2020-04-01_cpp20_grammar.txt
@@ -951,7 +951,8 @@ designator:
    . identifier
 
 expr-or-braced-init-list:
-   expression braced-init-list
+   expression
+   braced-init-list
 
 function-definition:
    attribute-specifier-seqopt decl-specifier-seqopt declarator virt-specifier-seqopt function-body

--- a/cxx-squid/src/test/resources/parser/own/C++20/designated initializers.cc
+++ b/cxx-squid/src/test/resources/parser/own/C++20/designated initializers.cc
@@ -1,0 +1,21 @@
+struct A { int x; int y; int z; };
+A a{ .x = 1, .z = 2 }; // ok, b.y initialized to 0
+
+union u { int a; const char* b; };
+u f = { .b = "asdf" }; // OK, active member of the union is b
+
+struct B {
+    string str;
+    int n = 42;
+    int m = -1;
+};
+B b{ .m = 21 }; // Initializes str with {}, which calls the default constructor
+                // then initializes n with = 42
+                // then initializes m with = 21
+
+struct C { int x, y; };
+struct D { struct C a; };
+struct C a = { .y = 1, .x = 2 }; // valid C, invalid C++ (out of order)
+int arr[3] = { [1] = 5 };        // valid C, invalid C++ (array)
+struct D d = { .a.x = 0 };       // valid C, invalid C++ (nested)
+struct C c = { .x = 1, 2 };      // valid C, invalid C++ (mixed)


### PR DESCRIPTION
- C++20 aggregate initialization close #1994
- C++20 designated initializers close #1988
- support C99 designated initializers
- support gcc's designated initializers range

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2004)
<!-- Reviewable:end -->
