### PR TITLE
test with sonarqube-8.6.0.39681

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: xenial
 jdk:
   - openjdk11
 env:
-  - SONARLABEL=sonarqube-7.9.4 SONARAPI=SqApi79
+  - SONARLABEL=sonarqube-8.6.0.39681 SONARAPI=SqApi79
 
 addons:
   # shorten the VM hostname with the new workaround
@@ -59,7 +59,7 @@ script:
   - RAILS_ENV=production PATH=$PATH:/tmp/sonar-scanner-4.5.0.2216/bin TestDataFolder=~/build/SonarOpenCommunity/sonar-cxx/integration-tests/testdata behave --no-capture --tags=$SONARAPI
 
 after_failure:
-  - cat $SONARHOME/logs/sonar.log
+  - cat $SONARHOME/logs/sonar-*.log
   - cat $SONARHOME/logs/web.log
   - cat $SONARHOME/logs/ce.log
   - cat $SONARHOME/logs/es.log

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,10 +43,10 @@ install:
       }
       if (!(Test-Path -Path "C:\sonarqube" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.9.4.zip',
-          'C:\sonarqube-7.9.4.zip'
+          'https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-8.6.0.39681.zip',
+          'C:\sonarqube-8.6.0.39681.zip'
         )
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonarqube-7.9.4.zip", "C:\sonarqube")
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonarqube-8.6.0.39681.zip", "C:\sonarqube")
       }
   - ps: |
       If ($env:Platform -Match "x86") {
@@ -65,7 +65,7 @@ install:
   - cmd: SET PATH=C:\maven\apache-maven-3.6.3\bin;%JAVA_HOME%\bin;C:\sonar-scanner\sonar-scanner-4.5.0.2216\bin;%PATH%
   - cmd: SET M2_HOME=C:\maven\apache-maven-3.6.3
   - cmd: SET MAVEN_HOME=C:\maven\apache-maven-3.6.3
-  - cmd: SET SONARHOME=C:\sonarqube\sonarqube-7.9.4
+  - cmd: SET SONARHOME=C:\sonarqube\sonarqube-8.6.0.39681
   - cmd: SET TestDataFolder=C:\projects\sonar-cxx\integration-tests\testdata
   - cmd: SET
 
@@ -107,4 +107,4 @@ on_failure:
   - ps: Get-ChildItem cxx-checks\target\surefire-reports\*.txt | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   - ps: Get-ChildItem sonar-cxx-plugin\target\surefire-reports\*.txt | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   - ps: Get-ChildItem *.log | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-  - ps: Get-ChildItem C:\sonarqube\sonarqube-7.9.4\logs\* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+  - ps: Get-ChildItem C:\sonarqube\sonarqube-8.6.0.39681\logs\* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/integration-tests/features/boosttest.feature
+++ b/integration-tests/features/boosttest.feature
@@ -30,7 +30,7 @@ Feature: Providing test execution measures
     testcases in SonarQube, i.e. the drilldown won't be possible.
 
     Given the project "boosttest_project"
-    When I run "sonar-scanner -X -Dsonar.cxx.xslt.1.inputs=btest_test_simple-test_suite.xml -Dsonar.cxx.xunit.reportPaths=btest_test_simple-test_suite.after_xslt"
+    When I run sonar-scanner with "-X -Dsonar.cxx.xslt.1.inputs=btest_test_simple-test_suite.xml -Dsonar.cxx.xunit.reportPaths=btest_test_simple-test_suite.after_xslt"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the analysis log contains no error/warning messages except those matching:
@@ -52,7 +52,7 @@ Feature: Providing test execution measures
     Verify the support of nested testsuites.
 
     Given the project "boosttest_project"
-    When I run "sonar-scanner -X -Dsonar.cxx.xslt.1.inputs=btest_test_nested-test_suite.xml -Dsonar.cxx.xunit.reportPaths=btest_test_nested-test_suite.after_xslt"
+    When I run sonar-scanner with "-X -Dsonar.cxx.xslt.1.inputs=btest_test_nested-test_suite.xml -Dsonar.cxx.xunit.reportPaths=btest_test_nested-test_suite.after_xslt"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the analysis log contains no error/warning messages except those matching:
@@ -75,7 +75,7 @@ Feature: Providing test execution measures
     dummy cpp unittest file in the test folder is needed.
 
     Given the project "boosttest_project"
-    When I run "sonar-scanner -X -Dsonar.tests=cxx-xunit -Dsonar.cxx.xslt.1.stylesheet=boosttest-1.x-to-junit-dummy-1.0.xsl -Dsonar.cxx.xslt.1.inputs=btest_test_nested-test_suite.xml -Dsonar.cxx.xunit.reportPaths=btest_test_nested-test_suite.after_xslt"
+    When I run sonar-scanner with "-X -Dsonar.tests=cxx-xunit -Dsonar.cxx.xslt.1.stylesheet=boosttest-1.x-to-junit-dummy-1.0.xsl -Dsonar.cxx.xslt.1.inputs=btest_test_nested-test_suite.xml -Dsonar.cxx.xunit.reportPaths=btest_test_nested-test_suite.after_xslt"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the analysis log contains no error/warning messages except those matching:
@@ -96,7 +96,7 @@ Feature: Providing test execution measures
     Test if plugin is able to handle this.
     Given the project "boosttest_project"
     And platform is not "Windows"
-    When I run "sonar-scanner -X -Dsonar.cxx.includeDirectories=/usr/include -Dsonar.cxx.xslt.1.inputs=btest_test_nested-test_suite.xml -Dsonar.cxx.xunit.reportPaths=btest_test_nested-test_suite.after_xslt"
+    When I run sonar-scanner with "-X -Dsonar.cxx.includeDirectories=/usr/include -Dsonar.cxx.xslt.1.inputs=btest_test_nested-test_suite.xml -Dsonar.cxx.xunit.reportPaths=btest_test_nested-test_suite.after_xslt"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the analysis log contains no error/warning messages except those matching:

--- a/integration-tests/features/clangsa.feature
+++ b/integration-tests/features/clangsa.feature
@@ -4,7 +4,7 @@ Feature: Importing Clang Static Analyzer reports
 
   Scenario: Clang Static Analyzer reports are missing
     Given the project "clangsa_project"
-    When I run "sonar-scanner -X -Dsonar.cxx.clangsa.reportPaths=empty.plist"
+    When I run sonar-scanner with "-X -Dsonar.cxx.clangsa.reportPaths=empty.plist"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the server log (if locatable) contains no error/warning messages
@@ -14,7 +14,7 @@ Feature: Importing Clang Static Analyzer reports
     Given the project "clangsa_project"
     And rule "clangsa:core.DivideZero" is enabled
     And rule "clangsa:deadcode.DeadStores" is enabled
-    When I run "sonar-scanner -X -Dsonar.cxx.clangsa.reportPaths=<reportpaths>"
+    When I run sonar-scanner with "-X -Dsonar.cxx.clangsa.reportPaths=<reportpaths>"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the server log (if locatable) contains no error/warning messages
@@ -29,7 +29,7 @@ Feature: Importing Clang Static Analyzer reports
     Given the project "clangsa_scanbuild_project"
     And rule "clangsa:core.DivideZero" is enabled
     And rule "clangsa:deadcode.DeadStores" is enabled
-    When I run "sonar-scanner -X -Dsonar.cxx.clangsa.reportPaths=<reportpaths>"
+    When I run sonar-scanner with "-X -Dsonar.cxx.clangsa.reportPaths=<reportpaths>"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the server log (if locatable) contains no error/warning messages
@@ -41,7 +41,7 @@ Feature: Importing Clang Static Analyzer reports
 
   Scenario Outline: Clang Static Analyzer reports are invalid
     Given the project "clangsa_project"
-    When I run "sonar-scanner -X -Dsonar.cxx.clangsa.reportPaths=<reportpaths>"
+    When I run sonar-scanner with "-X -Dsonar.cxx.clangsa.reportPaths=<reportpaths>"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the server log (if locatable) contains no error/warning messages

--- a/integration-tests/features/compiler.feature
+++ b/integration-tests/features/compiler.feature
@@ -7,7 +7,7 @@ Feature: Importing compiler reports
     And rule "compiler-vc:C4189" is enabled
     And rule "compiler-vc:C4457" is enabled
     And platform is "Windows"
-    When I run "sonar-scanner -X"
+    When I run sonar-scanner with "-X"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the server log (if locatable) contains no error/warning messages

--- a/integration-tests/features/cppcheck.feature
+++ b/integration-tests/features/cppcheck.feature
@@ -10,7 +10,7 @@ Feature: Importing Cppcheck reports
     And rule "cppcheck:doubleFree" is enabled
     And rule "cppcheck:uninitvar" is enabled
     And rule "cppcheck:unusedFunction" is enabled
-    When I run "sonar-scanner -X -Dsonar.cxx.cppcheck.reportPaths=empty.xml"
+    When I run sonar-scanner with "-X -Dsonar.cxx.cppcheck.reportPaths=empty.xml"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the server log (if locatable) contains no error/warning messages
@@ -29,7 +29,7 @@ Feature: Importing Cppcheck reports
     And rule "cppcheck:doubleFree" is enabled
     And rule "cppcheck:uninitvar" is enabled
     And rule "cppcheck:unusedFunction" is enabled
-    When I run "sonar-scanner -X -Dsonar.cxx.cppcheck.reportPaths=relative-to-src.xml"
+    When I run sonar-scanner with "-X -Dsonar.cxx.cppcheck.reportPaths=relative-to-src.xml"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the server log (if locatable) contains no error/warning messages
@@ -49,7 +49,7 @@ Feature: Importing Cppcheck reports
     And rule "cppcheck:uninitvar" is enabled
     And rule "cppcheck:unusedFunction" is enabled
     And platform is not "Windows"
-    When I run "sonar-scanner -X"
+    When I run sonar-scanner with "-X"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the server log (if locatable) contains no error/warning messages
@@ -64,7 +64,7 @@ Feature: Importing Cppcheck reports
     And rule "cppcheck:doubleFree" is enabled
     And rule "cppcheck:uninitvar" is enabled
     And rule "cppcheck:unusedFunction" is enabled
-    When I run "sonar-scanner -X -Dsonar.cxx.cppcheck.reportPaths=<reportpaths>"
+    When I run sonar-scanner with "-X -Dsonar.cxx.cppcheck.reportPaths=<reportpaths>"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the server log (if locatable) contains no error/warning messages
@@ -87,7 +87,7 @@ Feature: Importing Cppcheck reports
     And rule "cppcheck:doubleFree" is enabled
     And rule "cppcheck:uninitvar" is enabled
     And rule "cppcheck:unusedFunction" is enabled
-    When I run "sonar-scanner -X -Dsonar.cxx.cppcheck.reportPaths=<reportpaths>"
+    When I run sonar-scanner with "-X -Dsonar.cxx.cppcheck.reportPaths=<reportpaths>"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the server log (if locatable) contains no error/warning messages
@@ -110,7 +110,7 @@ Feature: Importing Cppcheck reports
     And rule "cppcheck:doubleFree" is enabled
     And rule "cppcheck:uninitvar" is enabled
     And rule "cppcheck:unusedFunction" is enabled
-    When I run "sonar-scanner -X -Dsonar.cxx.cppcheck.reportPaths=<reportpaths>"
+    When I run sonar-scanner with "-X -Dsonar.cxx.cppcheck.reportPaths=<reportpaths>"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the server log (if locatable) contains no error/warning messages

--- a/integration-tests/features/googletest.feature
+++ b/integration-tests/features/googletest.feature
@@ -31,7 +31,7 @@ Feature: Providing test execution measures
     testcases in SonarQube, i.e. the drilldown won't be possible.
 
     Given the project "googletest_project"
-    When I run "sonar-scanner -X -Dsonar.cxx.xunit.reportPaths=gtest_without_fixture.xml"
+    When I run sonar-scanner with "-X -Dsonar.cxx.xunit.reportPaths=gtest_without_fixture.xml"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the analysis log contains no error/warning messages except those matching:
@@ -51,7 +51,7 @@ Feature: Providing test execution measures
 
   Scenario: Importing invalid Google Test report
     Given the project "googletest_project"
-    When I run "sonar-scanner -Dsonar.cxx.errorRecoveryEnabled=false -Dsonar.cxx.xunit.reportPaths=invalid_report.xml"
+    When I run sonar-scanner with "-Dsonar.cxx.errorRecoveryEnabled=false -Dsonar.cxx.xunit.reportPaths=invalid_report.xml"
     Then the analysis breaks
     And the analysis log contains a line matching:
       """
@@ -65,7 +65,7 @@ Feature: Providing test execution measures
     correct source code files.
 
     Given the project "googletest_project"
-    When I run "sonar-scanner -X -Dsonar.cxx.xunit.reportPaths=<reportpaths>"
+    When I run sonar-scanner with "-X -Dsonar.cxx.xunit.reportPaths=<reportpaths>"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the analysis log contains no error/warning messages except those matching:
@@ -90,7 +90,7 @@ Feature: Providing test execution measures
 
   Scenario Outline: Google Test reports cannot be found or are empty
     Given the project "googletest_project"
-    When I run "sonar-scanner -Dsonar.cxx.xunit.reportPaths=<reportpaths>"
+    When I run sonar-scanner with "-Dsonar.cxx.xunit.reportPaths=<reportpaths>"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the analysis log contains no error/warning messages except those matching:

--- a/integration-tests/features/indexing.feature
+++ b/integration-tests/features/indexing.feature
@@ -5,7 +5,7 @@ Feature: Indexing files
 
   Scenario: CXX file suffixes
     Given the project "indexing_project"
-    When I run "sonar-scanner -X -Dsonar.cxx.file.suffixes=.cc"
+    When I run sonar-scanner with "-X -Dsonar.cxx.file.suffixes=.cc"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the following metrics have following values:
@@ -15,7 +15,7 @@ Feature: Indexing files
 
   Scenario: Turn CXX language off
     Given the project "indexing_project"
-    When I run "sonar-scanner -X -Dsonar.cxx.file.suffixes=-"
+    When I run sonar-scanner with "-X -Dsonar.cxx.file.suffixes=-"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the following metrics have following values:

--- a/integration-tests/features/smoketest.feature
+++ b/integration-tests/features/smoketest.feature
@@ -12,7 +12,7 @@ Feature: Smoketests
     And rule "cppcheck:uninitvar" is enabled
     And rule "cppcheck:unusedFunction" is enabled
     And rule "cppcheck:missingInclude" is enabled
-    When I run "sonar-scanner -X"
+    When I run sonar-scanner with "-X"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the analysis log contains no error/warning messages except those matching:
@@ -86,7 +86,7 @@ Feature: Smoketests
     And rule "cpplint_whitespace_parens_5" is created based on "other:CustomRuleTemplate" in repository "other"
     And rule "cpplint_whitespace_line_length_1" is created based on "other:CustomRuleTemplate" in repository "other"
     And rule "cpplint_tekla_custom_include_files_0" is created based on "other:CustomRuleTemplate" in repository "other"
-    When I run "sonar-scanner -X"
+    When I run sonar-scanner with "-X"
     Then the analysis finishes successfully
     And the analysis in server has completed
     And the analysis log contains no error/warning messages except those matching:


### PR DESCRIPTION

- Windows: InstallNTService.bat no more available
- Windows use StartSonar.bat instead of service
- make sonar_analysis_finished more robust
- provide sonar.login and sonar.password for sonar-scanner
- sonar.log is sonar-YYYYMMDD.log now
- adapt REST API changes:
  - most command needs authentification now (usr:psw)
  - /api/qualityprofiles/activate_rule
  - /api/qualityprofiles/set_default
  - /api/qualityprofiles/delete
  - /api/measures/component
  
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2013)
<!-- Reviewable:end -->
