### PR TITLE
Cppcheck: MISRA-C2012 rule support

### DIFF
--- a/cxx-sensors/src/main/resources/cppcheck.xml
+++ b/cxx-sensors/src/main/resources/cppcheck.xml
@@ -8680,13 +8680,13 @@ Iterator 'it' from different container 'v1' are used together.
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
- <rule>
+  <rule>
     <key>misra-c2012-1.1</key>
     <name>misra-c2012-1.1: Violations of the standard C (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) Violations of the standard C syntax and constraints]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8697,7 +8697,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) Language extensions should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -8707,7 +8707,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) There shall be no occurrence of undefined or critical unspecified behaviour]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8718,7 +8718,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A project shall not contain unreachable code]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8729,7 +8729,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) There shall be no dead code]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8740,7 +8740,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) A project should not contain unused ty pe declarations]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -8750,7 +8750,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) A project should not contain unused tag declarations ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -8760,7 +8760,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) A project should not contain unused macro declarations]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -8770,7 +8770,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) A function should not contain unused label declarations]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -8780,7 +8780,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) There should be no unused parameters in functions]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -8790,7 +8790,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The character sequences /* an d // shall not be used within a comment]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8801,7 +8801,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Line-splicing shall not be used in // comments]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8812,7 +8812,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Octal and hexadecimal escape sequences shall be terminated]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8823,7 +8823,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) Trigraphs should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -8833,29 +8833,29 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) External identifiers shall be distinct]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>misra-c2012-5.2</key>
-    <name>misra-c2012-5.2: Indistinct identifiers in same scope(MISRA C 2012)</name>
+    <name>misra-c2012-5.2: Indistinct identifiers in same scope (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) Identifiers declared in the same scope and name space shall be distinct]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>misra-c2012-5.3</key>
-    <name>misra-c2012-5.3: Identifier hiding other identifier(MISRA C 2012)</name>
+    <name>misra-c2012-5.3: Identifier hiding other identifier (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) An identifier declared in an inner scope shall not hide an identifier declared in an outer scope]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8866,7 +8866,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Macro identifiers shall be distinct]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8877,7 +8877,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Identifiers shall be distinct from macro names]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8888,7 +8888,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A typedef name shall be a unique identifier]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8899,7 +8899,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A tag name shall be a unique identifier]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8910,7 +8910,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Identifiers that define objects or functions with external linkage shall be unique]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8921,7 +8921,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Identifiers that define objects or functions with internal linkage should be unique]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -8931,7 +8931,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Bit-fields shall only be declared with an appropriate type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8942,7 +8942,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) Single-bit named bit fields shall not be of a signed type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -8952,7 +8952,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Octal constants shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8963,7 +8963,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A “u” or “U” suffix shall be applied to all integer constants that are represented in an unsigned type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8974,7 +8974,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The lowercase character “l” shall not be used in a literal suffix ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8985,7 +8985,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A string literal shall not be assigned to an object unless the object’s type is “pointer to const-qualifi ed char” ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -8996,7 +8996,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Types shall be explicitly specified]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9007,7 +9007,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Function types shall be in prototype form with named parameters]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9018,7 +9018,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required)  All declarations of an object or function shall use the same names and type qualifiers]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9029,7 +9029,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A compatible declaration shall be visible when an object or function with external linkage is defined]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9040,7 +9040,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) An external object or function shall be declared once in one and only one file]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9051,7 +9051,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) An identifier with external linkage shall have exactly one external definition]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9062,7 +9062,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) Functions and objects should not be defined with external linkage if they are referenced in only one translation unit]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9072,7 +9072,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The static storage class specifier shall be used in all declarations of objects and functions that have internal linkage]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9083,7 +9083,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) An object should be defined at block scope if its identifier only appears in a single function]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9093,7 +9093,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) An inline function shall be declared with the static storage class]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9104,7 +9104,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) When an array with external linkage is declared, its size should be explicitly specified]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9114,7 +9114,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Within an enumerator list, the value of an implicitly-specified enumeration constant shall be unique]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9125,7 +9125,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) A pointer should point to a const-qualified type whenever possible]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9135,7 +9135,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The restrict type qualifier shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9146,7 +9146,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Mandatory) The value of an object with automatic storage duration shall not be read before it has been set]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9157,7 +9157,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The initializer for an aggregate or union shall be enclosed in braces]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9168,7 +9168,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Arrays shall not be partially initialized]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9179,7 +9179,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) An element of an object shall not be initialized more than once]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9190,7 +9190,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Where designated initializers are used to initialize an array object the size of the array shall be specified explicitly]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9201,7 +9201,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Operands shall not be of an inappropriate essential type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9212,7 +9212,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Expressions of essentially character type shall not be used inappropriately in addition and subtraction operations]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9223,7 +9223,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The value of an expression shall not be assigned to an object with a narrower essential type or of a different essential type category]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9234,7 +9234,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Both operands of an operator in which the usual arithmetic conversions are performed shall have the same essential type category]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9245,7 +9245,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) The value of an expression should not be cast to an inappropriate essential type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9255,7 +9255,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The value of a composite expression shall not be assigned to an object with wider essential type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9266,7 +9266,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) If a composite expression is used as one operand of an operator in which the usual arithmetic conversions are performed then the other operand shall not have wider essential type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9277,7 +9277,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The value of a composite expression shall not be cast to a different essential type category or a wider essential type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9288,7 +9288,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Conversions shall not be performed between a pointer to a function and any other type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9299,7 +9299,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Conversions shall not be performed between a pointer to an incomplete type and any other type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9310,7 +9310,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A cast shall not be performed between a pointer to object type and a pointer to a different object type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9321,7 +9321,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A conversion should not be performed between a pointer to object and an integer type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9332,7 +9332,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A conversion should not be performed from pointer to void into pointer to object ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9343,7 +9343,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A cast shall not be performed between pointer to void and an arithmetic type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9354,7 +9354,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A cast shall not be performed between pointer to object and a non-integer arithmetic type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9365,7 +9365,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A cast shall not remove any const or volatile qualification from the type pointed to by a pointer]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9376,7 +9376,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The macro NULL shall be the only permitted form of integer null pointer constant]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9387,7 +9387,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) The precedence of operators within expressions should be made explicit]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9397,7 +9397,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The right hand operand of a shift operator shall lie in the range zero to one less than the width in bits of the essential type of the left hand operand]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9408,7 +9408,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) The comma operator should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9418,7 +9418,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) Evaluation of constant expressions should not lead to unsigned integer wrap-around]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9428,7 +9428,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Mandatory) The sizeof operator shall not have an operand which is a function parameter declared as "array of type"]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9438,7 +9438,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Initializer lists shall not contain persistent side effects ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9449,7 +9449,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The value of an expression and its persistent side effects shall be the same under all permitted evaluation orders]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9460,7 +9460,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) A full expression containing an increment (++) or decrement (--) operator should have no other potential side effects other than that caused by the increment or decrement operator]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9470,7 +9470,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) The result of an assignment operator should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9478,12 +9478,9 @@ Iterator 'it' from different container 'v1' are used together.
     <key>misra-c2012-13.5</key>
     <name>misra-c2012-13.5: Side effects on right hand of logical operator (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Advisory) The right hand operand of a logical &amp;&amp; or || operator shall not contain persistent side effects 
-
-		]]>
+      <![CDATA[(Advisory) The right hand operand of a logical &amp;&amp; or || operator shall not contain persistent side effects]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9493,7 +9490,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Mandatory) The operand of the sizeof operator shall not contain any expression which has potential side effects]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9504,7 +9501,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A loop counter shall not have essentially floating type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9515,7 +9512,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A for loop shall be well-formed]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9526,7 +9523,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Controlling expressions shall not be invariant]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9537,7 +9534,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The controlling expression of an if statement and the controlling expression of an iteration-statement shall have essentially Boolean type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9548,7 +9545,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) The goto statement should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9558,7 +9555,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The goto statement shall jump to a label declared later in the same function ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9569,7 +9566,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Any label referenced by a goto statement shall be declared in the same block, or in any block enclosing the goto statement]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9580,7 +9577,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) There should be no more than one break or goto statement used to terminate any iteration statement]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9590,7 +9587,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory)  A function should have a single point of exit at the end]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9600,7 +9597,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The body of an iteration-statement or a selection-statement shall be acompound-statement]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9611,7 +9608,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) All if ... else if constructs shall be terminated with an else statement]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9622,7 +9619,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) All switch statements shall be well-formed]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9633,7 +9630,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) A switch label shall only be used when the most closely-enclosing compound statement is the body of a switch statement ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9644,7 +9641,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) An unconditional break statement shall terminate every switch-clause]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9655,7 +9652,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Every switch statement shall have a default label]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9666,7 +9663,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A default label shall appear as either the first or the last switch label of a switch statement]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9677,7 +9674,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Every switch statement shall have at least two switch-clauses]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9688,21 +9685,18 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A switch-expression shall not have essentially Boolean type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>misra-c2012-17.1</key>
-    <name>misra-c2012-17.1: Usage of   stdarg.h   is forbidden (MISRA C 2012)</name>
+    <name>misra-c2012-17.1: Usage of stdarg.h is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The features of &lt;stdarg.h&gt; shall not be used 
-
-		]]>
+      <![CDATA[(Required) The features of &lt;stdarg.h&gt; shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9713,7 +9707,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Functions shall not call themselves, either directly or indirectly]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9724,7 +9718,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Mandatory) A function shall not be declared implicitly]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9735,7 +9729,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Mandatory) All exit paths from a function with non-void return type shall have an explicit return statement with an expression]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9746,7 +9740,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) The function argument corresponding to a parameter declared to have an array type shall have an appropriate number of elements]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9756,7 +9750,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Mandatory) The declaration of an array parameter shall not contain the static keyword between the [ ]]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9767,7 +9761,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The value returned by a function having non-void return type shall be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9778,7 +9772,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) A function parameter should not be modified ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9788,7 +9782,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A pointer resulting from arithmetic on a pointer operand shall address an element of the same array as that pointer operand]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9799,7 +9793,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Subtraction between pointers shall only be applied to pointers that address elements of the same array]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9808,12 +9802,9 @@ Iterator 'it' from different container 'v1' are used together.
     <key>misra-c2012-18.3</key>
     <name>misra-c2012-18.3: Relational or subtract operator applied to pointers (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The relational operators &gt;, &gt;=, &lt; and &lt;= shall not be applied to objects of pointer type except where they point into the same object
-
-		]]>
+      <![CDATA[(Required) The relational operators &gt;, &gt;=, &lt; and &lt;= shall not be applied to objects of pointer type except where they point into the same object]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9824,7 +9815,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) The +, -, += and -= operators should not be applied to an expression of pointer type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9834,7 +9825,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) Declarations should contain no more than two levels of pointer nesting]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9844,7 +9835,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The address of an object with automatic storage shall not be copied to another object that persists after the first object has ceased to exist]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9855,7 +9846,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Flexible array members shall not be declared]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9866,7 +9857,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Variable-length array types shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9877,7 +9868,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Mandatory) An object shall not be assigned or copied to an overlapping object]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9888,7 +9879,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) The union keyword should not be used ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9898,7 +9889,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) #include directives should only be preceded by preprocessor directives or comments]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9908,7 +9899,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The ',' or \ characters and the /* or // character sequences shall not occur in a header file name]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9917,12 +9908,9 @@ Iterator 'it' from different container 'v1' are used together.
     <key>misra-c2012-20.3</key>
     <name>misra-c2012-20.3: #include followed by wrong sequence (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The #include directive shall be followed by either a &lt;filename&gt; or "filename" sequence
-
-		]]>
+      <![CDATA[(Required) The #include directive shall be followed by either a &lt;filename&gt; or "filename" sequence]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9933,7 +9921,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A macro shall not be defined with the same name as a keyword]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9944,7 +9932,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) #undef should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -9954,7 +9942,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Tokens that look like a preprocessing directive shall not occur within a macro argument]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9965,7 +9953,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) Expressions resulting from the expansion of macro parameters shall be enclosed in parentheses]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9976,7 +9964,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The controlling expression of a #if or #elif preprocessing directive shall evaluate to 0 or 1]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9987,7 +9975,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) All identifiers used in the controlling expression of #if or #elif preprocessing directives shall be #define'd before evaluation]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -9998,7 +9986,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Advisory) The # and ## preprocessor operators should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -10008,18 +9996,18 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A macro parameter immediately following a # operator shall not immediately be followed by a ## operator]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>misra-c2012-20.12</key>
-    <name>misra-c2012-20.12: Macro operator usedas an operand to # or ## and is subject to replacment (MISRA C 2012)</name>
+    <name>misra-c2012-20.12: Macro operator usedas an operand to # or ## and is subject to replacement (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) A macro parameter used as an operand to the # or ## operators, which is itself subject to further macro replacement, shall only be used as an operand to these operators]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10030,7 +10018,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A line whose first token is # shall be a valid preprocessing directive]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10041,7 +10029,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) All #else, #elif and #endif preprocessor directives shall reside in the same file as the #if, #ifdef or #ifndef directive to which they are related]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10052,7 +10040,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) #define and #undef shall not be used on a reserved identifier or reserved macro name]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10063,49 +10051,40 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) A reserved identifier or macro name shall not be declared]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>misra-c2012-21.3</key>
-    <name>misra-c2012-21.3: Usage of memory allocation and deallocation from   stdlib.h   is forbidden (MISRA C 2012)</name>
+    <name>misra-c2012-21.3: Usage of memory allocation and deallocation from stdlib.h is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The memory allocation and deallocation functions of &lt;stdlib.h&gt; shall not be used
-
-		]]>
+      <![CDATA[(Required) The memory allocation and deallocation functions of &lt;stdlib.h&gt; shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>misra-c2012-21.4</key>
-    <name>misra-c2012-21.4: Usage of   setjmp.h   is forbidden (MISRA C 2012)</name>
+    <name>misra-c2012-21.4: Usage of setjmp.h is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The standard header file &lt;setjmp.h&gt; shall not be used 
-
-		]]>
+      <![CDATA[(Required) The standard header file &lt;setjmp.h&gt; shall not be used ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>misra-c2012-21.5</key>
-    <name>misra-c2012-21.5: Usage of   signal.h   is forbidden (MISRA C 2012)</name>
+    <name>misra-c2012-21.5: Usage of signal.h is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The standard header file &lt;signal.h&gt; shall not be used
-
-		]]>
+      <![CDATA[(Required) The standard header file &lt;signal.h&gt; shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10116,7 +10095,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The Standard Library input/output functions shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10125,12 +10104,9 @@ Iterator 'it' from different container 'v1' are used together.
     <key>misra-c2012-21.7</key>
     <name>misra-c2012-21.7: Usage of atol, atol and atoll is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The atof, atoi, atol and atoll functions of &lt;stdlib.h&gt; shall not be used
-
-		]]>
+      <![CDATA[(Required) The atof, atoi, atol and atoll functions of &lt;stdlib.h&gt; shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10139,12 +10115,9 @@ Iterator 'it' from different container 'v1' are used together.
     <key>misra-c2012-21.8</key>
     <name>misra-c2012-21.8: Usage of abort, exit, getenv and system is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The library functions abort, exit, getenv and system of &lt;stdlib.h&gt; shall not be used
-
-		]]>
+      <![CDATA[(Required) The library functions abort, exit, getenv and system of &lt;stdlib.h&gt; shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10153,12 +10126,9 @@ Iterator 'it' from different container 'v1' are used together.
     <key>misra-c2012-21.9</key>
     <name>misra-c2012-21.9: Usage of bsearch and qsort is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The library functions bsearch and qsort of &lt;stdlib.h&gt; shall not be used
-
-		]]>
+      <![CDATA[(Required) The library functions bsearch and qsort of &lt;stdlib.h&gt; shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10169,35 +10139,29 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The Standard Library time and date functions shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>misra-c2012-21.11</key>
-    <name>misra-c2012-21.11: Usage of   tgmath.h   is forbidden (MISRA C 2012)</name>
+    <name>misra-c2012-21.11: Usage of tgmath.h is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The standard header file &lt;tgmath.h&gt; shall not be used
-
-		]]>
+      <![CDATA[(Required) The standard header file &lt;tgmath.h&gt; shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>misra-c2012-21.12</key>
-    <name>misra-c2012-21.12: Usage of exception handling from   fenv.h   is forbidden (MISRA C 2012)</name>
+    <name>misra-c2012-21.12: Usage of exception handling from fenv.h is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Advisory) The exception handling features of &lt;fenv.h&gt; should not be used
-
-		]]>
+      <![CDATA[(Advisory) The exception handling features of &lt;fenv.h&gt; should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -10207,7 +10171,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Mandatory) Any value passed to a function in &lt;ctype.h&gt; shall be representable as an unsigned char or be the value EOF]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -10217,7 +10181,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The pointer arguments to the Standard Library functions memcpy, memmove and memcmp shall be pointers to qualified or unqualified versions of compatible types]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -10227,7 +10191,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The pointer arguments to the Standard Library function memcmp shall point to either a pointer type, an essentially signed type, an essentially unsigned type, an essentially Boolean type or an essentially enum type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10238,7 +10202,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Mandatory) Use of the string handling functions from &lt;string.h&gt; shall not result in accesses beyond the bounds of the objects referenced by their pointer parameters]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10249,7 +10213,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Mandatory) The size_t argument passed to any function in &lt;string.h&gt; shall have an appropriate value]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10260,7 +10224,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) All resources obtained dynamically by means of Standard Library functions shall be explicitly released]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10271,7 +10235,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Mandatory) A block of memory shall only be freed if it was allocated by means of a Standard Library function]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10282,7 +10246,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Required) The same file shall not be open for read and write access at the same time on different streams]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10293,7 +10257,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Mandatory) There shall be no attempt to write to a stream which has been opened as read-only]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10304,7 +10268,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Mandatory) A pointer to a FILE object shall not be dereferenced]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -10315,7 +10279,7 @@ Iterator 'it' from different container 'v1' are used together.
     <description>
       <![CDATA[(Mandatory) The value of a pointer to a FILE shall not be used after the associated stream has been closed]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>

--- a/cxx-sensors/src/main/resources/cppcheck.xml
+++ b/cxx-sensors/src/main/resources/cppcheck.xml
@@ -9014,7 +9014,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-8.3</key>
-    <name>misra-c2012-8.3: Different declaration of object function(MISRA C 2012)</name>
+    <name>misra-c2012-8.3: Different declaration of object function (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required)  All declarations of an object or function shall use the same names and type qualifiers]]>
     </description>
@@ -9025,7 +9025,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-8.4</key>
-    <name>misra-c2012-8.4: Non compatible declaration with external linkage(MISRA C 2012)</name>
+    <name>misra-c2012-8.4: Non compatible declaration with external linkage (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) A compatible declaration shall be visible when an object or function with external linkage is defined]]>
     </description>
@@ -9036,7 +9036,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-8.5</key>
-    <name>misra-c2012-8.5: An external element declared in several files(MISRA C 2012)</name>
+    <name>misra-c2012-8.5: An external element declared in several files (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) An external object or function shall be declared once in one and only one file]]>
     </description>
@@ -9079,7 +9079,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-8.9</key>
-    <name>misra-c2012-8.9: Object define outside of block for single function usage(MISRA C 2012)</name>
+    <name>misra-c2012-8.9: Object define outside of block for single function usage (MISRA C 2012)</name>
     <description>
       <![CDATA[(Advisory) An object should be defined at block scope if its identifier only appears in a single function]]>
     </description>
@@ -9208,7 +9208,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-10.2</key>
-    <name>misra-c2012-10.2: Inapropriate ussage of character type in operation(MISRA C 2012)</name>
+    <name>misra-c2012-10.2: Inapropriate ussage of character type in operation (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) Expressions of essentially character type shall not be used inappropriately in addition and subtraction operations]]>
     </description>
@@ -9230,7 +9230,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-10.4</key>
-    <name>misra-c2012-10.4: Operation with different type cathegory(MISRA C 2012)</name>
+    <name>misra-c2012-10.4: Operation with different type category (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) Both operands of an operator in which the usual arithmetic conversions are performed shall have the same essential type category]]>
     </description>
@@ -9273,7 +9273,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-10.8</key>
-    <name>misra-c2012-10.8: Type conversion of composit expression(MISRA C 2012)</name>
+    <name>misra-c2012-10.8: Type conversion of composit expression (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) The value of a composite expression shall not be cast to a different essential type category or a wider essential type]]>
     </description>
@@ -9284,7 +9284,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-11.1</key>
-    <name>misra-c2012-11.1: Convertion between pointer to function and other type(MISRA C 2012)</name>
+    <name>misra-c2012-11.1: Convertion between pointer to function and other type (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) Conversions shall not be performed between a pointer to a function and any other type]]>
     </description>
@@ -9328,7 +9328,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-11.5</key>
-    <name>misra-c2012-11.5: Conversion between pointer to void and pointer to object(MISRA C 2012)</name>
+    <name>misra-c2012-11.5: Conversion between pointer to void and pointer to object (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) A conversion should not be performed from pointer to void into pointer to object ]]>
     </description>
@@ -9339,7 +9339,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-11.6</key>
-    <name>misra-c2012-11.6: Conversion between pointer to void and arithmetic type(MISRA C 2012)</name>
+    <name>misra-c2012-11.6: Conversion between pointer to void and arithmetic type (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) A cast shall not be performed between pointer to void and an arithmetic type]]>
     </description>
@@ -9383,7 +9383,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-12.1</key>
-    <name>misra-c2012-12.1: Precedence of expression non explicit(MISRA C 2012)</name>
+    <name>misra-c2012-12.1: Precedence of expression non explicit (MISRA C 2012)</name>
     <description>
       <![CDATA[(Advisory) The precedence of operators within expressions should be made explicit]]>
     </description>
@@ -9445,7 +9445,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-13.2</key>
-    <name>misra-c2012-13.2: Different value of expression and persistent side effect(MISRA C 2012)</name>
+    <name>misra-c2012-13.2: Different value of expression and persistent side effect (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) The value of an expression and its persistent side effects shall be the same under all permitted evaluation orders]]>
     </description>
@@ -9795,7 +9795,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-18.2</key>
-    <name>misra-c2012-18.2: Substraction between different array with pointers(MISRA C 2012)</name>
+    <name>misra-c2012-18.2: Substraction between different array with pointers (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) Subtraction between pointers shall only be applied to pointers that address elements of the same array]]>
     </description>
@@ -9806,7 +9806,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-18.3</key>
-    <name>misra-c2012-18.3: Relational or subtract operator applied to pointers  (MISRA C 2012)</name>
+    <name>misra-c2012-18.3: Relational or subtract operator applied to pointers (MISRA C 2012)</name>
     <description>
       <![CDATA[
 (Required) The relational operators &gt;, &gt;=, &lt; and &lt;= shall not be applied to objects of pointer type except where they point into the same object
@@ -10059,7 +10059,7 @@ Iterator 'it' from different container 'v1' are used together.
     </rule>
   <rule>
     <key>misra-c2012-21.2</key>
-    <name>misra-c2012-21.2: Illegal macro name using reserved identifier(MISRA C 2012)</name>
+    <name>misra-c2012-21.2: Illegal macro name using reserved identifier (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) A reserved identifier or macro name shall not be declared]]>
     </description>

--- a/cxx-sensors/src/main/resources/cppcheck.xml
+++ b/cxx-sensors/src/main/resources/cppcheck.xml
@@ -8680,4 +8680,1644 @@ Iterator 'it' from different container 'v1' are used together.
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
   </rule>
+ <rule>
+    <key>misra-c2012-1.1</key>
+    <name>misra-c2012-1.1: Violations of the standard C (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Violations of the standard C syntax and constraints]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-1.2</key>
+    <name>misra-c2012-1.2: Language extensions (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) Language extensions should not be used]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-1.3</key>
+    <name>misra-c2012-1.3: Unspecified behaviour (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) There shall be no occurrence of undefined or critical unspecified behaviour]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-2.1</key>
+    <name>misra-c2012-2.1: Unreachable code (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A project shall not contain unreachable code]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-2.2</key>
+    <name>misra-c2012-2.2: Dead code (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) There shall be no dead code]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-2.3</key>
+    <name>misra-c2012-2.3: Unused type declarations (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) A project should not contain unused ty pe declarations]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-2.4</key>
+    <name>misra-c2012-2.4: Unused tag declarations (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) A project should not contain unused tag declarations ]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-2.5</key>
+    <name>misra-c2012-2.5: Unused macro declarations (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) A project should not contain unused macro declarations]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-2.6</key>
+    <name>misra-c2012-2.6: Unused label declarations (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) A function should not contain unused label declarations]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-2.7</key>
+    <name>misra-c2012-2.7: Unused parameters in functions (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) There should be no unused parameters in functions]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-3.1</key>
+    <name>misra-c2012-3.1: /* or // used within a comment (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The character sequences /* an d // shall not be used within a comment]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-3.2</key>
+    <name>misra-c2012-3.2: Line-splicing in // comment (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Line-splicing shall not be used in // comments]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-4.1</key>
+    <name>misra-c2012-4.1: Escape sequences not terminated (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Octal and hexadecimal escape sequences shall be terminated]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-4.2</key>
+    <name>misra-c2012-4.2: Trigraphs (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) Trigraphs should not be used]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-5.1</key>
+    <name>misra-c2012-5.1: Indistinct external identifiers (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) External identifiers shall be distinct]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-5.2</key>
+    <name>misra-c2012-5.2: Indistinct identifiers in same scope(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Identifiers declared in the same scope and name space shall be distinct]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-5.3</key>
+    <name>misra-c2012-5.3: Identifier hiding other identifier(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) An identifier declared in an inner scope shall not hide an identifier declared in an outer scope]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-5.4</key>
+    <name>misra-c2012-5.4: Indistinct macro identifier (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Macro identifiers shall be distinct]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-5.5</key>
+    <name>misra-c2012-5.5: Identifiers indistinct from macro names (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Identifiers shall be distinct from macro names]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-5.6</key>
+    <name>misra-c2012-5.6: A typedef identifier not unique (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A typedef name shall be a unique identifier]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-5.7</key>
+    <name>misra-c2012-5.7: Tag name identifier not unique (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A tag name shall be a unique identifier]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-5.8</key>
+    <name>misra-c2012-5.8: Identifiers with external linkage not unique (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Identifiers that define objects or functions with external linkage shall be unique]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-5.9</key>
+    <name>misra-c2012-5.9: Identifiers with internal linkage not unique (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Identifiers that define objects or functions with internal linkage should be unique]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-6.1</key>
+    <name>misra-c2012-6.1: Bit-fields have not appropriate type (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Bit-fields shall only be declared with an appropriate type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-6.2</key>
+    <name>misra-c2012-6.2: Single-bit is signed type (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) Single-bit named bit fields shall not be of a signed type]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-7.1</key>
+    <name>misra-c2012-7.1: Octal constants (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Octal constants shall not be used]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-7.2</key>
+    <name>misra-c2012-7.2: Unsigned constant integer required a 'U' or 'u' (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A “u” or “U” suffix shall be applied to all integer constants that are represented in an unsigned type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-7.3</key>
+    <name>misra-c2012-7.3: 'l' used in a literal suffix (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The lowercase character “l” shall not be used in a literal suffix ]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-7.4</key>
+    <name>misra-c2012-7.4: String literal assigned to wrong object (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A string literal shall not be assigned to an object unless the object’s type is “pointer to const-qualifi ed char” ]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-8.1</key>
+    <name>misra-c2012-8.1: Types not explicitly specified (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Types shall be explicitly specified]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-8.2</key>
+    <name>misra-c2012-8.2: Function prototype missing or incomplete (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Function types shall be in prototype form with named parameters]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-8.3</key>
+    <name>misra-c2012-8.3: Different declaration of object function(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required)  All declarations of an object or function shall use the same names and type qualifiers]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-8.4</key>
+    <name>misra-c2012-8.4: Non compatible declaration with external linkage(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A compatible declaration shall be visible when an object or function with external linkage is defined]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-8.5</key>
+    <name>misra-c2012-8.5: An external element declared in several files(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) An external object or function shall be declared once in one and only one file]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-8.6</key>
+    <name>misra-c2012-8.6: Symbol is redeclared or redefined (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) An identifier with external linkage shall have exactly one external definition]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-8.7</key>
+    <name>misra-c2012-8.7: Functions or objects defined with external linkage and is referenced in only one translation unit (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) Functions and objects should not be defined with external linkage if they are referenced in only one translation unit]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-8.8</key>
+    <name>misra-c2012-8.8: Storage class of symbol assumed static (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The static storage class specifier shall be used in all declarations of objects and functions that have internal linkage]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-8.9</key>
+    <name>misra-c2012-8.9: Object define outside of block for single function usage(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) An object should be defined at block scope if its identifier only appears in a single function]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-8.10</key>
+    <name>misra-c2012-8.10: Inline function defined without a storage-class specifier (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) An inline function shall be declared with the static storage class]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-8.11</key>
+    <name>misra-c2012-8.11: Externale array without explicit size (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) When an array with external linkage is declared, its size should be explicitly specified]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-8.12</key>
+    <name>misra-c2012-8.12: Element of enum whithout unique value (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Within an enumerator list, the value of an implicitly-specified enumeration constant shall be unique]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-8.13</key>
+    <name>misra-c2012-8.13: Pointer parameter could be declared as pointing to const (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) A pointer should point to a const-qualified type whenever possible]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-8.14</key>
+    <name>misra-c2012-8.14: Restrict type used (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The restrict type qualifier shall not be used]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-9.1</key>
+    <name>misra-c2012-9.1: Symbol read before been set (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Mandatory) The value of an object with automatic storage duration shall not be read before it has been set]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>BLOCKER</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-9.2</key>
+    <name>misra-c2012-9.2: Not initialized in braces (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The initializer for an aggregate or union shall be enclosed in braces]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-9.3</key>
+    <name>misra-c2012-9.3: Init of array not complete (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Arrays shall not be partially initialized]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-9.4</key>
+    <name>misra-c2012-9.4: Element initialized more than once (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) An element of an object shall not be initialized more than once]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-9.5</key>
+    <name>misra-c2012-9.5: Size of the array not specified explicitly (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Where designated initializers are used to initialize an array object the size of the array shall be specified explicitly]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-10.1</key>
+    <name>misra-c2012-10.1: Inapropriate essential type (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Operands shall not be of an inappropriate essential type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-10.2</key>
+    <name>misra-c2012-10.2: Inapropriate ussage of character type in operation(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Expressions of essentially character type shall not be used inappropriately in addition and subtraction operations]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-10.3</key>
+    <name>misra-c2012-10.3: Assignation of a narrower essential type (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The value of an expression shall not be assigned to an object with a narrower essential type or of a different essential type category]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-10.4</key>
+    <name>misra-c2012-10.4: Operation with different type cathegory(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Both operands of an operator in which the usual arithmetic conversions are performed shall have the same essential type category]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-10.5</key>
+    <name>misra-c2012-10.5: Cast to an inappropriate type (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) The value of an expression should not be cast to an inappropriate essential type]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-10.6</key>
+    <name>misra-c2012-10.6: Assignation to object with wider essential type (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The value of a composite expression shall not be assigned to an object with wider essential type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-10.7</key>
+    <name>misra-c2012-10.7: Implicit conversion in arithmetic conversion (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) If a composite expression is used as one operand of an operator in which the usual arithmetic conversions are performed then the other operand shall not have wider essential type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-10.8</key>
+    <name>misra-c2012-10.8: Type conversion of composit expression(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The value of a composite expression shall not be cast to a different essential type category or a wider essential type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-11.1</key>
+    <name>misra-c2012-11.1: Convertion between pointer to function and other type(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Conversions shall not be performed between a pointer to a function and any other type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-11.2</key>
+    <name>misra-c2012-11.2: Conversion between incomplete pointer type and other type (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Conversions shall not be performed between a pointer to an incomplete type and any other type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-11.3</key>
+    <name>misra-c2012-11.3: Cast between 2 pointers with different type (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A cast shall not be performed between a pointer to object type and a pointer to a different object type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-11.4</key>
+    <name>misra-c2012-11.4: Conversion between pointer to object and pointer to integer (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A conversion should not be performed between a pointer to object and an integer type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-11.5</key>
+    <name>misra-c2012-11.5: Conversion between pointer to void and pointer to object(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A conversion should not be performed from pointer to void into pointer to object ]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-11.6</key>
+    <name>misra-c2012-11.6: Conversion between pointer to void and arithmetic type(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A cast shall not be performed between pointer to void and an arithmetic type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-11.7</key>
+    <name>misra-c2012-11.7: Conversion between pointer to object and non-integer arithmetic type (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A cast shall not be performed between pointer to object and a non-integer arithmetic type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-11.8</key>
+    <name>misra-c2012-11.8: Pointer remove qualification to object (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A cast shall not remove any const or volatile qualification from the type pointed to by a pointer]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-11.9</key>
+    <name>misra-c2012-11.9: Macro NULL used inappropriately (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The macro NULL shall be the only permitted form of integer null pointer constant]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-12.1</key>
+    <name>misra-c2012-12.1: Precedence of expression non explicit(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) The precedence of operators within expressions should be made explicit]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-12.2</key>
+    <name>misra-c2012-12.2: The shift value is at least the precision of the essential type of the left hand side (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The right hand operand of a shift operator shall lie in the range zero to one less than the width in bits of the essential type of the left hand operand]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-12.3</key>
+    <name>misra-c2012-12.3: Usage of coma operator (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) The comma operator should not be used]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-12.4</key>
+    <name>misra-c2012-12.4: Overflow in computing constant for operation (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) Evaluation of constant expressions should not lead to unsigned integer wrap-around]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-12.5</key>
+    <name>misra-c2012-12.5: The parameter of the sizeof call is invalid (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Mandatory) The sizeof operator shall not have an operand which is a function parameter declared as "array of type"]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-13.1</key>
+    <name>misra-c2012-13.1: Initializer list with persistent side effect (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Initializer lists shall not contain persistent side effects ]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-13.2</key>
+    <name>misra-c2012-13.2: Different value of expression and persistent side effect(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The value of an expression and its persistent side effects shall be the same under all permitted evaluation orders]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-13.3</key>
+    <name>misra-c2012-13.3: Unexpected side effect for (++) or (--) operation (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) A full expression containing an increment (++) or decrement (--) operator should have no other potential side effects other than that caused by the increment or decrement operator]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-13.4</key>
+    <name>misra-c2012-13.4: Utilisation of assignment operator result (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) The result of an assignment operator should not be used]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-13.5</key>
+    <name>misra-c2012-13.5: Side effects on right hand of logical operator (MISRA C 2012)</name>
+    <description>
+      <![CDATA[
+(Advisory) The right hand operand of a logical &amp;&amp; or || operator shall not contain persistent side effects 
+
+		]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-13.6</key>
+    <name>misra-c2012-13.6: Sizeof used on expression with side effect (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Mandatory) The operand of the sizeof operator shall not contain any expression which has potential side effects]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>BLOCKER</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-14.1</key>
+    <name>misra-c2012-14.1: Use of floating type in a loop (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A loop counter shall not have essentially floating type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-14.2</key>
+    <name>misra-c2012-14.2: For loop not correct (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A for loop shall be well-formed]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-14.3</key>
+    <name>misra-c2012-14.3: Always evaluate to same value (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Controlling expressions shall not be invariant]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-14.4</key>
+    <name>misra-c2012-14.4: Usage of non boolean control expression in if statement (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The controlling expression of an if statement and the controlling expression of an iteration-statement shall have essentially Boolean type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-15.1</key>
+    <name>misra-c2012-15.1: Usage of Goto (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) The goto statement should not be used]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-15.2</key>
+    <name>misra-c2012-15.2: Goto jump outside of autorized position (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The goto statement shall jump to a label declared later in the same function ]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-15.3</key>
+    <name>misra-c2012-15.3: Label declared outside of goto block or enclosing block (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Any label referenced by a goto statement shall be declared in the same block, or in any block enclosing the goto statement]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-15.4</key>
+    <name>misra-c2012-15.4: More than one goto or break to terminate operation (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) There should be no more than one break or goto statement used to terminate any iteration statement]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-15.5</key>
+    <name>misra-c2012-15.5: More than one end point to exit function (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory)  A function should have a single point of exit at the end]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-15.6</key>
+    <name>misra-c2012-15.6: Sub-statement should be a compound statement (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The body of an iteration-statement or a selection-statement shall be acompound-statement]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-15.7</key>
+    <name>misra-c2012-15.7: Else statment missing (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) All if ... else if constructs shall be terminated with an else statement]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-16.1</key>
+    <name>misra-c2012-16.1: Switch statement not well formed (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) All switch statements shall be well-formed]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-16.2</key>
+    <name>misra-c2012-16.2:  Most closely-enclosing compound statement is not the body of a switch statement (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) A switch label shall only be used when the most closely-enclosing compound statement is the body of a switch statement ]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-16.3</key>
+    <name>misra-c2012-16.3: Break missing to terminate case (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) An unconditional break statement shall terminate every switch-clause]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-16.4</key>
+    <name>misra-c2012-16.4: Default missing in the switch-case (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Every switch statement shall have a default label]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-16.5</key>
+    <name>misra-c2012-16.5: Default not in first or salt label (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A default label shall appear as either the first or the last switch label of a switch statement]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-16.6</key>
+    <name>misra-c2012-16.6: Switch statment does not have enough case (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Every switch statement shall have at least two switch-clauses]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-16.7</key>
+    <name>misra-c2012-16.7: Usage of boolean type for switch statment (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A switch-expression shall not have essentially Boolean type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-17.1</key>
+    <name>misra-c2012-17.1: Usage of   stdarg.h   is forbidden (MISRA C 2012)</name>
+    <description>
+      <![CDATA[
+(Required) The features of &lt;stdarg.h&gt; shall not be used 
+
+		]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-17.2</key>
+    <name>misra-c2012-17.2: Function calling itself (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Functions shall not call themselves, either directly or indirectly]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-17.3</key>
+    <name>misra-c2012-17.3: Function declared implicitly (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Mandatory) A function shall not be declared implicitly]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>BLOCKER</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-17.4</key>
+    <name>misra-c2012-17.4: Function should return a value (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Mandatory) All exit paths from a function with non-void return type shall have an explicit return statement with an expression]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>BLOCKER</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-17.5</key>
+    <name>misra-c2012-17.5: Array has wrong size in function argument (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) The function argument corresponding to a parameter declared to have an array type shall have an appropriate number of elements]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-17.6</key>
+    <name>misra-c2012-17.6: Usage of static parameter of an array between [] (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Mandatory) The declaration of an array parameter shall not contain the static keyword between the [ ]]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>BLOCKER</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-17.7</key>
+    <name>misra-c2012-17.7: Velue returned by function not used (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The value returned by a function having non-void return type shall be used]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-17.8</key>
+    <name>misra-c2012-17.8: Modification of function parameter (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) A function parameter should not be modified ]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-18.1</key>
+    <name>misra-c2012-18.1: Likely creation of out-of-bounds pointer (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A pointer resulting from arithmetic on a pointer operand shall address an element of the same array as that pointer operand]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-18.2</key>
+    <name>misra-c2012-18.2: Substraction between different array with pointers(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Subtraction between pointers shall only be applied to pointers that address elements of the same array]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-18.3</key>
+    <name>misra-c2012-18.3: Relational or subtract operator applied to pointers  (MISRA C 2012)</name>
+    <description>
+      <![CDATA[
+(Required) The relational operators &gt;, &gt;=, &lt; and &lt;= shall not be applied to objects of pointer type except where they point into the same object
+
+		]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-18.4</key>
+    <name>misra-c2012-18.4: Increment or subtract operator applied tp pointer (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) The +, -, += and -= operators should not be applied to an expression of pointer type]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-18.5</key>
+    <name>misra-c2012-18.5: More than 2 level of pointer (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) Declarations should contain no more than two levels of pointer nesting]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-18.6</key>
+    <name>misra-c2012-18.6: Address of object with automatic storage affected to non persistant object (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The address of an object with automatic storage shall not be copied to another object that persists after the first object has ceased to exist]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-18.7</key>
+    <name>misra-c2012-18.7: Usage of flexible array (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Flexible array members shall not be declared]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-18.8</key>
+    <name>misra-c2012-18.8: Variable-length length arrya (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Variable-length array types shall not be used]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-19.1</key>
+    <name>misra-c2012-19.1: Assignation or copy to an overlapping object (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Mandatory) An object shall not be assigned or copied to an overlapping object]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>BLOCKER</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-19.2</key>
+    <name>misra-c2012-19.2: Usage of Union Keyword (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) The union keyword should not be used ]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-20.1</key>
+    <name>misra-c2012-20.1: #include misplaced (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) #include directives should only be preceded by preprocessor directives or comments]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-20.2</key>
+    <name>misra-c2012-20.2: Wrong character used in header file name (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The ',' or \ characters and the /* or // character sequences shall not occur in a header file name]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-20.3</key>
+    <name>misra-c2012-20.3: #include followed by wrong sequence (MISRA C 2012)</name>
+    <description>
+      <![CDATA[
+(Required) The #include directive shall be followed by either a &lt;filename&gt; or "filename" sequence
+
+		]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-20.4</key>
+    <name>misra-c2012-20.4: Macro name defined with a keyword (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A macro shall not be defined with the same name as a keyword]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-20.5</key>
+    <name>misra-c2012-20.5: Usage of #undef (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) #undef should not be used]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-20.6</key>
+    <name>misra-c2012-20.6: Apparent preprocessor directive in invocation of macro (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Tokens that look like a preprocessing directive shall not occur within a macro argument]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-20.7</key>
+    <name>misra-c2012-20.7: Unparenthesized parameter in macro (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) Expressions resulting from the expansion of macro parameters shall be enclosed in parentheses]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-20.8</key>
+    <name>misra-c2012-20.8: Conditional of #if does not evaluate to 0 or 1 (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The controlling expression of a #if or #elif preprocessing directive shall evaluate to 0 or 1]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-20.9</key>
+    <name>misra-c2012-20.9: Undefined preprocessor variable (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) All identifiers used in the controlling expression of #if or #elif preprocessing directives shall be #define'd before evaluation]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-20.10</key>
+    <name>misra-c2012-20.10: #or ## processor operator used (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Advisory) The # and ## preprocessor operators should not be used]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-20.11</key>
+    <name>misra-c2012-20.11: Stringize operator followed by macro parameter followed by pasting operator (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A macro parameter immediately following a # operator shall not immediately be followed by a ## operator]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-20.12</key>
+    <name>misra-c2012-20.12: Macro operator usedas an operand to # or ## and is subject to replacment (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A macro parameter used as an operand to the # or ## operators, which is itself subject to further macro replacement, shall only be used as an operand to these operators]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-20.13</key>
+    <name>misra-c2012-20.13: Not a valid preprocessing directive (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A line whose first token is # shall be a valid preprocessing directive]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-20.14</key>
+    <name>misra-c2012-20.14: #else, #elif or #endif not in same file than #if, #ifdef or #ifndef (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) All #else, #elif and #endif preprocessor directives shall reside in the same file as the #if, #ifdef or #ifndef directive to which they are related]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.1</key>
+    <name>misra-c2012-21.1: Illegal macro name with # usage (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) #define and #undef shall not be used on a reserved identifier or reserved macro name]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.2</key>
+    <name>misra-c2012-21.2: Illegal macro name using reserved identifier(MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) A reserved identifier or macro name shall not be declared]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.3</key>
+    <name>misra-c2012-21.3: Usage of memory allocation and deallocation from   stdlib.h   is forbidden (MISRA C 2012)</name>
+    <description>
+      <![CDATA[
+(Required) The memory allocation and deallocation functions of &lt;stdlib.h&gt; shall not be used
+
+		]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.4</key>
+    <name>misra-c2012-21.4: Usage of   setjmp.h   is forbidden (MISRA C 2012)</name>
+    <description>
+      <![CDATA[
+(Required) The standard header file &lt;setjmp.h&gt; shall not be used 
+
+		]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.5</key>
+    <name>misra-c2012-21.5: Usage of   signal.h   is forbidden (MISRA C 2012)</name>
+    <description>
+      <![CDATA[
+(Required) The standard header file &lt;signal.h&gt; shall not be used
+
+		]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.6</key>
+    <name>misra-c2012-21.6: Usage of input/output functions (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The Standard Library input/output functions shall not be used]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.7</key>
+    <name>misra-c2012-21.7: Usage of atol, atol and atoll is forbidden (MISRA C 2012)</name>
+    <description>
+      <![CDATA[
+(Required) The atof, atoi, atol and atoll functions of &lt;stdlib.h&gt; shall not be used
+
+		]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.8</key>
+    <name>misra-c2012-21.8: Usage of abort, exit, getenv and system is forbidden (MISRA C 2012)</name>
+    <description>
+      <![CDATA[
+(Required) The library functions abort, exit, getenv and system of &lt;stdlib.h&gt; shall not be used
+
+		]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.9</key>
+    <name>misra-c2012-21.9: Usage of bsearch and qsort is forbidden (MISRA C 2012)</name>
+    <description>
+      <![CDATA[
+(Required) The library functions bsearch and qsort of &lt;stdlib.h&gt; shall not be used
+
+		]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.10</key>
+    <name>misra-c2012-21.10: Usage of time and date function forbidden (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The Standard Library time and date functions shall not be used]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.11</key>
+    <name>misra-c2012-21.11: Usage of   tgmath.h   is forbidden (MISRA C 2012)</name>
+    <description>
+      <![CDATA[
+(Required) The standard header file &lt;tgmath.h&gt; shall not be used
+
+		]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.12</key>
+    <name>misra-c2012-21.12: Usage of exception handling from   fenv.h   is forbidden (MISRA C 2012)</name>
+    <description>
+      <![CDATA[
+(Advisory) The exception handling features of &lt;fenv.h&gt; should not be used
+
+		]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.13</key>
+    <name>misra-c2012-21.13: Value passed to ctype.h function has an invalid type (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Mandatory) Any value passed to a function in &lt;ctype.h&gt; shall be representable as an unsigned char or be the value EOF]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.15</key>
+    <name>misra-c2012-21.15: Different pointer types in memcpy, memmove or memcmp function parameters (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The pointer arguments to the Standard Library functions memcpy, memmove and memcmp shall be pointers to qualified or unqualified versions of compatible types]]>
+    </description>
+    <tag>misrac3</tag>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.16</key>
+    <name>misra-c2012-21.16: Invalid pointer types in memcmp function parameters (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The pointer arguments to the Standard Library function memcmp shall point to either a pointer type, an essentially signed type, an essentially unsigned type, an essentially Boolean type or an essentially enum type]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.17</key>
+    <name>misra-c2012-21.17: Read or write access beyond the bounds of an object passed as a parameter to function in string.h (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Mandatory) Use of the string handling functions from &lt;string.h&gt; shall not result in accesses beyond the bounds of the objects referenced by their pointer parameters]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-21.18</key>
+    <name>misra-c2012-21.18: Size_t argument passed to string.h functions must be valid (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Mandatory) The size_t argument passed to any function in &lt;string.h&gt; shall have an appropriate value]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-22.1</key>
+    <name>misra-c2012-22.1: Custodial pointer has not been freed or returned (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) All resources obtained dynamically by means of Standard Library functions shall be explicitly released]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-22.2</key>
+    <name>misra-c2012-22.2: Block of memory freed in bad conditions (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Mandatory) A block of memory shall only be freed if it was allocated by means of a Standard Library function]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>BLOCKER</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-22.3</key>
+    <name>misra-c2012-22.3: Read and write function made in same time (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Required) The same file shall not be open for read and write access at the same time on different streams]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-22.4</key>
+    <name>misra-c2012-22.4: Try to write on read only stream (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Mandatory) There shall be no attempt to write to a stream which has been opened as read-only]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>BLOCKER</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-22.5</key>
+    <name>misra-c2012-22.5: Pointer to file dereferenced (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Mandatory) A pointer to a FILE object shall not be dereferenced]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>BLOCKER</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>misra-c2012-22.6</key>
+    <name>misra-c2012-22.6: Value to pointer to file used after been closed (MISRA C 2012)</name>
+    <description>
+      <![CDATA[(Mandatory) The value of a pointer to a FILE shall not be used after the associated stream has been closed]]>
+    </description>
+    <tag>misrac3</tag>
+    <severity>BLOCKER</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
+    </rule>
 </rules>

--- a/cxx-sensors/src/main/resources/pclint.xml
+++ b/cxx-sensors/src/main/resources/pclint.xml
@@ -16790,14 +16790,14 @@ immediately cast to the underlying type of the operand.
     <severity>INFO</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
-    </rule>
+  </rule>
   <rule>
     <key>M2012-1.1</key>
     <name>M2012-1.1: Violations of the standard C (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) Violations of the standard C syntax and constraints]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -16808,7 +16808,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) Language extensions should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -16818,7 +16818,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) There shall be no occurrence of undefined or critical unspecified behaviour]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -16829,7 +16829,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A project shall not contain unreachable code]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -16840,7 +16840,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) There shall be no dead code]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -16851,7 +16851,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) A project should not contain unused ty pe declarations]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -16861,7 +16861,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) A project should not contain unused tag declarations ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -16871,7 +16871,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) A project should not contain unused macro declarations]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -16881,7 +16881,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) A function should not contain unused label declarations]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -16891,7 +16891,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) There should be no unused parameters in functions]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -16901,7 +16901,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The character sequences /* an d // shall not be used within a comment]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -16912,7 +16912,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Line-splicing shall not be used in // comments]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -16923,7 +16923,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Octal and hexadecimal escape sequences shall be terminated]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -16934,7 +16934,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) Trigraphs should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -16944,29 +16944,29 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) External identifiers shall be distinct]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>M2012-5.2</key>
-    <name>M2012-5.2: Indistinct identifiers in same scope(MISRA C 2012)</name>
+    <name>M2012-5.2: Indistinct identifiers in same scope (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) Identifiers declared in the same scope and name space shall be distinct]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>M2012-5.3</key>
-    <name>M2012-5.3: Identifier hiding other identifier(MISRA C 2012)</name>
+    <name>M2012-5.3: Identifier hiding other identifier (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) An identifier declared in an inner scope shall not hide an identifier declared in an outer scope]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -16977,7 +16977,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Macro identifiers shall be distinct]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -16988,7 +16988,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Identifiers shall be distinct from macro names]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -16999,7 +16999,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A typedef name shall be a unique identifier]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17010,7 +17010,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A tag name shall be a unique identifier]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17021,7 +17021,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Identifiers that define objects or functions with external linkage shall be unique]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17032,7 +17032,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Identifiers that define objects or functions with internal linkage should be unique]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17042,7 +17042,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Bit-fields shall only be declared with an appropriate type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17053,7 +17053,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) Single-bit named bit fields shall not be of a signed type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17063,7 +17063,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Octal constants shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17074,7 +17074,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A “u” or “U” suffix shall be applied to all integer constants that are represented in an unsigned type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17085,7 +17085,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The lowercase character “l” shall not be used in a literal suffix ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17096,7 +17096,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A string literal shall not be assigned to an object unless the object’s type is “pointer to const-qualifi ed char” ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17107,7 +17107,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Types shall be explicitly specified]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17118,7 +17118,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Function types shall be in prototype form with named parameters]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17129,7 +17129,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required)  All declarations of an object or function shall use the same names and type qualifiers]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17140,7 +17140,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A compatible declaration shall be visible when an object or function with external linkage is defined]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17151,7 +17151,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) An external object or function shall be declared once in one and only one file]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17162,7 +17162,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) An identifier with external linkage shall have exactly one external definition]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17173,7 +17173,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) Functions and objects should not be defined with external linkage if they are referenced in only one translation unit]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17183,7 +17183,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The static storage class specifier shall be used in all declarations of objects and functions that have internal linkage]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17194,7 +17194,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) An object should be defined at block scope if its identifier only appears in a single function]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17204,7 +17204,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) An inline function shall be declared with the static storage class]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17215,7 +17215,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) When an array with external linkage is declared, its size should be explicitly specified]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17225,7 +17225,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Within an enumerator list, the value of an implicitly-specified enumeration constant shall be unique]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17236,7 +17236,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) A pointer should point to a const-qualified type whenever possible]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17246,7 +17246,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The restrict type qualifier shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17257,7 +17257,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Mandatory) The value of an object with automatic storage duration shall not be read before it has been set]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17268,7 +17268,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The initializer for an aggregate or union shall be enclosed in braces]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17279,7 +17279,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Arrays shall not be partially initialized]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17290,7 +17290,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) An element of an object shall not be initialized more than once]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17301,7 +17301,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Where designated initializers are used to initialize an array object the size of the array shall be specified explicitly]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17312,7 +17312,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Operands shall not be of an inappropriate essential type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17323,7 +17323,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Expressions of essentially character type shall not be used inappropriately in addition and subtraction operations]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17334,7 +17334,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The value of an expression shall not be assigned to an object with a narrower essential type or of a different essential type category]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17345,7 +17345,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Both operands of an operator in which the usual arithmetic conversions are performed shall have the same essential type category]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17356,7 +17356,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) The value of an expression should not be cast to an inappropriate essential type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17366,7 +17366,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The value of a composite expression shall not be assigned to an object with wider essential type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17377,7 +17377,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) If a composite expression is used as one operand of an operator in which the usual arithmetic conversions are performed then the other operand shall not have wider essential type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17388,7 +17388,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The value of a composite expression shall not be cast to a different essential type category or a wider essential type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17399,7 +17399,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Conversions shall not be performed between a pointer to a function and any other type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17410,7 +17410,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Conversions shall not be performed between a pointer to an incomplete type and any other type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17421,7 +17421,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A cast shall not be performed between a pointer to object type and a pointer to a different object type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17432,7 +17432,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A conversion should not be performed between a pointer to object and an integer type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17443,7 +17443,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A conversion should not be performed from pointer to void into pointer to object ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17454,7 +17454,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A cast shall not be performed between pointer to void and an arithmetic type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17465,7 +17465,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A cast shall not be performed between pointer to object and a non-integer arithmetic type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17476,7 +17476,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A cast shall not remove any const or volatile qualification from the type pointed to by a pointer]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17487,7 +17487,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The macro NULL shall be the only permitted form of integer null pointer constant]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17498,7 +17498,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) The precedence of operators within expressions should be made explicit]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17508,7 +17508,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The right hand operand of a shift operator shall lie in the range zero to one less than the width in bits of the essential type of the left hand operand]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17519,7 +17519,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) The comma operator should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17529,7 +17529,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) Evaluation of constant expressions should not lead to unsigned integer wrap-around]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17539,7 +17539,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Mandatory) The sizeof operator shall not have an operand which is a function parameter declared as "array of type"]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17549,7 +17549,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Initializer lists shall not contain persistent side effects ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17560,7 +17560,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The value of an expression and its persistent side effects shall be the same under all permitted evaluation orders]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17571,7 +17571,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) A full expression containing an increment (++) or decrement (--) operator should have no other potential side effects other than that caused by the increment or decrement operator]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17581,7 +17581,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) The result of an assignment operator should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17589,12 +17589,9 @@ immediately cast to the underlying type of the operand.
     <key>M2012-13.5</key>
     <name>M2012-13.5: Side effects on right hand of logical operator (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Advisory) The right hand operand of a logical &amp;&amp; or || operator shall not contain persistent side effects 
-
-		]]>
+      <![CDATA[(Advisory) The right hand operand of a logical &amp;&amp; or || operator shall not contain persistent side effects]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17604,7 +17601,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Mandatory) The operand of the sizeof operator shall not contain any expression which has potential side effects]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17615,7 +17612,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A loop counter shall not have essentially floating type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17626,7 +17623,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A for loop shall be well-formed]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17637,7 +17634,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Controlling expressions shall not be invariant]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17648,7 +17645,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The controlling expression of an if statement and the controlling expression of an iteration-statement shall have essentially Boolean type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17659,7 +17656,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) The goto statement should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17669,7 +17666,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The goto statement shall jump to a label declared later in the same function ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17680,7 +17677,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Any label referenced by a goto statement shall be declared in the same block, or in any block enclosing the goto statement]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17691,7 +17688,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) There should be no more than one break or goto statement used to terminate any iteration statement]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17701,7 +17698,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory)  A function should have a single point of exit at the end]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17711,7 +17708,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The body of an iteration-statement or a selection-statement shall be acompound-statement]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17722,7 +17719,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) All if ... else if constructs shall be terminated with an else statement]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17733,7 +17730,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) All switch statements shall be well-formed]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17744,7 +17741,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) A switch label shall only be used when the most closely-enclosing compound statement is the body of a switch statement ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17755,7 +17752,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) An unconditional break statement shall terminate every switch-clause]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17766,7 +17763,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Every switch statement shall have a default label]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17777,7 +17774,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A default label shall appear as either the first or the last switch label of a switch statement]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17788,7 +17785,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Every switch statement shall have at least two switch-clauses]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17799,21 +17796,18 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A switch-expression shall not have essentially Boolean type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>M2012-17.1</key>
-    <name>M2012-17.1: Usage of   stdarg.h   is forbidden (MISRA C 2012)</name>
+    <name>M2012-17.1: Usage of stdarg.h is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The features of &lt;stdarg.h&gt; shall not be used 
-
-		]]>
+      <![CDATA[(Required) The features of &lt;stdarg.h&gt; shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17824,7 +17818,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Functions shall not call themselves, either directly or indirectly]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17835,7 +17829,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Mandatory) A function shall not be declared implicitly]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17846,7 +17840,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Mandatory) All exit paths from a function with non-void return type shall have an explicit return statement with an expression]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17857,7 +17851,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) The function argument corresponding to a parameter declared to have an array type shall have an appropriate number of elements]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17867,7 +17861,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Mandatory) The declaration of an array parameter shall not contain the static keyword between the [ ]]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17878,7 +17872,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The value returned by a function having non-void return type shall be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17889,7 +17883,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) A function parameter should not be modified ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17899,7 +17893,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A pointer resulting from arithmetic on a pointer operand shall address an element of the same array as that pointer operand]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17910,7 +17904,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Subtraction between pointers shall only be applied to pointers that address elements of the same array]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17919,12 +17913,9 @@ immediately cast to the underlying type of the operand.
     <key>M2012-18.3</key>
     <name>M2012-18.3: Relational or subtract operator applied to pointers (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The relational operators &gt;, &gt;=, &lt; and &lt;= shall not be applied to objects of pointer type except where they point into the same object
-
-		]]>
+      <![CDATA[(Required) The relational operators &gt;, &gt;=, &lt; and &lt;= shall not be applied to objects of pointer type except where they point into the same object]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17935,7 +17926,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) The +, -, += and -= operators should not be applied to an expression of pointer type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17945,7 +17936,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) Declarations should contain no more than two levels of pointer nesting]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -17955,7 +17946,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The address of an object with automatic storage shall not be copied to another object that persists after the first object has ceased to exist]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17966,7 +17957,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Flexible array members shall not be declared]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17977,7 +17968,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Variable-length array types shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17988,7 +17979,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Mandatory) An object shall not be assigned or copied to an overlapping object]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -17999,7 +17990,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) The union keyword should not be used ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -18009,7 +18000,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) #include directives should only be preceded by preprocessor directives or comments]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -18019,7 +18010,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The ',' or \ characters and the /* or // character sequences shall not occur in a header file name]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18028,12 +18019,9 @@ immediately cast to the underlying type of the operand.
     <key>M2012-20.3</key>
     <name>M2012-20.3: #include followed by wrong sequence (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The #include directive shall be followed by either a &lt;filename&gt; or "filename" sequence
-
-		]]>
+      <![CDATA[(Required) The #include directive shall be followed by either a &lt;filename&gt; or "filename" sequence]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18044,7 +18032,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A macro shall not be defined with the same name as a keyword]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18055,7 +18043,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) #undef should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -18065,7 +18053,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Tokens that look like a preprocessing directive shall not occur within a macro argument]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18076,7 +18064,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) Expressions resulting from the expansion of macro parameters shall be enclosed in parentheses]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18087,7 +18075,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The controlling expression of a #if or #elif preprocessing directive shall evaluate to 0 or 1]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18098,7 +18086,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) All identifiers used in the controlling expression of #if or #elif preprocessing directives shall be #define'd before evaluation]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18109,7 +18097,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Advisory) The # and ## preprocessor operators should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -18119,18 +18107,18 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A macro parameter immediately following a # operator shall not immediately be followed by a ## operator]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>M2012-20.12</key>
-    <name>M2012-20.12: Macro operator usedas an operand to # or ## and is subject to replacment (MISRA C 2012)</name>
+    <name>M2012-20.12: Macro operator usedas an operand to # or ## and is subject to replacement (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) A macro parameter used as an operand to the # or ## operators, which is itself subject to further macro replacement, shall only be used as an operand to these operators]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18141,7 +18129,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A line whose first token is # shall be a valid preprocessing directive]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18152,7 +18140,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) All #else, #elif and #endif preprocessor directives shall reside in the same file as the #if, #ifdef or #ifndef directive to which they are related]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18163,7 +18151,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) #define and #undef shall not be used on a reserved identifier or reserved macro name]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18174,49 +18162,40 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) A reserved identifier or macro name shall not be declared]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>M2012-21.3</key>
-    <name>M2012-21.3: Usage of memory allocation and deallocation from   stdlib.h   is forbidden (MISRA C 2012)</name>
+    <name>M2012-21.3: Usage of memory allocation and deallocation from stdlib.h is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The memory allocation and deallocation functions of &lt;stdlib.h&gt; shall not be used
-
-		]]>
+      <![CDATA[(Required) The memory allocation and deallocation functions of &lt;stdlib.h&gt; shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>M2012-21.4</key>
-    <name>M2012-21.4: Usage of   setjmp.h   is forbidden (MISRA C 2012)</name>
+    <name>M2012-21.4: Usage of setjmp.h is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The standard header file &lt;setjmp.h&gt; shall not be used 
-
-		]]>
+      <![CDATA[(Required) The standard header file &lt;setjmp.h&gt; shall not be used ]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>M2012-21.5</key>
-    <name>M2012-21.5: Usage of   signal.h   is forbidden (MISRA C 2012)</name>
+    <name>M2012-21.5: Usage of signal.h is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The standard header file &lt;signal.h&gt; shall not be used
-
-		]]>
+      <![CDATA[(Required) The standard header file &lt;signal.h&gt; shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18227,7 +18206,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The Standard Library input/output functions shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18236,12 +18215,9 @@ immediately cast to the underlying type of the operand.
     <key>M2012-21.7</key>
     <name>M2012-21.7: Usage of atol, atol and atoll is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The atof, atoi, atol and atoll functions of &lt;stdlib.h&gt; shall not be used
-
-		]]>
+      <![CDATA[(Required) The atof, atoi, atol and atoll functions of &lt;stdlib.h&gt; shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18250,12 +18226,9 @@ immediately cast to the underlying type of the operand.
     <key>M2012-21.8</key>
     <name>M2012-21.8: Usage of abort, exit, getenv and system is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The library functions abort, exit, getenv and system of &lt;stdlib.h&gt; shall not be used
-
-		]]>
+      <![CDATA[(Required) The library functions abort, exit, getenv and system of &lt;stdlib.h&gt; shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18264,12 +18237,9 @@ immediately cast to the underlying type of the operand.
     <key>M2012-21.9</key>
     <name>M2012-21.9: Usage of bsearch and qsort is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The library functions bsearch and qsort of &lt;stdlib.h&gt; shall not be used
-
-		]]>
+      <![CDATA[(Required) The library functions bsearch and qsort of &lt;stdlib.h&gt; shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18280,35 +18250,29 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The Standard Library time and date functions shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>M2012-21.11</key>
-    <name>M2012-21.11: Usage of   tgmath.h   is forbidden (MISRA C 2012)</name>
+    <name>M2012-21.11: Usage of tgmath.h is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Required) The standard header file &lt;tgmath.h&gt; shall not be used
-
-		]]>
+      <![CDATA[(Required) The standard header file &lt;tgmath.h&gt; shall not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>M2012-21.12</key>
-    <name>M2012-21.12: Usage of exception handling from   fenv.h   is forbidden (MISRA C 2012)</name>
+    <name>M2012-21.12: Usage of exception handling from fenv.h is forbidden (MISRA C 2012)</name>
     <description>
-      <![CDATA[
-(Advisory) The exception handling features of &lt;fenv.h&gt; should not be used
-
-		]]>
+      <![CDATA[(Advisory) The exception handling features of &lt;fenv.h&gt; should not be used]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -18318,7 +18282,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Mandatory) Any value passed to a function in &lt;ctype.h&gt; shall be representable as an unsigned char or be the value EOF]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -18328,7 +18292,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The pointer arguments to the Standard Library functions memcpy, memmove and memcmp shall be pointers to qualified or unqualified versions of compatible types]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
     </rule>
@@ -18338,7 +18302,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The pointer arguments to the Standard Library function memcmp shall point to either a pointer type, an essentially signed type, an essentially unsigned type, an essentially Boolean type or an essentially enum type]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18349,7 +18313,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Mandatory) Use of the string handling functions from &lt;string.h&gt; shall not result in accesses beyond the bounds of the objects referenced by their pointer parameters]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18360,7 +18324,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Mandatory) The size_t argument passed to any function in &lt;string.h&gt; shall have an appropriate value]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18371,7 +18335,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) All resources obtained dynamically by means of Standard Library functions shall be explicitly released]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18382,7 +18346,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Mandatory) A block of memory shall only be freed if it was allocated by means of a Standard Library function]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18393,7 +18357,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Required) The same file shall not be open for read and write access at the same time on different streams]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18404,7 +18368,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Mandatory) There shall be no attempt to write to a stream which has been opened as read-only]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18415,7 +18379,7 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Mandatory) A pointer to a FILE object shall not be dereferenced]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
@@ -18426,11 +18390,11 @@ immediately cast to the underlying type of the operand.
     <description>
       <![CDATA[(Mandatory) The value of a pointer to a FILE shall not be used after the associated stream has been closed]]>
     </description>
-    <tag>misrac3</tag>
+    <tag>misra-c2012</tag>
     <severity>BLOCKER</severity>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>1min</remediationFunctionGapMultiplier>
-    </rule>
+  </rule>
   <rule>
     <key>1301</key>
     <name>L1301: integer sequences must have non-negative sequence length</name>

--- a/cxx-sensors/src/main/resources/pclint.xml
+++ b/cxx-sensors/src/main/resources/pclint.xml
@@ -17125,7 +17125,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-8.3</key>
-    <name>M2012-8.3: Different declaration of object function(MISRA C 2012)</name>
+    <name>M2012-8.3: Different declaration of object function (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required)  All declarations of an object or function shall use the same names and type qualifiers]]>
     </description>
@@ -17136,7 +17136,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-8.4</key>
-    <name>M2012-8.4: Non compatible declaration with external linkage(MISRA C 2012)</name>
+    <name>M2012-8.4: Non compatible declaration with external linkage (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) A compatible declaration shall be visible when an object or function with external linkage is defined]]>
     </description>
@@ -17147,7 +17147,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-8.5</key>
-    <name>M2012-8.5: An external element declared in several files(MISRA C 2012)</name>
+    <name>M2012-8.5: An external element declared in several files (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) An external object or function shall be declared once in one and only one file]]>
     </description>
@@ -17190,7 +17190,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-8.9</key>
-    <name>M2012-8.9: Object define outside of block for single function usage(MISRA C 2012)</name>
+    <name>M2012-8.9: Object define outside of block for single function usage (MISRA C 2012)</name>
     <description>
       <![CDATA[(Advisory) An object should be defined at block scope if its identifier only appears in a single function]]>
     </description>
@@ -17319,7 +17319,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-10.2</key>
-    <name>M2012-10.2: Inapropriate ussage of character type in operation(MISRA C 2012)</name>
+    <name>M2012-10.2: Inapropriate ussage of character type in operation (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) Expressions of essentially character type shall not be used inappropriately in addition and subtraction operations]]>
     </description>
@@ -17341,7 +17341,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-10.4</key>
-    <name>M2012-10.4: Operation with different type cathegory(MISRA C 2012)</name>
+    <name>M2012-10.4: Operation with different type category (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) Both operands of an operator in which the usual arithmetic conversions are performed shall have the same essential type category]]>
     </description>
@@ -17384,7 +17384,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-10.8</key>
-    <name>M2012-10.8: Type conversion of composit expression(MISRA C 2012)</name>
+    <name>M2012-10.8: Type conversion of composit expression (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) The value of a composite expression shall not be cast to a different essential type category or a wider essential type]]>
     </description>
@@ -17395,7 +17395,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-11.1</key>
-    <name>M2012-11.1: Convertion between pointer to function and other type(MISRA C 2012)</name>
+    <name>M2012-11.1: Convertion between pointer to function and other type (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) Conversions shall not be performed between a pointer to a function and any other type]]>
     </description>
@@ -17439,7 +17439,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-11.5</key>
-    <name>M2012-11.5: Conversion between pointer to void and pointer to object(MISRA C 2012)</name>
+    <name>M2012-11.5: Conversion between pointer to void and pointer to object (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) A conversion should not be performed from pointer to void into pointer to object ]]>
     </description>
@@ -17450,7 +17450,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-11.6</key>
-    <name>M2012-11.6: Conversion between pointer to void and arithmetic type(MISRA C 2012)</name>
+    <name>M2012-11.6: Conversion between pointer to void and arithmetic type (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) A cast shall not be performed between pointer to void and an arithmetic type]]>
     </description>
@@ -17494,7 +17494,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-12.1</key>
-    <name>M2012-12.1: Precedence of expression non explicit(MISRA C 2012)</name>
+    <name>M2012-12.1: Precedence of expression non explicit (MISRA C 2012)</name>
     <description>
       <![CDATA[(Advisory) The precedence of operators within expressions should be made explicit]]>
     </description>
@@ -17556,7 +17556,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-13.2</key>
-    <name>M2012-13.2: Different value of expression and persistent side effect(MISRA C 2012)</name>
+    <name>M2012-13.2: Different value of expression and persistent side effect (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) The value of an expression and its persistent side effects shall be the same under all permitted evaluation orders]]>
     </description>
@@ -17906,7 +17906,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-18.2</key>
-    <name>M2012-18.2: Substraction between different array with pointers(MISRA C 2012)</name>
+    <name>M2012-18.2: Substraction between different array with pointers (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) Subtraction between pointers shall only be applied to pointers that address elements of the same array]]>
     </description>
@@ -17917,7 +17917,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-18.3</key>
-    <name>M2012-18.3: Relational or subtract operator applied to pointers  (MISRA C 2012)</name>
+    <name>M2012-18.3: Relational or subtract operator applied to pointers (MISRA C 2012)</name>
     <description>
       <![CDATA[
 (Required) The relational operators &gt;, &gt;=, &lt; and &lt;= shall not be applied to objects of pointer type except where they point into the same object
@@ -18170,7 +18170,7 @@ immediately cast to the underlying type of the operand.
     </rule>
   <rule>
     <key>M2012-21.2</key>
-    <name>M2012-21.2: Illegal macro name using reserved identifier(MISRA C 2012)</name>
+    <name>M2012-21.2: Illegal macro name using reserved identifier (MISRA C 2012)</name>
     <description>
       <![CDATA[(Required) A reserved identifier or macro name shall not be declared]]>
     </description>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
@@ -37,7 +37,7 @@ public class CxxCppCheckRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxCppCheckRuleRepository.KEY);
-    assertEquals(499, repo.rules().size());
+    assertEquals(648, repo.rules().size());
   }
 
 }


### PR DESCRIPTION
The rules are copied from `pclint.xml`, the key is modified to match Cppcheck key (Cppcheck used with MISRA plugin).
I am not sure if the tag `<tag>misrac3</tag>` should be deleted (in the case this is related to PCLINT) ?
See also #2069

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2070)
<!-- Reviewable:end -->
