### PR TITLE
CXX metrics

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/CxxMetrics.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/CxxMetrics.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
-import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.Metric;
 
 public final class CxxMetrics {
@@ -34,10 +33,11 @@ public final class CxxMetrics {
   public static final String PUBLIC_API_KEY = "CXX-public_api";
   public static final Metric<Integer> PUBLIC_API
                                         = new Metric.Builder(PUBLIC_API_KEY, "Public API", Metric.ValueType.INT)
-      .setDescription("Public API")
+      .setDescription(
+        "Total number of publicly accessible Application Programming Interfaces (API). Files that are to be analyzed are defined via 'sonar.cxx.metric.api.file.suffixes'.")
       .setDirection(Metric.DIRECTION_WORST)
       .setQualitative(Boolean.FALSE)
-      .setDomain("C++")
+      .setDomain("CXX")
       .create();
 
   public static final String PUBLIC_DOCUMENTED_API_DENSITY_KEY = "CXX-public_documented_api_density";
@@ -45,10 +45,11 @@ public final class CxxMetrics {
                                        = new Metric.Builder(PUBLIC_DOCUMENTED_API_DENSITY_KEY,
                                                             "Public Documented API (%)",
                                                             Metric.ValueType.PERCENT)
-      .setDescription("Public documented classes and functions balanced by ncloc")
+      .setDescription(
+        "Percentage of documented publicly accessible Application Programming Interfaces (API). 'Percentage = (Public API - Public Undocumented API) / Public API'")
       .setDirection(Metric.DIRECTION_BETTER)
       .setQualitative(Boolean.TRUE)
-      .setDomain("C++")
+      .setDomain("CXX")
       .setWorstValue(0.0)
       .setBestValue(100.0)
       .setOptimizedBestValue(Boolean.TRUE)
@@ -58,10 +59,11 @@ public final class CxxMetrics {
   public static final Metric<Integer> PUBLIC_UNDOCUMENTED_API = new Metric.Builder(PUBLIC_UNDOCUMENTED_API_KEY,
                                                                                    "Public Undocumented API",
                                                                                    Metric.ValueType.INT)
-    .setDescription("Public undocumented classes, functions and variables")
+    .setDescription(
+      "Total number of undocumented publicly available Application Programming Interfaces (API). Files that are to be analyzed are defined via 'sonar.cxx.metric.api.file.suffixes'.")
     .setDirection(Metric.DIRECTION_WORST)
     .setQualitative(Boolean.TRUE)
-    .setDomain("C++")
+    .setDomain("CXX")
     .setBestValue(0.0)
     .setOptimizedBestValue(Boolean.TRUE)
     .create();
@@ -71,30 +73,33 @@ public final class CxxMetrics {
   public static final Metric<Integer> COMPLEX_FUNCTIONS = new Metric.Builder(COMPLEX_FUNCTIONS_KEY,
                                                                              "Complex Functions",
                                                                              Metric.ValueType.INT)
-    .setDescription("Number of functions with high cyclomatic complexity")
+    .setDescription(
+      "Number of functions with high cyclomatic complexity. You can define the threshold with 'sonar.cxx.metric.func.complexity.threshold'.")
     .setDirection(Metric.DIRECTION_WORST)
     .setQualitative(Boolean.FALSE)
-    .setDomain(CoreMetrics.DOMAIN_COMPLEXITY)
+    .setDomain("CXX")
     .create();
 
   public static final String COMPLEX_FUNCTIONS_PERC_KEY = "CXX-perc_complex_functions";
   public static final Metric<Double> COMPLEX_FUNCTIONS_PERC = new Metric.Builder(COMPLEX_FUNCTIONS_PERC_KEY,
                                                                                  "Complex Functions (%)",
                                                                                  Metric.ValueType.PERCENT)
-    .setDescription("% of functions with high cyclomatic complexity")
+    .setDescription("Percentage of functions with high cyclomatic complexity."
+                      + " 'Percentage = Complex Functions / Functions'")
     .setDirection(Metric.DIRECTION_WORST)
     .setQualitative(Boolean.FALSE)
-    .setDomain(CoreMetrics.DOMAIN_COMPLEXITY)
+    .setDomain("CXX")
     .create();
 
   public static final String COMPLEX_FUNCTIONS_LOC_KEY = "CXX-loc_in_complex_functions";
   public static final Metric<Integer> COMPLEX_FUNCTIONS_LOC = new Metric.Builder(COMPLEX_FUNCTIONS_LOC_KEY,
                                                                                  "Complex Functions Lines of Code",
                                                                                  Metric.ValueType.INT)
-    .setDescription("Number of lines of code in functions with high cyclomatic complexity")
+    .setDescription("Lines of code in functions with high cyclomatic complexity."
+                      + " You can define the threshold with 'sonar.cxx.metric.func.complexity.threshold'.")
     .setDirection(Metric.DIRECTION_WORST)
     .setQualitative(Boolean.FALSE)
-    .setDomain(CoreMetrics.DOMAIN_COMPLEXITY)
+    .setDomain("CXX")
     .create();
 
   public static final String COMPLEX_FUNCTIONS_LOC_PERC_KEY = "CXX-perc_loc_in_complex_functions";
@@ -102,60 +107,64 @@ public final class CxxMetrics {
     COMPLEX_FUNCTIONS_LOC_PERC_KEY,
     "Complex Functions Lines of Code (%)",
     Metric.ValueType.PERCENT)
-    .setDescription("% of lines of code in functions with high cyclomatic complexity")
+    .setDescription("Percentage of lines of code in functions with high cyclomatic complexity."
+                      + " 'Percentage = Complex Functions Lines of Code / Lines of Code in Functions'")
     .setDirection(Metric.DIRECTION_WORST)
     .setQualitative(Boolean.FALSE)
-    .setDomain(CoreMetrics.DOMAIN_COMPLEXITY)
+    .setDomain("CXX")
     .create();
 
   public static final String BIG_FUNCTIONS_KEY = "CXX-big_functions";
   public static final Metric<Integer> BIG_FUNCTIONS = new Metric.Builder(BIG_FUNCTIONS_KEY,
                                                                          "Big Functions",
                                                                          Metric.ValueType.INT)
-    .setDescription("Number of functions with too many lines")
+    .setDescription("Number of functions with too many lines of code."
+                      + " You can define the threshold with 'sonar.cxx.metric.func.size.threshold'.")
     .setDirection(Metric.DIRECTION_WORST)
     .setQualitative(Boolean.FALSE)
-    .setDomain(CoreMetrics.DOMAIN_SIZE)
+    .setDomain("CXX")
     .create();
 
   public static final String BIG_FUNCTIONS_LOC_KEY = "CXX-loc_in_big_functions";
   public static final Metric<Integer> BIG_FUNCTIONS_LOC = new Metric.Builder(BIG_FUNCTIONS_LOC_KEY,
                                                                              "Big Functions Lines of Code",
                                                                              Metric.ValueType.INT)
-    .setDescription("Number of lines of code in functions with too many lines")
+    .setDescription("Lines of code in big functions."
+                      + " You can define the threshold with 'sonar.cxx.metric.func.size.threshold'.")
     .setDirection(Metric.DIRECTION_WORST)
     .setQualitative(Boolean.FALSE)
-    .setDomain(CoreMetrics.DOMAIN_SIZE)
+    .setDomain("CXX")
     .create();
 
   public static final String BIG_FUNCTIONS_PERC_KEY = "CXX-perc_big_functions";
   public static final Metric<Double> BIG_FUNCTIONS_PERC = new Metric.Builder(BIG_FUNCTIONS_PERC_KEY,
                                                                              "Big Functions (%)",
                                                                              Metric.ValueType.PERCENT)
-    .setDescription("% of functions with too many lines")
+    .setDescription("Percentage of functions with too many lines of codes. 'Percentage = Big Functions / Functions'")
     .setDirection(Metric.DIRECTION_WORST)
     .setQualitative(Boolean.FALSE)
-    .setDomain(CoreMetrics.DOMAIN_SIZE)
+    .setDomain("CXX")
     .create();
 
   public static final String BIG_FUNCTIONS_LOC_PERC_KEY = "CXX-perc_loc_in_big_functions";
   public static final Metric<Double> BIG_FUNCTIONS_LOC_PERC = new Metric.Builder(BIG_FUNCTIONS_LOC_PERC_KEY,
                                                                                  "Big Functions Lines of Code (%)",
                                                                                  Metric.ValueType.PERCENT)
-    .setDescription("% of lines of code in functions with too many lines")
+    .setDescription("Percentage of lines of code in big functions."
+                      + " 'Percentage = Big Functions Lines of Code / Lines of Code in Functions'")
     .setDirection(Metric.DIRECTION_WORST)
     .setQualitative(Boolean.FALSE)
-    .setDomain(CoreMetrics.DOMAIN_SIZE)
+    .setDomain("CXX")
     .create();
 
   public static final String LOC_IN_FUNCTIONS_KEY = "CXX-loc_in_functions";
   public static final Metric<Integer> LOC_IN_FUNCTIONS = new Metric.Builder(LOC_IN_FUNCTIONS_KEY,
                                                                             "Lines of Code in Functions",
                                                                             Metric.ValueType.INT)
-    .setDescription("Number of lines of code in function bodies")
+    .setDescription("Total number of lines of code within function bodies.")
     .setDirection(Metric.DIRECTION_WORST)
     .setQualitative(Boolean.FALSE)
-    .setDomain(CoreMetrics.DOMAIN_SIZE)
+    .setDomain("CXX")
     .create();
 
   private static final List<Metric> METRICS;

--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxPublicApiVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/CxxPublicApiVisitor.java
@@ -66,7 +66,7 @@ public class CxxPublicApiVisitor<G extends Grammar> extends AbstractCxxPublicApi
   /**
    * Key of the file suffix parameter
    */
-  public static final String API_FILE_SUFFIXES_KEY = "sonar.cxx.api.file.suffixes";
+  public static final String API_FILE_SUFFIXES_KEY = "sonar.cxx.metric.api.file.suffixes";
 
   /**
    * Default API files knows suffixes

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxSquidSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxSquidSensor.java
@@ -84,8 +84,8 @@ public class CxxSquidSensor implements ProjectSensor {
   public static final String FUNCTION_COMPLEXITY_THRESHOLD_KEY = "sonar.cxx.metric.func.complexity.threshold";
   public static final String FUNCTION_SIZE_THRESHOLD_KEY = "sonar.cxx.metric.func.size.threshold";
 
-  public static final String CPD_IGNORE_LITERALS_KEY = "sonar.cxx.cpd.ignoreLiterals";
-  public static final String CPD_IGNORE_IDENTIFIERS_KEY = "sonar.cxx.cpd.ignoreIdentifiers";
+  public static final String CPD_IGNORE_LITERALS_KEY = "sonar.cxx.metric.cpd.ignoreLiterals";
+  public static final String CPD_IGNORE_IDENTIFIERS_KEY = "sonar.cxx.metric.cpd.ignoreIdentifiers";
   private static final String USE_ANT_STYLE_WILDCARDS
                                 = " Use <a href='"
                                     + "https://ant.apache.org/manual/dirtasks.html"

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/DroppedPropertiesSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/DroppedPropertiesSensor.java
@@ -65,7 +65,7 @@ public class DroppedPropertiesSensor implements ProjectSensor {
             "Define C++ keywords in an own header file and include it with 'sonar.cxx.forceIncludes' instead."); // V2.0.0
     map.put("sonar.cxx.suffixes.sources", "Use key 'sonar.cxx.file.suffixes' instead."); // V2.0.0
     map.put("sonar.cxx.suffixes.headers",
-            "Use key 'sonar.cxx.file.suffixes' instead. For API detection use 'sonar.cxx.api.file.suffixes'."); // V2.0.0
+            "Use key 'sonar.cxx.file.suffixes' instead. For API detection use 'sonar.cxx.metric.api.file.suffixes'."); // V2.0.0
     map.put("sonar.cxx.other.xslt.1.stylesheet", "Use 'sonar.cxx.xslt.1.stylesheet' instead."); // V2.0.0
     map.put("sonar.cxx.other.xslt.1.inputs", "Use 'sonar.cxx.xslt.1.inputs' instead."); // V2.0.0
     map.put("sonar.cxx.other.xslt.1.outputs", "Use 'sonar.cxx.xslt.1.outputs' instead."); // V2.0.0
@@ -96,6 +96,8 @@ public class DroppedPropertiesSensor implements ProjectSensor {
     map.put("sonar.cxx.vc.charset", "Use 'sonar.cxx.vc.encoding' instead."); // V2.0.0
     map.put("sonar.cxx.ctctxt.charset", "Use 'sonar.cxx.ctctxt.encoding' instead."); // V2.0.0
     map.put("sonar.cxx.msbuild.charset", "Use 'sonar.cxx.msbuild.encoding' instead."); // V2.0.0
+    map.put("sonar.cxx.cpd.ignoreLiterals", "Use 'sonar.cxx.metric.cpd.ignoreLiterals' instead."); // V2.0.0
+    map.put("sonar.cxx.cpd.ignoreIdentifiers", "Use 'sonar.cxx.metric.cpd.ignoreIdentifiers' instead."); // V2.0.0
 
     return Collections.unmodifiableMap(map);
   }


### PR DESCRIPTION
- move them all to domain 'CXX'
- update descriptions
- sonar.cxx.api.file.suffixes => sonar.cxx.metric.api.file.suffixes
- sonar.cxx.cpd.ignoreLiterals => sonar.cxx.metric.cpd.ignoreLiterals
- sonar.cxx.cpd.ignoreIdentifiers => sonar.cxx.metric.cpd.ignoreIdentifiers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2050)
<!-- Reviewable:end -->
