### PR TITLE
support Cobertura coverage reports with drive letter only in source tag

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
       }
 
       (new-object System.Net.WebClient).DownloadFile(
-        'https://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip',
+        'https://dlcdn.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.zip',
         'C:\maven-bin.zip'
       )
       [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
@@ -62,9 +62,9 @@ install:
         $env:VCVARS_PLATFORM="amd64"
         $env:LANG_PLATFORM="-x64"
       }
-  - cmd: SET PATH=C:\maven\apache-maven-3.6.3\bin;%JAVA_HOME%\bin;C:\sonar-scanner\sonar-scanner-4.6.2.2472\bin;%PATH%
-  - cmd: SET M2_HOME=C:\maven\apache-maven-3.6.3
-  - cmd: SET MAVEN_HOME=C:\maven\apache-maven-3.6.3
+  - cmd: SET PATH=C:\maven\apache-maven-3.8.3\bin;%JAVA_HOME%\bin;C:\sonar-scanner\sonar-scanner-4.6.2.2472\bin;%PATH%
+  - cmd: SET M2_HOME=C:\maven\apache-maven-3.8.3
+  - cmd: SET MAVEN_HOME=C:\maven\apache-maven-3.8.3
   - cmd: SET SONARHOME=C:\sonarqube\sonarqube-8.9.2.46101
   - cmd: SET TestDataFolder=C:\projects\sonar-cxx\integration-tests\testdata
   - cmd: SET

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/cobertura/CoberturaParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/cobertura/CoberturaParser.java
@@ -49,13 +49,13 @@ public class CoberturaParser implements CoverageParser {
   /**
    * Join two paths
    *
-   * path1 | path2 | result
+   * path1    | path2    | result
    * ---------|----------|-------
-   * empty | empty | empty
-   * empty | absolute | absolute path2
-   * empty | relative | relative path2
-   * absolute | empty | empty
-   * relative | empty | empty
+   * empty    | empty    | empty
+   * empty    | absolute | absolute path2
+   * empty    | relative | relative path2
+   * absolute | empty    | empty
+   * relative | empty    | empty
    * absolute | absolute | absolute path2
    * absolute | relative | absolute path1 + relative path2
    * relative | absolute | absolute path2
@@ -70,7 +70,12 @@ public class CoberturaParser implements CoverageParser {
       return "";
     }
     if (!path1.isAbsolute()) {
-      path1 = Paths.get(".", path1.toString());
+      var root = path1.getRoot();
+      if (root != null && !root.toString().endsWith(File.separator)) { // special case drive letter only, e.g. c:
+        path1 = Paths.get(path1.toString(), File.separator);
+      } else {
+        path1 = Paths.get(".", path1.toString());
+      }
     }
     if (!path2.isAbsolute()) {
       path2 = Paths.get(".", path2.toString());

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxCoberturaSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxCoberturaSensorTest.java
@@ -75,70 +75,79 @@ public class CxxCoberturaSensorTest {
     if (TestUtils.isWindows()) {
 
       // Windows
-      var abs1 = Paths.get("c:\\test1");
-      var rel1 = Paths.get("\\test1");
-      var abs2 = Paths.get("c:\\test2\\report.txt");
-      var rel2 = Paths.get("\\test2\\report.txt");
+      var p1_abs1 = Paths.get("c:\\test1");
+      var p1_abs2 = Paths.get("c:");
+      var p1_abs3 = Paths.get("c:\\");
+      var p1_rel1 = Paths.get("\\test1");
+      var p2_abs1 = Paths.get("c:\\test2\\report.txt");
+      var p2_rel1 = Paths.get("\\test2\\report.txt");
+      var p2_rel2 = Paths.get("test2\\report.txt");
 
       result = CoberturaParser.join(empty, empty);
       assertThat(result).isEmpty();
 
-      result = CoberturaParser.join(empty, abs2);
+      result = CoberturaParser.join(empty, p2_abs1);
       assertThat(result).isEqualTo("c:\\test2\\report.txt");
 
-      result = CoberturaParser.join(empty, rel2);
+      result = CoberturaParser.join(empty, p2_rel1);
       assertThat(result).isEqualTo(".\\test2\\report.txt");
 
-      result = CoberturaParser.join(abs1, empty);
+      result = CoberturaParser.join(p1_abs1, empty);
       assertThat(result).isEmpty();
 
-      result = CoberturaParser.join(rel1, empty);
+      result = CoberturaParser.join(p1_rel1, empty);
       assertThat(result).isEmpty();
 
-      result = CoberturaParser.join(abs1, abs2);
+      result = CoberturaParser.join(p1_abs1, p2_abs1);
       assertThat(result).isEqualTo("c:\\test2\\report.txt");
 
-      result = CoberturaParser.join(abs1, rel2);
+      result = CoberturaParser.join(p1_abs1, p2_rel1);
       assertThat(result).isEqualTo("c:\\test1\\test2\\report.txt");
 
-      result = CoberturaParser.join(rel1, abs2);
+      result = CoberturaParser.join(p1_rel1, p2_abs1);
       assertThat(result).isEqualTo("c:\\test2\\report.txt");
 
-      result = CoberturaParser.join(rel1, rel2);
+      result = CoberturaParser.join(p1_rel1, p2_rel1);
       assertThat(result).isEqualTo(".\\test1\\test2\\report.txt");
+
+      result = CoberturaParser.join(p1_abs2, p2_rel2);
+      assertThat(result).isEqualTo("c:\\test2\\report.txt");
+
+      result = CoberturaParser.join(p1_abs3, p2_rel2);
+      assertThat(result).isEqualTo("c:\\test2\\report.txt");
     } else {
 
       // Linux
-      var abs1 = Paths.get("/home/test1");
-      var rel1 = Paths.get("test1");
-      var abs2 = Paths.get("/home/test2/report.txt");
-      var rel2 = Paths.get("test2/report.txt");
+      var p1_abs1 = Paths.get("/home/test1");
+      var p1_rel1 = Paths.get("test1");
+      var p2_abs1 = Paths.get("/home/test2/report.txt");
+      var p2_rel1 = Paths.get("test2/report.txt");
 
       result = CoberturaParser.join(empty, empty);
       assertThat(result).isEmpty();
 
-      result = CoberturaParser.join(empty, abs2);
+      result = CoberturaParser.join(empty, p2_abs1);
       assertThat(result).isEqualTo("/home/test2/report.txt");
 
-      result = CoberturaParser.join(empty, rel2);
+      result = CoberturaParser.join(empty, p2_rel1);
       assertThat(result).isEqualTo("./test2/report.txt");
 
-      result = CoberturaParser.join(abs1, empty);
+      result = CoberturaParser.join(p1_abs1, empty);
       assertThat(result).isEmpty();
 
-      result = CoberturaParser.join(rel1, empty);
+      result = CoberturaParser.join(p1_rel1, empty);
       assertThat(result).isEmpty();
 
-      result = CoberturaParser.join(abs1, abs2);
+      result = CoberturaParser.join(p1_abs1, p2_abs1);
       assertThat(result).isEqualTo("/home/test2/report.txt");
 
-      result = CoberturaParser.join(abs1, rel2);
+      result = CoberturaParser.join(p1_abs1, p2_rel1);
       assertThat(result).isEqualTo("/home/test1/test2/report.txt");
 
-      result = CoberturaParser.join(rel1, abs2);
+      result = CoberturaParser.join(p1_rel1, p2_abs1);
       assertThat(result).isEqualTo("/home/test2/report.txt");
 
-      result = CoberturaParser.join(rel1, rel2);
+      result = CoberturaParser.join(p1_rel1, p2_rel1);
       assertThat(result).isEqualTo("./test1/test2/report.txt");
     }
 


### PR DESCRIPTION
- source tag: drive letter without file separator was not supported in the past
- this was an issue with https://github.com/OpenCppCoverage/OpenCppCoverage
- close #1682

Sample:
```XML
<sources>
   <source>f:</source>
</sources> ...
<class name="file.h" filename="my/file/path/file.h" line-rate="0" branch-rate="0" complexity="0">
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2268)
<!-- Reviewable:end -->
