### PR TITLE
fix #2180

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/visitors/AbstractCxxPublicApiVisitor.java
@@ -21,17 +21,16 @@ package org.sonar.cxx.visitors;
 
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.GenericTokenType;
-import static com.sonar.sslr.api.GenericTokenType.IDENTIFIER;
 import com.sonar.sslr.api.Grammar;
 import com.sonar.sslr.api.Token;
 import com.sonar.sslr.impl.ast.AstXmlPrinter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.cxx.parser.CxxGrammarImpl;
-import static org.sonar.cxx.parser.CxxGrammarImpl.qualifiedId;
 import org.sonar.cxx.parser.CxxKeyword;
 import org.sonar.cxx.parser.CxxPunctuator;
 import org.sonar.cxx.squidbridge.checks.SquidCheck;
@@ -646,13 +645,10 @@ public abstract class AbstractCxxPublicApiVisitor<G extends Grammar> extends Squ
     if (declId == null) {
       return;
     }
-    var idNode = declId.getLastChild(qualifiedId);
-    if (idNode != null) {
-      idNode = idNode.getLastChild(IDENTIFIER);
-    } else {
-      idNode = declId;
-    }
-    String id = idNode.getTokenValue();
+
+    String id = declId.getTokens().stream()
+      .map(Token::getValue)
+      .collect(Collectors.joining());
 
     // handle cascaded template declarations
     AstNode node = templateDeclaration;
@@ -815,7 +811,7 @@ public abstract class AbstractCxxPublicApiVisitor<G extends Grammar> extends Squ
       docNode = enumSpecifierNode;
     }
 
-    visitPublicApi(enumSpecifierNode, enumId,getBlockDocumentation(docNode));
+    visitPublicApi(enumSpecifierNode, enumId, getBlockDocumentation(docNode));
 
     // deal with enumeration values
     AstNode enumeratorList = enumSpecifierNode.getFirstDescendant(CxxGrammarImpl.enumeratorList);
@@ -841,7 +837,7 @@ public abstract class AbstractCxxPublicApiVisitor<G extends Grammar> extends Squ
           }
         }
 
-        visitPublicApi(definition,  definition.getFirstDescendant(  GenericTokenType.IDENTIFIER).getTokenValue(), comments);
+        visitPublicApi(definition, definition.getFirstDescendant(GenericTokenType.IDENTIFIER).getTokenValue(), comments);
       }
     }
   }

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
@@ -83,7 +83,7 @@ public class CxxPublicApiVisitorTest {
 
   @Test
   public void template() throws IOException {
-    assertThat(verifyPublicApiOfFile("src/test/resources/metrics/template.h")).isEqualTo(tuple(14, 4));
+    assertThat(verifyPublicApiOfFile("src/test/resources/metrics/template.h")).isEqualTo(tuple(15, 4));
   }
 
   @Test

--- a/cxx-squid/src/test/resources/metrics/template.h
+++ b/cxx-squid/src/test/resources/metrics/template.h
@@ -75,3 +75,9 @@ struct A {
  * @brief issue #2138
  */
 template<> Formatter& LogMsg_applyFormat<int>(Formatter& format, int i);
+
+/**
+ * @brief issue #2180
+ */
+template <typename B>
+A<B>::~A() = default;


### PR DESCRIPTION
- NPE in case of unqualifiedId
- improved error message: create id from declaratorId token stream (instead of IDENTIFIER only)
- close #2180

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2182)
<!-- Reviewable:end -->
