### PR TITLE
fix error recovery

### DIFF
--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/ModuleTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/ModuleTest.java
@@ -29,18 +29,19 @@ public class ModuleTest extends ParserBaseTestHelper {
 
     mockRule(CxxGrammarImpl.globalModuleFragment);
     mockRule(CxxGrammarImpl.moduleDeclaration);
-    mockRule(CxxGrammarImpl.declarationSeq);
+    mockRule(CxxGrammarImpl.declaration);
     mockRule(CxxGrammarImpl.privateModuleFragment);
 
     assertThatParser()
       .matches("moduleDeclaration")
-      .matches("moduleDeclaration declarationSeq")
+      .matches("moduleDeclaration declaration")
+      .matches("moduleDeclaration declaration declaration") // declarationSeq
       .matches("globalModuleFragment moduleDeclaration")
-      .matches("globalModuleFragment moduleDeclaration declarationSeq")
+      .matches("globalModuleFragment moduleDeclaration declaration")
       .matches("moduleDeclaration privateModuleFragment")
-      .matches("moduleDeclaration declarationSeq privateModuleFragment")
+      .matches("moduleDeclaration declaration privateModuleFragment")
       .matches("globalModuleFragment moduleDeclaration privateModuleFragment")
-      .matches("globalModuleFragment moduleDeclaration declarationSeq privateModuleFragment");
+      .matches("globalModuleFragment moduleDeclaration declaration privateModuleFragment");
   }
 
   @Test


### PR DESCRIPTION
- error recovery was moved with 2.0 inside of declarationSeq which is not working
- move it back to top level (translationUnit) and handle it only there
- close #2037

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2038)
<!-- Reviewable:end -->
