### PR TITLE
Clang-Tidy refactoring

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/ClangTidyParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/ClangTidyParser.java
@@ -1,0 +1,161 @@
+/*
+ * C++ Community Plugin (cxx plugin)
+ * Copyright (C) 2010-2021 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.sensors.clangtidy;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import org.sonar.cxx.sensors.utils.TextScanner;
+import org.sonar.cxx.utils.CxxReportIssue;
+
+public class ClangTidyParser {
+
+  private static final Logger LOG = Loggers.get(ClangTidyParser.class);
+
+  private static final String REGEX = "(.+|[a-zA-Z]:\\\\.+):([0-9]+):([0-9]+): ([^:]+): (.+)";
+  private static final Pattern PATTERN = Pattern.compile(REGEX);
+
+  private final CxxClangTidySensor sensor;
+  private Issue issue = null;
+
+  public ClangTidyParser(CxxClangTidySensor sensor) {
+    this.sensor = sensor;
+  }
+
+  public void parse(File report, String defaultEncoding) throws IOException {
+    try ( var scanner = new TextScanner(report, defaultEncoding)) {
+      LOG.debug("Encoding='{}'", scanner.encoding());
+
+      CxxReportIssue currentIssue = null;
+      while (scanner.hasNextLine()) {
+        if (!parseLine(scanner.nextLine())) {
+          continue;
+        }
+        if ("note".equals(issue.level)) {
+          if (currentIssue != null) {
+            currentIssue.addFlowElement(issue.path, issue.line, issue.column, issue.info);
+          }
+        } else {
+          if (currentIssue != null) {
+            sensor.saveUniqueViolation(currentIssue);
+          }
+          currentIssue = new CxxReportIssue(issue.ruleId, issue.path, issue.line, issue.column, issue.info);
+          for (var aliasRuleId : issue.aliasRuleIds) {
+            currentIssue.addAliasRuleId(aliasRuleId);
+          }
+        }
+      }
+      if (currentIssue != null) {
+        sensor.saveUniqueViolation(currentIssue);
+      }
+    }
+  }
+
+  private boolean parseLine(String data) {
+    var matcher = PATTERN.matcher(data);
+    issue = null;
+    if (matcher.matches()) {
+      issue = new Issue();
+      // group: 1      2      3         4        5
+      //      <path>:<line>:<column>: <level>: <info> [ruleIds]
+      // sample:
+      //      c:\a\file.cc:5:20: warning: txt txt [clang-diagnostic-writable-strings]
+      var m = matcher.toMatchResult();
+      issue.path = m.group(1);   // relative paths
+      issue.line = m.group(2);   // 1...n
+      issue.column = m.group(3); // 1...n
+      issue.level = m.group(4);  // error, warning, note, ...
+      issue.info = m.group(5);   // info [ruleIds]
+
+      // Clang-Tidy column numbers are from 1...n and SQ is using 0...n
+      try {
+        issue.column = Integer.toString(Integer.parseInt(issue.column) - 1);
+      } catch (java.lang.NumberFormatException e) {
+        issue.column = "";
+      }
+
+      splitRuleIds(); // info [ruleId, aliasId, ...]
+    }
+
+    return issue != null;
+  }
+
+  private void splitRuleIds() {
+    issue.ruleId = getDefaultRuleId();
+
+    if (!issue.info.endsWith("]")) { // [...]
+      return;
+    }
+
+    var end = issue.info.length() - 1;
+    for (var start = issue.info.length() - 2; start >= 0; start--) {
+      var c = issue.info.charAt(start);
+      if (Character.isLetterOrDigit(c) || c == '-' || c == '.' || c == '_') {
+        continue;
+      } else if (c == ',') {
+        var aliasId = issue.info.substring(start + 1, end);
+        if (!"-warnings-as-errors".equals(aliasId)) {
+          issue.aliasRuleIds.addFirst(aliasId);
+        }
+        end = start;
+      } else {
+        if (c == '[') {
+          issue.ruleId = issue.info.substring(start + 1, end);
+          issue.info = issue.info.substring(0, start - 1);
+        } else {
+          issue.aliasRuleIds.clear();
+        }
+        break;
+      }
+    }
+  }
+
+  String getDefaultRuleId() {
+    Map<String, String> map = Map.of(
+      "note", "",
+      "warning", "clang-diagnostic-warning",
+      "error", "clang-diagnostic-error",
+      "fatal error", "clang-diagnostic-error"
+    );
+
+    return map.getOrDefault(issue.level, "clang-diagnostic-unknown");
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+
+  private static class Issue {
+
+    private String path;
+    private String line;
+    private String column;
+    private String level;
+    private String ruleId;
+    private LinkedList<String> aliasRuleIds = new LinkedList<>();
+    private String info;
+  }
+
+}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensor.java
@@ -23,19 +23,12 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.sensors.utils.CxxIssuesReportSensor;
 import org.sonar.cxx.sensors.utils.InvalidReportException;
-import org.sonar.cxx.sensors.utils.TextScanner;
-import org.sonar.cxx.utils.CxxReportIssue;
 
 /**
  * Sensor for clang-tidy
@@ -45,8 +38,6 @@ public class CxxClangTidySensor extends CxxIssuesReportSensor {
   public static final String REPORT_PATH_KEY = "sonar.cxx.clangtidy.reportPaths";
   public static final String REPORT_ENCODING_DEF = "sonar.cxx.clangtidy.encoding";
   public static final String DEFAULT_ENCODING_DEF = StandardCharsets.UTF_8.name();
-
-  private static final Logger LOG = Loggers.get(CxxClangTidySensor.class);
 
   public static List<PropertyDefinition> properties() {
     return Collections.unmodifiableList(Arrays.asList(
@@ -84,35 +75,10 @@ public class CxxClangTidySensor extends CxxIssuesReportSensor {
 
   @Override
   protected void processReport(File report) {
-    String reportEncoding = context.config().get(REPORT_ENCODING_DEF).orElse(DEFAULT_ENCODING_DEF);
-
-    try ( var scanner = new TextScanner(report, reportEncoding)) {
-      LOG.debug("Encoding='{}'", scanner.encoding());
-
-      // sample:
-      // c:\a\file.cc:5:20: warning: ... conversion from string literal to 'char *' [clang-diagnostic-writable-strings]
-      CxxReportIssue currentIssue = null;
-      while (scanner.hasNextLine()) {
-        var issue = Issue.create(scanner.nextLine());
-        if (issue != null) {
-          if ("note".equals(issue.level)) {
-            if (currentIssue != null) {
-              currentIssue.addFlowElement(issue.path, issue.line, issue.column, issue.info);
-            }
-          } else {
-            if (currentIssue != null) {
-              saveUniqueViolation(currentIssue);
-            }
-            currentIssue = new CxxReportIssue(issue.ruleId, issue.path, issue.line, issue.column, issue.info);
-            for (var aliasRuleId : issue.aliasRuleIds) {
-              currentIssue.addAliasRuleId(aliasRuleId);
-            }
-          }
-        }
-      }
-      if (currentIssue != null) {
-        saveUniqueViolation(currentIssue);
-      }
+    var parser = new ClangTidyParser(this);
+    try {
+      String defaultEncoding = context.config().get(REPORT_ENCODING_DEF).orElse(DEFAULT_ENCODING_DEF);
+      parser.parse(report, defaultEncoding);
     } catch (final java.io.IOException
                      | java.lang.IllegalArgumentException
                      | java.lang.IllegalStateException
@@ -129,75 +95,6 @@ public class CxxClangTidySensor extends CxxIssuesReportSensor {
   @Override
   protected String getRuleRepositoryKey() {
     return CxxClangTidyRuleRepository.KEY;
-  }
-
-  private static class Issue {
-
-    private static final String REGEX = "(.+|[a-zA-Z]:\\\\.+):([0-9]+):([0-9]+): ([^:]+): (.+)";
-    private static final Pattern PATTERN = Pattern.compile(REGEX);
-
-    private String path;
-    private String line;
-    private String column;
-    private String level;
-    private String ruleId;
-    private LinkedList<String> aliasRuleIds = new LinkedList<>();
-    private String info;
-
-    static Issue create(String data) {
-      var matcher = PATTERN.matcher(data);
-      if (matcher.matches()) {
-        var issue = new Issue();
-        // group: 1      2      3         4        5
-        //      <path>:<line>:<column>: <level>: <info>
-        var m = matcher.toMatchResult();
-        issue.path = m.group(1); // relative paths
-        issue.line = m.group(2);
-        issue.column = m.group(3);
-        issue.level = m.group(4); // error, warning, note, ...
-        issue.info = m.group(5); // info [ruleIds]
-
-        issue.splitRuleId();
-        return issue;
-      }
-      return null;
-    }
-
-    void splitRuleId() {
-      ruleId = getDefaultRuleId();
-
-      if (info.endsWith("]")) { // [ruleIds]
-        var end = info.length() - 1;
-        for (var start = info.length() - 2; start >= 0; start--) {
-          var c = info.charAt(start);
-          if (!(Character.isLetterOrDigit(c) || c == '-' || c == '.' || c == '_')) {
-            if (c == ',') {
-              var aliasId = info.substring(start + 1, end);
-              if (!"warnings-as-errors".equals(aliasId)) {
-                aliasRuleIds.addFirst(aliasId);
-              }
-              end = start;
-              continue;
-            } else if (c == '[') {
-              ruleId = info.substring(start + 1, end);
-              info = info.substring(0, start - 1);
-            }
-            break;
-          }
-        }
-      }
-    }
-
-    String getDefaultRuleId() {
-      Map<String, String> map = Map.of(
-        "note", "",
-        "warning", "clang-diagnostic-warning",
-        "error", "clang-diagnostic-error",
-        "fatal error", "clang-diagnostic-error"
-      );
-
-      return map.getOrDefault(level, "clang-diagnostic-unknown");
-    }
   }
 
 }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
@@ -131,8 +131,13 @@ public abstract class CxxIssuesReportSensor extends CxxReportSensor {
     if (column < 0) {
       return inputFile.selectLine(line);
     } else {
-      // since we do not have more information, we select only one character
-      return inputFile.newRange(line, column, line, column + 1);
+      try {
+        // since we do not have more information, we select only one character
+        return inputFile.newRange(line, column, line, column + 1);
+      } catch (IllegalArgumentException e) {
+        // second try without column number: sometimes locations is behind last valid column
+        return inputFile.selectLine(line);
+      }
     }
   }
 

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxReportSensor.java
@@ -81,7 +81,7 @@ public abstract class CxxReportSensor implements ProjectSensor {
         inputFile = getInputFileTryRealPath(path);
 
         if (inputFile == null) {
-          LOG.warn("Cannot find the file '{}' in project '{}' with baseDir '{}', skipping.",
+          LOG.warn("Cannot find the file '{}' in project '{}' with baseDir '{}', skipping",
                    path, context.project().key(), context.fileSystem().baseDir());
           notFoundFiles.add(path);
         }

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxUtils.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxUtils.java
@@ -63,15 +63,13 @@ public final class CxxUtils {
   /**
    * validateRecovery
    *
+   * @param msg
    * @param ex
    * @param config
    */
   public static void validateRecovery(String msg, Exception ex, Configuration config) {
-    var message = msg;
-    var cause = ex.getCause();
-    if (cause != null) {
-      message += ", cause='" + cause.toString().replaceAll("[\\r\\n]+", " ") + "'";
-    }
+    var message = (msg + ", cause='" + ExceptionUtils.getRootCauseMessage(ex) + "'")
+      .replaceAll("\\R+", " ");
     Optional<Boolean> recovery = config.getBoolean(CxxReportSensor.ERROR_RECOVERY_KEY);
     if (recovery.isPresent() && recovery.get()) {
       LOG.warn(message + ", skipping");
@@ -79,7 +77,7 @@ public final class CxxUtils {
     }
     LOG.info("Error recovery is disabled");
     LOG.error(message + ", stop analysis");
-    throw new IllegalStateException(ex.getMessage(), ex.getCause());
+    throw new IllegalStateException(msg, ex);
   }
 
   /**

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/cpd.report-duplicates.txt
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/cpd.report-duplicates.txt
@@ -1,0 +1,12 @@
+sources\utils\code_chunks.cpp:2:32: warning: field '_identityFunction' is uninitialized when used here [clang-diagnostic-uninitialized]
+                               _identityFunction,
+                               ^
+sources\utils\code_chunks.cpp:3:32: warning: field '_identityFunction' is uninitialized when used here [clang-diagnostic-uninitialized]
+                               _identityFunction) {
+                               ^
+sources\utils\code_chunks.cpp:2:32: warning: field '_identityFunction' is uninitialized when used here [clang-diagnostic-uninitialized]
+                               _identityFunction,
+                               ^
+sources\utils\code_chunks.cpp:3:32: warning: field '_identityFunction' is uninitialized when used here [clang-diagnostic-uninitialized]
+                               _identityFunction) {
+                               ^

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/cpd.report-min-max-cols.txt
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/cpd.report-min-max-cols.txt
@@ -1,0 +1,6 @@
+sources\utils\code_chunks.cpp:1:1: warning: ... [first-column]
+0123456789
+^
+sources\utils\code_chunks.cpp:1:10: warning: ... [last-column]
+0123456789
+         ^

--- a/integration-tests/features/cppcheck.feature
+++ b/integration-tests/features/cppcheck.feature
@@ -16,7 +16,7 @@ Feature: Importing Cppcheck reports
     And the server log (if locatable) contains no error/warning messages
     But the analysis log contains a line matching
       """
-      .*WARN: The 'Cppcheck V2' report is empty.*, skipping
+      .*WARN: The 'Cppcheck V2' report is empty.*skipping
       """
     And the number of violations fed is 0
 
@@ -35,7 +35,7 @@ Feature: Importing Cppcheck reports
     And the server log (if locatable) contains no error/warning messages
     But the analysis log contains a line matching
       """
-      .*WARN.*Cannot find the file .* skipping
+      .*WARN: Cannot find the file.*skipping
       """
     And the number of violations fed is 0
 
@@ -70,7 +70,7 @@ Feature: Importing Cppcheck reports
     And the server log (if locatable) contains no error/warning messages
     But the analysis log contains a line matching
       """
-      .*WARN: The 'Cppcheck V2' report is invalid.*, skipping
+      .*WARN: The 'Cppcheck V2' report is invalid.*skipping
       """
     And the number of violations fed is <violations>
     Examples:

--- a/integration-tests/features/googletest.feature
+++ b/integration-tests/features/googletest.feature
@@ -55,7 +55,7 @@ Feature: Providing test execution measures
     Then the analysis breaks
     And the analysis log contains a line matching:
       """
-      .*ERROR: Invalid xUnit report, stop analysis.*
+      .*ERROR: Invalid xUnit report.*stop analysis
       """
 
 


### PR DESCRIPTION
- fix Clang-Tidy column number reporting (column numbers in Clang-Tidy: 1...n; SQ: 0...n)
- be more tolerant in case of invalid column number: report issue in line (without column)
- improve error message in case of wrong line/column number
- refactoring: move file parser into extra class (ClangTidyParser)
- close #2174
- close #2175

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2177)
<!-- Reviewable:end -->
