### PR TITLE
optimize preprocessor

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/config/CxxSquidConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/config/CxxSquidConfiguration.java
@@ -234,6 +234,30 @@ public class CxxSquidConfiguration extends SquidConfiguration {
   }
 
   /**
+   * Used to read multi-valued properties from one level.
+   *
+   * The method can return an empty list if the property is not set.
+   *
+   * @param level level to read
+   * @param property key that is searched for
+   * @return the values with the specified key value
+   */
+  public List<String> getLevelValues(String level, String key) {
+    List<String> result = new ArrayList<>();
+    Element eLevel = findLevel(level, null);
+    if (eLevel != null) {
+      Element eKey = eLevel.getChild(key);
+      if (eKey != null) {
+        for (var value : eKey.getChildren("Value")) {
+          result.add(value.getText());
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
    * Used to read multi-valued properties.
    *
    * Collects all found values over all levels. It starts with the given level and further found values in parent levels
@@ -474,6 +498,10 @@ public class CxxSquidConfiguration extends SquidConfiguration {
     if (Verifier.checkElementName(level) == null) {
       xpath = "/CompilationDatabase/" + level;
     } else {
+      // handle special case 'FILES empty' no need to search in tree
+      if (parentList.getFirst().getContentSize() == 0) {
+        return defaultElement;
+      }
       xpath = "//Files/File[@path='" + unifyPath(level) + "']";
     }
     XPathExpression<Element> expr = xFactory.compile(xpath, Filters.element());

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/MapChain.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/MapChain.java
@@ -60,6 +60,11 @@ public class MapChain<K, V> {
     enabled.putAll(m);
   }
 
+  public void putAll(MapChain<K, V> m) {
+    enabled.putAll(m.enabled);
+    disabled.putAll(m.disabled);
+  }
+
   /**
    * remove
    *

--- a/cxx-squid/src/test/java/org/sonar/cxx/config/CxxSquidConfigurationTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/config/CxxSquidConfigurationTest.java
@@ -247,6 +247,19 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
+  public void testLevelValues() {
+    var db = new CxxSquidConfiguration();
+    db.add(CxxSquidConfiguration.GLOBAL, "key", "value1");
+    db.add(CxxSquidConfiguration.SONAR_PROJECT_PROPERTIES, "key", "value2");
+    List<String> values = db.getLevelValues(CxxSquidConfiguration.GLOBAL, "key");
+
+    var softly = new SoftAssertions();
+    softly.assertThat(values).hasSize(1);
+    softly.assertThat(values.get(0)).isEqualTo("value1");
+    softly.assertAll();
+  }
+
+  @Test
   public void testPathNames() {
     var db = new CxxSquidConfiguration();
     db.add("/a/b/c.cpp", "key1", "value1");

--- a/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithPreprocessingTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithPreprocessingTest.java
@@ -409,7 +409,7 @@ public class CxxLexerWithPreprocessingTest {
   @Test
   public void includes_are_working() throws IOException {
     SourceCodeProvider scp = mock(SourceCodeProvider.class);
-    when(scp.getSourceCodeFile(anyString(), anyString(), eq(false))).thenReturn(new File("file"));
+    when(scp.getSourceCodeFile(anyString(), eq(false))).thenReturn(new File("file"));
     when(scp.getSourceCode(any(File.class), any(Charset.class))).thenReturn("#define A B\n");
 
     SquidAstVisitorContext<Grammar> ctx = mock(SquidAstVisitorContext.class);
@@ -707,7 +707,7 @@ public class CxxLexerWithPreprocessingTest {
                     "false");
 
     final SourceCodeProvider provider = mock(SourceCodeProvider.class);
-    when(provider.getSourceCodeFile(Mockito.eq(forceIncludePath), Mockito.any(String.class), Mockito.anyBoolean()))
+    when(provider.getSourceCodeFile(Mockito.eq(forceIncludePath), Mockito.anyBoolean()))
       .thenReturn(forceIncludeFile);
     when(provider.getSourceCode(Mockito.eq(forceIncludeFile), Mockito.any(Charset.class)))
       .thenReturn("#define __LINE__ 345");

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/CxxParserTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/CxxParserTest.java
@@ -56,7 +56,7 @@ public class CxxParserTest {
   }
 
   @Test
-  public void testParsingOnDiverseCppSourceFiles() {
+  public void testParsingCppSourceFiles() {
     var map = new HashMap<String, Integer>() {
       private static final long serialVersionUID = 6029310517902718597L;
 
@@ -82,28 +82,34 @@ public class CxxParserTest {
 
     Parser<Grammar> p = createParser(null, false, null);
 
+    long start = System.currentTimeMillis();
     for (var file : listFiles(goodFiles, new String[]{"cc", "cpp", "hpp"})) {
       AstNode root = parse(p, file);
       verify(root, file, map);
     }
+    long finish = System.currentTimeMillis();
+    double duration = (finish - start) / 1000.;
   }
 
   //@Test todo
-  public void testParsingOnDiverseCSourceFiles() {
+  public void testParsingCSourceFiles() {
     var map = new HashMap<String, Integer>() {
     };
 
     Parser<Grammar> p = createParser(null, false, null);
 
+    long start = System.currentTimeMillis();
     for (var file : listFiles(cCompatibilityFiles, new String[]{"cc", "h"})) { // todo add "c"
       AstNode root = parse(p, file);
       verify(root, file, map);
     }
+    long finish = System.currentTimeMillis();
+    double duration = (finish - start) / 1000.;
   }
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testPreproccessorParsingOnDiverseSourceFiles() {
+  public void testPreproccessorParsingSourceFiles() {
     var includes = Arrays.asList(
       "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\INCLUDE",
       "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\ATLMFC\\INCLUDE",
@@ -131,10 +137,13 @@ public class CxxParserTest {
     var baseDir = new File("src/test").getAbsolutePath();
     Parser<Grammar> p = createParser(baseDir, false, includes);
 
+    long start = System.currentTimeMillis();
     for (var file : listFiles(preprocessorFiles, new String[]{"cc", "cpp", "hpp", "h"})) {
       AstNode root = parse(p, file);
       verify(root, file, map);
     }
+    long finish = System.currentTimeMillis();
+    double duration = (finish - start) / 1000.;
   }
 
   @Test

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/SourceCodeProviderTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/SourceCodeProviderTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 
 public class SourceCodeProviderTest {
 
-  private final SourceCodeProvider codeProvider = new SourceCodeProvider();
   private final File expected1 = new File(new File("src/test/resources/codeprovider/source.hh").getAbsolutePath());
   private final File expected2 = new File(new File("src/test/resources/codeprovider/source").getAbsolutePath());
 
@@ -42,117 +41,125 @@ public class SourceCodeProviderTest {
     // working directory and should work the same in the quoted and
     // unquoted case
 
+    SourceCodeProvider codeProvider = new SourceCodeProvider(new File("src/test/resources/codeprovider/dummy.cpp"));
     String path = expected1.getAbsolutePath();
-    String dummycwd = new File("src/test/resources/codeprovider").getAbsolutePath();
 
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, null, true));
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, null, false));
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, dummycwd, true));
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, dummycwd, false));
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, true));
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, false));
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, true));
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, false));
   }
 
   // ////////////////////////////////////////////////////////////////////////////
   // Relpathes, standard behavior: equal for quoted and angle cases
   // We have following cases here:
   // Include string form | Include root form |
-  // | absolute | relative |
-  // simple | 1 | 2 |
+  //           | absolute | relative |
+  // simple    | 1        | 2        |
   // -------------------------------------------
-  // rel. path | 3 | 4 |
+  // rel. path | 3        | 4        |
   @Test
   public void getting_file_relpath_case1() {
-    String baseDir = new File("src/test").getAbsolutePath();
-    String dummycwd = "/";
-    String path = "source.hh";
-    String includeRoot = Paths.get("src/test/resources/codeprovider").toAbsolutePath().toString();
+    SourceCodeProvider codeProvider = new SourceCodeProvider(new File("dummy"));
 
+    String includeRoot = Paths.get("src/test/resources/codeprovider").toAbsolutePath().toString();
+    String baseDir = new File("src/test").getAbsolutePath();
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, dummycwd, true));
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, dummycwd, false));
+
+    String path = "source.hh";
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, true));
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, false));
   }
 
   @Test
   public void getting_file_relpath_case1_without_extension() {
-    String baseDir = new File("src/test").getAbsolutePath();
-    String dummycwd = "/";
-    String path = "source";
-    String includeRoot = Paths.get("src/test/resources/codeprovider").toAbsolutePath().toString();
+    SourceCodeProvider codeProvider = new SourceCodeProvider(new File("dummy"));
 
+    String includeRoot = Paths.get("src/test/resources/codeprovider").toAbsolutePath().toString();
+    String baseDir = new File("src/test").getAbsolutePath();
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
-    assertEquals(expected2, codeProvider.getSourceCodeFile(path, dummycwd, true));
-    assertEquals(expected2, codeProvider.getSourceCodeFile(path, dummycwd, false));
+
+    String path = "source";
+    assertEquals(expected2, codeProvider.getSourceCodeFile(path, true));
+    assertEquals(expected2, codeProvider.getSourceCodeFile(path, false));
   }
 
   @Test
   public void getting_file_relpath_case2() {
-    String baseDir = new File("src/test").getAbsolutePath();
-    String dummycwd = "/";
-    String path = "source.hh";
-    String includeRoot = Paths.get("resources/codeprovider").toString();
+    SourceCodeProvider codeProvider = new SourceCodeProvider(new File("dummy"));
 
+    String includeRoot = Paths.get("resources/codeprovider").toString();
+    String baseDir = new File("src/test").getAbsolutePath();
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, dummycwd, true));
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, dummycwd, false));
+
+    String path = "source.hh";
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, true));
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, false));
   }
 
   @Test
   public void getting_file_relpath_case2_without_extension() {
-    String baseDir = new File("src/test").getAbsolutePath();
-    String dummycwd = "/";
-    String path = "source";
-    String includeRoot = Paths.get("resources/codeprovider").toString();
+    SourceCodeProvider codeProvider = new SourceCodeProvider(new File("dummy"));
 
+    String includeRoot = Paths.get("resources/codeprovider").toString();
+    String baseDir = new File("src/test").getAbsolutePath();
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
-    assertEquals(expected2, codeProvider.getSourceCodeFile(path, dummycwd, true));
-    assertEquals(expected2, codeProvider.getSourceCodeFile(path, dummycwd, false));
+
+    String path = "source";
+    assertEquals(expected2, codeProvider.getSourceCodeFile(path, true));
+    assertEquals(expected2, codeProvider.getSourceCodeFile(path, false));
   }
 
   @Test
   public void getting_file_relpath_case3() {
-    String baseDir = new File("src/test").getAbsolutePath();
-    String dummycwd = "/";
-    String path = "codeprovider/source.hh";
-    String includeRoot = Paths.get("src/test/resources").toAbsolutePath().toString();
+    SourceCodeProvider codeProvider = new SourceCodeProvider(new File("dummy"));
 
+    String includeRoot = Paths.get("src/test/resources").toAbsolutePath().toString();
+    String baseDir = new File("src/test").getAbsolutePath();
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, dummycwd, true));
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, dummycwd, false));
+
+    String path = "codeprovider/source.hh";
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, true));
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, false));
   }
 
   @Test
   public void getting_file_relpath_case3_without_extension() {
-    String baseDir = new File("src/test").getAbsolutePath();
-    String dummycwd = "/";
-    String path = "codeprovider/source";
-    String includeRoot = Paths.get("src/test/resources").toAbsolutePath().toString();
+    SourceCodeProvider codeProvider = new SourceCodeProvider(new File("dummy"));
 
+    String includeRoot = Paths.get("src/test/resources").toAbsolutePath().toString();
+    String baseDir = new File("src/test").getAbsolutePath();
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
-    assertEquals(expected2, codeProvider.getSourceCodeFile(path, dummycwd, true));
-    assertEquals(expected2, codeProvider.getSourceCodeFile(path, dummycwd, false));
+
+    String path = "codeprovider/source";
+    assertEquals(expected2, codeProvider.getSourceCodeFile(path, true));
+    assertEquals(expected2, codeProvider.getSourceCodeFile(path, false));
   }
 
   @Test
   public void getting_file_relpath_case4() {
-    String baseDir = new File("src/test").getAbsolutePath();
-    String dummycwd = "/";
-    String path = "codeprovider/source.hh";
-    String includeRoot = Paths.get("resources").toString();
+    SourceCodeProvider codeProvider = new SourceCodeProvider(new File("dummy"));
 
+    String includeRoot = Paths.get("resources").toString();
+    String baseDir = new File("src/test").getAbsolutePath();
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, dummycwd, true));
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, dummycwd, false));
+
+    String path = "codeprovider/source.hh";
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, true));
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, false));
   }
 
   @Test
   public void getting_file_relpath_case4_without_extension() {
-    String baseDir = new File("src/test").getAbsolutePath();
-    String dummycwd = "/";
-    String path = "codeprovider/source";
-    String includeRoot = Paths.get("resources").toString();
+    SourceCodeProvider codeProvider = new SourceCodeProvider(new File("dummy"));
 
+    String includeRoot = Paths.get("resources").toString();
+    String baseDir = new File("src/test").getAbsolutePath();
     codeProvider.setIncludeRoots(Arrays.asList(includeRoot), baseDir);
-    assertEquals(expected2, codeProvider.getSourceCodeFile(path, dummycwd, true));
-    assertEquals(expected2, codeProvider.getSourceCodeFile(path, dummycwd, false));
+
+    String path = "codeprovider/source";
+    assertEquals(expected2, codeProvider.getSourceCodeFile(path, true));
+    assertEquals(expected2, codeProvider.getSourceCodeFile(path, false));
   }
 
   // ////////////////////////////////////////////////////////////////////////////
@@ -160,35 +167,41 @@ public class SourceCodeProviderTest {
   // Lookup in the current directory. Has to fail for the angle case
   @Test
   public void getting_file_with_filename_and_cwd() {
-    String cwd = new File("src/test/resources/codeprovider").getAbsolutePath();
+    SourceCodeProvider codeProvider = new SourceCodeProvider(new File("src/test/resources/codeprovider/dummy.cpp"));
+
     String path = "source.hh";
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, cwd, true));
-    assertNull(codeProvider.getSourceCodeFile(path, cwd, false));
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, true));
+    assertNull(codeProvider.getSourceCodeFile(path, false));
   }
 
   @Test
   public void getting_file_with_relpath_and_cwd() {
-    String cwd = new File("src/test/resources").getAbsolutePath();
+    SourceCodeProvider codeProvider = new SourceCodeProvider(new File("src/test/resources/dummy.cpp"));
+
     String path = "codeprovider/source.hh";
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, cwd, true));
-    assertNull(codeProvider.getSourceCodeFile(path, cwd, false));
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, true));
+    assertNull(codeProvider.getSourceCodeFile(path, false));
   }
 
   @Test
   public void getting_file_with_relpath_containing_backsteps_and_cwd() {
-    String cwd = new File("src/test/resources/codeprovider/folder").getAbsolutePath();
+    SourceCodeProvider codeProvider = new SourceCodeProvider(
+      new File("src/test/resources/codeprovider/folder/dummy.cpp"));
+
     String path = "../source.hh";
-    assertEquals(expected1, codeProvider.getSourceCodeFile(path, cwd, true));
-    assertNull(codeProvider.getSourceCodeFile(path, cwd, false));
+    assertEquals(expected1, codeProvider.getSourceCodeFile(path, true));
+    assertNull(codeProvider.getSourceCodeFile(path, false));
   }
 
   @Test
   public void getting_source_code1() throws IOException {
+    SourceCodeProvider codeProvider = new SourceCodeProvider(new File("dummy"));
     assertEquals("source code", codeProvider.getSourceCode(expected1, Charset.defaultCharset()));
   }
 
   @Test
   public void getting_source_code2() throws IOException {
+    SourceCodeProvider codeProvider = new SourceCodeProvider(new File("dummy"));
     assertEquals("source code", codeProvider.getSourceCode(expected2, Charset.defaultCharset()));
   }
 


### PR DESCRIPTION
- parse global macros only once
- cache absolute path to contextFile (getFileUnderAnalysisPath)
- optimize CxxSquidConfiguration.findLevel: case that FILES are empty is the default and is optimized now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2017)
<!-- Reviewable:end -->
