### PR TITLE
SonarCFamily support

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensor.java
@@ -75,7 +75,7 @@ public class CxxClangSASensor extends CxxIssuesReportSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX Clang Static Analyzer report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx","cpp", "c")
       .createIssuesForRuleRepository(getRuleRepositoryKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathsKey()));
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensor.java
@@ -104,7 +104,7 @@ public class CxxClangTidySensor extends CxxIssuesReportSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX Clang-Tidy report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx","cpp", "c")
       .createIssuesForRuleRepository(getRuleRepositoryKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathsKey()));
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensor.java
@@ -85,7 +85,7 @@ public class CxxCompilerGccSensor extends CxxCompilerSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX GCC compiler report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx", "cpp", "c")
       .createIssuesForRuleRepositories(getRuleRepositoryKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathsKey()));
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcSensor.java
@@ -79,7 +79,7 @@ public class CxxCompilerVcSensor extends CxxCompilerSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX Visual Studio compiler report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx", "cpp", "c")
       .createIssuesForRuleRepositories(getRuleRepositoryKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathsKey()));
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/bullseye/CxxCoverageBullseyeSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/bullseye/CxxCoverageBullseyeSensor.java
@@ -56,7 +56,7 @@ public class CxxCoverageBullseyeSensor extends CoverageSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX Bullseye coverage report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx", "cpp", "c")
       .onlyWhenConfiguration(conf -> conf.hasKey(REPORT_PATH_KEY));
   }
 

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/cobertura/CxxCoverageCoberturaSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/cobertura/CxxCoverageCoberturaSensor.java
@@ -56,7 +56,7 @@ public class CxxCoverageCoberturaSensor extends CoverageSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX Cobertura XML coverage report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx", "cpp", "c")
       .onlyWhenConfiguration(conf -> conf.hasKey(REPORT_PATH_KEY));
   }
 

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/ctc/CxxCoverageTestwellCtcTxtSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/ctc/CxxCoverageTestwellCtcTxtSensor.java
@@ -56,7 +56,7 @@ public class CxxCoverageTestwellCtcTxtSensor extends CoverageSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX Testwell CTC++ TXT coverage report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx", "cpp", "c")
       .onlyWhenConfiguration(conf -> conf.hasKey(REPORT_PATH_KEY));
   }
 

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/vs/CxxCoverageVisualStudioSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/vs/CxxCoverageVisualStudioSensor.java
@@ -56,7 +56,7 @@ public class CxxCoverageVisualStudioSensor extends CoverageSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX Visual Studio XML coverage report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx", "cpp", "c")
       .onlyWhenConfiguration(conf -> conf.hasKey(REPORT_PATH_KEY));
   }
 

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckSensor.java
@@ -65,7 +65,7 @@ public class CxxCppCheckSensor extends CxxIssuesReportSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX Cppcheck report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx", "cpp", "c")
       .createIssuesForRuleRepository(getRuleRepositoryKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathsKey()));
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/CxxDrMemorySensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/CxxDrMemorySensor.java
@@ -73,7 +73,7 @@ public class CxxDrMemorySensor extends CxxIssuesReportSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX Dr. Memory report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx", "cpp", "c")
       .createIssuesForRuleRepository(getRuleRepositoryKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathsKey()));
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/infer/CxxInferSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/infer/CxxInferSensor.java
@@ -57,7 +57,7 @@ public class CxxInferSensor extends CxxIssuesReportSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX Infer report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx", "cpp", "c")
       .createIssuesForRuleRepository(getRuleRepositoryKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathsKey()));
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/other/CxxOtherSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/other/CxxOtherSensor.java
@@ -79,7 +79,7 @@ public class CxxOtherSensor extends CxxIssuesReportSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX external analyser report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx", "cpp", "c")
       .createIssuesForRuleRepository(getRuleRepositoryKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathsKey()));
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensor.java
@@ -84,7 +84,7 @@ public class CxxPCLintSensor extends CxxIssuesReportSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX PC-lint report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx", "cpp", "c")
       .createIssuesForRuleRepository(getRuleRepositoryKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathsKey()));
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/rats/CxxRatsSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/rats/CxxRatsSensor.java
@@ -74,7 +74,7 @@ public class CxxRatsSensor extends CxxIssuesReportSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX RATS report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx", "cpp", "c")
       .createIssuesForRuleRepository(getRuleRepositoryKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathsKey()));
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/tests/dotnet/CxxUnitTestResultsImportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/tests/dotnet/CxxUnitTestResultsImportSensor.java
@@ -95,7 +95,7 @@ public class CxxUnitTestResultsImportSensor implements ProjectSensor {
     descriptor
       .name("CXX VSTest/xUnit/NUnit Test report import")
       .onlyWhenConfiguration(conf -> new UnitTestConfiguration(conf).hasUnitTestResultsProperty())
-      .onlyOnLanguage("cxx");
+      .onlyOnLanguages("cxx", "cpp", "c");
   }
 
   @Override

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/tests/xunit/CxxXunitSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/tests/xunit/CxxXunitSensor.java
@@ -69,7 +69,7 @@ public class CxxXunitSensor extends CxxReportSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX xUnit Test report import")
-      //.onlyOnLanguage(getLanguage().getKey())
+      //.onlyOnLanguages("cxx","cpp", "c")
       .onlyWhenConfiguration(conf -> conf.hasKey(REPORT_PATH_KEY));
   }
 

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/valgrind/CxxValgrindSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/valgrind/CxxValgrindSensor.java
@@ -72,7 +72,7 @@ public class CxxValgrindSensor extends CxxIssuesReportSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX Valgrind report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx", "cpp", "c")
       .createIssuesForRuleRepository(getRuleRepositoryKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(REPORT_PATH_KEY));
   }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxSensor.java
@@ -63,7 +63,7 @@ public class CxxVeraxxSensor extends CxxIssuesReportSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor
       .name("CXX Vera++ report import")
-      .onlyOnLanguage("cxx")
+      .onlyOnLanguages("cxx", "cpp", "c")
       .createIssuesForRuleRepository(getRuleRepositoryKey())
       .onlyWhenConfiguration(conf -> conf.hasKey(getReportPathsKey()));
   }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensorTest.java
@@ -173,7 +173,7 @@ public class CxxClangSASensorTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo("CXX Clang Static Analyzer report import");
-    softly.assertThat(descriptor.languages()).containsOnly("cxx");
+    softly.assertThat(descriptor.languages()).containsOnly("cxx", "cpp", "c");
     softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxClangSARuleRepository.KEY);
     softly.assertAll();
   }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensorTest.java
@@ -232,7 +232,7 @@ public class CxxClangTidySensorTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo("CXX Clang-Tidy report import");
-    softly.assertThat(descriptor.languages()).containsOnly("cxx");
+    softly.assertThat(descriptor.languages()).containsOnly("cxx", "cpp", "c");
     softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxClangTidyRuleRepository.KEY);
     softly.assertAll();
   }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensorTest.java
@@ -49,7 +49,7 @@ public class CxxCompilerGccSensorTest {
     sensor.describe(descriptor);
     var softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo("CXX GCC compiler report import");
-    softly.assertThat(descriptor.languages()).containsOnly("cxx");
+    softly.assertThat(descriptor.languages()).containsOnly("cxx", "cpp", "c");
     softly.assertThat(descriptor.ruleRepositories())
       .containsOnly(CxxCompilerGccRuleRepository.KEY);
     softly.assertAll();

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcSensorTest.java
@@ -48,7 +48,7 @@ public class CxxCompilerVcSensorTest {
     sensor.describe(descriptor);
     var softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo("CXX Visual Studio compiler report import");
-    softly.assertThat(descriptor.languages()).containsOnly("cxx");
+    softly.assertThat(descriptor.languages()).containsOnly("cxx", "cpp", "c");
     softly.assertThat(descriptor.ruleRepositories())
       .containsOnly(CxxCompilerVcRuleRepository.KEY);
     softly.assertAll();

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxMSCoverageSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxMSCoverageSensorTest.java
@@ -153,7 +153,7 @@ public class CxxMSCoverageSensorTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo("CXX Visual Studio XML coverage report import");
-    softly.assertThat(descriptor.languages()).containsOnly("cxx");
+    softly.assertThat(descriptor.languages()).containsOnly("cxx", "cpp", "c");
     softly.assertAll();
   }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckSensorTest.java
@@ -123,7 +123,7 @@ public class CxxCppCheckSensorTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo("CXX Cppcheck report import");
-    softly.assertThat(descriptor.languages()).containsOnly("cxx");
+    softly.assertThat(descriptor.languages()).containsOnly("cxx", "cpp", "c");
     softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxCppCheckRuleRepository.KEY);
     softly.assertAll();
   }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/CxxDrMemorySensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/CxxDrMemorySensorTest.java
@@ -64,7 +64,7 @@ public class CxxDrMemorySensorTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo("CXX Dr. Memory report import");
-    softly.assertThat(descriptor.languages()).containsOnly("cxx");
+    softly.assertThat(descriptor.languages()).containsOnly("cxx", "cpp", "c");
     softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxDrMemoryRuleRepository.KEY);
     softly.assertAll();
   }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/infer/CxxInferSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/infer/CxxInferSensorTest.java
@@ -118,7 +118,7 @@ public class CxxInferSensorTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo("CXX Infer report import");
-    softly.assertThat(descriptor.languages()).containsOnly("cxx");
+    softly.assertThat(descriptor.languages()).containsOnly("cxx", "cpp", "c");
     softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxInferRuleRepository.KEY);
     softly.assertAll();
   }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherSensorTest.java
@@ -152,7 +152,7 @@ public class CxxOtherSensorTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo("CXX external analyser report import");
-    softly.assertThat(descriptor.languages()).containsOnly("cxx");
+    softly.assertThat(descriptor.languages()).containsOnly("cxx", "cpp", "c");
     softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxOtherRepository.KEY);
     softly.assertAll();
   }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensorTest.java
@@ -189,7 +189,7 @@ public class CxxPCLintSensorTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo("CXX PC-lint report import");
-    softly.assertThat(descriptor.languages()).containsOnly("cxx");
+    softly.assertThat(descriptor.languages()).containsOnly("cxx", "cpp", "c");
     softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxPCLintRuleRepository.KEY);
     softly.assertAll();
   }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/rats/CxxRatsSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/rats/CxxRatsSensorTest.java
@@ -68,7 +68,7 @@ public class CxxRatsSensorTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo("CXX RATS report import");
-    softly.assertThat(descriptor.languages()).containsOnly("cxx");
+    softly.assertThat(descriptor.languages()).containsOnly("cxx", "cpp", "c");
     softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxRatsRuleRepository.KEY);
     softly.assertAll();
   }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/CxxUnitTestResultsImportSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/CxxUnitTestResultsImportSensorTest.java
@@ -51,7 +51,7 @@ public class CxxUnitTestResultsImportSensorTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo("CXX VSTest/xUnit/NUnit Test report import");
-    softly.assertThat(descriptor.languages()).containsOnly("cxx");
+    softly.assertThat(descriptor.languages()).containsOnly("cxx", "cpp", "c");
     softly.assertAll();
   }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportSensorTest.java
@@ -117,7 +117,9 @@ public class CxxReportSensorTest {
 
     @Override
     public void describe(SensorDescriptor descriptor) {
-      descriptor.onlyOnLanguage("cxx").name("CxxReportSensorTest");
+      descriptor
+        .name("CxxReportSensorTest")
+        .onlyOnLanguages("cxx", "cpp", "c");
     }
   }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/CxxValgrindSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/CxxValgrindSensorTest.java
@@ -87,7 +87,7 @@ public class CxxValgrindSensorTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo("CXX Valgrind report import");
-    softly.assertThat(descriptor.languages()).containsOnly("cxx");
+    softly.assertThat(descriptor.languages()).containsOnly("cxx", "cpp", "c");
     softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxValgrindRuleRepository.KEY);
     softly.assertAll();
   }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxSensorTest.java
@@ -75,7 +75,7 @@ public class CxxVeraxxSensorTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(descriptor.name()).isEqualTo("CXX Vera++ report import");
-    softly.assertThat(descriptor.languages()).containsOnly("cxx");
+    softly.assertThat(descriptor.languages()).containsOnly("cxx", "cpp", "c");
     softly.assertThat(descriptor.ruleRepositories()).containsOnly(CxxVeraxxRuleRepository.KEY);
     softly.assertAll();
   }


### PR DESCRIPTION
- sensors for external reports are supporting languages with keys: `cxx`, `cpp` and `c`
- For reading in (indexing) the files, you have to decide whether you want to use the `cxx plugin` or the `SonarCFamily`. With SonarQube, file types can only be uniquely assigned to one programming language via the file extension. Several plugins cannot define the same programming language (language key). Therefore the `cxx plugin` uses `cxx` as language key and `SonarCFamily` uses `cpp` for C++ and `c` for C. The file extension must be deactivated in the respective other plugin: Each file extension may be defined only once in the `sonar.cxx.suffixes.sources`, `sonar.cpp.file.suffixes` or `sonar.c.file.suffixes settings`.
- The rules are configured consistently in the Quality Profiles under `CXX`.
- close #1784

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2018)
<!-- Reviewable:end -->
