### PR TITLE
optimize the whitespace channel

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/channels/WhitespaceChannel.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/channels/WhitespaceChannel.java
@@ -1,0 +1,53 @@
+/*
+ * C++ Community Plugin (cxx plugin)
+ * Copyright (C) 2010-2021 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.channels;
+
+import com.sonar.sslr.api.Token;
+import com.sonar.sslr.impl.Lexer;
+import org.sonar.cxx.parser.CxxTokenType;
+import org.sonar.sslr.channel.Channel;
+import org.sonar.sslr.channel.CodeReader;
+
+public class WhitespaceChannel extends Channel<Lexer> {
+
+  @Override
+  public boolean consume(CodeReader code, Lexer output) {
+    var isWhitespace = false;
+    while (Character.isWhitespace(code.peek())) {
+      if (!isWhitespace) {
+        int line = code.getLinePosition();
+        int column = code.getColumnPosition();
+        // merge multiple whitespaces into one
+        output.addToken(Token.builder()
+          .setLine(line)
+          .setColumn(column)
+          .setURI(output.getURI())
+          .setValueAndOriginalValue(" ")
+          .setType(CxxTokenType.WS)
+          .build());
+        isWhitespace = true;
+      }
+      code.pop();
+    }
+
+    return isWhitespace;
+  }
+
+}

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppLexer.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CppLexer.java
@@ -36,6 +36,7 @@ import java.nio.charset.Charset;
 import org.sonar.cxx.channels.CharacterLiteralsChannel;
 import org.sonar.cxx.channels.KeywordChannel;
 import org.sonar.cxx.channels.StringLiteralsChannel;
+import org.sonar.cxx.channels.WhitespaceChannel;
 import org.sonar.cxx.parser.CxxTokenType;
 
 public final class CppLexer {
@@ -68,7 +69,7 @@ public final class CppLexer {
     var builder = Lexer.builder()
       .withCharset(charset)
       .withFailIfNoChannelToConsumeOneCharacter(true)
-      .withChannel(regexp(CxxTokenType.WS, "\\s+"))
+      .withChannel(new WhitespaceChannel())
       .withChannel(commentRegexp("//[^\\n\\r]*+"))
       .withChannel(commentRegexp("/\\*", ANY_CHAR + "*?", "\\*/"))
       .withChannel(new CharacterLiteralsChannel())

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/Macro.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/Macro.java
@@ -76,16 +76,23 @@ public final class Macro {
 
   @Override
   public String toString() {
-    var paramsStr = "";
+    StringBuilder ab = new StringBuilder(64);
+    ab.append("{");
+    ab.append(name);
     if (params != null) {
-      final String joinedParams = params.stream().map(Token::getValue).collect(Collectors.joining(", "));
-      paramsStr = "(" + joinedParams + (isVariadic ? "..." : "") + ")";
+      ab.append("(");
+      ab.append(params.stream().map(Token::getValue).collect(Collectors.joining(", ")));
+      if (isVariadic) {
+        ab.append("...");
+      }
+      ab.append(")");
     }
-    var bodyStr = "";
     if (body != null) {
-      bodyStr = body.stream().map(Token::getValue).collect(Collectors.joining(" "));
+      ab.append(":");
+      ab.append(body.stream().map(Token::getValue).collect(Collectors.joining()));
     }
-    return "{" + name + paramsStr + ":" + bodyStr + "}";
+    ab.append("}");
+    return ab.toString();
   }
 
   public boolean checkArgumentsCount(int count) {


### PR DESCRIPTION
- add only one space to token (even with several in the code)
- use simple while loop instead of regex

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2200)
<!-- Reviewable:end -->
