### PR TITLE
fix NPE in API visitor: template specialization declaration

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
@@ -501,10 +501,9 @@ public abstract class AbstractCxxPublicApiVisitor<G extends Grammar> extends Squ
       AstNode linkageSpecification = declaration
         .getFirstAncestor(CxxGrammarImpl.linkageSpecification);
       if (linkageSpecification != null) {
-        if( linkageSpecification.hasDirectChildren(CxxPunctuator.CURLBR_LEFT)) {
+        if (linkageSpecification.hasDirectChildren(CxxPunctuator.CURLBR_LEFT)) {
           docNode = declaration; // extern "C" { ... }
-        }
-        else {
+        } else {
           docNode = linkageSpecification; // extern "C" ...
         }
       } else {
@@ -658,7 +657,7 @@ public abstract class AbstractCxxPublicApiVisitor<G extends Grammar> extends Squ
     if (idNode != null) {
       idNode = idNode.getLastChild(IDENTIFIER);
     } else {
-      idNode = declId.getLastChild(IDENTIFIER);
+      idNode = declId;
     }
     String id = idNode.getTokenValue();
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
@@ -84,7 +84,7 @@ public class CxxPublicApiVisitorTest {
 
   @Test
   public void template() throws IOException {
-    assertThat(testFile("src/test/resources/metrics/template.h")).isEqualTo(tuple(13, 4));
+    assertThat(testFile("src/test/resources/metrics/template.h")).isEqualTo(tuple(14, 4));
   }
 
   @Test

--- a/cxx-squid/src/test/resources/metrics/template.h
+++ b/cxx-squid/src/test/resources/metrics/template.h
@@ -70,3 +70,8 @@ void TestClass2::functionTest2()
 struct A {
    template<class T> class B;
 };
+
+/**
+ * @brief issue #2138
+ */
+template<> Formatter& LogMsg_applyFormat<int>(Formatter& format, int i);


### PR DESCRIPTION
- close #2138

template specialization declaration:
```Java
template<> Formatter& LogMsg_applyFormat<int>(Formatter& format, int i);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2141)
<!-- Reviewable:end -->
