### PR TITLE
CxxSquidSensor: run sensor only when related rules are active

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxRuleRepository.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxRuleRepository.java
@@ -26,10 +26,11 @@ import org.sonar.squidbridge.annotations.AnnotationBasedRulesDefinition;
 public class CxxRuleRepository implements RulesDefinition {
 
   private static final String REPOSITORY_NAME = "SonarQube";
+  protected static final String KEY = "cxx";
 
   @Override
   public void define(Context context) {
-    NewRepository repository = context.createRepository("cxx", CxxLanguage.KEY).
+    NewRepository repository = context.createRepository(KEY, CxxLanguage.KEY).
       setName(REPOSITORY_NAME);
     new AnnotationBasedRulesDefinition(repository, CxxLanguage.KEY).addRuleClasses(false, CheckList.getChecks());
     repository.done();

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxSquidSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxSquidSensor.java
@@ -269,6 +269,7 @@ public class CxxSquidSensor implements ProjectSensor {
     descriptor
       .name("CXX")
       .onlyOnLanguage("cxx")
+      .createIssuesForRuleRepository(getRuleRepositoryKey())
       .onlyOnFileType(InputFile.Type.MAIN);
   }
 
@@ -504,4 +505,7 @@ public class CxxSquidSensor implements ProjectSensor {
       .save();
   }
 
+  protected String getRuleRepositoryKey() {
+      return CxxRuleRepository.KEY;
+  }
 }


### PR DESCRIPTION
SquidSensor can take significant amount of time on big projects.
Skip execution if all appropriate rules are disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2080)
<!-- Reviewable:end -->
