### PR TITLE
nunit & vstest:

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,18 @@
 | **Travis CI**<br>(Linux Build and Integration Tests) | [![Build Status](https://travis-ci.org/SonarOpenCommunity/sonar-cxx.svg?branch=master)](https://travis-ci.org/SonarOpenCommunity/sonar-cxx) |
 | **AppVeyor CI**<br>(Windows Build and Deployment) | [![Build status](https://ci.appveyor.com/api/projects/status/f6p12h9n59w01770/branch/master?svg=true)](https://ci.appveyor.com/project/SonarOpenCommunity/sonar-cxx/branch/master) | [Download latest snapshot](https://ci.appveyor.com/project/SonarOpenCommunity/sonar-cxx/branch/master/artifacts) |
 
-## SonarQube C++ plugin (Community)
+# SonarQube C++ plugin (Community)
 
 [SonarQube](https://www.sonarqube.org) is an open platform to manage code quality. This plugin
 adds C++ support to SonarQube with the focus on integration of existing C++ tools.
 
+The sensors for reading reports can be used with the _CXX plugin_ or [SonarCFamily](https://www.sonarsource.com/cpp/) plugin.
+
 This plugin is free software; you can redistribute it and/or modify it under the terms of the [GNU Lesser General Public License](https://www.gnu.org/licenses/lgpl-3.0.en.html) as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.
 
-* parser supporting C89, C99, C11, C17, C++03, C++11, C++14, C++17 and C++20 standards
+* parser supporting
+  * `C89`, `C99`, `C11`, `C17`
+  * `C++03`, `C++11`, `C++14`,`C++17`, `C++20`
   * Microsoft extensions: C++/CLI, Attributed ATL
   * GNU extensions
   * CUDA extensions
@@ -21,58 +25,81 @@ This plugin is free software; you can redistribute it and/or modify it under the
 
 Sensors for **static and dynamic code analysis**:
 * Cppcheck warnings support (http://cppcheck.sourceforge.net/)
+  - [[sonar.cxx.cppcheck.reportPaths]]
 * GCC/G++ warnings support (https://gcc.gnu.org/)
-* Visual Studio warnings support (https://www.visualstudio.com/)
-* Visual Studio Core Guideline Checker warnings support
+  - [[sonar.cxx.gcc.reportPaths]]
+* Visual Studio and Core Guideline Checker warnings support (https://www.visualstudio.com/)
+  - [[sonar.cxx.vc.reportPaths]]
 * Clang Static Analyzer support (https://clang-analyzer.llvm.org/)
+  - [[sonar.cxx.clangsa.reportPaths]]
 * Clang Tidy warnings support (http://clang.llvm.org/extra/clang-tidy/)
+  - [[sonar.cxx.clangtidy.reportPaths]]
 * Infer warnings support (https://fbinfer.com/)
+  - [[sonar.cxx.infer.reportPaths]]
 * PC-Lint warnings support (http://www.gimpel.com/)
+  - [[sonar.cxx.pclint.reportPaths]]
 * RATS (https://github.com/andrew-d/rough-auditing-tool-for-security)
+  - [[sonar.cxx.rats.reportPaths]]
 * Valgrind (http://valgrind.org/)
+  - [[sonar.cxx.valgrind.reportPaths]]
 * Vera++ (https://bitbucket.org/verateam/vera/wiki/Home)
+  - [[sonar.cxx.vera.reportPaths]]
 * Dr. Memory warnings support (http://drmemory.org/)
+  - [[sonar.cxx.drmemory.reportPaths]]
+* [Generic Issue Import Format](https://docs.sonarqube.org/latest/analysis/generic-issue/) support
+* any other tools can be integrated
+  - [[sonar.cxx.other.reportPaths]]
 
 **Test framework** sensors for:
 * XUnit file format
-* Google Test file format
-* Boost.Test file format
-* CppUnit file format
-* VSTest file format
-* NUnit file format
+  - [[sonar.cxx.xunit.reportPaths]]
+* Google Test file format (https://github.com/google/googletest)
+  - [[sonar.cxx.xunit.reportPaths]]
+* Boost.Test file format (https://www.boost.org/doc/libs/release/libs/test/)
+  - [[sonar.cxx.xunit.reportPaths]] with [[sonar.cxx.xslt]]
+* CppTest file format (https://cpptest.sourceforge.io/)
+  - [[sonar.cxx.xunit.reportPaths]] with [[sonar.cxx.xslt]] 
+* CppUnit file format (https://sourceforge.net/projects/cppunit/)
+  - [[sonar.cxx.xunit.reportPaths]] with [[sonar.cxx.xslt]]
+* VSTest file format (https://github.com/microsoft/vstest)
+  - [[sonar.cxx.vstest.reportPaths]]
+* NUnit file format (https://nunit.org/)
+  - [[sonar.cxx.nunit.reportPaths]]
+* [Generic Test Data](https://docs.sonarqube.org/latest/analysis/generic-test/) support
 * extensions over XSLT possible
+  - [[sonar.cxx.xslt]]
 
 **Coverage** sensors for:
-* Visual Studio coverage reports
+* Visual Studio coverage reports (https://www.visualstudio.com/)
+  - [[sonar.cxx.vscoveragexml.reportPaths]]
 * Bullseye coverage reports (http://www.bullseye.com/)
+  - [[sonar.cxx.bullseye.reportPaths]]
 * Cobertura coverage reports (http://cobertura.github.io/cobertura/)
    * gcov / gcovr coverage reports --xml https://gcovr.com/en/stable/guide.html
    * OpenCppCoverage --export_type=cobertura (https://github.com/OpenCppCoverage/OpenCppCoverage/)
+     - [[sonar.cxx.cobertura.reportPaths]]
 * Testwell CTC++ coverage reports (https://www.verifysoft.com/en_ctcpp.html)
+  - [[sonar.cxx.ctctxt.reportPaths]]
+* [Generic Coverage](https://docs.sonarqube.org/latest/analysis/generic-test/) support
 
 Simple to **customize**
 * provide the ability to write custom rules
 * custom rules by XPath checks possible
 * custom rules by regular expression checks possible
 * easy 3rd party tool integration with XML rule definitions and reports possible
+  - [[sonar.cxx.other.reportPaths]]
 
+# Quickstart
+1. [Setup a SonarQube instance](https://docs.sonarqube.org/latest/setup/overview/)
+2. [Install the Plugin](https://github.com/SonarOpenCommunity/sonar-cxx/wiki/Install-the-Plugin)
+3. [Run an analysis](https://github.com/SonarOpenCommunity/sonar-cxx/wiki/Scan-Source-Code)
 
-## Quickstart
-1. Setup a SonarQube instance
-2. Install the plugin (see [Installation](https://github.com/SonarOpenCommunity/sonar-cxx/wiki/Installation))
-3. Run an analysis (see [Running the analysis](https://github.com/SonarOpenCommunity/sonar-cxx/wiki/Running-the-analysis))
-
-
-## Resources
+# Resources
 - [Latest release](https://github.com/SonarOpenCommunity/sonar-cxx/releases)
 - [Documentation](https://github.com/SonarOpenCommunity/sonar-cxx/wiki)
 - [Issue Tracker](https://github.com/SonarOpenCommunity/sonar-cxx/issues)
-- [Continuous Integration Unix](https://travis-ci.org/SonarOpenCommunity/sonar-cxx)
-- [Continuous Integration Windows](https://ci.appveyor.com/project/SonarOpenCommunity/sonar-cxx)
-- [Sample project](https://github.com/SonarOpenCommunity/sonar-cxx/tree/master/sonar-cxx-plugin/src/samples/SampleProject)
 
-
-## Alternatives:
+# Alternatives:
 That's not the only choice when you are looking for C++ support in SonarQube there is also
 * the commercial [C/C++ plugin from SonarSource](http://www.sonarsource.com/products/plugins/languages/cpp/).
 * the commercial [C/C++ plugin from CppDepend](http://www.cppdepend.com/sonarplugin)
@@ -80,6 +107,3 @@ That's not the only choice when you are looking for C++ support in SonarQube the
 * the commercial [PVS-Studio plugin](https://www.viva64.com/en/pvs-studio-download/)
 
 Choose whatever fits your needs.
-
-## Subscribe
-Subscribe our [release feed](https://github.com/SonarOpenCommunity/sonar-cxx/releases.atom)

--- a/cxx-sensors/src/main/resources/rnc/xunit.rnc
+++ b/cxx-sensors/src/main/resources/rnc/xunit.rnc
@@ -1,0 +1,113 @@
+#
+# The following is a grammar in Relax NG Compact syntax for
+# JUnit-compatible report files which sonar-cxx is able to import.
+# Many test frameworks are able to generate output which is JUnit-compatible
+# or at least, 'JUnit-inspirated'. The following grammar
+# combines the flavors implemented by JUnit itself and Googletest.
+#
+# It can be used to validate xunit-reports, i.e. to determine, if
+# a report is valid according to the expectations of sonar-cxx.
+# It can be done as follows:
+#
+# $ rnv xunit.rnc <your xml report>
+#
+# rnv is a XML validator which can be obtained here:
+# http://www.davidashen.net/rnv.html
+#
+
+start = TestSuites
+
+TestSuites = element testsuites {
+   # The following attributes are accepted but ignored, thus 'optional'
+   attribute tests { text } ?,
+   attribute failures { text } ?,
+   attribute disabled { text } ?,
+   attribute errors { text } ?,
+   attribute time { text } ?,
+   attribute name { text } ?,
+   attribute ignored { text } ?,
+
+   TestSuite*
+}
+
+# The output from a single testsuite. The way how testcases are
+# composed into testsuites is framework dependend.
+TestSuite = element testsuite {
+   attribute name { text },
+
+   # This is our extension which helps to locate test resources. If
+   # present, the value of this attribute is interpreted as path to
+   # the source file which contains the testcases inside this
+   # testsuite.
+   #
+   attribute filename { text }?,
+
+   # The following attributes are accepted but ignored, thus 'optional'
+   attribute tests { text } ?,
+   attribute failures { text } ?,
+   attribute disabled { text } ?,
+   attribute errors { text } ?,
+   attribute time { text } ?,
+   attribute skipped { text } ?,
+
+   # Defined properties (name-value pairs) at test execution.
+   # Ignored by the plugin, thus optional.
+   element properties {
+      element property {
+         attribute name { text },
+         attribute value { text }
+      }+
+   }?,
+
+   (TestSuite* | TestCase*)
+}
+
+TestCase = element testcase {
+   # Name of the testcase which is displayed in the UI.
+   attribute name { text },
+
+   # The value of the classname attribute varies quite a lot across test frameworks.
+   # supported: unqualified classname or classname
+   # qualified name: ((namespacename|structname|classname)::)*(namespacename|structname|classname)
+   attribute classname { text },
+
+   # Execution time of the testcase in ms. Is parsed and passed to SQ.
+   attribute time { text },
+
+   # If present, the value of this attribute is interpreted as path to
+   # the source file which contains the testcases
+   # (supersede the filename of the testsuite).
+   #
+   attribute filename { text }?,
+   
+   # Status is evaluated optionally: googletest marks skipped tests
+   # with status="notrun"
+   attribute status { text }?,
+
+   # Test failed
+   # Indicates that the test failed. A failure is a test which
+   # the code has explicitly failed by using the mechanisms for
+   # that purpose. For example via an assertEquals.
+   ( element failure {
+      attribute message { text },
+      attribute type { text } ?,
+      text
+
+      # Test errored
+      # Indicates that the test errored. An errored test is one
+      # that had an unanticipated problem. For example an unchecked
+      # throwable or a problem with the implementation of the test.
+   } | element error {
+      attribute message { text },
+      attribute type { text } ?,
+      text
+
+      # Test was skipped (JUnit-style)
+   } | element skipped {
+      attribute message { text } ?,
+      attribute type { text } ?,
+      text?
+
+      # Test was successfull
+   } | empty )
+}

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/DroppedPropertiesSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/DroppedPropertiesSensor.java
@@ -98,6 +98,8 @@ public class DroppedPropertiesSensor implements ProjectSensor {
     map.put("sonar.cxx.msbuild.charset", "Use 'sonar.cxx.msbuild.encoding' instead."); // V2.0.0
     map.put("sonar.cxx.cpd.ignoreLiterals", "Use 'sonar.cxx.metric.cpd.ignoreLiterals' instead."); // V2.0.0
     map.put("sonar.cxx.cpd.ignoreIdentifiers", "Use 'sonar.cxx.metric.cpd.ignoreIdentifiers' instead."); // V2.0.0
+    map.put("sonar.cxx.nunit.reportPaths", "If possible use 'sonar.cs.nunit.reportsPaths' instead."); // V2.0.0
+    map.put("sonar.cxx.vstest.reportPaths", "If possible use 'sonar.cs.vstest.reportsPaths' instead."); // V2.0.0
 
     return Collections.unmodifiableMap(map);
   }


### PR DESCRIPTION
- sonar.cxx.nunit.reportPaths: If possible use 'sonar.cs.nunit.reportsPaths' instead.
- sonar.cxx.vstest.reportPaths: If possible use 'sonar.cs.vstest.reportsPaths' instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2057)
<!-- Reviewable:end -->
