### PR TITLE
add __VA_OPT__ support

### DIFF
--- a/cxx-squid/dox/2020-04-01_cpp20_grammar-diff.txt
+++ b/cxx-squid/dox/2020-04-01_cpp20_grammar-diff.txt
@@ -4,20 +4,6 @@ Annex A (informative)
 
 **A.2 Lexical conventions [gram.lex]**
 
-preprocessing-token:
-   header-name
-   import-keyword // todo
-   module-keyword // todo
-   export-keyword // todo
-   identifier
-   pp-number
-   character-literal
-   user-defined-character-literal
-   string-literal
-   user-defined-string-literal
-   preprocessing-op-or-punc
-   each non-white-space character that cannot be one of the above
-
 token:
    identifier
    keyword
@@ -170,75 +156,3 @@ operator: one of // todo
   || << >> <<= >>= ++ -- ,
 
 **A.10 Templates [gram.temp]**
-
-deduction-guide: // todo
-   explicit-specifieropt template-name ( parameter-declaration-clause )-> simple-template-id ;
-
-**A.11 Exception handling [gram.except]**
-
-**A.12 Preprocessing directives [gram.cpp]**
-
-preprocessing-file:
-   groupopt
-   module-file // todo
-
-module-file: // todo
-   pp-global-module-fragmentopt pp-module groupopt pp-private-module-fragmentopt
-
-pp-global-module-fragment: // todo
-   module; new-line groupopt
-
-pp-private-module-fragment: // todo
-   module : private ; new-line groupopt
-
-group-part:
-   control-line
-   if-section // todo
-   text-line
-   # conditionally-supported-directive
-
-control-line:
-   # include pp-tokens new-line
-   pp-import // todo
-   # define identifier replacement-list new-line
-   # define identifier lparen identifier-listopt ) replacement-list new-line
-   # define identifier lparen ... ) replacement-list new-line
-   # define identifier lparen identifier-list , ... ) replacement-list new-line
-   # undef identifier new-line
-   # line pp-tokens new-line
-   # error pp-tokensopt new-line
-   # pragma pp-tokensopt new-line
-   # new-line
-
-defined-macro-expression: // todo
-   defined identifier
-   defined ( identifier )
-
-h-preprocessing-token: // todo
-   any preprocessing-token other than >
-
-h-pp-tokens: // todo
-   h-preprocessing-token
-   h-pp-tokens h-preprocessing-token
-
-header-name-tokens: // todo
-   string-literal
-   < h-pp-tokens >
-
-has-include-expression: // todo
-   __has_include( header-name )
-   __has_include( header-name-tokens )
-
-has-attribute-expression: // todo
-   __has_cpp_attribute ( pp-tokens )
-
-pp-module: // todo
-   exportopt module pp-tokensopt ; new-line
-
-pp-import: // todo
-   exportopt import header-name pp-tokensopt ; new-line
-   exportopt import header-name-tokens pp-tokensopt ; new-line
-   exportopt import pp-tokens ; new-line
-
-va-opt-replacement: // todo
-   __VA_OPT__ ( pp-tokensopt )

--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxParser.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxParser.java
@@ -54,7 +54,7 @@ public final class CxxParser {
     var cxxpp = new CxxPreprocessor(context, squidConfig);
     currentPreprocessorInstance = new WeakReference<>(cxxpp);
     return Parser.builder(CxxGrammarImpl.create(squidConfig))
-      .withLexer(CxxLexer.create(squidConfig, cxxpp, new JoinStringsPreprocessor()))
+      .withLexer(CxxLexer.create(squidConfig.getCharset(), cxxpp, new JoinStringsPreprocessor()))
       .build();
   }
 

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppGrammarImpl.java
@@ -50,7 +50,7 @@ import org.sonar.sslr.grammar.LexerfulGrammarBuilder;
  * Deviating from the grammar in the standard, whitespaces between the tokens must also be processed here.
  */
 @SuppressWarnings({"squid:S00115", "squid:S00103"})
-public enum CppGrammar implements GrammarRuleKey {
+public enum CppGrammarImpl implements GrammarRuleKey {
   preprocessorLine,
   defineLine,
   includeLine,

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppLexer.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppLexer.java
@@ -31,11 +31,11 @@ import static com.sonar.sslr.impl.channel.RegexpChannelBuilder.opt;
 import static com.sonar.sslr.impl.channel.RegexpChannelBuilder.or;
 import static com.sonar.sslr.impl.channel.RegexpChannelBuilder.regexp;
 import com.sonar.sslr.impl.channel.UnknownCharacterChannel;
+import java.nio.charset.Charset;
 import org.sonar.cxx.parser.CxxTokenType;
 import org.sonar.cxx.channels.CharacterLiteralsChannel;
 import org.sonar.cxx.channels.KeywordChannel;
 import org.sonar.cxx.channels.StringLiteralsChannel;
-import org.sonar.cxx.config.CxxSquidConfiguration;
 
 public final class CppLexer {
 
@@ -56,16 +56,16 @@ public final class CppLexer {
   }
 
   public static Lexer create() {
-    return create(new CxxSquidConfiguration());
+    return create(Charset.defaultCharset());
   }
 
-  public static Lexer create(CxxSquidConfiguration squidConfig) {
+  public static Lexer create(Charset charset) {
 
     //
     // changes here must be always aligned: CxxLexer.java <=> CppLexer.java
     //
     Lexer.Builder builder = Lexer.builder()
-      .withCharset(squidConfig.getCharset())
+      .withCharset(charset)
       .withFailIfNoChannelToConsumeOneCharacter(true)
       .withChannel(regexp(CxxTokenType.WS, "\\s+"))
       .withChannel(commentRegexp("//[^\\n\\r]*+"))

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppParser.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppParser.java
@@ -21,25 +21,25 @@ package org.sonar.cxx.preprocessor;
 
 import com.sonar.sslr.api.Grammar;
 import com.sonar.sslr.impl.Parser;
-import org.sonar.cxx.config.CxxSquidConfiguration;
+import java.nio.charset.Charset;
 
 public final class CppParser {
 
   private CppParser() {
   }
 
-  public static Parser<Grammar> create(CxxSquidConfiguration squidConfig) {
-    return Parser.builder(CppGrammar.create())
-      .withLexer(CppLexer.create(squidConfig))
+  public static Parser<Grammar> create(Charset charset) {
+    return Parser.builder(CppGrammarImpl.create())
+      .withLexer(CppLexer.create(charset))
       .build();
   }
 
-  public static Parser<Grammar> createConstantExpressionParser(CxxSquidConfiguration squidConfig) {
-    Grammar grammar = CppGrammar.create();
+  public static Parser<Grammar> createConstantExpressionParser(Charset charset) {
+    Grammar grammar = CppGrammarImpl.create();
     Parser<Grammar> parser = Parser.builder(grammar)
-      .withLexer(CppLexer.create(squidConfig))
+      .withLexer(CppLexer.create(charset))
       .build();
-    parser.setRootRule(grammar.rule(CppGrammar.constantExpression));
+    parser.setRootRule(grammar.rule(CppGrammarImpl.constantExpression));
     return parser;
   }
 

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/ExpressionEvaluator.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/ExpressionEvaluator.java
@@ -33,7 +33,6 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
-import org.sonar.cxx.config.CxxSquidConfiguration;
 import org.sonar.cxx.parser.CxxTokenType;
 
 public final class ExpressionEvaluator {
@@ -44,19 +43,19 @@ public final class ExpressionEvaluator {
   private final CxxPreprocessor preprocessor;
   private final Deque<String> macroEvaluationStack;
 
-  private ExpressionEvaluator(CxxSquidConfiguration squidConfig, CxxPreprocessor preprocessor) {
-    parser = CppParser.createConstantExpressionParser(squidConfig);
+  private ExpressionEvaluator(CxxPreprocessor preprocessor) {
+    parser = CppParser.createConstantExpressionParser(preprocessor.getCharset());
 
     this.preprocessor = preprocessor;
     macroEvaluationStack = new LinkedList<>();
   }
 
-  public static boolean eval(CxxSquidConfiguration squidConfig, CxxPreprocessor preprocessor, String constExpr) {
-    return new ExpressionEvaluator(squidConfig, preprocessor).evalToBoolean(constExpr, null);
+  public static boolean eval(CxxPreprocessor preprocessor, String constExpr) {
+    return new ExpressionEvaluator(preprocessor).evalToBoolean(constExpr, null);
   }
 
-  public static boolean eval(CxxSquidConfiguration squidConfig, CxxPreprocessor preprocessor, AstNode constExpr) {
-    return new ExpressionEvaluator(squidConfig, preprocessor).evalToBoolean(constExpr);
+  public static boolean eval(CxxPreprocessor preprocessor, AstNode constExpr) {
+    return new ExpressionEvaluator(preprocessor).evalToBoolean(constExpr);
   }
 
   public static BigInteger decode(String number) {
@@ -239,7 +238,7 @@ public final class ExpressionEvaluator {
     // Evaluation of booleans and 'pass-through's
     //
     AstNodeType nodeType = exprAst.getType();
-    if (nodeType.equals(CppGrammar.bool)) {
+    if (nodeType.equals(CppGrammarImpl.bool)) {
       return evalBool(exprAst.getTokenValue());
     }
     return evalToInt(exprAst.getFirstChild());
@@ -250,37 +249,37 @@ public final class ExpressionEvaluator {
     // More complex expressions with more than one child
     //
     AstNodeType nodeType = exprAst.getType();
-    if (nodeType.equals(CppGrammar.unaryExpression)) {
+    if (nodeType.equals(CppGrammarImpl.unaryExpression)) {
       return evalUnaryExpression(exprAst);
-    } else if (nodeType.equals(CppGrammar.conditionalExpression)) {
+    } else if (nodeType.equals(CppGrammarImpl.conditionalExpression)) {
       return evalConditionalExpression(exprAst);
-    } else if (nodeType.equals(CppGrammar.logicalOrExpression)) {
+    } else if (nodeType.equals(CppGrammarImpl.logicalOrExpression)) {
       return evalLogicalOrExpression(exprAst);
-    } else if (nodeType.equals(CppGrammar.logicalAndExpression)) {
+    } else if (nodeType.equals(CppGrammarImpl.logicalAndExpression)) {
       return evalLogicalAndExpression(exprAst);
-    } else if (nodeType.equals(CppGrammar.inclusiveOrExpression)) {
+    } else if (nodeType.equals(CppGrammarImpl.inclusiveOrExpression)) {
       return evalInclusiveOrExpression(exprAst);
-    } else if (nodeType.equals(CppGrammar.exclusiveOrExpression)) {
+    } else if (nodeType.equals(CppGrammarImpl.exclusiveOrExpression)) {
       return evalExclusiveOrExpression(exprAst);
-    } else if (nodeType.equals(CppGrammar.andExpression)) {
+    } else if (nodeType.equals(CppGrammarImpl.andExpression)) {
       return evalAndExpression(exprAst);
-    } else if (nodeType.equals(CppGrammar.equalityExpression)) {
+    } else if (nodeType.equals(CppGrammarImpl.equalityExpression)) {
       return evalEqualityExpression(exprAst);
-    } else if (nodeType.equals(CppGrammar.relationalExpression)) {
+    } else if (nodeType.equals(CppGrammarImpl.relationalExpression)) {
       return evalRelationalExpression(exprAst);
-    } else if (nodeType.equals(CppGrammar.shiftExpression)) {
+    } else if (nodeType.equals(CppGrammarImpl.shiftExpression)) {
       return evalShiftExpression(exprAst);
-    } else if (nodeType.equals(CppGrammar.additiveExpression)) {
+    } else if (nodeType.equals(CppGrammarImpl.additiveExpression)) {
       return evalAdditiveExpression(exprAst);
-    } else if (nodeType.equals(CppGrammar.multiplicativeExpression)) {
+    } else if (nodeType.equals(CppGrammarImpl.multiplicativeExpression)) {
       return evalMultiplicativeExpression(exprAst);
-    } else if (nodeType.equals(CppGrammar.primaryExpression)) {
+    } else if (nodeType.equals(CppGrammarImpl.primaryExpression)) {
       return evalPrimaryExpression(exprAst);
-    } else if (nodeType.equals(CppGrammar.definedExpression)) {
+    } else if (nodeType.equals(CppGrammarImpl.definedExpression)) {
       return evalDefinedExpression(exprAst);
-    } else if (nodeType.equals(CppGrammar.functionlikeMacro)) {
+    } else if (nodeType.equals(CppGrammarImpl.functionlikeMacro)) {
       return evalFunctionlikeMacro(exprAst);
-    } else if (nodeType.equals(CppGrammar.hasIncludeExpression)) {
+    } else if (nodeType.equals(CppGrammarImpl.hasIncludeExpression)) {
       return evalHasIncludeExpression(exprAst);
     } else {
       LOG.error("'evalComplexAst' Unknown expression type '" + nodeType + "' for AstExt '"

--- a/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerIncludeTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerIncludeTest.java
@@ -184,7 +184,7 @@ public class CxxLexerIncludeTest {
     when(context.getFile()).thenReturn(file);
 
     var pp = new CxxPreprocessor(context, squidConfig);
-    var lexer = CxxLexer.create(squidConfig, pp, new JoinStringsPreprocessor());
+    var lexer = CxxLexer.create(squidConfig.getCharset(), pp, new JoinStringsPreprocessor());
 
     String fileContent = cmd + " " + include + "\n" + macro;
     List<Token> tokens = lexer.lex(fileContent);

--- a/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithPreprocessingTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithPreprocessingTest.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.cxx.lexer;
 
-import org.sonar.cxx.parser.CxxLexer;
 import com.sonar.sslr.api.GenericTokenType;
 import com.sonar.sslr.api.Grammar;
 import com.sonar.sslr.api.Token;
@@ -38,11 +37,12 @@ import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import org.sonar.cxx.parser.CxxKeyword;
-import org.sonar.cxx.parser.CxxPunctuator;
-import org.sonar.cxx.parser.CxxTokenType;
 import org.sonar.cxx.config.CxxSquidConfiguration;
 import static org.sonar.cxx.lexer.LexerAssert.assertThat;
+import org.sonar.cxx.parser.CxxKeyword;
+import org.sonar.cxx.parser.CxxLexer;
+import org.sonar.cxx.parser.CxxPunctuator;
+import org.sonar.cxx.parser.CxxTokenType;
 import org.sonar.cxx.preprocessor.CxxPreprocessor;
 import org.sonar.cxx.preprocessor.JoinStringsPreprocessor;
 import org.sonar.cxx.preprocessor.SourceCodeProvider;
@@ -107,7 +107,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_functionlike_macros_withvarargs() {
+  public void expanding_functionlike_macros_with_varargs() {
     List<Token> tokens = lexer.lex("#define wrapper(...) __VA_ARGS__\n wrapper(1, 2)");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(4);
@@ -117,7 +117,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_functionlike_macros_withnamedvarargs() {
+  public void expanding_functionlike_macros_withnamed_varargs() {
     List<Token> tokens = lexer.lex("#define wrapper(args...) args\n wrapper(1, 2)");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(4);
@@ -127,7 +127,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_functionlike_macros_withemptyvarargs() {
+  public void expanding_functionlike_macros_with_empty_varargs() {
     List<Token> tokens = lexer.lex("#define wrapper(...) (__VA_ARGS__)\n wrapper()");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(3);
@@ -137,7 +137,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_macro_with_empty_parameterlist() {
+  public void expanding_macro_with_empty_parameter_list() {
     List<Token> tokens = lexer.lex("#define M() 0\n M()");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(2);
@@ -339,7 +339,7 @@ public class CxxLexerWithPreprocessingTest {
     squidConfig.add(CxxSquidConfiguration.SONAR_PROJECT_PROPERTIES, CxxSquidConfiguration.DEFINES,
                     "M body");
     var cxxpp = new CxxPreprocessor(context, squidConfig);
-    lexer = CxxLexer.create(squidConfig, cxxpp, new JoinStringsPreprocessor());
+    lexer = CxxLexer.create(squidConfig.getCharset(), cxxpp, new JoinStringsPreprocessor());
 
     List<Token> tokens = lexer.lex("M");
     var softly = new SoftAssertions();
@@ -355,7 +355,7 @@ public class CxxLexerWithPreprocessingTest {
     squidConfig.add(CxxSquidConfiguration.SONAR_PROJECT_PROPERTIES, CxxSquidConfiguration.DEFINES,
                     "minus(a, b) a - b");
     var cxxpp = new CxxPreprocessor(context, squidConfig);
-    lexer = CxxLexer.create(squidConfig, cxxpp, new JoinStringsPreprocessor());
+    lexer = CxxLexer.create(squidConfig.getCharset(), cxxpp, new JoinStringsPreprocessor());
 
     List<Token> tokens = lexer.lex("minus(1, 2)");
     var softly = new SoftAssertions();
@@ -629,7 +629,7 @@ public class CxxLexerWithPreprocessingTest {
     var squidConfig = new CxxSquidConfiguration();
     squidConfig.add(CxxSquidConfiguration.GLOBAL, CxxSquidConfiguration.DEFINES, "macro globalvalue");
     var cxxpp = new CxxPreprocessor(context, squidConfig);
-    lexer = CxxLexer.create(squidConfig, cxxpp);
+    lexer = CxxLexer.create(squidConfig.getCharset(), cxxpp);
 
     List<Token> tokens = lexer.lex("#define macro overriden\n"
                                      + "macro");
@@ -649,7 +649,7 @@ public class CxxLexerWithPreprocessingTest {
     var squidConfig = new CxxSquidConfiguration();
     var cxxpp = new CxxPreprocessor(context, squidConfig);
 
-    final Lexer l = CxxLexer.create(squidConfig, cxxpp);
+    final Lexer l = CxxLexer.create(squidConfig.getCharset(), cxxpp);
     final List<Token> tokens = l.lex("__LINE__");
 
     var softly = new SoftAssertions();
@@ -673,7 +673,7 @@ public class CxxLexerWithPreprocessingTest {
     squidConfig.add(CxxSquidConfiguration.GLOBAL, CxxSquidConfiguration.DEFINES, "__LINE__ 123");
     var cxxpp = new CxxPreprocessor(context, squidConfig);
 
-    final Lexer l = CxxLexer.create(squidConfig, cxxpp);
+    final Lexer l = CxxLexer.create(squidConfig.getCharset(), cxxpp);
     final List<Token> tokens = l.lex("__LINE__");
 
     var softly = new SoftAssertions();
@@ -713,7 +713,7 @@ public class CxxLexerWithPreprocessingTest {
       .thenReturn("#define __LINE__ 345");
 
     var cxxpp = new CxxPreprocessor(context, squidConfig, provider);
-    final Lexer l = CxxLexer.create(squidConfig, cxxpp);
+    final Lexer l = CxxLexer.create(squidConfig.getCharset(), cxxpp);
 
     final List<Token> tokens = l.lex("__LINE__\n");
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/PreprocessorDirectivesTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/PreprocessorDirectivesTest.java
@@ -242,6 +242,36 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
+  public void va_opt_macros() {
+    // C++20 : Replacement-list may contain the token sequence __VA_OPT__ ( content ),
+    // which is replaced by content if __VA_ARGS__ is non-empty, and expands to nothing otherwise.
+
+    assertThat(serialize(p.parse(
+      "#define LOG(msg, ...) printf(msg __VA_OPT__(,) __VA_ARGS__)\n"
+        + "LOG(\"hello world\");")))
+      .isEqualTo("printf ( \"hello world\" ) ; EOF");
+
+    assertThat(serialize(p.parse(
+      "#define LOG(msg, ...) printf(msg __VA_OPT__(,) __VA_ARGS__)\n"
+        + "LOG(\"hello world\", );")))
+      .isEqualTo("printf ( \"hello world\" ) ; EOF");
+
+    assertThat(serialize(p.parse(
+      "#define LOG(msg, ...) printf(msg __VA_OPT__(,) __VA_ARGS__)\n"
+        + "LOG(\"hello %d\", n);")))
+      .isEqualTo("printf ( \"hello %d\" , n ) ; EOF");
+    assertThat(serialize(p.parse(
+      "#define SDEF(sname, ...) S sname __VA_OPT__(= { __VA_ARGS__ })\n"
+        + "SDEF(foo);")))
+      .isEqualTo("S foo ; EOF");
+
+    assertThat(serialize(p.parse(
+      "#define SDEF(sname, ...) S sname __VA_OPT__(= { __VA_ARGS__ })\n"
+        + "SDEF(bar, 1, 2);")))
+      .isEqualTo("S bar = { 1 , 2 } ; EOF");
+  }
+
+  @Test
   public void stringification() {
     // default use case
     assertThat(serialize(p.parse(

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppGrammarImplTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppGrammarImplTest.java
@@ -26,27 +26,27 @@ import org.junit.Test;
 import org.sonar.sslr.grammar.GrammarRuleKey;
 import static org.sonar.sslr.tests.Assertions.assertThat;
 
-public class CppGrammarTest {
+public class CppGrammarImplTest {
 
-  private final Parser<Grammar> p = Parser.builder(CppGrammar.create())
+  private final Parser<Grammar> p = Parser.builder(CppGrammarImpl.create())
     .withLexer(CppLexer.create())
     .build();
   private final Grammar g = p.getGrammar();
 
   @Test
   public void preprocessorLine() {
-    mockRule(CppGrammar.defineLine);
-    mockRule(CppGrammar.includeLine);
-    mockRule(CppGrammar.ifdefLine);
-    mockRule(CppGrammar.ifLine);
-    mockRule(CppGrammar.elifLine);
-    mockRule(CppGrammar.elseLine);
-    mockRule(CppGrammar.endifLine);
-    mockRule(CppGrammar.undefLine);
-    mockRule(CppGrammar.lineLine);
-    mockRule(CppGrammar.errorLine);
-    mockRule(CppGrammar.pragmaLine);
-    mockRule(CppGrammar.warningLine);
+    mockRule(CppGrammarImpl.defineLine);
+    mockRule(CppGrammarImpl.includeLine);
+    mockRule(CppGrammarImpl.ifdefLine);
+    mockRule(CppGrammarImpl.ifLine);
+    mockRule(CppGrammarImpl.elifLine);
+    mockRule(CppGrammarImpl.elseLine);
+    mockRule(CppGrammarImpl.endifLine);
+    mockRule(CppGrammarImpl.undefLine);
+    mockRule(CppGrammarImpl.lineLine);
+    mockRule(CppGrammarImpl.errorLine);
+    mockRule(CppGrammarImpl.pragmaLine);
+    mockRule(CppGrammarImpl.warningLine);
 
     assertThat(p).matches("defineLine");
     assertThat(p).matches("includeLine");
@@ -75,7 +75,7 @@ public class CppGrammarTest {
 
   @Test
   public void defineLine_reallife() {
-    p.setRootRule(g.rule(CppGrammar.defineLine));
+    p.setRootRule(g.rule(CppGrammarImpl.defineLine));
 
     assertThat(p).matches("#define ALGOSTUFF_HPPEOF");
     assertThat(p).matches("#define lala(a, b) a b");
@@ -89,16 +89,16 @@ public class CppGrammarTest {
   @Test
   public void define_containing_argumentList() {
     AstNode define = p.parse("#define lala(a, b) a b");
-    org.assertj.core.api.Assertions.assertThat(define.getDescendants(CppGrammar.parameterList)).isNotNull();
+    org.assertj.core.api.Assertions.assertThat(define.getDescendants(CppGrammarImpl.parameterList)).isNotNull();
   }
 
   @Test
   public void functionlikeMacroDefinition() {
-    p.setRootRule(g.rule(CppGrammar.functionlikeMacroDefinition));
+    p.setRootRule(g.rule(CppGrammarImpl.functionlikeMacroDefinition));
 
-    mockRule(CppGrammar.replacementList);
-    mockRule(CppGrammar.argumentList);
-    mockRule(CppGrammar.ppToken);
+    mockRule(CppGrammarImpl.replacementList);
+    mockRule(CppGrammarImpl.argumentList);
+    mockRule(CppGrammarImpl.ppToken);
 
     assertThat(p).matches("#define ppToken( argumentList ) replacementList");
     assertThat(p).matches("#define ppToken(argumentList) replacementList");
@@ -110,7 +110,7 @@ public class CppGrammarTest {
 
   @Test
   public void functionlikeMacroDefinition_reallife() {
-    p.setRootRule(g.rule(CppGrammar.functionlikeMacroDefinition));
+    p.setRootRule(g.rule(CppGrammarImpl.functionlikeMacroDefinition));
 
     assertThat(p).matches("#define foo() bar");
     assertThat(p).matches("#define foo() ()");
@@ -120,17 +120,17 @@ public class CppGrammarTest {
 
   @Test
   public void objectlikeMacroDefinition() {
-    p.setRootRule(g.rule(CppGrammar.objectlikeMacroDefinition));
+    p.setRootRule(g.rule(CppGrammarImpl.objectlikeMacroDefinition));
 
-    mockRule(CppGrammar.replacementList);
-    mockRule(CppGrammar.ppToken);
+    mockRule(CppGrammarImpl.replacementList);
+    mockRule(CppGrammarImpl.ppToken);
 
     assertThat(p).matches("#define ppToken replacementList");
   }
 
   @Test
   public void objectlikeMacroDefinition_reallife() {
-    p.setRootRule(g.rule(CppGrammar.objectlikeMacroDefinition));
+    p.setRootRule(g.rule(CppGrammarImpl.objectlikeMacroDefinition));
 
     assertThat(p).matches("#define foo");
     assertThat(p).matches("#define foo bar");
@@ -140,7 +140,7 @@ public class CppGrammarTest {
 
   @Test
   public void replacementList() {
-    p.setRootRule(g.rule(CppGrammar.replacementList));
+    p.setRootRule(g.rule(CppGrammarImpl.replacementList));
 
     assertThat(p).matches("");
     assertThat(p).matches("ppToken");
@@ -154,7 +154,7 @@ public class CppGrammarTest {
 
   @Test
   public void argumentList() {
-    p.setRootRule(g.rule(CppGrammar.argumentList));
+    p.setRootRule(g.rule(CppGrammarImpl.argumentList));
 
     assertThat(p).matches("foo");
     assertThat(p).matches("foo, bar");
@@ -165,7 +165,7 @@ public class CppGrammarTest {
 
   @Test
   public void argument() {
-    p.setRootRule(g.rule(CppGrammar.argument));
+    p.setRootRule(g.rule(CppGrammarImpl.argument));
 
     assertThat(p).matches("a");
     assertThat(p).matches("call()");
@@ -174,7 +174,7 @@ public class CppGrammarTest {
 
   @Test
   public void somethingContainingParantheses() {
-    p.setRootRule(g.rule(CppGrammar.somethingContainingParantheses));
+    p.setRootRule(g.rule(CppGrammarImpl.somethingContainingParantheses));
 
     assertThat(p).matches("call()");
     assertThat(p).matches("()");
@@ -182,14 +182,14 @@ public class CppGrammarTest {
 
   @Test
   public void somethingWithoutParantheses() {
-    p.setRootRule(g.rule(CppGrammar.somethingWithoutParantheses));
+    p.setRootRule(g.rule(CppGrammarImpl.somethingWithoutParantheses));
 
     assertThat(p).matches("abc");
   }
 
   @Test
   public void ppToken() {
-    p.setRootRule(g.rule(CppGrammar.ppToken));
+    p.setRootRule(g.rule(CppGrammarImpl.ppToken));
 
     assertThat(p).matches("foo");
     assertThat(p).matches("(");
@@ -199,9 +199,9 @@ public class CppGrammarTest {
 
   @Test
   public void includeLine() {
-    p.setRootRule(g.rule(CppGrammar.includeLine));
+    p.setRootRule(g.rule(CppGrammarImpl.includeLine));
 
-    mockRule(CppGrammar.ppToken);
+    mockRule(CppGrammarImpl.ppToken);
 
     assertThat(p).matches("#include <ppToken>");
     assertThat(p).matches("#include_next <ppToken>");
@@ -211,7 +211,7 @@ public class CppGrammarTest {
 
   @Test
   public void importLine_reallife() {
-    p.setRootRule(g.rule(CppGrammar.ppImport));
+    p.setRootRule(g.rule(CppGrammarImpl.ppImport));
 
     assertThat(p).matches("import foo;");
     assertThat(p).matches("export import foo;");
@@ -224,7 +224,7 @@ public class CppGrammarTest {
 
   @Test
   public void moduleLine_reallife() {
-    p.setRootRule(g.rule(CppGrammar.ppModule));
+    p.setRootRule(g.rule(CppGrammarImpl.ppModule));
 
     assertThat(p).matches("module;");
     assertThat(p).matches("module :private;");
@@ -234,9 +234,9 @@ public class CppGrammarTest {
 
   @Test
   public void expandedIncludeBody() {
-    p.setRootRule(g.rule(CppGrammar.expandedIncludeBody));
+    p.setRootRule(g.rule(CppGrammarImpl.expandedIncludeBody));
 
-    mockRule(CppGrammar.ppToken);
+    mockRule(CppGrammarImpl.ppToken);
 
     assertThat(p).matches("<ppToken>");
     assertThat(p).matches("\"jabadu\"");
@@ -244,7 +244,7 @@ public class CppGrammarTest {
 
   @Test
   public void includeLine_reallife() {
-    p.setRootRule(g.rule(CppGrammar.includeLine));
+    p.setRootRule(g.rule(CppGrammarImpl.includeLine));
 
     assertThat(p).matches("#include <file>");
     assertThat(p).matches("#include <file.h>");
@@ -264,7 +264,7 @@ public class CppGrammarTest {
 
   @Test
   public void ifdefLine() {
-    p.setRootRule(g.rule(CppGrammar.ifdefLine));
+    p.setRootRule(g.rule(CppGrammarImpl.ifdefLine));
 
     assertThat(p).matches("#ifdef foo");
     assertThat(p).matches("#ifndef foo");
@@ -274,7 +274,7 @@ public class CppGrammarTest {
 
   @Test
   public void elseLine() {
-    p.setRootRule(g.rule(CppGrammar.elseLine));
+    p.setRootRule(g.rule(CppGrammarImpl.elseLine));
 
     assertThat(p).matches("#else");
     assertThat(p).matches("#else  // if lala");
@@ -282,7 +282,7 @@ public class CppGrammarTest {
 
   @Test
   public void endifLine() {
-    p.setRootRule(g.rule(CppGrammar.endifLine));
+    p.setRootRule(g.rule(CppGrammarImpl.endifLine));
 
     assertThat(p).matches("#endif");
     assertThat(p).matches("#endif  // LLVM_DEBUGINFO_DWARFDEBUGRANGELIST_H");
@@ -290,21 +290,21 @@ public class CppGrammarTest {
 
   @Test
   public void undefLine() {
-    p.setRootRule(g.rule(CppGrammar.undefLine));
+    p.setRootRule(g.rule(CppGrammarImpl.undefLine));
 
     assertThat(p).matches("#undef foo");
   }
 
   @Test
   public void lineLine() {
-    p.setRootRule(g.rule(CppGrammar.lineLine));
+    p.setRootRule(g.rule(CppGrammarImpl.lineLine));
 
     assertThat(p).matches("#line foo bar");
   }
 
   @Test
   public void errorLine() {
-    p.setRootRule(g.rule(CppGrammar.errorLine));
+    p.setRootRule(g.rule(CppGrammarImpl.errorLine));
 
     assertThat(p).matches("#error foo");
     assertThat(p).matches("#error");
@@ -312,21 +312,21 @@ public class CppGrammarTest {
 
   @Test
   public void pragmaLine() {
-    p.setRootRule(g.rule(CppGrammar.pragmaLine));
+    p.setRootRule(g.rule(CppGrammarImpl.pragmaLine));
 
     assertThat(p).matches("#pragma foo");
   }
 
   @Test
   public void warningLine() {
-    p.setRootRule(g.rule(CppGrammar.warningLine));
+    p.setRootRule(g.rule(CppGrammarImpl.warningLine));
 
     assertThat(p).matches("#warning foo");
   }
 
   @Test
   public void miscLine() {
-    p.setRootRule(g.rule(CppGrammar.miscLine));
+    p.setRootRule(g.rule(CppGrammarImpl.miscLine));
 
     assertThat(p).matches("#");
     assertThat(p).matches("# lala");
@@ -335,52 +335,52 @@ public class CppGrammarTest {
 
   @Test
   public void ifLine() {
-    p.setRootRule(g.rule(CppGrammar.ifLine));
+    p.setRootRule(g.rule(CppGrammarImpl.ifLine));
 
-    mockRule(CppGrammar.constantExpression);
+    mockRule(CppGrammarImpl.constantExpression);
 
     assertThat(p).matches("#if constantExpression");
   }
 
   @Test
   public void elifLine() {
-    p.setRootRule(g.rule(CppGrammar.elifLine));
+    p.setRootRule(g.rule(CppGrammarImpl.elifLine));
 
-    mockRule(CppGrammar.constantExpression);
+    mockRule(CppGrammarImpl.constantExpression);
 
     assertThat(p).matches("#elif constantExpression");
   }
 
   @Test
   public void ifLine_reallive() {
-    p.setRootRule(g.rule(CppGrammar.ifLine));
+    p.setRootRule(g.rule(CppGrammarImpl.ifLine));
 
     assertThat(p).matches(
       "#if defined _FORTIFY_SOURCE && _FORTIFY_SOURCE > 0 && __GNUC_PREREQ (4, 1) && defined __OPTIMIZE__ && __OPTIMIZE__ > 0");
     assertThat(p).matches("#if 0   // Re-enable once PR13021 is fixed.");
     assertThat(p).matches("#if ((OSVER(NTDDI_VERSION) == NTDDI_WIN2K) && (1))");
 
-    assert (p.parse("#if A (4, 1)").getFirstDescendant(CppGrammar.functionlikeMacro) != null);
-    assert (p.parse("#if A ()").getFirstDescendant(CppGrammar.functionlikeMacro) != null);
-    assert (p.parse("#if A()").getFirstDescendant(CppGrammar.functionlikeMacro) != null);
+    assert (p.parse("#if A (4, 1)").getFirstDescendant(CppGrammarImpl.functionlikeMacro) != null);
+    assert (p.parse("#if A ()").getFirstDescendant(CppGrammarImpl.functionlikeMacro) != null);
+    assert (p.parse("#if A()").getFirstDescendant(CppGrammarImpl.functionlikeMacro) != null);
 
-    assert (p.parse("#if defined(A)").getFirstDescendant(CppGrammar.definedExpression) != null);
-    assert (p.parse("#if defined (A)").getFirstDescendant(CppGrammar.definedExpression) != null);
-    assert (p.parse("#if defined A").getFirstDescendant(CppGrammar.definedExpression) != null);
+    assert (p.parse("#if defined(A)").getFirstDescendant(CppGrammarImpl.definedExpression) != null);
+    assert (p.parse("#if defined (A)").getFirstDescendant(CppGrammarImpl.definedExpression) != null);
+    assert (p.parse("#if defined A").getFirstDescendant(CppGrammarImpl.definedExpression) != null);
   }
 
   @Test
   public void constantExpression() {
-    p.setRootRule(g.rule(CppGrammar.constantExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.constantExpression));
 
-    mockRule(CppGrammar.conditionalExpression);
+    mockRule(CppGrammarImpl.conditionalExpression);
 
     assertThat(p).matches("conditionalExpression");
   }
 
   @Test
   public void constantExpression_reallive() {
-    p.setRootRule(g.rule(CppGrammar.constantExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.constantExpression));
 
     assertThat(p).matches("(1 || 0) && (0 && 1)");
     assertThat(p).matches("(1)");
@@ -392,10 +392,10 @@ public class CppGrammarTest {
 
   @Test
   public void conditionalExpression() {
-    p.setRootRule(g.rule(CppGrammar.conditionalExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.conditionalExpression));
 
-    mockRule(CppGrammar.logicalOrExpression);
-    mockRule(CppGrammar.expression);
+    mockRule(CppGrammarImpl.logicalOrExpression);
+    mockRule(CppGrammarImpl.expression);
 
     assertThat(p).matches("logicalOrExpression");
     assertThat(p).matches("logicalOrExpression ? expression : logicalOrExpression");
@@ -404,9 +404,9 @@ public class CppGrammarTest {
 
   @Test
   public void logicalOrExpression() {
-    p.setRootRule(g.rule(CppGrammar.logicalOrExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.logicalOrExpression));
 
-    mockRule(CppGrammar.logicalAndExpression);
+    mockRule(CppGrammarImpl.logicalAndExpression);
 
     assertThat(p).matches("logicalAndExpression");
     assertThat(p).matches("logicalAndExpression || logicalAndExpression");
@@ -414,9 +414,9 @@ public class CppGrammarTest {
 
   @Test
   public void logicalAndExpression() {
-    p.setRootRule(g.rule(CppGrammar.logicalAndExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.logicalAndExpression));
 
-    mockRule(CppGrammar.inclusiveOrExpression);
+    mockRule(CppGrammarImpl.inclusiveOrExpression);
 
     assertThat(p).matches("inclusiveOrExpression");
     assertThat(p).matches("inclusiveOrExpression && inclusiveOrExpression");
@@ -424,16 +424,16 @@ public class CppGrammarTest {
 
   @Test
   public void logicalAndExpression_reallive() {
-    p.setRootRule(g.rule(CppGrammar.logicalAndExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.logicalAndExpression));
 
     assertThat(p).matches("A() && B()");
   }
 
   @Test
   public void inclusiveOrExpression() {
-    p.setRootRule(g.rule(CppGrammar.inclusiveOrExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.inclusiveOrExpression));
 
-    mockRule(CppGrammar.exclusiveOrExpression);
+    mockRule(CppGrammarImpl.exclusiveOrExpression);
 
     assertThat(p).matches("exclusiveOrExpression");
     assertThat(p).matches("exclusiveOrExpression | exclusiveOrExpression");
@@ -441,9 +441,9 @@ public class CppGrammarTest {
 
   @Test
   public void exclusiveOrExpression() {
-    p.setRootRule(g.rule(CppGrammar.exclusiveOrExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.exclusiveOrExpression));
 
-    mockRule(CppGrammar.andExpression);
+    mockRule(CppGrammarImpl.andExpression);
 
     assertThat(p).matches("andExpression");
     assertThat(p).matches("andExpression ^ andExpression");
@@ -451,9 +451,9 @@ public class CppGrammarTest {
 
   @Test
   public void andExpression() {
-    p.setRootRule(g.rule(CppGrammar.andExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.andExpression));
 
-    mockRule(CppGrammar.equalityExpression);
+    mockRule(CppGrammarImpl.equalityExpression);
 
     assertThat(p).matches("equalityExpression");
     assertThat(p).matches("equalityExpression & equalityExpression");
@@ -461,9 +461,9 @@ public class CppGrammarTest {
 
   @Test
   public void equalityExpression() {
-    p.setRootRule(g.rule(CppGrammar.equalityExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.equalityExpression));
 
-    mockRule(CppGrammar.relationalExpression);
+    mockRule(CppGrammarImpl.relationalExpression);
 
     assertThat(p).matches("relationalExpression");
     assertThat(p).matches("relationalExpression == relationalExpression");
@@ -472,9 +472,9 @@ public class CppGrammarTest {
 
   @Test
   public void relationalExpression() {
-    p.setRootRule(g.rule(CppGrammar.relationalExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.relationalExpression));
 
-    mockRule(CppGrammar.shiftExpression);
+    mockRule(CppGrammarImpl.shiftExpression);
 
     assertThat(p).matches("shiftExpression");
     assertThat(p).matches("shiftExpression < shiftExpression");
@@ -485,9 +485,9 @@ public class CppGrammarTest {
 
   @Test
   public void shiftExpression() {
-    p.setRootRule(g.rule(CppGrammar.shiftExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.shiftExpression));
 
-    mockRule(CppGrammar.additiveExpression);
+    mockRule(CppGrammarImpl.additiveExpression);
 
     assertThat(p).matches("additiveExpression");
     assertThat(p).matches("additiveExpression << additiveExpression");
@@ -496,9 +496,9 @@ public class CppGrammarTest {
 
   @Test
   public void additiveExpression() {
-    p.setRootRule(g.rule(CppGrammar.additiveExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.additiveExpression));
 
-    mockRule(CppGrammar.multiplicativeExpression);
+    mockRule(CppGrammarImpl.multiplicativeExpression);
 
     assertThat(p).matches("multiplicativeExpression");
     assertThat(p).matches("multiplicativeExpression + multiplicativeExpression");
@@ -507,9 +507,9 @@ public class CppGrammarTest {
 
   @Test
   public void multiplicativeExpression() {
-    p.setRootRule(g.rule(CppGrammar.multiplicativeExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.multiplicativeExpression));
 
-    mockRule(CppGrammar.unaryExpression);
+    mockRule(CppGrammarImpl.unaryExpression);
 
     assertThat(p).matches("unaryExpression");
     assertThat(p).matches("unaryExpression * unaryExpression");
@@ -519,11 +519,11 @@ public class CppGrammarTest {
 
   @Test
   public void unaryExpression() {
-    p.setRootRule(g.rule(CppGrammar.unaryExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.unaryExpression));
 
-    mockRule(CppGrammar.multiplicativeExpression);
-    mockRule(CppGrammar.primaryExpression);
-    mockRule(CppGrammar.unaryOperator);
+    mockRule(CppGrammarImpl.multiplicativeExpression);
+    mockRule(CppGrammarImpl.primaryExpression);
+    mockRule(CppGrammarImpl.unaryOperator);
 
     assertThat(p).matches("unaryOperator multiplicativeExpression");
     assertThat(p).matches("primaryExpression");
@@ -531,12 +531,12 @@ public class CppGrammarTest {
 
   @Test
   public void primaryExpression() {
-    p.setRootRule(g.rule(CppGrammar.primaryExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.primaryExpression));
 
-    mockRule(CppGrammar.literal);
-    mockRule(CppGrammar.expression);
-    mockRule(CppGrammar.hasIncludeExpression);
-    mockRule(CppGrammar.definedExpression);
+    mockRule(CppGrammarImpl.literal);
+    mockRule(CppGrammarImpl.expression);
+    mockRule(CppGrammarImpl.hasIncludeExpression);
+    mockRule(CppGrammarImpl.definedExpression);
 
     assertThat(p).matches("literal");
     assertThat(p).matches("( expression )");
@@ -547,16 +547,16 @@ public class CppGrammarTest {
 
   @Test
   public void primaryExpression_reallive() {
-    p.setRootRule(g.rule(CppGrammar.primaryExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.primaryExpression));
 
     assertThat(p).matches("(C(A() && B()))");
   }
 
   @Test
   public void expression() {
-    p.setRootRule(g.rule(CppGrammar.expression));
+    p.setRootRule(g.rule(CppGrammarImpl.expression));
 
-    mockRule(CppGrammar.conditionalExpression);
+    mockRule(CppGrammarImpl.conditionalExpression);
 
     assertThat(p).matches("conditionalExpression");
     assertThat(p).matches("conditionalExpression, conditionalExpression");
@@ -564,14 +564,14 @@ public class CppGrammarTest {
 
   @Test
   public void expression_reallive() {
-    p.setRootRule(g.rule(CppGrammar.expression));
+    p.setRootRule(g.rule(CppGrammarImpl.expression));
 
     assertThat(p).matches("C(A() && B())");
   }
 
   @Test
   public void definedExpression() {
-    p.setRootRule(g.rule(CppGrammar.definedExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.definedExpression));
 
     assertThat(p).matches("defined LALA");
     assertThat(p).matches("defined (LALA)");
@@ -583,19 +583,19 @@ public class CppGrammarTest {
 
   @Test
   public void functionlikeMacro() {
-    p.setRootRule(g.rule(CppGrammar.functionlikeMacro));
+    p.setRootRule(g.rule(CppGrammarImpl.functionlikeMacro));
 
-    mockRule(CppGrammar.argumentList);
+    mockRule(CppGrammarImpl.argumentList);
 
     assertThat(p).matches("__has_feature(argumentList)");
   }
 
   @Test
   public void hasIncludeExpression() {
-    p.setRootRule(g.rule(CppGrammar.hasIncludeExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.hasIncludeExpression));
 
-    mockRule(CppGrammar.includeBodyBracketed);
-    mockRule(CppGrammar.includeBodyQuoted);
+    mockRule(CppGrammarImpl.includeBodyBracketed);
+    mockRule(CppGrammarImpl.includeBodyQuoted);
 
     assertThat(p).matches("__has_include( includeBodyBracketed )");
     assertThat(p).matches("__has_include( includeBodyQuoted )");
@@ -603,7 +603,7 @@ public class CppGrammarTest {
 
   @Test
   public void hasIncludeExpression_reallife() {
-    p.setRootRule(g.rule(CppGrammar.hasIncludeExpression));
+    p.setRootRule(g.rule(CppGrammarImpl.hasIncludeExpression));
 
     assertThat(p).matches("__has_include( <optional> )");
     assertThat(p).matches("__has_include( \"optional.hpp\" )");
@@ -611,7 +611,7 @@ public class CppGrammarTest {
 
   @Test
   public void functionlikeMacro_reallife() {
-    p.setRootRule(g.rule(CppGrammar.functionlikeMacro));
+    p.setRootRule(g.rule(CppGrammarImpl.functionlikeMacro));
 
     assertThat(p).matches("__has_feature(cxx_rvalue)");
     assertThat(p).matches("__has_feature(cxx_rvalue, bla)");

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/ExpressionEvaluatorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/ExpressionEvaluatorTest.java
@@ -31,13 +31,12 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import org.sonar.cxx.config.CxxSquidConfiguration;
 import org.sonar.squidbridge.SquidAstVisitorContext;
 
 public class ExpressionEvaluatorTest {
 
   static boolean eval(String constExpr, CxxPreprocessor pp) {
-    return ExpressionEvaluator.eval(mock(CxxSquidConfiguration.class), pp, constExpr);
+    return ExpressionEvaluator.eval(pp, constExpr);
   }
 
   static boolean eval(String constExpr) {

--- a/integration-tests/features/common.py
+++ b/integration-tests/features/common.py
@@ -50,7 +50,7 @@ try:
     RESET_ALL = colorama.Style.RESET_ALL   
 except ImportError:
     print("Can't init colorama!")
-    pass
+
 
 INDENT = "    "    
 SONAR_URL = "http://localhost:9000"

--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -64,7 +64,6 @@ try:
     RESET_ALL = colorama.Style.RESET_ALL   
 except ImportError:
     print("Can't init colorama!")
-    pass
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
- __VA_OPT__ support, close #2014
- rename CppGrammarImpl (same as CxxGrammarImpl)
- remove CxxSquidConfiguration from CxxLexer, CppLexer and ExpressionEvaluator
- correct line number of module tokens
- CxxPreprocessor refactoring

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2015)
<!-- Reviewable:end -->
