### PR TITLE
CXX External Analyzers

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensor.java
@@ -56,7 +56,7 @@ public class CxxClangSASensor extends CxxIssuesReportSensor {
         .description(
           "Path to Clang Static Analyzer reports, relative to projects root. If neccessary, "
           + "<a href='https://ant.apache.org/manual/dirtasks.html'>Ant-style wildcards</a> are at your service.")
-        .category("External Analyzers")
+        .category("CXX External Analyzers")
         .subCategory("Clang Static Analyzer")
         .onQualifiers(Qualifiers.PROJECT)
         .multiValues(true)


### PR DESCRIPTION
- external report sensors are all in category 'CXX External Analyzers'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2039)
<!-- Reviewable:end -->
