### PR TITLE
cppcheck 2.60 support

### DIFF
--- a/cxx-sensors/src/main/resources/cppcheck.xml
+++ b/cxx-sensors/src/main/resources/cppcheck.xml
@@ -165,12 +165,18 @@ prevent that the iterator is incremented beyond the end.
   </rule>
   <rule>
     <key>argumentSize</key>
-    <name>The array 'array' is too small, the function 'function' expects a bigger one</name>
+    <name>Buffer 'buffer' is too small, the function 'function' expects a bigger buffer in 2nd argument</name>
     <description>
       <![CDATA[
-The array 'array' is too small, the function 'function' expects a bigger one.
+      <p>
+Buffer 'buffer' is too small, the function 'function' expects a bigger
+buffer in 2nd argument
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
 ]]>
     </description>
+    <tag>cwe</tag>
     <severity>MINOR</severity>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8875,7 +8881,106 @@ https://isocpp.org/wiki/faq/exceptions#throw-without-an-object
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
-  </rule>  
+  </rule>
+  <!-- ########### New in Cppcheck 2.60 ########### -->
+  <rule>
+    <key>compareValueOutOfTypeRangeError</key>
+    <name>Comparing expression of type 'unsigned char' against value 256</name>
+    <description>
+      <![CDATA[
+      <p>
+Comparing expression of type 'unsigned char' against value 256.
+Condition is always true.
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/398.html" target="_blank">CWE-398: 7PK - Code Quality</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <tag>cwe</tag>
+    <severity>MINOR</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>incompatibleFileOpen</key>
+    <name>The file 'tmp' is opened for read and write access at the same time on different streams</name>
+    <description>
+      <![CDATA[
+      <p>
+The file 'tmp' is opened for read and write access at the same time on
+different streams
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/664.html" target="_blank">CWE-664: Improper Control of a Resource Through its Lifetime</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <tag>cwe</tag>
+    <severity>MINOR</severity>
+    <type>BUG</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>missingReturn</key>
+    <name>Found a exit path from function with non-void return type that has missing return statement</name>
+    <description>
+      <![CDATA[
+      <p>
+Found a exit path from function with non-void return type that has
+missing return statement
+</p>
+<h2>References</h2>
+<p><a href="https://cwe.mitre.org/data/definitions/758.html" target="_blank">CWE-758: Reliance on Undefined, Unspecified, or Implementation-Defined Behavior</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <tag>cwe</tag>
+    <type>BUG</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>overlappingWriteFunction</key>
+    <name>Overlapping read/write in () is undefined behavior</name>
+    <description>
+      <![CDATA[
+      Overlapping read/write in () is undefined behavior
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <type>BUG</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>overlappingWriteUnion</key>
+    <name>Overlapping read/write of union is undefined behavior</name>
+    <description>
+      <![CDATA[
+      Overlapping read/write of union is undefined behavior
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <type>BUG</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>returnStdMoveLocal</key>
+    <name>Using std::move for returning object by-value from function will affect copy elision optimization</name>
+    <description>
+      <![CDATA[
+      Using std::move for returning object by-value from function will affect copy elision optimization. More: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-return-move-local
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>MINOR</severity>
+    <type>BUG</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
   <!-- ########### Misra Rules ########### -->
   <rule>
     <key>misra-c2012-1.1</key>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
@@ -37,7 +37,7 @@ public class CxxCppCheckRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxCppCheckRuleRepository.KEY);
-    assertEquals(659, repo.rules().size());
+    assertEquals(665, repo.rules().size());
   }
 
 }

--- a/cxx-sensors/src/tools/cppcheck_createrules.py
+++ b/cxx-sensors/src/tools/cppcheck_createrules.py
@@ -85,9 +85,11 @@ def error_to_rule(error):
     if cweNr is not None:
         et.SubElement(rule, 'tag').text = "cwe"
 
-    et.SubElement(rule, 'severity').text = sonarQubeIssueSeverity
-    et.SubElement(rule, 'type').text = sonarQubeIssueType
-    if sonarQubeIssueSeverity != 'INFO':
+    if sonarQubeIssueSeverity != 'MAJOR': # MAJOR is the default
+        et.SubElement(rule, 'severity').text = sonarQubeIssueSeverity
+    if sonarQubeIssueType != 'CODE_SMELL': # CODE_SMELL is the default
+        et.SubElement(rule, 'type').text = sonarQubeIssueType
+    if sonarQubeIssueSeverity != 'INFO': # INFO has no effort
         et.SubElement(rule, 'remediationFunction').text = "LINEAR"
         et.SubElement(rule, 'remediationFunctionGapMultiplier').text = "5min"
 

--- a/cxx-sensors/src/tools/generate_cppcheck_resources.cmd
+++ b/cxx-sensors/src/tools/generate_cppcheck_resources.cmd
@@ -3,7 +3,7 @@ cls
 
 SET SCRIPT_DIR=%~dp0
 SET CPPCHECK_DIR=C:\Program Files\Cppcheck\
-SET PYTHON_DIR=
+SET PYTHON_DIR=C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python37_64\
 
 SET CPPCHECK_LIBRARY_ARGS=--library=avr.cfg --library=bento4.cfg --library=boost.cfg --library=bsd.cfg --library=cairo.cfg --library=cppunit.cfg --library=dpdk.cfg --library=embedded_sql.cfg --library=gnu.cfg --library=googletest.cfg --library=gtk.cfg --library=kde.cfg --library=libcerror.cfg --library=libcurl.cfg --library=libsigc++.cfg --library=lua.cfg --library=mfc.cfg--library=microsoft_atl.cfg --library=microsoft_sal.cfg --library=microsoft_unittest.cfg --library=motif.cfg --library=nspr.cfg --library=opencv2.cfg --library=opengl.cfg --library=openmp.cfg --library=openssl.cfg --library=posix.cfg --library=python.cfg --library=qt.cfg --library=ruby.cfg --library=sdl.cfg --library=sfml.cfg --library=sqlite3.cfg --library=std.cfg --library=tinyxml2.cfg --library=vcl.cfg --library=windows.cfg --library=wxwidgets.cfg --library=zlib.cfg
 


### PR DESCRIPTION
add new rules:
* compareValueOutOfTypeRangeError
* incompatibleFileOpen
* missingReturn
* overlappingWriteFunction
* overlappingWriteUnion
* returnStdMoveLocal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2265)
<!-- Reviewable:end -->
