### PR TITLE
set C++14 as default

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/config/MsBuild.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/config/MsBuild.java
@@ -50,9 +50,6 @@ public class MsBuild {
   private static final String MSC_IX86_600 = "_M_IX86 600";
   private static final String MSC_X64_100 = "_M_X64 100";
 
-  private static final String CPPWINRTVERSION = "__cplusplus_winrt=201009";
-  private static final String CPPVERSION = "__cplusplus=199711L";
-
   private static final Pattern[] INCLUDE_PATTERNS = {Pattern.compile("/I\"(.*?)\""),
                                                      Pattern.compile("/I([^\\s\"]++) ")};
   private static final Pattern[] DEFINE_PATTERNS = {Pattern.compile("[/-]D\\s([^\\s]++)"),
@@ -71,7 +68,7 @@ public class MsBuild {
   private static final Pattern PATH_TO_VCXPROJ = Pattern.compile(
     "^\\S+\\s\\\"ClCompile\\\".+\\\"((?>[^\\\\]{1,260}\\\\)*[^\\\\]{1,260}\\.vcxproj)\\\".*$");
 
-  private String platformToolset = "V120";
+  private String platformToolset = "V142";
   private String platform = "Win32";
 
   private final CxxSquidConfiguration squidConfig;
@@ -543,95 +540,82 @@ public class MsBuild {
   }
 
   private void parseV100CompilerOptions(String line, String fileElement) {
-    // VC++ V16.0 - VS2010 (V10.0)
-    addMacro(CPPVERSION, fileElement);
+    // Visual Studio 2010 SP1 [10.0]
+    addMacro("__cplusplus=199711L", fileElement);
     // __cplusplus_winrt Defined when you use the /ZW option to compile. The value of __cplusplus_winrt is 201009.
     if (line.contains("/ZW ")) {
-      addMacro(CPPWINRTVERSION, fileElement);
+      addMacro("__cplusplus_winrt=201009", fileElement);
     }
     addMacro("_MSC_VER=1600", fileElement);
-    // VS2010 SP1
-    addMacro("_MSC_FULL_VER=16004021901", fileElement);
-    //_MFC_VER Defines the MFC version. For example, in Visual Studio 2010, _MFC_VER is defined as 0x0C00.
+    addMacro("_MSC_FULL_VER=160040219", fileElement);
     addMacro("_MFC_VER=0x0A00", fileElement);
     addMacro("_ATL_VER=0x0A00", fileElement);
-    // VC++ 16.0
     if (line.contains("/GX ")) {
       addMacro("_CPPUNWIND", fileElement);
     }
   }
 
   private void parseV110CompilerOptions(String line, String fileElement) {
-    // VC++ V17.0 - VS2012 (V11.0)
-    addMacro(CPPVERSION, fileElement);
+    // Visual Studio 2012 Update 4 [11.0]
+    addMacro("__cplusplus=199711L", fileElement);
     // __cplusplus_winrt Defined when you use the /ZW option to compile. The value of __cplusplus_winrt is 201009.
     if (line.contains("/ZW ")) {
-      addMacro(CPPWINRTVERSION, fileElement);
+      addMacro("__cplusplus_winrt=201009", fileElement);
     }
     addMacro("_MSC_VER=1700", fileElement);
-    // VS2012 Update 4
-    addMacro("_MSC_FULL_VER=1700610301", fileElement);
-    //_MFC_VER Defines the MFC version (see afxver_.h)
+    addMacro("_MSC_FULL_VER=170061030", fileElement);
     addMacro("_MFC_VER=0x0B00", fileElement);
     addMacro("_ATL_VER=0x0B00", fileElement);
   }
 
   private void parseV120CompilerOptions(String line, String fileElement) {
-    // VC++ V18.0 - VS2013 (V12.0)
-    addMacro(CPPVERSION, fileElement);
+    // Visual Studio 2013 Update 5 [12.0]
+    addMacro("__cplusplus=199711L", fileElement);
     // __cplusplus_winrt Defined when you use the /ZW option to compile. The value of __cplusplus_winrt is 201009.
     if (line.contains("/ZW ")) {
-      addMacro(CPPWINRTVERSION, fileElement);
+      addMacro("__cplusplus_winrt=201009", fileElement);
     }
     addMacro("_MSC_VER=1800", fileElement);
-    // VS2013 Update 4
-    addMacro("_MSC_FULL_VER=180031101", fileElement);
-    //_MFC_VER Defines the MFC version (see afxver_.h)
+    addMacro("_MSC_FULL_VER=180040629", fileElement);
     addMacro("_MFC_VER=0x0C00", fileElement);
     addMacro("_ATL_VER=0x0C00", fileElement);
   }
 
   private void parseV140CompilerOptions(String line, String fileElement) {
-    // VC++ V19.0 - VS2015 (V14.0)
-    addMacro(CPPVERSION, fileElement);
+    // Visual Studio 2015 Update 3 [14.0]
+    addMacro("__cplusplus=199711L", fileElement);
     // __cplusplus_winrt Defined when you use the /ZW option to compile. The value of __cplusplus_winrt is 201009.
     if (line.contains("/ZW ")) {
-      addMacro(CPPWINRTVERSION, fileElement);
+      addMacro("__cplusplus_winrt=201009", fileElement);
     }
     addMacro("_MSC_VER=1900", fileElement);
-    // VS2015 Update 3 V19.00.24215.1
-    addMacro("_MSC_FULL_VER=190024215", fileElement);
-    //_MFC_VER Defines the MFC version (see afxver_.h)
+    addMacro("_MSC_FULL_VER=190024210", fileElement);
     addMacro("_MFC_VER=0x0E00", fileElement);
     addMacro("_ATL_VER=0x0E00", fileElement);
   }
 
   private void parseV141CompilerOptions(String line, String fileElement) {
-    // VC++ V19.1 - VS2017 (V15.0)
-    addMacro(CPPVERSION, fileElement);
+    // Visual Studio 2017 version 15.9.11
+    addMacro("__cplusplus=199711L", fileElement);
     // __cplusplus_winrt Defined when you use the /ZW option to compile. The value of __cplusplus_winrt is 201009.
     if (line.contains("/ZW ")) {
-      addMacro(CPPWINRTVERSION, fileElement);
+      addMacro("__cplusplus_winrt=201009", fileElement);
     }
     addMacro("_MSC_VER=1910", fileElement);
-    // VS2017 RC
-    addMacro("_MSC_FULL_VER=191024629", fileElement);
-    //_MFC_VER Defines the MFC version (see afxver_.h)
+    addMacro("_MSC_FULL_VER=191627030", fileElement);
     addMacro("_MFC_VER=0x0E00", fileElement);
     addMacro("_ATL_VER=0x0E00", fileElement);
   }
 
   private void parseV142CompilerOptions(String line, String fileElement) {
-    // VC++ V19.2 - VS2019 (V16.0)
-    addMacro(CPPVERSION, fileElement);
+    // Visual Studio 2019 version 16.9.2
+    addMacro("__cplusplus=201402L", fileElement);
     // __cplusplus_winrt Defined when you use the /ZW option to compile. The value of __cplusplus_winrt is 201009.
     if (line.contains("/ZW ")) {
-      addMacro(CPPWINRTVERSION, fileElement);
+      addMacro("__cplusplus_winrt=201009", fileElement);
     }
-    addMacro("_MSC_VER=1921", fileElement);
-    // VS2017 RC
-    addMacro("_MSC_FULL_VER=192127702", fileElement);
-    //_MFC_VER Defines the MFC version (see afxver_.h)
+    addMacro("_MSC_VER=1920", fileElement);
+    addMacro("_MSC_FULL_VER=192829913", fileElement);
     addMacro("_MFC_VER=0x0E00", fileElement);
     addMacro("_ATL_VER=0x0E00", fileElement);
   }

--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -116,11 +116,10 @@ public class CxxPreprocessor extends Preprocessor {
   private final Set<File> analysedFiles = new HashSet<>();
   private final Parser<Grammar> pplineParser;
 
-  private static final String MISSING_INCLUDE_MSG =
-     "Preprocessor: {} include directive error(s). "
-     + "This is only relevant if parser creates syntax errors."
-     + " The preprocessor searches for include files in the with "
-     + "'sonar.cxx.includeDirectories' defined directories and order.";
+  private static final String MISSING_INCLUDE_MSG = "Preprocessor: {} include directive error(s). "
+                                                      + "This is only relevant if parser creates syntax errors."
+                                                      + " The preprocessor searches for include files in the with "
+                                                      + "'sonar.cxx.includeDirectories' defined directories and order.";
   private static int missingIncludeFilesCounter = 0;
 
   public CxxPreprocessor(SquidAstVisitorContext<Grammar> context) {
@@ -623,7 +622,8 @@ public class CxxPreprocessor extends Preprocessor {
       "__TIME__ \"??:??:??\"",
       "__STDC__ 1",
       "__STDC_HOSTED__ 1",
-      "__cplusplus 201103L",
+      // set C++14 as default
+      "__cplusplus 201402L",
       // __has_include support (C++17)
       "__has_include 1"
     };
@@ -1106,7 +1106,7 @@ public class CxxPreprocessor extends Preprocessor {
     File includedFile = findIncludedFile(ast, token, filename);
     if (includedFile == null) {
       missingIncludeFilesCounter++;
-      LOG.debug("[" + filename + ":" + token.getLine() 
+      LOG.debug("[" + filename + ":" + token.getLine()
                   + "]: preprocessor cannot find include file '" + token.getValue() + "'");
     } else if (analysedFiles.add(includedFile.getAbsoluteFile())) {
       unitCodeProvider.pushFileState(includedFile);

--- a/cxx-squid/src/test/java/org/sonar/cxx/config/CxxSquidConfigurationTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/config/CxxSquidConfigurationTest.java
@@ -503,7 +503,7 @@ public class CxxSquidConfigurationTest {
     softly.assertThat(defines).contains("_WIN32");
     softly.assertThat(defines).contains("_M_IX86_FP 2");
     softly.assertThat(defines).contains("_MSC_VER 1700");
-    softly.assertThat(defines).contains("_MSC_FULL_VER 1700610301");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 170061030");
     softly.assertThat(defines).contains("_ATL_VER 0x0B00");
     softly.assertAll();
   }
@@ -529,7 +529,7 @@ public class CxxSquidConfigurationTest {
     softly.assertThat(defines).contains("_M_IX86 600");
     softly.assertThat(defines).contains("_M_IX86_FP 2");
     softly.assertThat(defines).contains("_MSC_VER 1800");
-    softly.assertThat(defines).contains("_MSC_FULL_VER 180031101");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 180040629");
     softly.assertThat(defines).contains("_ATL_VER 0x0C00");
     softly.assertAll();
   }
@@ -554,7 +554,7 @@ public class CxxSquidConfigurationTest {
     softly.assertThat(defines).contains("_M_IX86 600");
     softly.assertThat(defines).contains("_M_IX86_FP 2");
     softly.assertThat(defines).contains("_MSC_VER 1900");
-    softly.assertThat(defines).contains("_MSC_FULL_VER 190024215");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 190024210");
     softly.assertThat(defines).contains("_ATL_VER 0x0E00");
     softly.assertAll();
   }
@@ -575,7 +575,7 @@ public class CxxSquidConfigurationTest {
     softly.assertThat(defines).contains("_M_IX86 600");
     softly.assertThat(defines).contains("_M_IX86_FP 2");
     softly.assertThat(defines).contains("_MSC_VER 1910");
-    softly.assertThat(defines).contains("_MSC_FULL_VER 191024629");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 191627030");
     softly.assertThat(defines).contains("_ATL_VER 0x0E00");
     softly.assertAll();
   }
@@ -596,7 +596,7 @@ public class CxxSquidConfigurationTest {
     softly.assertThat(defines).contains("_M_IX86 600");
     softly.assertThat(defines).contains("_M_IX86_FP 2");
     softly.assertThat(defines).contains("_MSC_VER 1910");
-    softly.assertThat(defines).contains("_MSC_FULL_VER 191024629");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 191627030");
     softly.assertThat(defines).contains("_ATL_VER 0x0E00");
     softly.assertAll();
   }
@@ -616,7 +616,7 @@ public class CxxSquidConfigurationTest {
     softly.assertThat(defines).contains("_M_IX86 600");
     softly.assertThat(defines).contains("__cplusplus 199711L");
     softly.assertThat(defines).contains("_MSC_VER 1910");
-    softly.assertThat(defines).contains("_MSC_FULL_VER 191024629");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 191627030");
     // check atldef.h for _ATL_VER
     softly.assertThat(defines).contains("_ATL_VER 0x0E00");
     softly.assertAll();
@@ -637,7 +637,7 @@ public class CxxSquidConfigurationTest {
     softly.assertThat(defines.contains("_M_IX86 600")).isFalse();
     softly.assertThat(defines).contains("__cplusplus 199711L");
     softly.assertThat(defines).contains("_MSC_VER 1910");
-    softly.assertThat(defines).contains("_MSC_FULL_VER 191024629");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 191627030");
     // check atldef.h for _ATL_VER
     softly.assertThat(defines).contains("_ATL_VER 0x0E00");
     softly.assertAll();


### PR DESCRIPTION
- set predefined macro value of  `__cplusplus` to `201402L` (C++14)
- MsBuild sensor:
  - set default platform toolset to `V142`
  - set default C++ standard for VC2019 to C++14

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2203)
<!-- Reviewable:end -->
