### PR TITLE
update rules from LLVM tools

### DIFF
--- a/cxx-sensors/src/main/resources/clangsa.xml
+++ b/cxx-sensors/src/main/resources/clangsa.xml
@@ -292,6 +292,21 @@ Rules list was generated based on clang version 11.0.1 -->
     <tag>cplusplus</tag>
   </rule>
   <rule>
+    <key>cplusplus.StringChecker</key>
+    <name>cplusplus.StringChecker</name>
+    <description>
+<![CDATA[
+<p>Checks C++ std::string bugs
+</p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p> 
+]]>    </description>
+    <severity>MAJOR</severity>
+    <type>BUG</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    <tag>cplusplus</tag>
+  </rule>
+  <rule>
     <key>deadcode.DeadStores</key>
     <name>deadcode.DeadStores</name>
     <description>

--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -3,7 +3,7 @@
   C and C++ rules from
   * https://clang.llvm.org/extra/clang-tidy/checks/list.html
   * https://clang-analyzer.llvm.org/available_checks.html
-  * last update: llvmorg-13-init-4898-g270a336ff462
+  * last update: llvmorg-14-init-8123-ga875e6e1225a (git describe)
 -->
 <rules>
 
@@ -362,7 +362,7 @@ for (auto piece : absl::StrSplit(str, absl::MaxSplits(&#39;B&#39;, 1))) {</code>
     <description>
       <![CDATA[<p>subl.. title:: clang-tidy - abseil-no-internal-dependencies</p>
 <h1 id="abseil-no-internal-dependencies">abseil-no-internal-dependencies</h1>
-<p>Warns if code using Abseil depends on internal details. If something is in a namespace that includes the word 'internal', code is not allowed to depend upon it beaucse it's an implementation detail. They cannot friend it, include it, you mention it or refer to it in any way. Doing so violates Abseil's compatibility guidelines and may result in breakage. See <a href="https://abseil.io/about/compatibility">https://abseil.io/about/compatibility</a> for more information.</p>
+<p>Warns if code using Abseil depends on internal details. If something is in a namespace that includes the word "internal", code is not allowed to depend upon it because it's an implementation detail. They cannot friend it, include it, you mention it or refer to it in any way. Doing so violates Abseil's compatibility guidelines and may result in breakage. See <a href="https://abseil.io/about/compatibility">https://abseil.io/about/compatibility</a> for more information.</p>
 <p>The following cases will result in warnings:</p>
 <pre class="c++"><code>absl::strings_internal::foo();
 // warning triggered on this line
@@ -392,7 +392,7 @@ absl::memory_internal::MakeUniqueResult();
  ...
 }</code></pre>
 <p>will be prompted with a warning.</p>
-<p>See the full Abseil compatibility guidelines &lt;https://abseil.io/about/compatibility&gt; for more information.</p>
+<p>See <a href="https://abseil.io/about/compatibility">the full Abseil compatibility guidelines</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-no-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -568,7 +568,7 @@ if (absl::FromUnixSeconds(x) &lt; t) ...</code></pre>
 <pre class="c++"><code>int x;
 absl::Time t;
 
-// Original - absl::Duration result and first operand is a absl::Time.
+// Original - absl::Duration result and first operand is an absl::Time.
 absl::Duration d = absl::Seconds(absl::ToUnixSeconds(t) - x);
 
 // Suggestion - Perform subtraction in the Time domain instead.
@@ -609,6 +609,35 @@ d *= static_cast&lt;int64_t&gt;(a);</code></pre>
 <p>Note that this check always adds a cast to <code>int64_t</code> in order to preserve the current behavior of user code. It is possible that this uncovers unintended behavior due to types implicitly convertible to a floating-point type.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-upgrade-duration-conversions.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>altera-id-dependent-backward-branch</key>
+    <name>altera-id-dependent-backward-branch</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - altera-id-dependent-backward-branch</p>
+</div>
+<h1 id="altera-id-dependent-backward-branch">altera-id-dependent-backward-branch</h1>
+<p>Finds ID-dependent variables and fields that are used within loops. This causes branches to occur inside the loops, and thus leads to performance degradation.</p>
+<pre class="c++"><code>// The following code will produce a warning because this ID-dependent
+// variable is used in a loop condition statement.
+int ThreadID = get_local_id(0);
+// The following loop will produce a warning because the loop condition
+// statement depends on an ID-dependent variable.
+for (int i = 0; i &lt; ThreadID; ++i) {
+  std::cout &lt;&lt; i &lt;&lt; std::endl;
+}
+// The following loop will not produce a warning, because the ID-dependent
+// variable is not used in the loop condition statement.
+for (int i = 0; i &lt; 100; ++i) {
+  std::cout &lt;&lt; ThreadID &lt;&lt; std::endl;
+}</code></pre>
+<p>Based on the <a href="https://www.altera.com/en_US/pdfs/literature/hb/opencl-sdk/aocl_optimization_guide.pdf">Altera SDK for OpenCL: Best Practices Guide</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/altera-id-dependent-backward-branch.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -1105,7 +1134,7 @@ openat(0, &quot;filename&quot;, O_RDWR | O_CLOEXEC);</code></pre>
 <p>clang-tidy - android-cloexec-pipe2</p>
 </div>
 <h1 id="android-cloexec-pipe2">android-cloexec-pipe2</h1>
-<p>This checks ensures that pipe2() is called with the O_CLOEXEC flag. The check also adds the O_CLOEXEC flag that marks the file descriptor to be closed in child processes. Without this flag a sensitive file descriptor can be leaked to a child process, potentially into a lower-privileged SELinux domain.</p>
+<p>This check ensures that pipe2() is called with the O_CLOEXEC flag. The check also adds the O_CLOEXEC flag that marks the file descriptor to be closed in child processes. Without this flag a sensitive file descriptor can be leaked to a child process, potentially into a lower-privileged SELinux domain.</p>
 <p>Examples:</p>
 <pre class="c++"><code>pipe2(pipefd, O_NONBLOCK);</code></pre>
 <p>Suggested replacement:</p>
@@ -1180,7 +1209,7 @@ while (TEMP_FAILURE_RETRY(read(STDIN_FILENO, cs, sizeof(cs))) != 0) {
 </div>
 <h1 id="boost-use-to-string">boost-use-to-string</h1>
 <p>This check finds conversion from integer type like <code>int</code> to <code>std::string</code> or <code>std::wstring</code> using <code>boost::lexical_cast</code>, and replace it with calls to <code>std::to_string</code> and <code>std::to_wstring</code>.</p>
-<p>It doesn't replace conversion from floating points despite the <code>to_string</code> overloads, because it would change the behaviour.</p>
+<p>It doesn't replace conversion from floating points despite the <code>to_string</code> overloads, because it would change the behavior.</p>
 <pre class="c++"><code>auto str = boost::lexical_cast&lt;std::string&gt;(42);
 auto wstr = boost::lexical_cast&lt;std::wstring&gt;(2137LL);
 
@@ -1439,7 +1468,7 @@ default:
 <p>Finally, the check also examines conditional operators and reports code like:</p>
 <pre class="c++"><code>return test_value(x) ? x : x;</code></pre>
 <p>Unlike if statements, the check does not detect chains of conditional operators.</p>
-<p>Note: This check also reports situations where branches become identical only after preprocession.</p>
+<p>Note: This check also reports situations where branches become identical only after preprocessing.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-branch-clone.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -1484,7 +1513,7 @@ class X2 : public Copyable {
 <p>clang-tidy - bugprone-dangling-handle</p>
 </div>
 <h1 id="bugprone-dangling-handle">bugprone-dangling-handle</h1>
-<p>Detect dangling references in value handles like <code>std::experimental::string_view</code>. These dangling references can be a result of constructing handles from temporary values, where the temporary is destroyed soon after the handle is created.</p>
+<p>Detect dangling references in value handles like <code>std::string_view</code>. These dangling references can be a result of constructing handles from temporary values, where the temporary is destroyed soon after the handle is created.</p>
 <p>Examples:</p>
 <pre class="c++"><code>string_view View = string();  // View will dangle.
 string A;
@@ -1505,7 +1534,7 @@ string_view f() {
 <h2 id="options">Options</h2>
 <div class="option">
 <p>HandleClasses</p>
-<p>A semicolon-separated list of class names that should be treated as handles. By default only <code>std::experimental::basic_string_view</code> is considered.</p>
+<p>A semicolon-separated list of class names that should be treated as handles. By default only <code>std::basic_string_view</code> and <code>std::experimental::basic_string_view</code> are considered.</p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-dangling-handle.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -1533,6 +1562,136 @@ string_view f() {
 <p>When synchronization of static initialization is disabled, if two threads both call <span class="title-ref">foo</span> for the first time, there is the possibility that <span class="title-ref">k</span> will be double initialized, creating a race condition.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-dynamic-static-initializers.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>bugprone-easily-swappable-parameters</key>
+    <name>bugprone-easily-swappable-parameters</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-easily-swappable-parameters</p>
+</div>
+<h1 id="bugprone-easily-swappable-parameters">bugprone-easily-swappable-parameters</h1>
+<p>Finds function definitions where parameters of convertible types follow each other directly, making call sites prone to calling the function with swapped (or badly ordered) arguments.</p>
+<pre class="c++"><code>void drawPoint(int X, int Y) { /* ... */ }
+FILE *open(const char *Dir, const char *Name, Flags Mode) { /* ... */ }</code></pre>
+<p>A potential call like <code>drawPoint(-2, 5)</code> or <code>openPath("a.txt", "tmp", Read)</code> is perfectly legal from the language's perspective, but might not be what the developer of the function intended.</p>
+<p>More elaborate and type-safe constructs, such as opaque typedefs or strong types should be used instead, to prevent a mistaken order of arguments.</p>
+<pre class="c++"><code>struct Coord2D { int X; int Y; };
+void drawPoint(const Coord2D Pos) { /* ... */ }
+FILE *open(const Path &amp;Dir, const Filename &amp;Name, Flags Mode) { /* ... */ }</code></pre>
+<p>Due to the potentially elaborate refactoring and API-breaking that is necessary to strengthen the type safety of a project, no automatic fix-its are offered.</p>
+<h2 id="options">Options</h2>
+<h3 id="extensionrelaxation-options">Extension/relaxation options</h3>
+<p>Relaxation (or extension) options can be used to broaden the scope of the analysis and fine-tune the enabling of more mixes between types. Some mixes may depend on coding style or preference specific to a project, however, it should be noted that enabling <em>all</em> of these relaxations model the way of mixing at call sites the most. These options are expected to make the check report for more functions, and report longer mixable ranges.</p>
+<div class="option">
+<p>QualifiersMix</p>
+<p>Whether to consider parameters of some <em>cvr-qualified</em> <code>T</code> and a differently <em>cvr-qualified</em> <code>T</code> (i.e. <code>T</code> and <code>const T</code>, <code>const T</code> and <code>volatile T</code>, etc.) mixable between one another. If <span class="title-ref">false</span>, the check will consider differently qualified types unmixable. <span class="title-ref">True</span> turns the warnings on. Defaults to <span class="title-ref">false</span>.</p>
+<p>The following example produces a diagnostic only if <span class="title-ref">QualifiersMix</span> is enabled:</p>
+<pre class="c++"><code>void *memcpy(const void *Destination, void *Source, std::size_t N) { /* ... */ }</code></pre>
+</div>
+<div class="option">
+<p>ModelImplicitConversions</p>
+<p>Whether to consider parameters of type <code>T</code> and <code>U</code> mixable if there exists an implicit conversion from <code>T</code> to <code>U</code> and <code>U</code> to <code>T</code>. If <span class="title-ref">false</span>, the check will not consider implicitly convertible types for mixability. <span class="title-ref">True</span> turns warnings for implicit conversions on. Defaults to <span class="title-ref">true</span>.</p>
+<p>The following examples produce a diagnostic only if <span class="title-ref">ModelImplicitConversions</span> is enabled:</p>
+<pre class="c++"><code>void fun(int Int, double Double) { /* ... */ }
+void compare(const char *CharBuf, std::string String) { /* ... */ }</code></pre>
+<div class="note">
+<div class="title">
+<p>Note</p>
+</div>
+<p>Changing the qualifiers of an expression's type (e.g. from <code>int</code> to <code>const int</code>) is defined as an <em>implicit conversion</em> in the C++ Standard. However, the check separates this decision-making on the mixability of differently qualified types based on whether <span class="title-ref">QualifiersMix</span> was enabled.</p>
+<p>For example, the following code snippet will only produce a diagnostic if <strong>both</strong> <span class="title-ref">QualifiersMix</span> and <span class="title-ref">ModelImplicitConversions</span> are enabled:</p>
+<pre class="c++"><code>void fun2(int Int, const double Double) { /* ... */ }</code></pre>
+</div>
+</div>
+<h3 id="filtering-options">Filtering options</h3>
+<p>Filtering options can be used to lessen the size of the diagnostics emitted by the checker, whether the aim is to ignore certain constructs or dampen the noisiness.</p>
+<div class="option">
+<p>MinimumLength</p>
+<p>The minimum length required from an adjacent parameter sequence to be diagnosed. Defaults to <span class="title-ref">2</span>. Might be any positive integer greater or equal to <span class="title-ref">2</span>. If <span class="title-ref">0</span> or <span class="title-ref">1</span> is given, the default value <span class="title-ref">2</span> will be used instead.</p>
+<p>For example, if <span class="title-ref">3</span> is specified, the examples above will not be matched.</p>
+</div>
+<div class="option">
+<p>IgnoredParameterNames</p>
+<p>The list of parameter <strong>names</strong> that should never be considered part of a swappable adjacent parameter sequence. The value is a <span class="title-ref">;</span>-separated list of names. To ignore unnamed parameters, add <span class="title-ref">""</span> to the list verbatim (not the empty string, but the two quotes, potentially escaped!). <strong>This option is case-sensitive!</strong></p>
+<p>By default, the following parameter names, and their Uppercase-initial variants are ignored: <span class="title-ref">""</span> (unnamed parameters), <span class="title-ref">iterator</span>, <span class="title-ref">begin</span>, <span class="title-ref">end</span>, <span class="title-ref">first</span>, <span class="title-ref">last</span>, <span class="title-ref">lhs</span>, <span class="title-ref">rhs</span>.</p>
+</div>
+<div class="option">
+<p>IgnoredParameterTypeSuffixes</p>
+<p>The list of parameter <strong>type name suffixes</strong> that should never be considered part of a swappable adjacent parameter sequence. Parameters which type, as written in the source code, end with an element of this option will be ignored. The value is a <span class="title-ref">;</span>-separated list of names. <strong>This option is case-sensitive!</strong></p>
+<p>By default, the following, and their lowercase-initial variants are ignored: <span class="title-ref">bool</span>, <span class="title-ref">It</span>, <span class="title-ref">Iterator</span>, <span class="title-ref">InputIt</span>, <span class="title-ref">ForwardIt</span>, <span class="title-ref">BidirIt</span>, <span class="title-ref">RandomIt</span>, <span class="title-ref">random_iterator</span>, <span class="title-ref">ReverseIt</span>, <span class="title-ref">reverse_iterator</span>, <span class="title-ref">reverse_const_iterator</span>, <span class="title-ref">RandomIt</span>, <span class="title-ref">random_iterator</span>, <span class="title-ref">ReverseIt</span>, <span class="title-ref">reverse_iterator</span>, <span class="title-ref">reverse_const_iterator</span>, <span class="title-ref">Const_Iterator</span>, <span class="title-ref">ConstIterator</span>, <span class="title-ref">const_reverse_iterator</span>, <span class="title-ref">ConstReverseIterator</span>. In addition, <span class="title-ref">_Bool</span> (but not <span class="title-ref">_bool</span>) is also part of the default value.</p>
+</div>
+<div class="option">
+<p>SuppressParametersUsedTogether</p>
+<p>Suppresses diagnostics about parameters that are used together or in a similar fashion inside the function's body. Defaults to <span class="title-ref">true</span>. Specifying <span class="title-ref">false</span> will turn off the heuristics.</p>
+<p>Currently, the following heuristics are implemented which will suppress the warning about the parameter pair involved:</p>
+<ul>
+<li><p>The parameters are used in the same expression, e.g. <code>f(a, b)</code> or <code>a &lt; b</code>.</p></li>
+<li><p>The parameters are further passed to the same function to the same parameter of that function, of the same overload. e.g. <code>f(a, 1)</code> and <code>f(b, 2)</code> to some <code>f(T, int)</code>.</p>
+<div class="note">
+<div class="title">
+<p>Note</p>
+</div>
+<p>The check does not perform path-sensitive analysis, and as such, "same function" in this context means the same function declaration. If the same member function of a type on two distinct instances are called with the parameters, it will still be regarded as "same function".</p>
+</div></li>
+<li><p>The same member field is accessed, or member method is called of the two parameters, e.g. <code>a.foo()</code> and <code>b.foo()</code>.</p></li>
+<li><p>Separate <code>return</code> statements return either of the parameters on different code paths.</p></li>
+</ul>
+</div>
+<div class="option">
+<p>NamePrefixSuffixSilenceDissimilarityTreshold</p>
+<p>The number of characters two parameter names might be different on <em>either</em> the head or the tail end with the rest of the name the same so that the warning about the two parameters are silenced. Defaults to <span class="title-ref">1</span>. Might be any positive integer. If <span class="title-ref">0</span>, the filtering heuristic based on the parameters' names is turned off.</p>
+<p>This option can be used to silence warnings about parameters where the naming scheme indicates that the order of those parameters do not matter.</p>
+<p>For example, the parameters <code>LHS</code> and <code>RHS</code> are 1-dissimilar suffixes of each other: <code>L</code> and <code>R</code> is the different character, while <code>HS</code> is the common suffix. Similarly, parameters <code>text1, text2, text3</code> are 1-dissimilar prefixes of each other, with the numbers at the end being the dissimilar part. If the value is at least <span class="title-ref">1</span>, such cases will not be reported.</p>
+</div>
+<h2 id="limitations">Limitations</h2>
+<p><strong>This check is designed to check function signatures!</strong></p>
+<p>The check does not investigate functions that are generated by the compiler in a context that is only determined from a call site. These cases include variadic functions, functions in C code that do not have an argument list, and C++ template instantiations. Most of these cases, which are otherwise swappable from a caller's standpoint, have no way of getting "fixed" at the definition point. In the case of C++ templates, only primary template definitions and explicit specializations are matched and analyzed.</p>
+<p>None of the following cases produce a diagnostic:</p>
+<pre class="c++"><code>int printf(const char *Format, ...) { /* ... */ }
+int someOldCFunction() { /* ... */ }
+template &lt;typename T, typename U&gt;
+int add(T X, U Y) { return X + Y };
+void theseAreNotWarnedAbout() {
+    printf(&quot;%d %d\n&quot;, 1, 2);   // Two ints passed, they could be swapped.
+    someOldCFunction(1, 2, 3); // Similarly, multiple ints passed.
+    add(1, 2); // Instantiates &#39;add&lt;int, int&gt;&#39;, but that&#39;s not a user-defined function.
+}</code></pre>
+<p>Due to the limitation above, parameters which type are further dependent upon template instantiations to <em>prove</em> that they mix with another parameter's is not diagnosed.</p>
+<pre class="c++"><code>template &lt;typename T&gt;
+struct Vector {
+  typedef T element_type;
+};
+// Diagnosed: Explicit instantiation was done by the user, we can prove it
+// is the same type.
+void instantiated(int A, Vector&lt;int&gt;::element_type B) { /* ... */ }
+// Diagnosed: The two parameter types are exactly the same.
+template &lt;typename T&gt;
+void exact(typename Vector&lt;T&gt;::element_type A,
+           typename Vector&lt;T&gt;::element_type B) { /* ... */ }
+// Skipped: The two parameters are both &#39;T&#39; but we cannot prove this
+// without actually instantiating.
+template &lt;typename T&gt;
+void falseNegative(T A, typename Vector&lt;T&gt;::element_type B) { /* ... */ }</code></pre>
+<p>In the context of <em>implicit conversions</em> (when <span class="title-ref">ModelImplicitConversions</span> is enabled), the modelling performed by the check warns if the parameters are swappable and the swapped order matches implicit conversions. It does not model whether there exists an unrelated third type from which <em>both</em> parameters can be given in a function call. This means that in the following example, even while <code>strs()</code> clearly carries the possibility to be called with swapped arguments (as long as the arguments are string literals), will not be warned about.</p>
+<pre class="c++"><code>struct String {
+    String(const char *Buf);
+};
+struct StringView {
+    StringView(const char *Buf);
+    operator const char *() const;
+};
+// Skipped: Directly swapping expressions of the two type cannot mix.
+// (Note: StringView -&gt; const char * -&gt; String would be **two**
+// user-defined conversions, which is disallowed by the language.)
+void strs(String Str, StringView SV) { /* ... */ }
+// Diagnosed: StringView implicitly converts to and from a buffer.
+void cStr(StringView SV, const char *Buf() { /* ... */ }</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-easily-swappable-parameters.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -1584,7 +1743,7 @@ string_view f() {
 <h1 id="bugprone-fold-init-type">bugprone-fold-init-type</h1>
 <p>The check flags type mismatches in <a href="https://en.wikipedia.org/wiki/Fold_(higher-order_function)">folds</a> like <code>std::accumulate</code> that might result in loss of precision. <code>std::accumulate</code> folds an input range into an initial value using the type of the latter, with <code>operator+</code> by default. This can cause loss of precision through:</p>
 <ul>
-<li>Truncation: The following code uses a floating point range and an int initial value, so trucation will happen at every application of <code>operator+</code> and the result will be <span class="title-ref">0</span>, which might not be what the user expected.</li>
+<li>Truncation: The following code uses a floating point range and an int initial value, so truncation will happen at every application of <code>operator+</code> and the result will be <span class="title-ref">0</span>, which might not be what the user expected.</li>
 </ul>
 <pre class="c++"><code>auto a = {0.5f, 0.5f, 0.5f, 0.5f};
 return std::accumulate(std::begin(a), std::end(a), 0);</code></pre>
@@ -1649,12 +1808,16 @@ public:
   template&lt;typename T, typename X = enable_if_t&lt;is_special&lt;T&gt;,void&gt;&gt;
   explicit Person(T&amp;&amp; n) {}
 
+  // C4: variadic perfect forwarding ctor guarded with enable_if
+  template&lt;typename... A,
+    enable_if_t&lt;is_constructible_v&lt;tuple&lt;string, int&gt;, A&amp;&amp;...&gt;, int&gt; = 0&gt;
+  explicit Person(A&amp;&amp;... a) {}
   // (possibly compiler generated) copy ctor
   Person(const Person&amp; rhs);
 };</code></pre>
-<p>The check warns for constructors C1 and C2, because those can hide copy and move constructors. We suppress warnings if the copy and the move constructors are both disabled (deleted or private), because there is nothing the perfect forwarding constructor could hide in this case. We also suppress warnings for constructors like C3 that are guarded with an <code>enable_if</code>, assuming the programmer was aware of the possible hiding.</p>
+<p>The check warns for constructors C1 and C2, because those can hide copy and move constructors. We suppress warnings if the copy and the move constructors are both disabled (deleted or private), because there is nothing the perfect forwarding constructor could hide in this case. We also suppress warnings for constructors like C3 and C4 that are guarded with an <code>enable_if</code>, assuming the programmer was aware of the possible hiding.</p>
 <h2 id="background">Background</h2>
-<p>For deciding whether a constructor is guarded with enable_if, we consider the default values of the type parameters and the types of the constructor parameters. If any part of these types is <code>std::enable_if</code> or <code>std::enable_if_t</code>, we assume the constructor is guarded.</p>
+<p>For deciding whether a constructor is guarded with enable_if, we consider the types of the constructor parameters, the default values of template type parameters and the types of non-type template parameters with a default literal value. If any part of these types is <code>std::enable_if</code> or <code>std::enable_if_t</code>, we assume the constructor is guarded.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-forwarding-reference-overload.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -1662,6 +1825,51 @@ public:
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>bugprone-implicit-widening-of-multiplication-result</key>
+    <name>bugprone-implicit-widening-of-multiplication-result</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-implicit-widening-of-multiplication-result</p>
+</div>
+<h1 id="bugprone-implicit-widening-of-multiplication-result">bugprone-implicit-widening-of-multiplication-result</h1>
+<p>The check diagnoses instances where a result of a multiplication is implicitly widened, and suggests (with fix-it) to either silence the code by making widening explicit, or to perform the multiplication in a wider type, to avoid the widening afterwards.</p>
+<p>This is mainly useful when operating on very large buffers. For example, consider:</p>
+<pre class="c++"><code>void zeroinit(char* base, unsigned width, unsigned height) {
+  for(unsigned row = 0; row != height; ++row) {
+    for(unsigned col = 0; col != width; ++col) {
+      char* ptr = base + row * width + col;
+      *ptr = 0;
+    }
+  }
+}</code></pre>
+<p>This is fine in general, but if <code>width * height</code> overflows, you end up wrapping back to the beginning of <code>base</code> instead of processing the entire requested buffer.</p>
+<p>Indeed, this only matters for pretty large buffers (4GB+), but that can happen very easily for example in image processing, where for that to happen you "only" need a ~269MPix image.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>UseCXXStaticCastsInCppSources</p>
+<p>When suggesting fix-its for C++ code, should C++-style <code>static_cast&lt;&gt;()</code>'s be suggested, or C-style casts. Defaults to <code>true</code>.</p>
+</div>
+<div class="option">
+<p>UseCXXHeadersInCppSources</p>
+<p>When suggesting to include the appropriate header in C++ code, should <code>&lt;cstddef&gt;</code> header be suggested, or <code>&lt;stddef.h&gt;</code>. Defaults to <code>true</code>.</p>
+</div>
+<p>Examples:</p>
+<pre class="c++"><code>long mul(int a, int b) {
+  return a * b; // warning: performing an implicit widening conversion to type &#39;long&#39; of a multiplication performed in type &#39;int&#39;
+}
+char* ptr_add(char *base, int a, int b) {
+  return base + a * b; // warning: result of multiplication in type &#39;int&#39; is used as a pointer offset after an implicit widening conversion to type &#39;ssize_t&#39;
+}
+char ptr_subscript(char *base, int a, int b) {
+  return base[a * b]; // warning: result of multiplication in type &#39;int&#39; is used as a pointer offset after an implicit widening conversion to type &#39;ssize_t&#39;
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-implicit-widening-of-multiplication-result.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
     </rule>
   <rule>
     <key>bugprone-inaccurate-erase</key>
@@ -1821,8 +2029,8 @@ Now called from FancyFunction</code></pre>
 <p>clang-tidy - bugprone-macro-parentheses</p>
 </div>
 <h1 id="bugprone-macro-parentheses">bugprone-macro-parentheses</h1>
-<p>Finds macros that can have unexpected behaviour due to missing parentheses.</p>
-<p>Macros are expanded by the preprocessor as-is. As a result, there can be unexpected behaviour; operators may be evaluated in unexpected order and unary operators may become binary operators, etc.</p>
+<p>Finds macros that can have unexpected behavior due to missing parentheses.</p>
+<p>Macros are expanded by the preprocessor as-is. As a result, there can be unexpected behavior; operators may be evaluated in unexpected order and unary operators may become binary operators, etc.</p>
 <p>When the replacement list has an expression, it is recommended to surround it with parentheses. This ensures that the macro result is evaluated completely before it is used.</p>
 <p>It is also recommended to surround macro arguments in the replacement list with parentheses. This ensures that the argument value is calculated properly.</p>
 <h2>References</h2>
@@ -1938,7 +2146,7 @@ Now called from FancyFunction</code></pre>
 <h2 id="options">Options</h2>
 <div class="option">
 <p>CheckImplicitCasts</p>
-<p>If <span class="title-ref">true</span>, enables detection of implicit casts. Default is <span class="title-ref">true</span>.</p>
+<p>If <span class="title-ref">true</span>, enables detection of implicit casts. Default is <span class="title-ref">false</span>.</p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-misplaced-widening-cast.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -2033,7 +2241,7 @@ if (do_increment)
 <p>clang-tidy - bugprone-not-null-terminated-result</p>
 </div>
 <h1 id="bugprone-not-null-terminated-result">bugprone-not-null-terminated-result</h1>
-<p>Finds function calls where it is possible to cause a not null-terminated result. Usually the proper length of a string is <code>strlen(src) + 1</code> or equal length of this expression, because the null terminator needs an extra space. Without the null terminator it can result in undefined behaviour when the string is read.</p>
+<p>Finds function calls where it is possible to cause a not null-terminated result. Usually the proper length of a string is <code>strlen(src) + 1</code> or equal length of this expression, because the null terminator needs an extra space. Without the null terminator it can result in undefined behavior when the string is read.</p>
 <p>The following and their respective <code>wchar_t</code> based functions are checked:</p>
 <p><code>memcpy</code>, <code>memcpy_s</code>, <code>memchr</code>, <code>memmove</code>, <code>memmove_s</code>, <code>strerror_s</code>, <code>strncmp</code>, <code>strxfrm</code></p>
 <p>The following is a real-world example where the programmer forgot to increase the passed third argument, which is <code>size_t length</code>. That is why the length of the allocated memory is not enough to hold the null terminator.</p>
@@ -2055,7 +2263,7 @@ if (do_increment)
 <ul>
 <li>If copy to the destination array cannot overflow [1] the new function should be the older copy function (ending with <code>cpy</code>), because it is more efficient than the safe version.</li>
 <li>If copy to the destination array can overflow [1] and <code class="interpreted-text" role="option">WantToUseSafeFunctions</code> is set to <span class="title-ref">true</span> and it is possible to obtain the capacity of the destination array then the new function could be the safe version (ending with <code>cpy_s</code>).</li>
-<li>If the new function is could be safe version and C++ files are analysed and the destination array is plain <code>char</code>/<code>wchar_t</code> without <code>un/signed</code> then the length of the destination array can be omitted.</li>
+<li>If the new function is could be safe version and C++ files are analyzed and the destination array is plain <code>char</code>/<code>wchar_t</code> without <code>un/signed</code> then the length of the destination array can be omitted.</li>
 <li>If the new function is could be safe version and the destination array is <code>un/signed</code> it needs to be casted to plain <code>char *</code>/<code>wchar_t *</code>.</li>
 </ul>
 <dl>
@@ -2173,7 +2381,7 @@ if (onFire) {
   if (onFire || isCollapsing())
     scream();
 }</code></pre>
-<p>In the first case (logical "and") the suggested fix is to remove the redundant condition variable and keep the other side of the <code>&amp;&amp;</code>. In the second case (logical "or") the whole <code>if</code> is removed similarily to the simple case on the top.</p>
+<p>In the first case (logical "and") the suggested fix is to remove the redundant condition variable and keep the other side of the <code>&amp;&amp;</code>. In the second case (logical "or") the whole <code>if</code> is removed similarly to the simple case on the top.</p>
 <p>The condition of the outer <code>if</code> statement may also be a logical "and" (<code>&amp;&amp;</code>) expression:</p>
 <pre class="c"><code>bool onFire = isBurning();
 if (onFire &amp;&amp; fireFighters &lt; 10) {
@@ -2270,7 +2478,7 @@ int _g(); // disallowed in global namespace only</code></pre>
 <p>This check corresponds to the CERT C Coding Standard rule <a href="https://www.securecoding.cert.org/confluence/display/c/SIG30-C.+Call+only+asynchronous-safe+functions+within+signal+handlers">SIG30-C. Call only asynchronous-safe functions within signal handlers</a> and has an alias name <code>cert-sig30-c</code>.</p>
 <div class="option">
 <p>AsyncSafeFunctionSet</p>
-<p>Selects wich set of functions is considered as asynchronous-safe (and therefore allowed in signal handlers). Value <code>minimal</code> selects a minimal set that is defined in the CERT SIG30-C rule and includes functions <code>abort()</code>, <code>_Exit()</code>, <code>quick_exit()</code> and <code>signal()</code>. Value <code>POSIX</code> selects a larger set of functions that is listed in POSIX.1-2017 (see <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_04_03">this link</a> for more information). The function <code>quick_exit</code> is not included in the shown list. It is assumable that the reason is that the list was not updated for C11. The checker includes <code>quick_exit</code> in the set of safe functions. Functions registered as exit handlers are not checked.</p>
+<p>Selects which set of functions is considered as asynchronous-safe (and therefore allowed in signal handlers). Value <code>minimal</code> selects a minimal set that is defined in the CERT SIG30-C rule and includes functions <code>abort()</code>, <code>_Exit()</code>, <code>quick_exit()</code> and <code>signal()</code>. Value <code>POSIX</code> selects a larger set of functions that is listed in POSIX.1-2017 (see <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_04_03">this link</a> for more information). The function <code>quick_exit</code> is not included in the shown list. It is assumable that the reason is that the list was not updated for C11. The checker includes <code>quick_exit</code> in the set of safe functions. Functions registered as exit handlers are not checked.</p>
 <p>Default is <code>POSIX</code>.</p>
 </div>
 <h2>References</h2>
@@ -2477,7 +2685,7 @@ void getInt(int* dst) {
 </div>
 <div class="option">
 <p>WarnOnSizeOfCompareToConstant</p>
-<p>When <span class="title-ref">true</span>, the check will warn on an expression like <code>sizeof(epxr) &lt;= k</code> for a suspicious constant <span class="title-ref">k</span> while <span class="title-ref">k</span> is <span class="title-ref">0</span> or greater than <span class="title-ref">0x8000</span>. Default is <span class="title-ref">true</span>.</p>
+<p>When <span class="title-ref">true</span>, the check will warn on an expression like <code>sizeof(expr) &lt;= k</code> for a suspicious constant <span class="title-ref">k</span> while <span class="title-ref">k</span> is <span class="title-ref">0</span> or greater than <span class="title-ref">0x8000</span>. Default is <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-sizeof-expression.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -2724,6 +2932,27 @@ flag |=
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
+    <key>bugprone-suspicious-memory-comparison</key>
+    <name>bugprone-suspicious-memory-comparison</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-suspicious-memory-comparison</p>
+</div>
+<h1 id="bugprone-suspicious-memory-comparison">bugprone-suspicious-memory-comparison</h1>
+<p>Finds potentially incorrect calls to <code>memcmp()</code> based on properties of the arguments. The following cases are covered:</p>
+<p><strong>Case 1: Non-standard-layout type</strong></p>
+<p>Comparing the object representations of non-standard-layout objects may not properly compare the value representations.</p>
+<p><strong>Case 2: Types with no unique object representation</strong></p>
+<p>Objects with the same value may not have the same object representation. This may be caused by padding or floating-point types.</p>
+<p>See also: <a href="https://wiki.sei.cmu.edu/confluence/display/c/EXP42-C.+Do+not+compare+padding+data">EXP42-C. Do not compare padding data</a> and <a href="https://wiki.sei.cmu.edu/confluence/display/c/FLP37-C.+Do+not+use+object+representations+to+compare+floating-point+values">FLP37-C. Do not use object representations to compare floating-point values</a></p>
+<p>This check is also related to and partially overlaps the CERT C++ Coding Standard rules <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP57-CPP.+Prefer+special+member+functions+and+overloaded+operators+to+C+Standard+Library+functions">OOP57-CPP. Prefer special member functions and overloaded operators to C Standard Library functions</a> and <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/EXP62-CPP.+Do+not+access+the+bits+of+an+object+representation+that+are+not+part+of+the+object%27s+value+representation">EXP62-CPP. Do not access the bits of an object representation that are not part of the object's value representation</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-memory-comparison.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>bugprone-suspicious-memset-usage</key>
     <name>bugprone-suspicious-memset-usage</name>
     <description>
@@ -2869,7 +3098,7 @@ Token t = readNextToken();</code></pre>
 <pre class="c++"><code>if (strcmp(...))       // Implicitly compare to zero
 if (!strcmp(...))      // Won&#39;t warn
 if (strcmp(...) != 0)  // Won&#39;t warn</code></pre>
-<p>Checks that compare function results (i,e, <code>strcmp</code>) are compared to valid constant. The resulting value is</p>
+<p>Checks that compare function results (i.e., <code>strcmp</code>) are compared to valid constant. The resulting value is</p>
 <pre class=""><code>&lt;  0    when lower than,
 &gt;  0    when greater than,
 == 0    when equals.</code></pre>
@@ -2980,10 +3209,10 @@ do {
 <pre class="c++"><code>int doSomething(const std::vector&amp; items) {
   for (short i = 0; i &lt; items.size(); ++i) {}
 }</code></pre>
-<p>This algorithm works for small amount of objects, but will lead to freeze for a a larger user input.</p>
+<p>This algorithm works for a small amount of objects, but will lead to freeze for a larger user input.</p>
 <div class="option">
 <p>MagnitudeBitsUpperLimit</p>
-<p>Upper limit for the magnitude bits of the loop variable. If it's set the check filters out those catches in which the loop variable's type has more magnitude bits as the specified upper limit. The default value is 16. For example, if the user sets this option to 31 (bits), then a 32-bit <code>unsigend int</code> is ignored by the check, however a 32-bit <code>int</code> is not (A 32-bit <code>signed int</code> has 31 magnitude bits).</p>
+<p>Upper limit for the magnitude bits of the loop variable. If it's set the check filters out those catches in which the loop variable's type has more magnitude bits as the specified upper limit. The default value is 16. For example, if the user sets this option to 31 (bits), then a 32-bit <code>unsigned int</code> is ignored by the check, however a 32-bit <code>int</code> is not (A 32-bit <code>signed int</code> has 31 magnitude bits).</p>
 </div>
 <pre class="c++"><code>int main() {
   long size = 294967296l;
@@ -3032,6 +3261,27 @@ do {
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>bugprone-unhandled-exception-at-new</key>
+    <name>bugprone-unhandled-exception-at-new</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-unhandled-exception-at-new</p>
+</div>
+<h1 id="bugprone-unhandled-exception-at-new">bugprone-unhandled-exception-at-new</h1>
+<p>Finds calls to <code>new</code> with missing exception handler for <code>std::bad_alloc</code>.</p>
+<pre class="c++"><code>int *f() noexcept {
+  int *p = new int[1000];
+  // ...
+  return p;
+}</code></pre>
+<p>Calls to <code>new</code> can throw exceptions of type <code>std::bad_alloc</code> that should be handled by the code. Alternatively, the nonthrowing form of <code>new</code> can be used. The check verifies that the exception is handled in the function that calls <code>new</code>, unless a nonthrowing version is used or the exception is allowed to propagate out of the function (exception handler is checked for types <code>std::bad_alloc</code>, <code>std::exception</code>, and catch-all handler). The check assumes that any user-defined <code>operator new</code> is either <code>noexcept</code> or may throw an exception of type <code>std::bad_alloc</code> (or derived from it). Other exception types or exceptions occurring in the object's constructor are not taken into account.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-unhandled-exception-at-new.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
     </rule>
   <rule>
     <key>bugprone-unhandled-self-assignment</key>
@@ -3176,7 +3426,7 @@ public:
 <h2 id="options">Options</h2>
 <div class="option">
 <p>CheckedFunctions</p>
-<p>Semicolon-separated list of functions to check. Defaults to <code>::std::async;::std::launder;::std::remove;::std::remove_if;::std::unique;::std::unique_ptr::release;::std::basic_string::empty;::std::vector::empty</code>. This means that the calls to following functions are checked by default:</p>
+<p>Semicolon-separated list of functions to check. The function is checked if the name and scope matches, with any arguments. By default the following functions are checked: <code>std::async, std::launder, std::remove, std::remove_if, std::unique, std::unique_ptr::release, std::basic_string::empty, std::vector::empty, std::back_inserter, std::distance, std::find, std::find_if, std::inserter, std::lower_bound, std::make_pair, std::map::count, std::map::find, std::map::lower_bound, std::multimap::equal_range, std::multimap::upper_bound, std::set::count, std::set::find, std::setfill, std::setprecision, std::setw, std::upper_bound, std::vector::at, bsearch, ferror, feof, isalnum, isalpha, isblank, iscntrl, isdigit, isgraph, islower, isprint, ispunct, isspace, isupper, iswalnum, iswprint, iswspace, isxdigit, memchr, memcmp, strcmp, strcoll, strncmp, strpbrk, strrchr, strspn, strstr, wcscmp, access, bind, connect, difftime, dlsym, fnmatch, getaddrinfo, getopt, htonl, htons, iconv_open, inet_addr, isascii, isatty, mmap, newlocale, openat, pathconf, pthread_equal, pthread_getspecific, pthread_mutex_trylock, readdir, readlink, recvmsg, regexec, scandir, semget, setjmp, shm_open, shmget, sigismember, strcasecmp, strsignal, ttyname</code></p>
 <ul>
 <li><code>std::async()</code>. Not using the return value makes the call synchronous.</li>
 <li><code>std::launder()</code>. Not using the return value usually means that the function interface was misunderstood by the programmer. Only the returned pointer is "laundered", not the argument.</li>
@@ -3318,14 +3568,14 @@ s.i = 99;</code></pre>
 <p>clang-tidy - bugprone-virtual-near-miss</p>
 </div>
 <h1 id="bugprone-virtual-near-miss">bugprone-virtual-near-miss</h1>
-<p>Warn if a function is a near miss (ie. the name is very similar and the function signature is the same) to a virtual function from a base class.</p>
+<p>Warn if a function is a near miss (i.e. the name is very similar and the function signature is the same) to a virtual function from a base class.</p>
 <p>Example:</p>
 <pre class="c++"><code>struct Base {
   virtual void func();
 };
 
 struct Derived : Base {
-  virtual funk();
+  virtual void funk();
   // warning: &#39;Derived::funk&#39; has a similar name and the same signature as virtual method &#39;Base::func&#39;; did you mean to override it?
 };</code></pre>
 <h2>References</h2>
@@ -3681,6 +3931,20 @@ void func(const char *buff) {
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
+    <key>cert-exp42-c</key>
+    <name>cert-exp42-c</name>
+    <description>
+      <![CDATA[<div class="meta" data-http-equiv=refresh="5;URL=bugprone-suspicious-memory-comparison.html">
+</div>
+<h1 id="cert-exp42-c">cert-exp42-c</h1>
+<p>The cert-exp42-c check is an alias, please see <a href="bugprone-suspicious-memory-comparison.html">bugprone-suspicious-memory-comparison</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-exp42-c.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>cert-fio38-c</key>
     <name>cert-fio38-c</name>
     <description>
@@ -3717,6 +3981,20 @@ void func(const char *buff) {
     <type>CODE_SMELL</type>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>cert-flp37-c</key>
+    <name>cert-flp37-c</name>
+    <description>
+      <![CDATA[<div class="meta" data-http-equiv=refresh="5;URL=bugprone-suspicious-memory-comparison.html">
+</div>
+<h1 id="cert-flp37-c">cert-flp37-c</h1>
+<p>The cert-flp37-c check is an alias, please see <a href="bugprone-suspicious-memory-comparison.html">bugprone-suspicious-memory-comparison</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-flp37-c.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
     </rule>
   <rule>
     <key>cert-mem57-cpp</key>
@@ -3873,15 +4151,15 @@ void func(const char *buff) {
 <h2 id="options">Options</h2>
 <div class="option">
 <p>MemSetNames</p>
-<p>Specify extra functions to flag that act similarily to <code>memset</code>. Specify names in a semicolon delimited list. Default is an empty string. The check will detect the following functions: <span class="title-ref">memset</span>, <span class="title-ref">std::memset</span>.</p>
+<p>Specify extra functions to flag that act similarly to <code>memset</code>. Specify names in a semicolon delimited list. Default is an empty string. The check will detect the following functions: <span class="title-ref">memset</span>, <span class="title-ref">std::memset</span>.</p>
 </div>
 <div class="option">
 <p>MemCpyNames</p>
-<p>Specify extra functions to flag that act similarily to <code>memcpy</code>. Specify names in a semicolon delimited list. Default is an empty string. The check will detect the following functions: <span class="title-ref">std::memcpy</span>, <span class="title-ref">memcpy</span>, <span class="title-ref">std::memmove</span>, <span class="title-ref">memmove</span>, <span class="title-ref">std::strcpy</span>, <span class="title-ref">strcpy</span>, <span class="title-ref">memccpy</span>, <span class="title-ref">stpncpy</span>, <span class="title-ref">strncpy</span>.</p>
+<p>Specify extra functions to flag that act similarly to <code>memcpy</code>. Specify names in a semicolon delimited list. Default is an empty string. The check will detect the following functions: <span class="title-ref">std::memcpy</span>, <span class="title-ref">memcpy</span>, <span class="title-ref">std::memmove</span>, <span class="title-ref">memmove</span>, <span class="title-ref">std::strcpy</span>, <span class="title-ref">strcpy</span>, <span class="title-ref">memccpy</span>, <span class="title-ref">stpncpy</span>, <span class="title-ref">strncpy</span>.</p>
 </div>
 <div class="option">
 <p>MemCmpNames</p>
-<p>Specify extra functions to flag that act similarily to <code>memcmp</code>. Specify names in a semicolon delimited list. Default is an empty string. The check will detect the following functions: <span class="title-ref">std::memcmp</span>, <span class="title-ref">memcmp</span>, <span class="title-ref">std::strcmp</span>, <span class="title-ref">strcmp</span>, <span class="title-ref">strncmp</span>.</p>
+<p>Specify extra functions to flag that act similarly to <code>memcmp</code>. Specify names in a semicolon delimited list. Default is an empty string. The check will detect the following functions: <span class="title-ref">std::memcmp</span>, <span class="title-ref">memcmp</span>, <span class="title-ref">std::strcmp</span>, <span class="title-ref">strcmp</span>, <span class="title-ref">strncmp</span>.</p>
 </div>
 <p>This check corresponds to the CERT C++ Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP57-CPP.+Prefer+special+member+functions+and+overloaded+operators+to+C+Standard+Library+functions">OOP57-CPP. Prefer special member functions and overloaded operators to C Standard Library functions</a>.</p>
 <h2>References</h2>
@@ -5651,7 +5929,7 @@ private:
 <p>clang-tidy - cppcoreguidelines-init-variables</p>
 </div>
 <h1 id="cppcoreguidelines-init-variables">cppcoreguidelines-init-variables</h1>
-<p>Checks whether there are local variables that are declared without an initial value. These may lead to unexpected behaviour if there is a code path that reads the variable before assigning to it.</p>
+<p>Checks whether there are local variables that are declared without an initial value. These may lead to unexpected behavior if there is a code path that reads the variable before assigning to it.</p>
 <p>Only integers, booleans, floats, doubles and pointers are checked. The fix option initializes all detected values with the value of zero. An exception is float and double types, which are initialized to NaN.</p>
 <p>As an example a function that looks like this:</p>
 <pre class="c++"><code>void function() {
@@ -5670,6 +5948,17 @@ void function() {
   double d = NAN;
 
   // Rest of the function.
+}</code></pre>
+<p>It warns for the uninitialized enum case, but without a FixIt:</p>
+<pre class="c++"><code>enum A {A1, A2, A3};
+enum A_c : char { A_c1, A_c2, A_c3 };
+enum class B { B1, B2, B3 };
+enum class B_i : int { B_i1, B_i2, B_i3 };
+void function() {
+  A a;     // Warning: variable &#39;a&#39; is not initialized
+  A_c a_c; // Warning: variable &#39;a_c&#39; is not initialized
+  B b;     // Warning: variable &#39;b&#39; is not initialized
+  B_i b_i; // Warning: variable &#39;b_i&#39; is not initialized
 }</code></pre>
 <h2 id="options">Options</h2>
 <div class="option">
@@ -5750,7 +6039,7 @@ void function() {
 <dl>
 <dt>We enforce only part of the guideline, more specifically, we flag narrowing conversions from:</dt>
 <dd><ul>
-<li>an integer to a narrower integer (e.g. <code>char</code> to <code>unsigned char</code>),</li>
+<li>an integer to a narrower integer (e.g. <code>char</code> to <code>unsigned char</code>) if WarnOnIntegerNarrowingConversion Option is set,</li>
 <li>an integer to a narrower floating-point (e.g. <code>uint64_t</code> to <code>float</code>),</li>
 <li>a floating-point to an integer (e.g. <code>double</code> to <code>int</code>),</li>
 <li>a floating-point to a narrower floating-point (e.g. <code>double</code> to <code>float</code>) if WarnOnFloatingPointNarrowingConversion Option is set.</li>
@@ -5765,8 +6054,24 @@ void function() {
 </dl>
 <h2 id="options">Options</h2>
 <div class="option">
+<p>WarnOnIntegerNarrowingConversion</p>
+<p>When <span class="title-ref">true</span>, the check will warn on narrowing integer conversion (e.g. <code>int</code> to <code>size_t</code>). <span class="title-ref">true</span> by default.</p>
+</div>
+<div class="option">
 <p>WarnOnFloatingPointNarrowingConversion</p>
 <p>When <span class="title-ref">true</span>, the check will warn on narrowing floating point conversion (e.g. <code>double</code> to <code>float</code>). <span class="title-ref">true</span> by default.</p>
+</div>
+<div class="option">
+<p>WarnWithinTemplateInstantiation</p>
+<p>When <span class="title-ref">true</span>, the check will warn on narrowing conversions within template instantiations. <span class="title-ref">false</span> by default.</p>
+</div>
+<div class="option">
+<p>WarnOnEquivalentBitWidth</p>
+<p>When <span class="title-ref">true</span>, the check will warn on narrowing conversions that arise from casting between types of equivalent bit width. (e.g. <span class="title-ref">int n = uint(0);</span> or <span class="title-ref">long long n = double(0);</span>) <span class="title-ref">true</span> by default.</p>
+</div>
+<div class="option">
+<p>IgnoreConversionFromTypes</p>
+<p>Narrowing conversions from any type in this semicolon-separated list will be ignored. This may be useful to weed out commonly occurring, but less commonly problematic assignments such as <span class="title-ref">int n = std::vector&lt;char&gt;().size();</span> or <span class="title-ref">int n = std::difference(it1, it2);</span>. The default list is empty, but one suggested list for a legacy codebase would be <span class="title-ref">size_t;ptrdiff_t;size_type;difference_type</span>.</p>
 </div>
 <div class="option">
 <p>PedanticMode</p>
@@ -6305,7 +6610,7 @@ use(d);  // Slice.</code></pre>
 </div>
 <div class="option">
 <p>AllowMissingMoveFunctionsWhenCopyIsDeleted</p>
-<p>When set to <span class="title-ref">true</span> (default is <span class="title-ref">false</span>), this check doesn't flag classes which define deleted copy operations but don't define move operations. This flags is related to Google C++ Style Guide <a href="https://google.github.io/styleguide/cppguide.html#Copyable_Movable_Types">https://google.github.io/styleguide/cppguide.html#Copyable_Movable_Types</a>. With this option enabled, the following class won't be flagged:</p>
+<p>When set to <span class="title-ref">true</span> (default is <span class="title-ref">false</span>), this check doesn't flag classes which define deleted copy operations but don't define move operations. This flag is related to Google C++ Style Guide <a href="https://google.github.io/styleguide/cppguide.html#Copyable_Movable_Types">https://google.github.io/styleguide/cppguide.html#Copyable_Movable_Types</a>. With this option enabled, the following class won't be flagged:</p>
 <pre class="c++"><code>struct A {
   A(const A&amp;) = delete;
   A&amp; operator=(const A&amp;) = delete;
@@ -6319,6 +6624,47 @@ use(d);  // Slice.</code></pre>
     <type>CODE_SMELL</type>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>cppcoreguidelines-virtual-class-destructor</key>
+    <name>cppcoreguidelines-virtual-class-destructor</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-virtual-class-destructor</p>
+</div>
+<h1 id="cppcoreguidelines-virtual-class-destructor">cppcoreguidelines-virtual-class-destructor</h1>
+<p>Finds virtual classes whose destructor is neither public and virtual nor protected and non-virtual. A virtual class's destructor should be specified in one of these ways to prevent undefined behavior.</p>
+<p>This check implements <a href="http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-virtual">C.35</a> from the CppCoreGuidelines.</p>
+<p>Note that this check will diagnose a class with a virtual method regardless of whether the class is used as a base class or not.</p>
+<p>Fixes are available for user-declared and implicit destructors that are either public and non-virtual or protected and virtual. No fixes are offered for private destructors. There, the decision whether to make them private and virtual or protected and non-virtual depends on the use case and is thus left to the user.</p>
+<h2 id="example">Example</h2>
+<p>For example, the following classes/structs get flagged by the check since they violate guideline <strong>C.35</strong>:</p>
+<pre class="c++"><code>struct Foo {        // NOK, protected destructor should not be virtual
+  virtual void f();
+protected:
+  virtual ~Foo(){}
+};
+class Bar {         // NOK, public destructor should be virtual
+  virtual void f();
+public:
+  ~Bar(){}
+};</code></pre>
+<p>This would be rewritten to look like this:</p>
+<pre class="c++"><code>struct Foo {        // OK, destructor is not virtual anymore
+  virtual void f();
+protected:
+  ~Foo(){}
+};
+class Bar {         // OK, destructor is now virtual
+  virtual void f();
+public:
+  virtual ~Bar(){}
+};</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-virtual-class-destructor.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
     </rule>
   <rule>
     <key>darwin-avoid-spinlock</key>
@@ -7027,7 +7373,7 @@ public:
 };
 
 TYPED_TEST_SUITE(BarTest, BarTypes);</code></pre>
-<p>For better consistency of user code, the check renames both virtual and non-virtual member functions with matching names in derived types. The check tries to provide a only warning when a fix cannot be made safely, as is the case with some template and macro uses.</p>
+<p>For better consistency of user code, the check renames both virtual and non-virtual member functions with matching names in derived types. The check tries to provide only a warning when a fix cannot be made safely, as is the case with some template and macro uses.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-upgrade-googletest-case.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7297,7 +7643,7 @@ void f3(enum Color c) {
 int i = 42;
 switch(i) {
   case 1: // do something here
-  default: // do somethe else here
+  default: // do something else here
 }
 
 // Should rather be the following:
@@ -7385,7 +7731,7 @@ switch(i) {}</code></pre>
 </div>
 <h1 id="hicpp-no-assembler">hicpp-no-assembler</h1>
 <p>Check for assembler statements. No fix is offered.</p>
-<p>Inline assembler is forbidden by the <a href="http://www.codingstandard.com/section/7-5-the-asm-declaration/">High Intergrity C++ Coding Standard</a> as it restricts the portability of code.</p>
+<p>Inline assembler is forbidden by the <a href="http://www.codingstandard.com/section/7-5-the-asm-declaration/">High Integrity C++ Coding Standard</a> as it restricts the portability of code.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-no-assembler.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7438,7 +7784,7 @@ switch(i) {}</code></pre>
 <p>clang-tidy - hicpp-signed-bitwise</p>
 </div>
 <h1 id="hicpp-signed-bitwise">hicpp-signed-bitwise</h1>
-<p>Finds uses of bitwise operations on signed integer types, which may lead to undefined or implementation defined behaviour.</p>
+<p>Finds uses of bitwise operations on signed integer types, which may lead to undefined or implementation defined behavior.</p>
 <p>The according rule is defined in the <a href="http://www.codingstandard.com/section/5-6-shift-operators/">High Integrity C++ Standard, Section 5.6.1</a>.</p>
 <h2 id="options">Options</h2>
 <div class="option">
@@ -8241,7 +8587,7 @@ void f(const int_ptr ptr) {
 </div>
 <h1 id="misc-static-assert">misc-static-assert</h1>
 <p><span class="title-ref">cert-dcl03-c</span> redirects here as an alias for this check.</p>
-<p>Replaces <code>assert()</code> with <code>static_assert()</code> if the condition is evaluatable at compile time.</p>
+<p>Replaces <code>assert()</code> with <code>static_assert()</code> if the condition is evaluable at compile time.</p>
 <p>The condition of <code>static_assert()</code> is evaluated at compile time which is safer and more efficient.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-static-assert.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -8262,11 +8608,11 @@ void f(const int_ptr ptr) {
 <dl>
 <dt>Exceptions:</dt>
 <dd><ul>
-<li>Throwing string literals will not be flagged despite being a pointer. They are not susceptible to slicing and the usage of string literals is idomatic.</li>
+<li>Throwing string literals will not be flagged despite being a pointer. They are not susceptible to slicing and the usage of string literals is idiomatic.</li>
 <li>Catching character pointers (<code>char</code>, <code>wchar_t</code>, unicode character types) will not be flagged to allow catching sting literals.</li>
 <li>Moved named values will not be flagged as not throwing an anonymous temporary. In this case we can be sure that the user knows that the object can't be accessed outside catch blocks handling the error.</li>
 <li>Throwing function parameters will not be flagged as not throwing an anonymous temporary. This allows helper functions for throwing.</li>
-<li>Re-throwing caught exception variables will not be flragged as not throwing an anonymous temporary. Although this can usually be done by just writing <code>throw;</code> it happens often enough in real code.</li>
+<li>Re-throwing caught exception variables will not be flagged as not throwing an anonymous temporary. Although this can usually be done by just writing <code>throw;</code> it happens often enough in real code.</li>
 </ul>
 </dd>
 </dl>
@@ -8329,6 +8675,11 @@ void f(const int_ptr ptr) {
 <pre class="c++"><code>std::unique_ptr&lt;Foo&gt; x, y;
 x.reset(y.release()); -&gt; x = std::move(y);</code></pre>
 <p>If <code>y</code> is already rvalue, <code>std::move()</code> is not added. <code>x</code> and <code>y</code> can also be <code>std::unique_ptr&lt;Foo&gt;*</code>.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IncludeStyle</p>
+<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
+</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-uniqueptr-reset-release.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -8446,7 +8797,7 @@ int foo() {
   std::function&lt;int(int,int)&gt; ignore_args = [] { return add(2, 2); }
   return ignore_args(3, 3);
 }</code></pre>
-<p>which will <em>not</em> compile, since the lambda does not contain an <code>operator()</code> that that accepts 2 arguments. With permissive parameter list, it instead generates</p>
+<p>which will <em>not</em> compile, since the lambda does not contain an <code>operator()</code> that accepts 2 arguments. With permissive parameter list, it instead generates</p>
 <pre class="c++"><code>int add(int x, int y) { return x + y; }
 int foo() {
   std::function&lt;int(int,int)&gt; ignore_args = [](auto&amp;&amp;...) { return add(2, 2); }
@@ -8732,7 +9083,7 @@ for (auto &amp; elem : v)
 </div>
 <div class="option">
 <p>MakeReverseRangeFunction</p>
-<p>Specify the function used to reverse an iterator pair, the function should accept a class with <code>rbegin</code> and <code>rend</code> methods and return a class with <code>begin</code> and <code>end</code> methods methods that call the <code>rbegin</code> and <code>rend</code> methods respectively. Common examples are <code>ranges::reverse_view</code> and <code>llvm::reverse</code>. Default value is an empty string.</p>
+<p>Specify the function used to reverse an iterator pair, the function should accept a class with <code>rbegin</code> and <code>rend</code> methods and return a class with <code>begin</code> and <code>end</code> methods that call the <code>rbegin</code> and <code>rend</code> methods respectively. Common examples are <code>ranges::reverse_view</code> and <code>llvm::reverse</code>. Default value is an empty string.</p>
 </div>
 <div class="option">
 <p>MakeReverseRangeHeader</p>
@@ -8743,7 +9094,7 @@ for (auto &amp; elem : v)
 <p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
 </div>
 <h2 id="limitations">Limitations</h2>
-<p>There are certain situations where the tool may erroneously perform transformations that remove information and change semantics. Users of the tool should be aware of the behaviour and limitations of the check outlined by the cases below.</p>
+<p>There are certain situations where the tool may erroneously perform transformations that remove information and change semantics. Users of the tool should be aware of the behavior and limitations of the check outlined by the cases below.</p>
 <h3 id="comments-inside-loop-headers">Comments inside loop headers</h3>
 <p>Comments inside the original loop header are ignored and deleted when transformed.</p>
 <pre class="c++"><code>for (int i = 0; i &lt; N; /* This will be deleted */ ++i) { }</code></pre>
@@ -8813,7 +9164,7 @@ for (vector&lt;int&gt;::iterator it = vec.begin(), e = vec.end(); it != e; ++it)
   }
 }</code></pre>
 <h3 id="openmp">OpenMP</h3>
-<p>As range-based for loops are only available since OpenMP 5, this check should not been used on code with a compatibility requirements of OpenMP prior to version 5. It is <strong>intentional</strong> that this check does not make any attempts to exclude incorrect diagnostics on OpenMP for loops prior to OpenMP 5.</p>
+<p>As range-based for loops are only available since OpenMP 5, this check should not be used on code with a compatibility requirement of OpenMP prior to version 5. It is <strong>intentional</strong> that this check does not make any attempts to exclude incorrect diagnostics on OpenMP for loops prior to OpenMP 5.</p>
 <p>To prevent this check to be applied (and to break) OpenMP for loops but still be applied to non-OpenMP for loops the usage of <code>NOLINT</code> (see <code class="interpreted-text" role="ref">clang-tidy-nolint</code>) on the specific for loops is recommended.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-loop-convert.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -9193,7 +9544,7 @@ void f() {
 </div>
 <h1 id="modernize-replace-disallow-copy-and-assign-macro">modernize-replace-disallow-copy-and-assign-macro</h1>
 <p>Finds macro expansions of <code>DISALLOW_COPY_AND_ASSIGN(Type)</code> and replaces them with a deleted copy constructor and a deleted assignment operator.</p>
-<p>Before the <code>delete</code> keyword was introduced in C++11 it was common practice to declare a copy constructor and an assignment operator as a private members. This effectively makes them unusable to the public API of a class.</p>
+<p>Before the <code>delete</code> keyword was introduced in C++11 it was common practice to declare a copy constructor and an assignment operator as private members. This effectively makes them unusable to the public API of a class.</p>
 <p>With the advent of the <code>delete</code> keyword in C++11 we can abandon the <code>private</code> access of the copy constructor and the assignment operator and delete the methods entirely.</p>
 <p>When running this check on a code like this:</p>
 <pre class="c++"><code>class Foo {
@@ -9360,7 +9711,7 @@ for (auto I = my_container.begin(), E = my_container.end(); I != E; ++I) {
 }</code></pre>
 <p>The check will only replace iterator type-specifiers when all of the following conditions are satisfied:</p>
 <ul>
-<li>The iterator is for one of the standard container in <code>std</code> namespace:
+<li>The iterator is for one of the standard containers in <code>std</code> namespace:
 <ul>
 <li><code>array</code></li>
 <li><code>deque</code></li>
@@ -9407,7 +9758,7 @@ __gnu_cxx::__normal_iterator&lt;int*, std::vector&gt; K = MyVec.begin();</code><
 <li>The initializer for the variable being declared is not a braced initializer list. Otherwise, use of <code>auto</code> would cause the type of the variable to be deduced as <code>std::initializer_list</code>.</li>
 </ul>
 <h2 id="new-expressions">New expressions</h2>
-<p>Frequently, when a pointer is declared and initialized with <code>new</code>, the pointee type is written twice: in the declaration type and in the <code>new</code> expression. In this cases, the declaration type can be replaced with <code>auto</code> improving readability and maintainability.</p>
+<p>Frequently, when a pointer is declared and initialized with <code>new</code>, the pointee type is written twice: in the declaration type and in the <code>new</code> expression. In this case, the declaration type can be replaced with <code>auto</code> improving readability and maintainability.</p>
 <pre class="c++"><code>TypeName *my_pointer = new TypeName(my_param);
 
 // becomes
@@ -9425,7 +9776,7 @@ auto *my_pointer = new TypeName(my_param);</code></pre>
 
 auto *my_first_pointer = new TypeName, *my_second_pointer = new TypeName;</code></pre>
 <h2 id="cast-expressions">Cast expressions</h2>
-<p>Frequently, when a variable is declared and initialized with a cast, the variable type is written twice: in the declaration type and in the cast expression. In this cases, the declaration type can be replaced with <code>auto</code> improving readability and maintainability.</p>
+<p>Frequently, when a variable is declared and initialized with a cast, the variable type is written twice: in the declaration type and in the cast expression. In this case, the declaration type can be replaced with <code>auto</code> improving readability and maintainability.</p>
 <pre class="c++"><code>TypeName *my_pointer = static_cast&lt;TypeName&gt;(my_param);
 
 // becomes
@@ -9552,7 +9903,7 @@ struct A {
 <h2 id="options">Options</h2>
 <div class="option">
 <p>UseAssignment</p>
-<p>If this option is set to <span class="title-ref">true</span> (default is <span class="title-ref">false</span>), the check will initialise members with an assignment. For example:</p>
+<p>If this option is set to <span class="title-ref">true</span> (default is <span class="title-ref">false</span>), the check will initialize members with an assignment. For example:</p>
 </div>
 <pre class="c++"><code>struct A {
   A() {}
@@ -9782,8 +10133,8 @@ private:
 <pre class="c++"><code>bool empty() const;
 bool empty(int i) const;</code></pre>
 <p>transforms to:</p>
-<pre class="c++"><code>[[nodiscard] bool empty() const;
-[[nodiscard] bool empty(int i) const;</code></pre>
+<pre class="c++"><code>[[nodiscard]] bool empty() const;
+[[nodiscard]] bool empty(int i) const;</code></pre>
 <h2 id="options">Options</h2>
 <div class="option">
 <p>ReplacementString</p>
@@ -9878,7 +10229,7 @@ struct bar {
 <p>clang-tidy - modernize-use-nullptr</p>
 </div>
 <h1 id="modernize-use-nullptr">modernize-use-nullptr</h1>
-<p>The check converts the usage of null pointer constants (eg. <code>NULL</code>, <code>0</code>) to use the new C++11 <code>nullptr</code> keyword.</p>
+<p>The check converts the usage of null pointer constants (e.g. <code>NULL</code>, <code>0</code>) to use the new C++11 <code>nullptr</code> keyword.</p>
 <h2 id="example">Example</h2>
 <pre class="c++"><code>void assignment() {
   char *a = NULL;
@@ -10292,7 +10643,7 @@ MPI_Send(&amp;buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);</code></pre>
 <p>clang-tidy - objc-nsinvocation-argument-lifetime</p>
 </div>
 <h1 id="objc-nsinvocation-argument-lifetime">objc-nsinvocation-argument-lifetime</h1>
-<p>Finds calls to <code>NSInvocation</code> methods under ARC that don't have proper argument object lifetimes. When passing Objective-C objects as parameters to the <code>NSInvocation</code> methods <code>getArgument:atIndex:</code> and <code>getReturnValue:</code>, the values are copied by value into the argument pointer, which leads to to incorrect releasing behavior if the object pointers are not declared <code>__unsafe_unretained</code>.</p>
+<p>Finds calls to <code>NSInvocation</code> methods under ARC that don't have proper argument object lifetimes. When passing Objective-C objects as parameters to the <code>NSInvocation</code> methods <code>getArgument:atIndex:</code> and <code>getReturnValue:</code>, the values are copied by value into the argument pointer, which leads to incorrect releasing behavior if the object pointers are not declared <code>__unsafe_unretained</code>.</p>
 <p>For code:</p>
 <pre class="objc"><code>id arg;
 [invocation getArgument:&amp;arg atIndex:2];
@@ -10365,7 +10716,7 @@ __unsafe_unretained id returnValue;
 </div>
 <h1 id="openmp-exception-escape">openmp-exception-escape</h1>
 <p>Analyzes OpenMP Structured Blocks and checks that no exception escapes out of the Structured Block it was thrown in.</p>
-<p>As per the OpenMP specification, a structured block is an executable statement, possibly compound, with a single entry at the top and a single exit at the bottom. Which means, <code>throw</code> may not be used to to 'exit' out of the structured block. If an exception is not caught in the same structured block it was thrown in, the behaviour is undefined.</p>
+<p>As per the OpenMP specification, a structured block is an executable statement, possibly compound, with a single entry at the top and a single exit at the bottom. Which means, <code>throw</code> may not be used to 'exit' out of the structured block. If an exception is not caught in the same structured block it was thrown in, the behavior is undefined.</p>
 <p>FIXME: this check does not model SEH, <code>setjmp</code>/<code>longjmp</code>.</p>
 <p>WARNING! This check may be expensive on large source files.</p>
 <h2 id="options">Options</h2>
@@ -10488,7 +10839,7 @@ str.find(&#39;A&#39;);</code></pre>
 </div>
 <div class="option">
 <p>AllowedTypes</p>
-<p>A semicolon-separated list of names of types allowed to be copied in each iteration. Regular expressions are accepted, e.g. <span class="title-ref">[Rr]ef(erence)?$</span> matches every type with suffix <span class="title-ref">Ref</span>, <span class="title-ref">ref</span>, <span class="title-ref">Reference</span> and <span class="title-ref">reference</span>. The default is empty.</p>
+<p>A semicolon-separated list of names of types allowed to be copied in each iteration. Regular expressions are accepted, e.g. <span class="title-ref">[Rr]ef(erence)?$</span> matches every type with suffix <span class="title-ref">Ref</span>, <span class="title-ref">ref</span>, <span class="title-ref">Reference</span> and <span class="title-ref">reference</span>. The default is empty. If a name in the list contains the sequence <span class="title-ref">::</span> it is matched against the qualified typename (i.e. <span class="title-ref">namespace::Type</span>, otherwise it is matched against only the type name (i.e. <span class="title-ref">Type</span>).</p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-for-range-copy.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -10555,7 +10906,7 @@ for (const pair&lt;int, vector&lt;string&gt;&gt;&amp; p : my_map) {}
 </div>
 <h1 id="performance-inefficient-algorithm">performance-inefficient-algorithm</h1>
 <p>Warns on inefficient use of STL algorithms on associative containers.</p>
-<p>Associative containers implements some of the algorithms as methods which should be preferred to the algorithms in the algorithm header. The methods can take advantage of the order of the elements.</p>
+<p>Associative containers implement some of the algorithms as methods which should be preferred to the algorithms in the algorithm header. The methods can take advantage of the order of the elements.</p>
 <pre class="c++"><code>std::set&lt;int&gt; s;
 auto it = std::find(s.begin(), s.end(), 43);
 
@@ -10859,7 +11210,7 @@ A::~A() = default;</code></pre>
 </div>
 <h1 id="performance-type-promotion-in-math-fn">performance-type-promotion-in-math-fn</h1>
 <p>Finds calls to C math library functions (from <code>math.h</code> or, in C++, <code>cmath</code>) with implicit <code>float</code> to <code>double</code> promotions.</p>
-<p>For example, warns on <code>::sin(0.f)</code>, because this funciton's parameter is a double. You probably meant to call <code>std::sin(0.f)</code> (in C++), or <code>sinf(0.f)</code> (in C).</p>
+<p>For example, warns on <code>::sin(0.f)</code>, because this function's parameter is a double. You probably meant to call <code>std::sin(0.f)</code> (in C++), or <code>sinf(0.f)</code> (in C).</p>
 <pre class="c++"><code>float a;
 asin(a);
 
@@ -10907,7 +11258,11 @@ void Function(const Foo&amp; foo) {
 <h2 id="options">Options</h2>
 <div class="option">
 <p>AllowedTypes</p>
-<p>A semicolon-separated list of names of types allowed to be initialized by copying. Regular expressions are accepted, e.g. <span class="title-ref">[Rr]ef(erence)?$</span> matches every type with suffix <span class="title-ref">Ref</span>, <span class="title-ref">ref</span>, <span class="title-ref">Reference</span> and <span class="title-ref">reference</span>. The default is empty.</p>
+<p>A semicolon-separated list of names of types allowed to be initialized by copying. Regular expressions are accepted, e.g. <span class="title-ref">[Rr]ef(erence)?$</span> matches every type with suffix <span class="title-ref">Ref</span>, <span class="title-ref">ref</span>, <span class="title-ref">Reference</span> and <span class="title-ref">reference</span>. The default is empty. If a name in the list contains the sequence <span class="title-ref">::</span> it is matched against the qualified typename (i.e. <span class="title-ref">namespace::Type</span>, otherwise it is matched against only the type name (i.e. <span class="title-ref">Type</span>).</p>
+</div>
+<div class="option">
+<p>ExcludedContainerTypes</p>
+<p>A semicolon-separated list of names of types whose methods are allowed to return the const reference the variable is copied from. When an expensive to copy variable is copy initialized by the return value from a type on this list the check does not trigger. This can be used to exclude types known to be const incorrect or where the lifetime or immutability of returned references is not tied to mutations of the container. An example are view types that don't own the underlying data. Like for <span class="title-ref">AllowedTypes</span> above, regular expressions are accepted and the inclusion of <span class="title-ref">::</span> determines whether the qualified typename is matched or not.</p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-copy-initialization.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -10960,7 +11315,7 @@ void setValue(string Value) {
 </div>
 <div class="option">
 <p>AllowedTypes</p>
-<p>A semicolon-separated list of names of types allowed to be passed by value. Regular expressions are accepted, e.g. <span class="title-ref">[Rr]ef(erence)?$</span> matches every type with suffix <span class="title-ref">Ref</span>, <span class="title-ref">ref</span>, <span class="title-ref">Reference</span> and <span class="title-ref">reference</span>. The default is empty.</p>
+<p>A semicolon-separated list of names of types allowed to be passed by value. Regular expressions are accepted, e.g. <span class="title-ref">[Rr]ef(erence)?$</span> matches every type with suffix <span class="title-ref">Ref</span>, <span class="title-ref">ref</span>, <span class="title-ref">Reference</span> and <span class="title-ref">reference</span>. The default is empty. If a name in the list contains the sequence <span class="title-ref">::</span> it is matched against the qualified typename (i.e. <span class="title-ref">namespace::Type</span>, otherwise it is matched against only the type name (i.e. <span class="title-ref">Type</span>).</p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-value-param.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -11159,6 +11514,22 @@ bool empty() const;</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>readability-data-pointer</key>
+    <name>readability-data-pointer</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - readability-data-pointer</p>
+</div>
+<h1 id="readability-data-pointer">readability-data-pointer</h1>
+<p>Finds cases where code could use <code>data()</code> rather than the address of the element at index 0 in a container. This pattern is commonly used to materialize a pointer to the backing data of a container. <code>std::vector</code> and <code>std::string</code> provide a <code>data()</code> accessor to retrieve the data pointer which should be preferred.</p>
+<p>This also ensures that in the case that the container is empty, the data pointer access does not perform an errant memory access.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-data-pointer.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>readability-delete-null-pointer</key>
     <name>readability-delete-null-pointer</name>
     <description>
@@ -11233,7 +11604,7 @@ if (p)
 </div>
 <div class="option">
 <p>WarnOnConditionVariables</p>
-<p>When <span class="title-ref">true</span>, the check will attempt to refactor a variable defined inside the condition of the <code>if</code> statement that is used in the <code>else</code> branch defining them just before the <code>if</code> statement. This can only be done if the <code>if</code> statement is the last statement in its parents scope. Default value is <span class="title-ref">true</span>.</p>
+<p>When <span class="title-ref">true</span>, the check will attempt to refactor a variable defined inside the condition of the <code>if</code> statement that is used in the <code>else</code> branch defining them just before the <code>if</code> statement. This can only be done if the <code>if</code> statement is the last statement in its parent's scope. Default value is <span class="title-ref">true</span>.</p>
 </div>
 <h2 id="llvm-alias">LLVM alias</h2>
 <p>There is an alias of this check called llvm-else-after-return. In that version the options <code class="interpreted-text" role="option">WarnOnUnfixable</code> and <code class="interpreted-text" role="option">WarnOnConditionVariables</code> are both set to <span class="title-ref">false</span> by default.</p>
@@ -11262,6 +11633,10 @@ if (p)
 <div class="option">
 <p>DescribeBasicIncrements</p>
 <p>If set to <span class="title-ref">true</span>, then for each function exceeding the complexity threshold the check will issue additional diagnostics on every piece of code (loop, <span class="title-ref">if</span> statement, etc.) which contributes to that complexity. See also the examples below. Default is <span class="title-ref">true</span>.</p>
+</div>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>If set to <span class="title-ref">true</span>, the check will ignore code inside macros. Note, that also any macro arguments are ignored, even if they should count to the complexity. As this might change in the future, this option isn't guaranteed to be forward-compatible. Default is <span class="title-ref">false</span>.</p>
 </div>
 <h2 id="building-blocks">Building blocks</h2>
 <p>There are three basic building blocks of a Cognitive Complexity metric:</p>
@@ -11298,7 +11673,7 @@ if (p)
 </blockquote></li>
 </ul>
 <h3 id="nesting-level">Nesting level</h3>
-<p>While by itself the nesting level not change the function's Cognitive Complexity metric, it is tracked, and is used by the next, third building block. The following structures increase the nesting level (by <span class="title-ref">1</span>):</p>
+<p>While by itself the nesting level does not change the function's Cognitive Complexity metric, it is tracked, and is used by the next, third building block. The following structures increase the nesting level (by <span class="title-ref">1</span>):</p>
 <ul>
 <li><p>Conditional operators:</p>
 <blockquote>
@@ -11433,6 +11808,93 @@ if (p)
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
+    <key>readability-identifier-length</key>
+    <name>readability-identifier-length</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - readability-identifier-length</p>
+</div>
+<h1 id="readability-identifier-length">readability-identifier-length</h1>
+<p>This check finds variables and function parameters whose length are too short. The desired name length is configurable.</p>
+<p>Special cases are supported for loop counters and for exception variable names.</p>
+<h2 id="options">Options</h2>
+<p>The following options are described below:</p>
+<blockquote>
+<ul>
+<li><code class="interpreted-text" role="option">MinimumVariableNameLength</code>, <code class="interpreted-text" role="option">IgnoredVariableNames</code></li>
+<li><code class="interpreted-text" role="option">MinimumParameterNameLength</code>, <code class="interpreted-text" role="option">IgnoredParameterNames</code></li>
+<li><code class="interpreted-text" role="option">MinimumLoopCounterNameLength</code>, <code class="interpreted-text" role="option">IgnoredLoopCounterNames</code></li>
+<li><code class="interpreted-text" role="option">MinimumExceptionNameLength</code>, <code class="interpreted-text" role="option">IgnoredExceptionVariableNames</code></li>
+</ul>
+</blockquote>
+<div class="option">
+<p>MinimumVariableNameLength</p>
+<p>All variables (other than loop counter, exception names and function parameters) are expected to have at least a length of <span class="title-ref">MinimumVariableNameLength</span> (default is <span class="title-ref">3</span>). Setting it to <span class="title-ref">0</span> or <span class="title-ref">1</span> disables the check entirely.</p>
+<pre class="c++"><code>int doubler(int x)   // warns that x is too short
+{
+   return 2 * x;
+}</code></pre>
+<p>This check does not have any fix suggestions in the general case since variable names have semantic value.</p>
+</div>
+<div class="option">
+<p>IgnoredVariableNames</p>
+<p>Specifies a regular expression for variable names that are to be ignored. The default value is empty, thus no names are ignored.</p>
+</div>
+<div class="option">
+<p>MinimumParameterNameLength</p>
+<p>All function parameter names are expected to have a length of at least <span class="title-ref">MinimumParameterNameLength</span> (default is <span class="title-ref">3</span>). Setting it to <span class="title-ref">0</span> or <span class="title-ref">1</span> disables the check entirely.</p>
+<pre class="c++"><code>int i = 42;    // warns that &#39;i&#39; is too short</code></pre>
+<p>This check does not have any fix suggestions in the general case since variable names have semantic value.</p>
+</div>
+<div class="option">
+<p>IgnoredParameterNames</p>
+<p>Specifies a regular expression for parameters that are to be ignored. The default value is <span class="title-ref">^[n]$</span> for historical reasons.</p>
+</div>
+<div class="option">
+<p>MinimumLoopCounterNameLength</p>
+<p>Loop counter variables are expected to have a length of at least <span class="title-ref">MinimumLoopCounterNameLength</span> characters (default is <span class="title-ref">2</span>). Setting it to <span class="title-ref">0</span> or <span class="title-ref">1</span> disables the check entirely.</p>
+<pre class="c++"><code>// This warns that &#39;q&#39; is too short.
+for (int q = 0; q &lt; size; ++ q) {
+   // ...
+}</code></pre>
+</div>
+<div class="option">
+<p>IgnoredLoopCounterNames</p>
+<p>Specifies a regular expression for counter names that are to be ignored. The default value is <span class="title-ref">^[ijk_]$</span>; the first three symbols for historical reasons and the last one since it is frequently used as a "don't care" value, specifically in tools such as Google Benchmark.</p>
+<pre class="c++"><code>// This does not warn by default, for historical reasons.
+for (int i = 0; i &lt; size; ++ i) {
+    // ...
+}</code></pre>
+</div>
+<div class="option">
+<p>MinimumExceptionNameLength</p>
+<p>Exception clause variables are expected to have a length of at least <span class="title-ref">MinimumExceptionNameLength</span> (default is <span class="title-ref">2</span>). Setting it to <span class="title-ref">0</span> or <span class="title-ref">1</span> disables the check entirely.</p>
+<pre class="c++"><code>try {
+    // ...
+}
+// This warns that &#39;e&#39; is too short.
+catch (const std::exception&amp; x) {
+    // ...
+}</code></pre>
+</div>
+<div class="option">
+<p>IgnoredExceptionVariableNames</p>
+<p>Specifies a regular expression for exception variable names that are to be ignored. The default value is <span class="title-ref">^[e]$</span> mainly for historical reasons.</p>
+<pre class="c++"><code>try {
+    // ...
+}
+// This does not warn by default, for historical reasons.
+catch (const std::exception&amp; e) {
+    // ...
+}</code></pre>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-identifier-length.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>readability-identifier-naming</key>
     <name>readability-identifier-naming</name>
     <description>
@@ -11458,53 +11920,53 @@ if (p)
 <p>Many configuration options are available, in order to be able to create different rules for different kinds of identifiers. In general, the rules are falling back to a more generic rule if the specific case is not configured.</p>
 <p>The naming of virtual methods is reported where they occur in the base class, but not where they are overridden, as it can't be fixed locally there. This also applies for pseudo-override patterns like CRTP.</p>
 <h2 id="options">Options</h2>
-<p>The following options are describe below:</p>
+<p>The following options are described below:</p>
 <blockquote>
 <ul>
-<li><code class="interpreted-text" role="option">AbstractClassCase</code>, <code class="interpreted-text" role="option">AbstractClassPrefix</code>, <code class="interpreted-text" role="option">AbstractClassSuffix</code>, <code class="interpreted-text" role="option">AbstractClassIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">AbstractClassCase</code>, <code class="interpreted-text" role="option">AbstractClassPrefix</code>, <code class="interpreted-text" role="option">AbstractClassSuffix</code>, <code class="interpreted-text" role="option">AbstractClassIgnoredRegexp</code>, <code class="interpreted-text" role="option">AbstractClassHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">AggressiveDependentMemberLookup</code></li>
-<li><code class="interpreted-text" role="option">ClassCase</code>, <code class="interpreted-text" role="option">ClassPrefix</code>, <code class="interpreted-text" role="option">ClassSuffix</code>, <code class="interpreted-text" role="option">ClassIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">ClassConstantCase</code>, <code class="interpreted-text" role="option">ClassConstantPrefix</code>, <code class="interpreted-text" role="option">ClassConstantSuffix</code>, <code class="interpreted-text" role="option">ClassConstantIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">ClassMemberCase</code>, <code class="interpreted-text" role="option">ClassMemberPrefix</code>, <code class="interpreted-text" role="option">ClassMemberSuffix</code>, <code class="interpreted-text" role="option">ClassMemberIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">ClassCase</code>, <code class="interpreted-text" role="option">ClassPrefix</code>, <code class="interpreted-text" role="option">ClassSuffix</code>, <code class="interpreted-text" role="option">ClassIgnoredRegexp</code>, <code class="interpreted-text" role="option">ClassHungarianPrefix</code></li>
+<li><code class="interpreted-text" role="option">ClassConstantCase</code>, <code class="interpreted-text" role="option">ClassConstantPrefix</code>, <code class="interpreted-text" role="option">ClassConstantSuffix</code>, <code class="interpreted-text" role="option">ClassConstantIgnoredRegexp</code>, <code class="interpreted-text" role="option">ClassConstantHungarianPrefix</code></li>
+<li><code class="interpreted-text" role="option">ClassMemberCase</code>, <code class="interpreted-text" role="option">ClassMemberPrefix</code>, <code class="interpreted-text" role="option">ClassMemberSuffix</code>, <code class="interpreted-text" role="option">ClassMemberIgnoredRegexp</code>, <code class="interpreted-text" role="option">ClassMemberHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">ClassMethodCase</code>, <code class="interpreted-text" role="option">ClassMethodPrefix</code>, <code class="interpreted-text" role="option">ClassMethodSuffix</code>, <code class="interpreted-text" role="option">ClassMethodIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">ConstantCase</code>, <code class="interpreted-text" role="option">ConstantPrefix</code>, <code class="interpreted-text" role="option">ConstantSuffix</code>, <code class="interpreted-text" role="option">ConstantIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">ConstantMemberCase</code>, <code class="interpreted-text" role="option">ConstantMemberPrefix</code>, <code class="interpreted-text" role="option">ConstantMemberSuffix</code>, <code class="interpreted-text" role="option">ConstantMemberIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">ConstantParameterCase</code>, <code class="interpreted-text" role="option">ConstantParameterPrefix</code>, <code class="interpreted-text" role="option">ConstantParameterSuffix</code>, <code class="interpreted-text" role="option">ConstantParameterIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">ConstantPointerParameterCase</code>, <code class="interpreted-text" role="option">ConstantPointerParameterPrefix</code>, <code class="interpreted-text" role="option">ConstantPointerParameterSuffix</code>, <code class="interpreted-text" role="option">ConstantPointerParameterIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">ConstantCase</code>, <code class="interpreted-text" role="option">ConstantPrefix</code>, <code class="interpreted-text" role="option">ConstantSuffix</code>, <code class="interpreted-text" role="option">ConstantIgnoredRegexp</code>, <code class="interpreted-text" role="option">ConstantHungarianPrefix</code></li>
+<li><code class="interpreted-text" role="option">ConstantMemberCase</code>, <code class="interpreted-text" role="option">ConstantMemberPrefix</code>, <code class="interpreted-text" role="option">ConstantMemberSuffix</code>, <code class="interpreted-text" role="option">ConstantMemberIgnoredRegexp</code>, <code class="interpreted-text" role="option">ConstantMemberHungarianPrefix</code></li>
+<li><code class="interpreted-text" role="option">ConstantParameterCase</code>, <code class="interpreted-text" role="option">ConstantParameterPrefix</code>, <code class="interpreted-text" role="option">ConstantParameterSuffix</code>, <code class="interpreted-text" role="option">ConstantParameterIgnoredRegexp</code>, <code class="interpreted-text" role="option">ConstantParameterHungarianPrefix</code></li>
+<li><code class="interpreted-text" role="option">ConstantPointerParameterCase</code>, <code class="interpreted-text" role="option">ConstantPointerParameterPrefix</code>, <code class="interpreted-text" role="option">ConstantPointerParameterSuffix</code>, <code class="interpreted-text" role="option">ConstantPointerParameterIgnoredRegexp</code>, <code class="interpreted-text" role="option">ConstantPointerParameterHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">ConstexprFunctionCase</code>, <code class="interpreted-text" role="option">ConstexprFunctionPrefix</code>, <code class="interpreted-text" role="option">ConstexprFunctionSuffix</code>, <code class="interpreted-text" role="option">ConstexprFunctionIgnoredRegexp</code></li>
 <li><code class="interpreted-text" role="option">ConstexprMethodCase</code>, <code class="interpreted-text" role="option">ConstexprMethodPrefix</code>, <code class="interpreted-text" role="option">ConstexprMethodSuffix</code>, <code class="interpreted-text" role="option">ConstexprMethodIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">ConstexprVariableCase</code>, <code class="interpreted-text" role="option">ConstexprVariablePrefix</code>, <code class="interpreted-text" role="option">ConstexprVariableSuffix</code>, <code class="interpreted-text" role="option">ConstexprVariableIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">ConstexprVariableCase</code>, <code class="interpreted-text" role="option">ConstexprVariablePrefix</code>, <code class="interpreted-text" role="option">ConstexprVariableSuffix</code>, <code class="interpreted-text" role="option">ConstexprVariableIgnoredRegexp</code>, <code class="interpreted-text" role="option">ConstexprVariableHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">EnumCase</code>, <code class="interpreted-text" role="option">EnumPrefix</code>, <code class="interpreted-text" role="option">EnumSuffix</code>, <code class="interpreted-text" role="option">EnumIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">EnumConstantCase</code>, <code class="interpreted-text" role="option">EnumConstantPrefix</code>, <code class="interpreted-text" role="option">EnumConstantSuffix</code>, <code class="interpreted-text" role="option">EnumConstantIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">EnumConstantCase</code>, <code class="interpreted-text" role="option">EnumConstantPrefix</code>, <code class="interpreted-text" role="option">EnumConstantSuffix</code>, <code class="interpreted-text" role="option">EnumConstantIgnoredRegexp</code>, <code class="interpreted-text" role="option">EnumConstantHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">FunctionCase</code>, <code class="interpreted-text" role="option">FunctionPrefix</code>, <code class="interpreted-text" role="option">FunctionSuffix</code>, <code class="interpreted-text" role="option">FunctionIgnoredRegexp</code></li>
 <li><code class="interpreted-text" role="option">GetConfigPerFile</code></li>
-<li><code class="interpreted-text" role="option">GlobalConstantCase</code>, <code class="interpreted-text" role="option">GlobalConstantPrefix</code>, <code class="interpreted-text" role="option">GlobalConstantSuffix</code>, <code class="interpreted-text" role="option">GlobalConstantIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">GlobalConstantPointerCase</code>, <code class="interpreted-text" role="option">GlobalConstantPointerPrefix</code>, <code class="interpreted-text" role="option">GlobalConstantPointerSuffix</code>, <code class="interpreted-text" role="option">GlobalConstantPointerIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">GlobalConstantCase</code>, <code class="interpreted-text" role="option">GlobalConstantPrefix</code>, <code class="interpreted-text" role="option">GlobalConstantSuffix</code>, <code class="interpreted-text" role="option">GlobalConstantIgnoredRegexp</code>, <code class="interpreted-text" role="option">GlobalConstantHungarianPrefix</code></li>
+<li><code class="interpreted-text" role="option">GlobalConstantPointerCase</code>, <code class="interpreted-text" role="option">GlobalConstantPointerPrefix</code>, <code class="interpreted-text" role="option">GlobalConstantPointerSuffix</code>, <code class="interpreted-text" role="option">GlobalConstantPointerIgnoredRegexp</code>, <code class="interpreted-text" role="option">GlobalConstantPointerHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">GlobalFunctionCase</code>, <code class="interpreted-text" role="option">GlobalFunctionPrefix</code>, <code class="interpreted-text" role="option">GlobalFunctionSuffix</code>, <code class="interpreted-text" role="option">GlobalFunctionIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">GlobalPointerCase</code>, <code class="interpreted-text" role="option">GlobalPointerPrefix</code>, <code class="interpreted-text" role="option">GlobalPointerSuffix</code>, <code class="interpreted-text" role="option">GlobalPointerIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">GlobalVariableCase</code>, <code class="interpreted-text" role="option">GlobalVariablePrefix</code>, <code class="interpreted-text" role="option">GlobalVariableSuffix</code>, <code class="interpreted-text" role="option">GlobalVariableIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">GlobalPointerCase</code>, <code class="interpreted-text" role="option">GlobalPointerPrefix</code>, <code class="interpreted-text" role="option">GlobalPointerSuffix</code>, <code class="interpreted-text" role="option">GlobalPointerIgnoredRegexp</code>, <code class="interpreted-text" role="option">GlobalPointerHungarianPrefix</code></li>
+<li><code class="interpreted-text" role="option">GlobalVariableCase</code>, <code class="interpreted-text" role="option">GlobalVariablePrefix</code>, <code class="interpreted-text" role="option">GlobalVariableSuffix</code>, <code class="interpreted-text" role="option">GlobalVariableIgnoredRegexp</code>, <code class="interpreted-text" role="option">GlobalVariableHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">IgnoreMainLikeFunctions</code></li>
 <li><code class="interpreted-text" role="option">InlineNamespaceCase</code>, <code class="interpreted-text" role="option">InlineNamespacePrefix</code>, <code class="interpreted-text" role="option">InlineNamespaceSuffix</code>, <code class="interpreted-text" role="option">InlineNamespaceIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">LocalConstantCase</code>, <code class="interpreted-text" role="option">LocalConstantPrefix</code>, <code class="interpreted-text" role="option">LocalConstantSuffix</code>, <code class="interpreted-text" role="option">LocalConstantIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">LocalConstantPointerCase</code>, <code class="interpreted-text" role="option">LocalConstantPointerPrefix</code>, <code class="interpreted-text" role="option">LocalConstantPointerSuffix</code>, <code class="interpreted-text" role="option">LocalConstantPointerIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">LocalPointerCase</code>, <code class="interpreted-text" role="option">LocalPointerPrefix</code>, <code class="interpreted-text" role="option">LocalPointerSuffix</code>, <code class="interpreted-text" role="option">LocalPointerIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">LocalVariableCase</code>, <code class="interpreted-text" role="option">LocalVariablePrefix</code>, <code class="interpreted-text" role="option">LocalVariableSuffix</code>, <code class="interpreted-text" role="option">LocalVariableIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">LocalConstantCase</code>, <code class="interpreted-text" role="option">LocalConstantPrefix</code>, <code class="interpreted-text" role="option">LocalConstantSuffix</code>, <code class="interpreted-text" role="option">LocalConstantIgnoredRegexp</code>, <code class="interpreted-text" role="option">LocalConstantHungarianPrefix</code></li>
+<li><code class="interpreted-text" role="option">LocalConstantPointerCase</code>, <code class="interpreted-text" role="option">LocalConstantPointerPrefix</code>, <code class="interpreted-text" role="option">LocalConstantPointerSuffix</code>, <code class="interpreted-text" role="option">LocalConstantPointerIgnoredRegexp</code>, <code class="interpreted-text" role="option">LocalConstantPointerHungarianPrefix</code></li>
+<li><code class="interpreted-text" role="option">LocalPointerCase</code>, <code class="interpreted-text" role="option">LocalPointerPrefix</code>, <code class="interpreted-text" role="option">LocalPointerSuffix</code>, <code class="interpreted-text" role="option">LocalPointerIgnoredRegexp</code>, <code class="interpreted-text" role="option">LocalPointerHungarianPrefix</code></li>
+<li><code class="interpreted-text" role="option">LocalVariableCase</code>, <code class="interpreted-text" role="option">LocalVariablePrefix</code>, <code class="interpreted-text" role="option">LocalVariableSuffix</code>, <code class="interpreted-text" role="option">LocalVariableIgnoredRegexp</code>, <code class="interpreted-text" role="option">LocalVariableHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">MacroDefinitionCase</code>, <code class="interpreted-text" role="option">MacroDefinitionPrefix</code>, <code class="interpreted-text" role="option">MacroDefinitionSuffix</code>, <code class="interpreted-text" role="option">MacroDefinitionIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">MemberCase</code>, <code class="interpreted-text" role="option">MemberPrefix</code>, <code class="interpreted-text" role="option">MemberSuffix</code>, <code class="interpreted-text" role="option">MemberIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">MemberCase</code>, <code class="interpreted-text" role="option">MemberPrefix</code>, <code class="interpreted-text" role="option">MemberSuffix</code>, <code class="interpreted-text" role="option">MemberIgnoredRegexp</code>, <code class="interpreted-text" role="option">MemberHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">MethodCase</code>, <code class="interpreted-text" role="option">MethodPrefix</code>, <code class="interpreted-text" role="option">MethodSuffix</code>, <code class="interpreted-text" role="option">MethodIgnoredRegexp</code></li>
 <li><code class="interpreted-text" role="option">NamespaceCase</code>, <code class="interpreted-text" role="option">NamespacePrefix</code>, <code class="interpreted-text" role="option">NamespaceSuffix</code>, <code class="interpreted-text" role="option">NamespaceIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">ParameterCase</code>, <code class="interpreted-text" role="option">ParameterPrefix</code>, <code class="interpreted-text" role="option">ParameterSuffix</code>, <code class="interpreted-text" role="option">ParameterIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">ParameterCase</code>, <code class="interpreted-text" role="option">ParameterPrefix</code>, <code class="interpreted-text" role="option">ParameterSuffix</code>, <code class="interpreted-text" role="option">ParameterIgnoredRegexp</code>, <code class="interpreted-text" role="option">ParameterHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">ParameterPackCase</code>, <code class="interpreted-text" role="option">ParameterPackPrefix</code>, <code class="interpreted-text" role="option">ParameterPackSuffix</code>, <code class="interpreted-text" role="option">ParameterPackIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">PointerParameterCase</code>, <code class="interpreted-text" role="option">PointerParameterPrefix</code>, <code class="interpreted-text" role="option">PointerParameterSuffix</code>, <code class="interpreted-text" role="option">PointerParameterIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">PrivateMemberCase</code>, <code class="interpreted-text" role="option">PrivateMemberPrefix</code>, <code class="interpreted-text" role="option">PrivateMemberSuffix</code>, <code class="interpreted-text" role="option">PrivateMemberIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">PointerParameterCase</code>, <code class="interpreted-text" role="option">PointerParameterPrefix</code>, <code class="interpreted-text" role="option">PointerParameterSuffix</code>, <code class="interpreted-text" role="option">PointerParameterIgnoredRegexp</code>, <code class="interpreted-text" role="option">PointerParameterHungarianPrefix</code></li>
+<li><code class="interpreted-text" role="option">PrivateMemberCase</code>, <code class="interpreted-text" role="option">PrivateMemberPrefix</code>, <code class="interpreted-text" role="option">PrivateMemberSuffix</code>, <code class="interpreted-text" role="option">PrivateMemberIgnoredRegexp</code>, <code class="interpreted-text" role="option">PrivateMemberHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">PrivateMethodCase</code>, <code class="interpreted-text" role="option">PrivateMethodPrefix</code>, <code class="interpreted-text" role="option">PrivateMethodSuffix</code>, <code class="interpreted-text" role="option">PrivateMethodIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">ProtectedMemberCase</code>, <code class="interpreted-text" role="option">ProtectedMemberPrefix</code>, <code class="interpreted-text" role="option">ProtectedMemberSuffix</code>, <code class="interpreted-text" role="option">ProtectedMemberIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">ProtectedMemberCase</code>, <code class="interpreted-text" role="option">ProtectedMemberPrefix</code>, <code class="interpreted-text" role="option">ProtectedMemberSuffix</code>, <code class="interpreted-text" role="option">ProtectedMemberIgnoredRegexp</code>, <code class="interpreted-text" role="option">ProtectedMemberHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">ProtectedMethodCase</code>, <code class="interpreted-text" role="option">ProtectedMethodPrefix</code>, <code class="interpreted-text" role="option">ProtectedMethodSuffix</code>, <code class="interpreted-text" role="option">ProtectedMethodIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">PublicMemberCase</code>, <code class="interpreted-text" role="option">PublicMemberPrefix</code>, <code class="interpreted-text" role="option">PublicMemberSuffix</code>, <code class="interpreted-text" role="option">PublicMemberIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">PublicMemberCase</code>, <code class="interpreted-text" role="option">PublicMemberPrefix</code>, <code class="interpreted-text" role="option">PublicMemberSuffix</code>, <code class="interpreted-text" role="option">PublicMemberIgnoredRegexp</code>, <code class="interpreted-text" role="option">PublicMemberHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">PublicMethodCase</code>, <code class="interpreted-text" role="option">PublicMethodPrefix</code>, <code class="interpreted-text" role="option">PublicMethodSuffix</code>, <code class="interpreted-text" role="option">PublicMethodIgnoredRegexp</code></li>
 <li><code class="interpreted-text" role="option">ScopedEnumConstantCase</code>, <code class="interpreted-text" role="option">ScopedEnumConstantPrefix</code>, <code class="interpreted-text" role="option">ScopedEnumConstantSuffix</code>, <code class="interpreted-text" role="option">ScopedEnumConstantIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">StaticConstantCase</code>, <code class="interpreted-text" role="option">StaticConstantPrefix</code>, <code class="interpreted-text" role="option">StaticConstantSuffix</code>, <code class="interpreted-text" role="option">StaticConstantIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">StaticVariableCase</code>, <code class="interpreted-text" role="option">StaticVariablePrefix</code>, <code class="interpreted-text" role="option">StaticVariableSuffix</code>, <code class="interpreted-text" role="option">StaticVariableIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">StaticConstantCase</code>, <code class="interpreted-text" role="option">StaticConstantPrefix</code>, <code class="interpreted-text" role="option">StaticConstantSuffix</code>, <code class="interpreted-text" role="option">StaticConstantIgnoredRegexp</code>, <code class="interpreted-text" role="option">StaticConstantHungarianPrefix</code></li>
+<li><code class="interpreted-text" role="option">StaticVariableCase</code>, <code class="interpreted-text" role="option">StaticVariablePrefix</code>, <code class="interpreted-text" role="option">StaticVariableSuffix</code>, <code class="interpreted-text" role="option">StaticVariableIgnoredRegexp</code>, <code class="interpreted-text" role="option">StaticVariableHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">StructCase</code>, <code class="interpreted-text" role="option">StructPrefix</code>, <code class="interpreted-text" role="option">StructSuffix</code>, <code class="interpreted-text" role="option">StructIgnoredRegexp</code></li>
 <li><code class="interpreted-text" role="option">TemplateParameterCase</code>, <code class="interpreted-text" role="option">TemplateParameterPrefix</code>, <code class="interpreted-text" role="option">TemplateParameterSuffix</code>, <code class="interpreted-text" role="option">TemplateParameterIgnoredRegexp</code></li>
 <li><code class="interpreted-text" role="option">TemplateTemplateParameterCase</code>, <code class="interpreted-text" role="option">TemplateTemplateParameterPrefix</code>, <code class="interpreted-text" role="option">TemplateTemplateParameterSuffix</code>, <code class="interpreted-text" role="option">TemplateTemplateParameterIgnoredRegexp</code></li>
@@ -11513,7 +11975,7 @@ if (p)
 <li><code class="interpreted-text" role="option">TypeTemplateParameterCase</code>, <code class="interpreted-text" role="option">TypeTemplateParameterPrefix</code>, <code class="interpreted-text" role="option">TypeTemplateParameterSuffix</code>, <code class="interpreted-text" role="option">TypeTemplateParameterIgnoredRegexp</code></li>
 <li><code class="interpreted-text" role="option">UnionCase</code>, <code class="interpreted-text" role="option">UnionPrefix</code>, <code class="interpreted-text" role="option">UnionSuffix</code>, <code class="interpreted-text" role="option">UnionIgnoredRegexp</code></li>
 <li><code class="interpreted-text" role="option">ValueTemplateParameterCase</code>, <code class="interpreted-text" role="option">ValueTemplateParameterPrefix</code>, <code class="interpreted-text" role="option">ValueTemplateParameterSuffix</code>, <code class="interpreted-text" role="option">ValueTemplateParameterIgnoredRegexp</code></li>
-<li><code class="interpreted-text" role="option">VariableCase</code>, <code class="interpreted-text" role="option">VariablePrefix</code>, <code class="interpreted-text" role="option">VariableSuffix</code>, <code class="interpreted-text" role="option">VariableIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">VariableCase</code>, <code class="interpreted-text" role="option">VariablePrefix</code>, <code class="interpreted-text" role="option">VariableSuffix</code>, <code class="interpreted-text" role="option">VariableIgnoredRegexp</code>, <code class="interpreted-text" role="option">VariableHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">VirtualMethodCase</code>, <code class="interpreted-text" role="option">VirtualMethodPrefix</code>, <code class="interpreted-text" role="option">VirtualMethodSuffix</code>, <code class="interpreted-text" role="option">VirtualMethodIgnoredRegexp</code></li>
 </ul>
 </blockquote>
@@ -11533,12 +11995,17 @@ if (p)
 <p>AbstractClassSuffix</p>
 <p>When defined, the check will ensure abstract class names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>AbstractClassHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>AbstractClassCase of <code>lower_case</code></li>
 <li>AbstractClassPrefix of <code>pre_</code></li>
 <li>AbstractClassSuffix of <code>_post</code></li>
+<li>AbstractClassHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms abstract class names as follows:</p>
@@ -11614,12 +12081,17 @@ struct Derived : Base&lt;T&gt; {
 <p>ClassSuffix</p>
 <p>When defined, the check will ensure class names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>ClassHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>ClassCase of <code>lower_case</code></li>
 <li>ClassPrefix of <code>pre_</code></li>
 <li>ClassSuffix of <code>_post</code></li>
+<li>ClassHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms class names as follows:</p>
@@ -11651,12 +12123,17 @@ public:
 <p>ClassConstantSuffix</p>
 <p>When defined, the check will ensure class constant names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>ClassConstantHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>ClassConstantCase of <code>lower_case</code></li>
 <li>ClassConstantPrefix of <code>pre_</code></li>
 <li>ClassConstantSuffix of <code>_post</code></li>
+<li>ClassConstantHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms class constant names as follows:</p>
@@ -11686,12 +12163,17 @@ public:
 <p>ClassMemberSuffix</p>
 <p>When defined, the check will ensure class member names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>ClassMemberHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>ClassMemberCase of <code>lower_case</code></li>
 <li>ClassMemberPrefix of <code>pre_</code></li>
 <li>ClassMemberSuffix of <code>_post</code></li>
+<li>ClassMemberHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms class member names as follows:</p>
@@ -11756,12 +12238,17 @@ public:
 <p>ConstantSuffix</p>
 <p>When defined, the check will ensure constant names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>ConstantHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>ConstantCase of <code>lower_case</code></li>
 <li>ConstantPrefix of <code>pre_</code></li>
 <li>ConstantSuffix of <code>_post</code></li>
+<li>ConstantHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms constant names as follows:</p>
@@ -11785,12 +12272,17 @@ public:
 <p>ConstantMemberSuffix</p>
 <p>When defined, the check will ensure constant member names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>ConstantMemberHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>ConstantMemberCase of <code>lower_case</code></li>
 <li>ConstantMemberPrefix of <code>pre_</code></li>
 <li>ConstantMemberSuffix of <code>_post</code></li>
+<li>ConstantMemberHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms constant member names as follows:</p>
@@ -11818,12 +12310,17 @@ public:
 <p>ConstantParameterSuffix</p>
 <p>When defined, the check will ensure constant parameter names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>ConstantParameterHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>ConstantParameterCase of <code>lower_case</code></li>
 <li>ConstantParameterPrefix of <code>pre_</code></li>
 <li>ConstantParameterSuffix of <code>_post</code></li>
+<li>ConstantParameterHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms constant parameter names as follows:</p>
@@ -11847,12 +12344,17 @@ public:
 <p>ConstantPointerParameterSuffix</p>
 <p>When defined, the check will ensure constant pointer parameter names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>ConstantPointerParameterHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>ConstantPointerParameterCase of <code>lower_case</code></li>
 <li>ConstantPointerParameterPrefix of <code>pre_</code></li>
 <li>ConstantPointerParameterSuffix of <code>_post</code></li>
+<li>ConstantPointerParameterHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms constant pointer parameter names as follows:</p>
@@ -11940,12 +12442,17 @@ public:
 <p>ConstexprVariableSuffix</p>
 <p>When defined, the check will ensure constexpr variable names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>ConstexprVariableHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>ConstexprVariableCase of <code>lower_case</code></li>
 <li>ConstexprVariablePrefix of <code>pre_</code></li>
 <li>ConstexprVariableSuffix of <code>_post</code></li>
+<li>ConstexprVariableHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms constexpr variable names as follows:</p>
@@ -11998,12 +12505,17 @@ public:
 <p>EnumConstantSuffix</p>
 <p>When defined, the check will ensure enumeration constant names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>EnumConstantHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>EnumConstantCase of <code>lower_case</code></li>
 <li>EnumConstantPrefix of <code>pre_</code></li>
 <li>EnumConstantSuffix of <code>_post</code></li>
+<li>EnumConstantHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms enumeration constant names as follows:</p>
@@ -12060,12 +12572,17 @@ public:
 <p>GlobalConstantSuffix</p>
 <p>When defined, the check will ensure global constant names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>GlobalConstantHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>GlobalConstantCase of <code>lower_case</code></li>
 <li>GlobalConstantPrefix of <code>pre_</code></li>
 <li>GlobalConstantSuffix of <code>_post</code></li>
+<li>GlobalConstantHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms global constant names as follows:</p>
@@ -12089,12 +12606,17 @@ public:
 <p>GlobalConstantPointerSuffix</p>
 <p>When defined, the check will ensure global constant pointer names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>GlobalConstantPointerHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>GlobalConstantPointerCase of <code>lower_case</code></li>
 <li>GlobalConstantPointerPrefix of <code>pre_</code></li>
 <li>GlobalConstantPointerSuffix of <code>_post</code></li>
+<li>GlobalConstantPointerHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms global constant pointer names as follows:</p>
@@ -12147,12 +12669,17 @@ public:
 <p>GlobalPointerSuffix</p>
 <p>When defined, the check will ensure global pointer names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>GlobalPointerHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>GlobalPointerCase of <code>lower_case</code></li>
 <li>GlobalPointerPrefix of <code>pre_</code></li>
 <li>GlobalPointerSuffix of <code>_post</code></li>
+<li>GlobalPointerHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms global pointer names as follows:</p>
@@ -12176,12 +12703,17 @@ public:
 <p>GlobalVariableSuffix</p>
 <p>When defined, the check will ensure global variable names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>GlobalVariableHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>GlobalVariableCase of <code>lower_case</code></li>
 <li>GlobalVariablePrefix of <code>pre_</code></li>
 <li>GlobalVariableSuffix of <code>_post</code></li>
+<li>GlobalVariableHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms global variable names as follows:</p>
@@ -12246,12 +12778,17 @@ inline namespace pre_inlinenamespace_post {
 <p>LocalConstantSuffix</p>
 <p>When defined, the check will ensure local constant names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>LocalConstantHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>LocalConstantCase of <code>lower_case</code></li>
 <li>LocalConstantPrefix of <code>pre_</code></li>
 <li>LocalConstantSuffix of <code>_post</code></li>
+<li>LocalConstantHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms local constant names as follows:</p>
@@ -12275,12 +12812,17 @@ inline namespace pre_inlinenamespace_post {
 <p>LocalConstantPointerSuffix</p>
 <p>When defined, the check will ensure local constant pointer names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>LocalConstantPointerHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>LocalConstantPointerCase of <code>lower_case</code></li>
 <li>LocalConstantPointerPrefix of <code>pre_</code></li>
 <li>LocalConstantPointerSuffix of <code>_post</code></li>
+<li>LocalConstantPointerHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms local constant pointer names as follows:</p>
@@ -12304,12 +12846,17 @@ inline namespace pre_inlinenamespace_post {
 <p>LocalPointerSuffix</p>
 <p>When defined, the check will ensure local pointer names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>LocalPointerHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>LocalPointerCase of <code>lower_case</code></li>
 <li>LocalPointerPrefix of <code>pre_</code></li>
 <li>LocalPointerSuffix of <code>_post</code></li>
+<li>LocalPointerHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms local pointer names as follows:</p>
@@ -12341,12 +12888,17 @@ inline namespace pre_inlinenamespace_post {
 <p>LocalVariableSuffix</p>
 <p>When defined, the check will ensure local variable names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>LocalVariableHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>LocalVariableCase of <code>lower_case</code></li>
 <li>LocalVariablePrefix of <code>pre_</code></li>
 <li>LocalVariableSuffix of <code>_post</code></li>
+<li>LocalVariableHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms local variable names as follows:</p>
@@ -12400,12 +12952,17 @@ inline namespace pre_inlinenamespace_post {
 <p>MemberSuffix</p>
 <p>When defined, the check will ensure member names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>MemberHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>MemberCase of <code>lower_case</code></li>
 <li>MemberPrefix of <code>pre_</code></li>
 <li>MemberSuffix of <code>_post</code></li>
+<li>MemberHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms member names as follows:</p>
@@ -12499,12 +13056,17 @@ inline namespace pre_inlinenamespace_post {
 <p>ParameterSuffix</p>
 <p>When defined, the check will ensure parameter names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>ParameterHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>ParameterCase of <code>lower_case</code></li>
 <li>ParameterPrefix of <code>pre_</code></li>
 <li>ParameterSuffix of <code>_post</code></li>
+<li>ParameterHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms parameter names as follows:</p>
@@ -12561,12 +13123,17 @@ inline namespace pre_inlinenamespace_post {
 <p>PointerParameterSuffix</p>
 <p>When defined, the check will ensure pointer parameter names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>PointerParameterHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>PointerParameterCase of <code>lower_case</code></li>
 <li>PointerParameterPrefix of <code>pre_</code></li>
 <li>PointerParameterSuffix of <code>_post</code></li>
+<li>PointerParameterHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms pointer parameter names as follows:</p>
@@ -12590,12 +13157,17 @@ inline namespace pre_inlinenamespace_post {
 <p>PrivateMemberSuffix</p>
 <p>When defined, the check will ensure private member names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>PrivateMemberHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>PrivateMemberCase of <code>lower_case</code></li>
 <li>PrivateMemberPrefix of <code>pre_</code></li>
 <li>PrivateMemberSuffix of <code>_post</code></li>
+<li>PrivateMemberHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms private member names as follows:</p>
@@ -12660,12 +13232,17 @@ private:
 <p>ProtectedMemberSuffix</p>
 <p>When defined, the check will ensure protected member names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>ProtectedMemberHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>ProtectedMemberCase of <code>lower_case</code></li>
 <li>ProtectedMemberPrefix of <code>pre_</code></li>
 <li>ProtectedMemberSuffix of <code>_post</code></li>
+<li>ProtectedMemberHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms protected member names as follows:</p>
@@ -12730,12 +13307,17 @@ protected:
 <p>PublicMemberSuffix</p>
 <p>When defined, the check will ensure public member names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>PublicMemberHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>PublicMemberCase of <code>lower_case</code></li>
 <li>PublicMemberPrefix of <code>pre_</code></li>
 <li>PublicMemberSuffix of <code>_post</code></li>
+<li>PublicMemberHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms public member names as follows:</p>
@@ -12800,12 +13382,17 @@ public:
 <p>ScopedEnumConstantSuffix</p>
 <p>When defined, the check will ensure scoped enum constant names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>ScopedEnumConstantHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>ScopedEnumConstantCase of <code>lower_case</code></li>
 <li>ScopedEnumConstantPrefix of <code>pre_</code></li>
 <li>ScopedEnumConstantSuffix of <code>_post</code></li>
+<li>ScopedEnumConstantHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms enumeration constant names as follows:</p>
@@ -12829,12 +13416,17 @@ public:
 <p>StaticConstantSuffix</p>
 <p>When defined, the check will ensure static constant names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>StaticConstantHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>StaticConstantCase of <code>lower_case</code></li>
 <li>StaticConstantPrefix of <code>pre_</code></li>
 <li>StaticConstantSuffix of <code>_post</code></li>
+<li>StaticConstantHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms static constant names as follows:</p>
@@ -12858,12 +13450,17 @@ public:
 <p>StaticVariableSuffix</p>
 <p>When defined, the check will ensure static variable names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>StaticVariableHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>StaticVariableCase of <code>lower_case</code></li>
 <li>StaticVariablePrefix of <code>pre_</code></li>
 <li>StaticVariableSuffix of <code>_post</code></li>
+<li>StaticVariableHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms static variable names as follows:</p>
@@ -13137,12 +13734,17 @@ public:
 <p>VariableSuffix</p>
 <p>When defined, the check will ensure variable names will add the suffix with the given value (regardless of casing).</p>
 </div>
+<div class="option">
+<p>VariableHungarianPrefix</p>
+<p>When enabled, the check ensures that the declared identifier will have a Hungarian notation prefix based on the declared type.</p>
+</div>
 <p>For example using values of:</p>
 <blockquote>
 <ul>
 <li>VariableCase of <code>lower_case</code></li>
 <li>VariablePrefix of <code>pre_</code></li>
 <li>VariableSuffix of <code>_post</code></li>
+<li>VariableHungarianPrefix of <code>On</code></li>
 </ul>
 </blockquote>
 <p>Identifies and/or transforms variable names as follows:</p>
@@ -13185,6 +13787,272 @@ public:
 public:
   virtual int pre_member_function_post();
 }</code></pre>
+<h2 id="the-default-mapping-table-of-hungarian-notation">The default mapping table of Hungarian Notation</h2>
+<p>In Hungarian notation, a variable name starts with a group of lower-case letters which are mnemonics for the type or purpose of that variable, followed by whatever name the programmer has chosen; this last part is sometimes distinguished as the given name. The first character of the given name can be capitalized to separate it from the type indicators (see also CamelCase). Otherwise the case of this character denotes scope.</p>
+<p>The following table is the default mapping table of Hungarian Notation which maps Decl to its prefix string. You can also have your own style in config file.</p>
+<table>
+<thead>
+<tr class="header">
+<th>Primitive Types</th>
+<th>Microsoft data types</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><blockquote>
+<p>Type Prefix Type Prefix</p>
+</blockquote></td>
+<td>Type Prefix</td>
+</tr>
+<tr class="even">
+<td>================= ============== ====================== ==============</td>
+<td>=========== ==============</td>
+</tr>
+<tr class="odd">
+<td>int8_t i8 signed int si</td>
+<td>BOOL b</td>
+</tr>
+<tr class="even">
+<td>int16_t i16 signed short ss</td>
+<td>BOOLEAN b</td>
+</tr>
+<tr class="odd">
+<td>int32_t i32 signed short int ssi</td>
+<td>BYTE by</td>
+</tr>
+<tr class="even">
+<td>int64_t i64 signed long long int slli</td>
+<td>CHAR c</td>
+</tr>
+<tr class="odd">
+<td>uint8_t u8 signed long long sll</td>
+<td>UCHAR uc</td>
+</tr>
+<tr class="even">
+<td>uint16_t u16 signed long int sli</td>
+<td>SHORT s</td>
+</tr>
+<tr class="odd">
+<td>uint32_t u32 signed long sl</td>
+<td>USHORT us</td>
+</tr>
+<tr class="even">
+<td>uint64_t u64 signed s</td>
+<td>WORD w</td>
+</tr>
+<tr class="odd">
+<td>char8_t c8 unsigned long long int ulli</td>
+<td>DWORD dw</td>
+</tr>
+<tr class="even">
+<td>char16_t c16 unsigned long long ull</td>
+<td>DWORD32 dw32</td>
+</tr>
+<tr class="odd">
+<td>char32_t c32 unsigned long int uli</td>
+<td>DWORD64 dw64</td>
+</tr>
+<tr class="even">
+<td>float f unsigned long ul</td>
+<td>LONG l</td>
+</tr>
+<tr class="odd">
+<td>double d unsigned short int usi</td>
+<td>ULONG ul</td>
+</tr>
+<tr class="even">
+<td>char c unsigned short us</td>
+<td>ULONG32 ul32</td>
+</tr>
+<tr class="odd">
+<td>bool b unsigned int ui</td>
+<td>ULONG64 ul64</td>
+</tr>
+<tr class="even">
+<td>_Bool b unsigned u</td>
+<td>ULONGLONG ull</td>
+</tr>
+<tr class="odd">
+<td>int i long long int lli</td>
+<td>HANDLE h</td>
+</tr>
+<tr class="even">
+<td>size_t n long double ld</td>
+<td>INT i</td>
+</tr>
+<tr class="odd">
+<td>short s long long ll</td>
+<td>INT8 i8</td>
+</tr>
+<tr class="even">
+<td>signed i long int li</td>
+<td>INT16 i16</td>
+</tr>
+<tr class="odd">
+<td>unsigned u long l</td>
+<td>INT32 i32</td>
+</tr>
+<tr class="even">
+<td>long l ptrdiff_t p</td>
+<td>INT64 i64</td>
+</tr>
+<tr class="odd">
+<td>long long ll</td>
+<td>UINT ui</td>
+</tr>
+<tr class="even">
+<td>unsigned long ul</td>
+<td>UINT8 u8</td>
+</tr>
+<tr class="odd">
+<td>long double ld</td>
+<td>UINT16 u16</td>
+</tr>
+<tr class="even">
+<td>ptrdiff_t p</td>
+<td>UINT32 u32</td>
+</tr>
+<tr class="odd">
+<td>wchar_t wc</td>
+<td>UINT64 u64</td>
+</tr>
+<tr class="even">
+<td><p>short int si short s</p></td>
+<td><p>PVOID p</p></td>
+</tr>
+</tbody>
+</table>
+<p><strong>There are more trivial options for Hungarian Notation:</strong></p>
+<dl>
+<dt><strong>HungarianNotation.General.</strong>*</dt>
+<dd><p>Options are not belonging to any specific Decl.</p>
+</dd>
+<dt><strong>HungarianNotation.CString.</strong>*</dt>
+<dd><p>Options for NULL-terminated string.</p>
+</dd>
+<dt><strong>HungarianNotation.DerivedType.</strong>*</dt>
+<dd><p>Options for derived types.</p>
+</dd>
+<dt><strong>HungarianNotation.PrimitiveType.</strong>*</dt>
+<dd><p>Options for primitive types.</p>
+</dd>
+<dt><strong>HungarianNotation.UserDefinedType.</strong>*</dt>
+<dd><p>Options for user-defined types.</p>
+</dd>
+</dl>
+<h2 id="options-for-hungarian-notation">Options for Hungarian Notation</h2>
+<ul>
+<li><code class="interpreted-text" role="option">HungarianNotation.General.TreatStructAsClass</code></li>
+<li><code class="interpreted-text" role="option">HungarianNotation.DerivedType.Array</code></li>
+<li><code class="interpreted-text" role="option">HungarianNotation.DerivedType.Pointer</code></li>
+<li><code class="interpreted-text" role="option">HungarianNotation.DerivedType.FunctionPointer</code></li>
+<li><code class="interpreted-text" role="option">HungarianNotation.CString.CharPrinter</code></li>
+<li><code class="interpreted-text" role="option">HungarianNotation.CString.CharArray</code></li>
+<li><code class="interpreted-text" role="option">HungarianNotation.CString.WideCharPrinter</code></li>
+<li><code class="interpreted-text" role="option">HungarianNotation.CString.WideCharArray</code></li>
+<li><code class="interpreted-text" role="option">HungarianNotation.PrimitiveType.*</code></li>
+<li><code class="interpreted-text" role="option">HungarianNotation.UserDefinedType.*</code></li>
+</ul>
+<div class="option">
+<p>HungarianNotation.General.TreatStructAsClass</p>
+<p>When defined, the check will treat naming of struct as a class. The default value is <span class="title-ref">false</span>.</p>
+</div>
+<div class="option">
+<p>HungarianNotation.DerivedType.Array</p>
+<p>When defined, the check will ensure variable name will add the prefix with the given string. The default prefix is <span class="title-ref">a</span>.</p>
+</div>
+<div class="option">
+<p>HungarianNotation.DerivedType.Pointer</p>
+<p>When defined, the check will ensure variable name will add the prefix with the given string. The default prefix is <span class="title-ref">p</span>.</p>
+</div>
+<div class="option">
+<p>HungarianNotation.DerivedType.FunctionPointer</p>
+<p>When defined, the check will ensure variable name will add the prefix with the given string. The default prefix is <span class="title-ref">fn</span>.</p>
+</div>
+<p>Before:</p>
+<pre class="c++"><code>// Array
+int DataArray[2] = {0};
+// Pointer
+void *DataBuffer = NULL;
+// FunctionPointer
+typedef void (*FUNC_PTR)();
+FUNC_PTR FuncPtr = NULL;</code></pre>
+<p>After:</p>
+<pre class="c++"><code>// Array
+int aDataArray[2] = {0};
+// Pointer
+void *pDataBuffer = NULL;
+// FunctionPointer
+typedef void (*FUNC_PTR)();
+FUNC_PTR fnFuncPtr = NULL;</code></pre>
+<div class="option">
+<p>HungarianNotation.CString.CharPrinter</p>
+<p>When defined, the check will ensure variable name will add the prefix with the given string. The default prefix is <span class="title-ref">sz</span>.</p>
+</div>
+<div class="option">
+<p>HungarianNotation.CString.CharArray</p>
+<p>When defined, the check will ensure variable name will add the prefix with the given string. The default prefix is <span class="title-ref">sz</span>.</p>
+</div>
+<div class="option">
+<p>HungarianNotation.CString.WideCharPrinter</p>
+<p>When defined, the check will ensure variable name will add the prefix with the given string. The default prefix is <span class="title-ref">wsz</span>.</p>
+</div>
+<div class="option">
+<p>HungarianNotation.CString.WideCharArray</p>
+<p>When defined, the check will ensure variable name will add the prefix with the given string. The default prefix is <span class="title-ref">wsz</span>.</p>
+</div>
+<p>Before:</p>
+<pre class="c++"><code>// CharPrinter
+const char *NamePtr = &quot;Name&quot;;
+// CharArray
+const char NameArray[] = &quot;Name&quot;;
+// WideCharPrinter
+const wchar_t *WideNamePtr = L&quot;Name&quot;;
+// WideCharArray
+const wchar_t WideNameArray[] = L&quot;Name&quot;;</code></pre>
+<p>After:</p>
+<pre class="c++"><code>// CharPrinter
+const char *szNamePtr = &quot;Name&quot;;
+// CharArray
+const char szNameArray[] = &quot;Name&quot;;
+// WideCharPrinter
+const wchar_t *wszWideNamePtr = L&quot;Name&quot;;
+// WideCharArray
+const wchar_t wszWideNameArray[] = L&quot;Name&quot;;</code></pre>
+<div class="option">
+<p>HungarianNotation.PrimitiveType.*</p>
+<p>When defined, the check will ensure variable name of involved primitive types will add the prefix with the given string. The default prefixes are defined in the default mapping table.</p>
+</div>
+<div class="option">
+<p>HungarianNotation.UserDefinedType.*</p>
+<p>When defined, the check will ensure variable name of involved primitive types will add the prefix with the given string. The default prefixes are defined in the default mapping table.</p>
+</div>
+<p>Before:</p>
+<pre class="c++"><code>int8_t   ValueI8      = 0;
+int16_t  ValueI16     = 0;
+int32_t  ValueI32     = 0;
+int64_t  ValueI64     = 0;
+uint8_t  ValueU8      = 0;
+uint16_t ValueU16     = 0;
+uint32_t ValueU32     = 0;
+uint64_t ValueU64     = 0;
+float    ValueFloat   = 0.0;
+double   ValueDouble  = 0.0;
+ULONG    ValueUlong   = 0;
+DWORD    ValueDword   = 0;</code></pre>
+<p>After:</p>
+<pre class="c++"><code>int8_t   i8ValueI8    = 0;
+int16_t  i16ValueI16  = 0;
+int32_t  i32ValueI32  = 0;
+int64_t  i64ValueI64  = 0;
+uint8_t  u8ValueU8    = 0;
+uint16_t u16ValueU16  = 0;
+uint32_t u32ValueU32  = 0;
+uint64_t u64ValueU64  = 0;
+float    fValueFloat  = 0.0;
+double   dValueDouble = 0.0;
+ULONG    ulValueUlong = 0;
+DWORD    dwValueDword = 0;</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-identifier-naming.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -13452,7 +14320,7 @@ void macros() {
 <p>Many coding guidelines advise replacing the magic values with symbolic constants to improve readability. Here are a few references:</p>
 <blockquote>
 <ul>
-<li><a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-magic">Rule ES.45: Avoid 'magic constants'; use symbolic constants in C++ Core Guidelines</a></li>
+<li><a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-magic">Rule ES.45: Avoid "magic constants"; use symbolic constants in C++ Core Guidelines</a></li>
 <li><a href="http://www.codingstandard.com/rule/5-1-1-use-symbolic-names-instead-of-literal-values-in-code/">Rule 5.1.1 Use symbolic names instead of literal values in code in High Integrity C++</a></li>
 <li>Item 17 in "C++ Coding Standards: 101 Rules, Guidelines and Best Practices" by Herb Sutter and Andrei Alexandrescu</li>
 <li>Chapter 17 in "Clean Code - A handbook of agile software craftsmanship." by Robert C. Martin</li>
@@ -13849,7 +14717,7 @@ void f() {
 extern int X;</code></pre>
 <p>becomes</p>
 <pre class="c++"><code>extern int X;</code></pre>
-<p>Such redundant declarations can be removed without changing program behaviour. They can for instance be unintentional left overs from previous refactorings when code has been moved around. Having redundant declarations could in worst case mean that there are typos in the code that cause bugs.</p>
+<p>Such redundant declarations can be removed without changing program behavior. They can for instance be unintentional left overs from previous refactorings when code has been moved around. Having redundant declarations could in worst case mean that there are typos in the code that cause bugs.</p>
 <p>Normally the code can be automatically fixed, <code class="interpreted-text" role="program">clang-tidy</code> can remove the second declaration. However there are 2 cases when you need to fix the code manually:</p>
 <ul>
 <li>When the declarations are in different header files;</li>
@@ -13913,7 +14781,7 @@ private:
 <div class="option">
 <p>IgnoreBaseInCopyConstructors</p>
 <p>Default is <span class="title-ref">false</span>.</p>
-<p>When <span class="title-ref">true</span>, the check will ignore unnecessary base class initializations within copy constructors, since some compilers issue warnings/errors when base classes are not explicitly intialized in copy constructors. For example, <code>gcc</code> with <code>-Wextra</code> or <code>-Werror=extra</code> issues warning or error <code>base class 'Bar' should be explicitly initialized in the copy constructor</code> if <code>Bar()</code> were removed in the following example:</p>
+<p>When <span class="title-ref">true</span>, the check will ignore unnecessary base class initializations within copy constructors, since some compilers issue warnings/errors when base classes are not explicitly initialized in copy constructors. For example, <code>gcc</code> with <code>-Wextra</code> or <code>-Werror=extra</code> issues warning or error <code>base class 'Bar' should be explicitly initialized in the copy constructor</code> if <code>Bar()</code> were removed in the following example:</p>
 </div>
 <pre class="c++"><code>// Explicitly initializing member s and base class Bar is unnecessary.
 struct Foo : public Bar {
@@ -14335,9 +15203,128 @@ if (0 != str1.compare(str2)) {
 // Use str1 == &quot;foo&quot; instead.
 if (str1.compare(&quot;foo&quot;) == 0) {
 }</code></pre>
-<p>The above code examples shows the list of if-statements that this check will give a warning for. All of them uses <code>compare</code> to check if equality or inequality of two strings instead of using the correct operators.</p>
+<p>The above code examples show the list of if-statements that this check will give a warning for. All of them uses <code>compare</code> to check if equality or inequality of two strings instead of using the correct operators.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-string-compare.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>readability-suspicious-call-argument</key>
+    <name>readability-suspicious-call-argument</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - readability-suspicious-call-argument</p>
+</div>
+<h1 id="readability-suspicious-call-argument">readability-suspicious-call-argument</h1>
+<p>Finds function calls where the arguments passed are provided out of order, based on the difference between the argument name and the parameter names of the function.</p>
+<p>Given a function call <code>f(foo, bar);</code> and a function signature <code>void f(T tvar, U uvar)</code>, the arguments <code>foo</code> and <code>bar</code> are swapped if <code>foo</code> (the argument name) is more similar to <code>uvar</code> (the other parameter) than <code>tvar</code> (the parameter it is currently passed to) <strong>and</strong> <code>bar</code> is more similar to <code>tvar</code> than <code>uvar</code>.</p>
+<p>Warnings might indicate either that the arguments are swapped, or that the names' cross-similarity might hinder code comprehension.</p>
+<h2 id="heuristics">Heuristics</h2>
+<p>The following heuristics are implemented in the check. If <strong>any</strong> of the enabled heuristics deem the arguments to be provided out of order, a warning will be issued.</p>
+<p>The heuristics themselves are implemented by considering pairs of strings, and are symmetric, so in the following there is no distinction on which string is the argument name and which string is the parameter name.</p>
+<h3 id="equality">Equality</h3>
+<p>The most trivial heuristic, which compares the two strings for case-insensitive equality.</p>
+<h3 id="abbreviation_heuristic">Abbreviation</h3>
+<p>Common abbreviations can be specified which will deem the strings similar if the abbreviated and the abbreviation stand together. For example, if <code>src</code> is registered as an abbreviation for <code>source</code>, then the following code example will be warned about.</p>
+<pre class="c++"><code>void foo(int source, int x);
+foo(b, src);</code></pre>
+<p>The abbreviations to recognise can be configured with the <code class="interpreted-text" role="ref">Abbreviations&lt;opt_Abbreviations&gt;</code> check option. This heuristic is case-insensitive.</p>
+<h3 id="prefix">Prefix</h3>
+<p>The <em>prefix</em> heuristic reports if one of the strings is a sufficiently long prefix of the other string, e.g. <code>target</code> to <code>targetPtr</code>. The similarity percentage is the length ratio of the prefix to the longer string, in the previous example, it would be <span class="title-ref">6 / 9 = 66.66...</span>%.</p>
+<p>This heuristic can be configured with <code class="interpreted-text" role="ref">bounds&lt;opt_Bounds&gt;</code>. The default bounds are: below <span class="title-ref">25</span>% dissimilar and above <span class="title-ref">30</span>% similar. This heuristic is case-insensitive.</p>
+<h3 id="suffix">Suffix</h3>
+<p>Analogous to the <span class="title-ref">Prefix</span> heuristic. In the case of <code>oldValue</code> and <code>value</code> compared, the similarity percentage is <span class="title-ref">8 / 5 = 62.5</span>%.</p>
+<p>This heuristic can be configured with <code class="interpreted-text" role="ref">bounds&lt;opt_Bounds&gt;</code>. The default bounds are: below <span class="title-ref">25</span>% dissimilar and above <span class="title-ref">30</span>% similar. This heuristic is case-insensitive.</p>
+<h3 id="substring">Substring</h3>
+<p>The substring heuristic combines the prefix and the suffix heuristic, and tries to find the <em>longest common substring</em> in the two strings provided. The similarity percentage is the ratio of the found longest common substring against the <em>longer</em> of the two input strings. For example, given <code>val</code> and <code>rvalue</code>, the similarity is <span class="title-ref">3 / 6 = 50</span>%. If no characters are common in the two string, <span class="title-ref">0</span>%.</p>
+<p>This heuristic can be configured with <code class="interpreted-text" role="ref">bounds&lt;opt_Bounds&gt;</code>. The default bounds are: below <span class="title-ref">40</span>% dissimilar and above <span class="title-ref">50</span>% similar. This heuristic is case-insensitive.</p>
+<h3 id="levenshtein-distance-as-levenshtein">Levenshtein distance (as <span class="title-ref">Levenshtein</span>)</h3>
+<p>The <a href="http://en.wikipedia.org/wiki/Levenshtein_distance">Levenshtein distance</a> describes how many single-character changes (additions, changes, or removals) must be applied to transform one string into another.</p>
+<p>The Levenshtein distance is translated into a similarity percentage by dividing it with the length of the <em>longer</em> string, and taking its complement with regards to <span class="title-ref">100</span>%. For example, given <code>something</code> and <code>anything</code>, the distance is <span class="title-ref">4</span> edits, and the similarity percentage is <span class="title-ref">100</span>% <span class="title-ref">- 4 / 9 = 55.55...</span>%.</p>
+<p>This heuristic can be configured with <code class="interpreted-text" role="ref">bounds&lt;opt_Bounds&gt;</code>. The default bounds are: below <span class="title-ref">50</span>% dissimilar and above <span class="title-ref">66</span>% similar. This heuristic is case-sensitive.</p>
+<h3 id="jaro-winkler-distance-as-jarowinkler">Jaro-Winkler distance (as <span class="title-ref">JaroWinkler</span>)</h3>
+<p>The Jaro-Winkler distance is an edit distance like the Levenshtein distance. It is calculated from the amount of common characters that are sufficiently close to each other in position, and to-be-changed characters. The original definition of Jaro has been extended by Winkler to weigh prefix similarities more. The similarity percentage is expressed as an average of the common and non-common characters against the length of both strings.</p>
+<p>This heuristic can be configured with <code class="interpreted-text" role="ref">bounds&lt;opt_Bounds&gt;</code>. The default bounds are: below <span class="title-ref">75</span>% dissimilar and above <span class="title-ref">85</span>% similar. This heuristic is case-insensitive.</p>
+<h3 id="sorensen-dice-coefficient-as-dice">Sorensen-Dice coefficient (as <span class="title-ref">Dice</span>)</h3>
+<p>The Sorensen-Dice coefficient was originally defined to measure the similarity of two sets. Formally, the coefficient is calculated by dividing <span class="title-ref">2 * #(intersection)</span> with <span class="title-ref">#(set1) + #(set2)</span>, where <span class="title-ref">#()</span> is the cardinality function of sets. This metric is applied to strings by creating bigrams (substring sequences of length 2) of the two strings and using the set of bigrams for the two strings as the two sets.</p>
+<p>This heuristic can be configured with <code class="interpreted-text" role="ref">bounds&lt;opt_Bounds&gt;</code>. The default bounds are: below <span class="title-ref">60</span>% dissimilar and above <span class="title-ref">70</span>% similar. This heuristic is case-insensitive.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>MinimumIdentifierNameLength</p>
+<p>Sets the minimum required length the argument and parameter names need to have. Names shorter than this length will be ignored. Defaults to <span class="title-ref">3</span>.</p>
+</div>
+<div id="opt_Abbreviations">
+<div class="option">
+<p>Abbreviations</p>
+<p>For the <strong>Abbreviation</strong> heuristic (<code class="interpreted-text" role="ref">see here&lt;abbreviation_heuristic&gt;</code>), this option configures the abbreviations in the <span class="title-ref">"abbreviation=abbreviated_value"</span> format. The option is a string, with each value joined by <span class="title-ref">";"</span>.</p>
+<p>By default, the following abbreviations are set:</p>
+<blockquote>
+<ul>
+<li><span class="title-ref">addr=address</span></li>
+<li><span class="title-ref">arr=array</span></li>
+<li><span class="title-ref">attr=attribute</span></li>
+<li><span class="title-ref">buf=buffer</span></li>
+<li><span class="title-ref">cl=client</span></li>
+<li><span class="title-ref">cnt=count</span></li>
+<li><span class="title-ref">col=column</span></li>
+<li><span class="title-ref">cpy=copy</span></li>
+<li><span class="title-ref">dest=destination</span></li>
+<li><span class="title-ref">dist=distance</span></li>
+<li><span class="title-ref">dst=distance</span></li>
+<li><span class="title-ref">elem=element</span></li>
+<li><span class="title-ref">hght=height</span></li>
+<li><span class="title-ref">i=index</span></li>
+<li><span class="title-ref">idx=index</span></li>
+<li><span class="title-ref">len=length</span></li>
+<li><span class="title-ref">ln=line</span></li>
+<li><span class="title-ref">lst=list</span></li>
+<li><span class="title-ref">nr=number</span></li>
+<li><span class="title-ref">num=number</span></li>
+<li><span class="title-ref">pos=position</span></li>
+<li><span class="title-ref">ptr=pointer</span></li>
+<li><span class="title-ref">ref=reference</span></li>
+<li><span class="title-ref">src=source</span></li>
+<li><span class="title-ref">srv=server</span></li>
+<li><span class="title-ref">stmt=statement</span></li>
+<li><span class="title-ref">str=string</span></li>
+<li><span class="title-ref">val=value</span></li>
+<li><span class="title-ref">var=variable</span></li>
+<li><span class="title-ref">vec=vector</span></li>
+<li><span class="title-ref">wdth=width</span></li>
+</ul>
+</blockquote>
+</div>
+</div>
+<p>The configuration options for each implemented heuristic (see above) is constructed dynamically. In the following, <span class="title-ref">&lt;HeuristicName&gt;</span> refers to one of the keys from the heuristics implemented.</p>
+<div class="option">
+<p>&lt;HeuristicName&gt;</p>
+<p><span class="title-ref">True</span> or <span class="title-ref">False</span>, whether a particular heuristic, such as <span class="title-ref">Equality</span> or <span class="title-ref">Levenshtein</span> is enabled.</p>
+<p>Defaults to <span class="title-ref">True</span> for every heuristic.</p>
+</div>
+<div id="opt_Bounds">
+<div class="option">
+<p>&lt;HeuristicName&gt;DissimilarBelow, &lt;HeuristicName&gt;SimilarAbove</p>
+<p>A value between <span class="title-ref">0</span> and <span class="title-ref">100</span>, expressing a percentage. The bounds set what percentage of similarity the heuristic must deduce for the two identifiers to be considered similar or dissimilar by the check.</p>
+<p>Given arguments <code>arg1</code> and <code>arg2</code> passed to <code>param1</code> and <code>param2</code>, respectively, the bounds check is performed in the following way: If the similarity of the currently passed argument order (<code>arg1</code> to <code>param1</code>) is <strong>below</strong> the <span class="title-ref">DissimilarBelow</span> threshold, and the similarity of the suggested swapped order (<code>arg1</code> to <code>param2</code>) is <strong>above</strong> the <span class="title-ref">SimilarAbove</span> threshold, the swap is reported.</p>
+<p>For the defaults of each heuristic, <code class="interpreted-text" role="ref">see above&lt;heuristics&gt;</code>.</p>
+</div>
+</div>
+<h2 id="name-synthesis">Name synthesis</h2>
+<p>When comparing the argument names and parameter names, the following logic is used to gather the names for comparison:</p>
+<p>Parameter names are the identifiers as written in the source code.</p>
+<p>Argument names are:</p>
+<blockquote>
+<ul>
+<li>If a variable is passed, the variable's name.</li>
+<li>If a subsequent function call's return value is used as argument, the called function's name.</li>
+<li>Otherwise, empty string.</li>
+</ul>
+</blockquote>
+<p>Empty argument or parameter names are ignored by the heuristics.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-suspicious-call-argument.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -14493,7 +15480,22 @@ Derived();             // and so temporary construction is okay</code></pre>
   
   <!-- Clang Diagnostic Rules -->  
 
-<rule>
+   <rule>
+    <key>clang-diagnostic-aix-compat</key>
+    <name>clang-diagnostic-aix-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma align(packed) may not be compatible with objects generated with AIX XL C/C++</li>
+<li>warning: requesting an alignment of 16 bytes or greater for struct members is not binary compatible with AIX XL 16.1 and older</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waix-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-arc-non-pod-memaccess</key>
     <name>clang-diagnostic-arc-non-pod-memaccess</name>
     <description>
@@ -14710,6 +15712,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: assigning %select{field|instance variable}0 to itself</li>
 <li>warning: base class %0 is uninitialized when used here to access %q1</li>
 <li>warning: bitwise comparison always evaluates to %select{false|true}0</li>
+<li>warning: bitwise negation of a boolean expression%select{;| always evaluates to 'true';}0 did you mean logical negation?</li>
 <li>warning: bitwise or with non-zero value always evaluates to true</li>
 <li>warning: block pointer variable %0 is %select{uninitialized|null}1 when captured by block</li>
 <li>warning: calling '%0' with a nonzero argument is unsafe</li>
@@ -14766,12 +15769,13 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: implicit declaration of function %0 is invalid in C99</li>
 <li>warning: implicitly declaring library function '%0' with type %1</li>
 <li>warning: incomplete format specifier</li>
+<li>warning: initializer order does not match the declaration order</li>
 <li>warning: invalid conversion specifier '%0'</li>
 <li>warning: invalid position specified for %select{field width|field precision}0</li>
 <li>warning: ivar %0 which backs the property is not referenced in this property's accessor</li>
 <li>warning: lambda capture %0 is not %select{used|required to be captured for this use}1</li>
+<li>warning: left operand of comma operator has no effect</li>
 <li>warning: length modifier '%0' results in undefined behavior or no effect with '%1' conversion specifier</li>
-<li>warning: local variable %0 will be copied despite being %select{returned|thrown}1 by name</li>
 <li>warning: logical not is only applied to the left hand side of this %select{comparison|bitwise operator}0</li>
 <li>warning: loop variable %0 %diff{of type $ binds to a temporary constructed from type $|binds to a temporary constructed from a different type}1,2</li>
 <li>warning: loop variable %0 creates a copy from type %1</li>
@@ -14835,6 +15839,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: unused variable %0</li>
 <li>warning: unused variable %0</li>
 <li>warning: use of __private_extern__ on a declaration may not produce external symbol private to the linkage unit and is deprecated</li>
+<li>warning: use of bitwise '%0' with boolean operands</li>
 <li>warning: use of unknown builtin %0</li>
 <li>warning: using '%%P' format specifier without precision</li>
 <li>warning: using '%0' format specifier annotation outside of os_log()/os_trace()</li>
@@ -14845,6 +15850,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: variable %0 is uninitialized when %select{used here|captured by block}1</li>
 <li>warning: variable %0 is uninitialized when passed as a const reference argument here</li>
 <li>warning: variable %0 is uninitialized when used within its own initialization</li>
+<li>warning: variable %0 set but not used</li>
 <li>warning: variable%select{s| %1|s %1 and %2|s %1, %2, and %3|s %1, %2, %3, and %4}0 used in loop condition not modified in loop body</li>
 <li>warning: zero field width in scanf format string is unused</li>
 </ul>
@@ -14908,6 +15914,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: array argument is too small; %select{contains %0 elements|is of size %0}2, callee requires at least %1</li>
 <li>warning: array index %0 is before the beginning of the array</li>
 <li>warning: array index %0 is past the end of the array (which contains %1 element%s2)</li>
+<li>warning: array index %0 refers past the last possible element for an array in %1-bit address space containing %2-bit (%3-byte) elements (max possible %4 element%s5)</li>
+<li>warning: the pointer incremented by %0 refers past the last possible element for an array in %1-bit address space containing %2-bit (%3-byte) elements (max possible %4 element%s5)</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warray-bounds" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -14974,7 +15982,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %0 attribute ignored on a non-definition declaration</li>
 <li>warning: %0 attribute ignored on inline function</li>
 <li>warning: %0 attribute ignored when parsing type</li>
-<li>warning: %0 attribute is deprecated and ignored in OpenCL version %1</li>
+<li>warning: %0 attribute is deprecated and ignored in %1</li>
 <li>warning: %0 attribute is ignored because there exists no call expression inside the statement</li>
 <li>warning: %0 attribute isn't implemented by this Objective-C runtime</li>
 <li>warning: %0 attribute only applies to %1</li>
@@ -14986,6 +15994,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %0 attribute only applies to return values that are pointers or references</li>
 <li>warning: %0 attribute only applies to%select{| constant}1 pointer arguments</li>
 <li>warning: %0 calling convention is not supported %select{for this target|on variadic function|on constructor/destructor|on builtin function}1</li>
+<li>warning: %0 currently has no effect on a using declaration</li>
 <li>warning: %q0 redeclared inline; %1 attribute ignored</li>
 <li>warning: %select{MIPS|MSP430|RISC-V}0 'interrupt' attribute only applies to functions that have %select{no parameters|a 'void' return type}1</li>
 <li>warning: %select{alias|ifunc}1 will not be in section '%0' but in the same section as the %select{aliasee|resolver}2</li>
@@ -15019,7 +16028,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: __weak attribute cannot be specified on an automatic variable when ARC is not enabled</li>
 <li>warning: attribute %0 after definition is ignored</li>
 <li>warning: attribute %0 cannot be applied to %select{functions|Objective-C method}1 without return value</li>
-<li>warning: attribute %0 has no effect when annotating an 'if constexpr' statement</li>
+<li>warning: attribute %0 has no effect when annotating an 'if %select{constexpr|consteval}1' statement</li>
 <li>warning: attribute %0 has no effect when annotating an infinite loop</li>
 <li>warning: attribute %0 ignored, because it cannot be applied to a type</li>
 <li>warning: attribute %0 ignored, because it cannot be applied to omitted return type</li>
@@ -15039,6 +16048,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: inheritance model ignored on %select{primary template|partial specialization}0</li>
 <li>warning: qualifiers after comma in declarator list are ignored</li>
 <li>warning: repeated RISC-V 'interrupt' attribute</li>
+<li>warning: requested alignment is less than minimum alignment of %1 for type %0</li>
 <li>warning: template parameter of a function template with the 'sycl_kernel' attribute cannot be a non-type template parameter</li>
 <li>warning: transparent union definition must contain at least one field; transparent_union attribute ignored</li>
 <li>warning: transparent_union attribute can only be applied to a union definition; attribute ignored</li>
@@ -15107,6 +16117,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %select{|overriding }1method cannot be unavailable on %0 when %select{the protocol method it implements|its overridden method}1 is available</li>
 <li>warning: %select{|overriding }4method %select{introduced after|deprecated before|obsoleted before}0 %select{the protocol method it implements|overridden method}4 on %1 (%2 vs. %3)</li>
 <li>warning: 'unavailable' availability overrides all other availability information</li>
+<li>warning: Fuchsia API Level prohibits specifying a minor or sub-minor version</li>
 <li>warning: availability does not match previous declaration</li>
 <li>warning: feature cannot be %select{introduced|deprecated|obsoleted}0 in %1 version %2 before it was %select{introduced|deprecated|obsoleted}3 in version %4; attribute ignored</li>
 <li>warning: ignoring availability attribute %select{on '+load' method|with constructor attribute|with destructor attribute}0</li>
@@ -15121,16 +16132,16 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
-    <key>clang-diagnostic-frame-larger-than=</key>
-    <name>clang-diagnostic-frame-larger-than=</name>
+    <key>clang-diagnostic-frame-larger-than</key>
+    <name>clang-diagnostic-frame-larger-than</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: %0</li>
-<li>warning: stack frame size of %0 bytes in %q1</li>
+<li>warning: stack frame size (%0) exceeds limit (%1) in '%2'</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wframe-larger-than=" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wframe-larger-than" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15231,6 +16242,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsource-mgr" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-attribute-warning</key>
+    <name>clang-diagnostic-attribute-warning</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: call to %0 declared with 'warning' attribute: %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wattribute-warning" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15340,6 +16365,20 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-bitwise-instead-of-logical</key>
+    <name>clang-diagnostic-bitwise-instead-of-logical</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: use of bitwise '%0' with boolean operands</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbitwise-instead-of-logical" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-bitwise-op-parentheses</key>
     <name>clang-diagnostic-bitwise-op-parentheses</name>
     <description>
@@ -15381,6 +16420,21 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbool-conversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-bool-operation</key>
+    <name>clang-diagnostic-bool-operation</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: bitwise negation of a boolean expression%select{;| always evaluates to 'true';}0 did you mean logical negation?</li>
+<li>warning: use of bitwise '%0' with boolean operands</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbool-operation" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15601,7 +16655,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|constexpr if condition|explicit specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
 <li>warning: '%0' is a keyword in C++11</li>
@@ -15610,12 +16664,15 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
 <li>warning: constexpr if is incompatible with C++ standards before C++17</li>
@@ -15646,6 +16703,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: inline variables are incompatible with C++ standards before C++17</li>
 <li>warning: integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
 <li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
 <li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
 <li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
@@ -15654,6 +16713,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: return type deduction is incompatible with C++ standards before C++14</li>
 <li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
@@ -15667,6 +16727,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: use of right-shift operator ('&gt;&gt;') in template argument will require parentheses in C++11</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
 <li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: variable templates are incompatible with C++ standards before C++14</li>
 <li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
@@ -15699,7 +16761,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|constexpr if condition|explicit specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
@@ -15714,8 +16776,12 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
 <li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
 <li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
@@ -15726,6 +16792,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
@@ -15780,6 +16848,10 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
 <li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
 <li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
 <li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
 <li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
@@ -15794,6 +16866,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: return type deduction is incompatible with C++ standards before C++14</li>
@@ -15817,6 +16891,10 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
 <li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: variable templates are incompatible with C++ standards before C++14</li>
@@ -15894,7 +16972,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|constexpr if condition|explicit specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
 <li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
@@ -16013,10 +17091,13 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr if is incompatible with C++ standards before C++17</li>
 <li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
@@ -16034,11 +17115,14 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
 <li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
 <li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
 <li>warning: unicode literals are incompatible with C++ standards before C++17</li>
@@ -16046,6 +17130,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
 <li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
 </ul>
 <h2>References</h2>
@@ -16070,8 +17156,12 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
 <li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
@@ -16079,6 +17169,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr if is incompatible with C++ standards before C++17</li>
@@ -16116,6 +17208,10 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: inline variables are incompatible with C++ standards before C++17</li>
 <li>warning: inline variables are incompatible with C++ standards before C++17</li>
 <li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
 <li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
@@ -16126,6 +17222,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
@@ -16140,6 +17238,10 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
 <li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
 <li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
 </ul>
@@ -16190,7 +17292,10 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
@@ -16205,11 +17310,16 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
 <li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
 <li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
 <li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
 </ul>
 <h2>References</h2>
@@ -16245,8 +17355,14 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
@@ -16275,8 +17391,14 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
 <li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
 <li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
@@ -16285,6 +17407,10 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
 <li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
 <li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
 </ul>
@@ -16313,11 +17439,14 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: initialized lambda pack captures are a C++20 extension</li>
 <li>warning: inline nested namespace definition is a C++20 extension</li>
 <li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is a C++20 extension</li>
+<li>warning: member using declaration naming a non-member enumerator is a C++20 extension</li>
 <li>warning: range-based for loop initialization statements are a C++20 extension</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is a C++20 extension</li>
 <li>warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension</li>
 <li>warning: use of the %0 attribute is a C++20 extension</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++20 extension</li>
+<li>warning: using declaration naming a scoped enumerator is a C++20 extension</li>
+<li>warning: using enum declaration is a C++20 extension</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-20-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -16335,8 +17464,11 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
 <li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
 <li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
 <li>warning: this expression will be parsed as explicit(bool) in C++20</li>
 <li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
 </ul>
@@ -16356,9 +17488,15 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
 <li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
 <li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
 <li>warning: this expression will be parsed as explicit(bool) in C++20</li>
 <li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
 </ul>
@@ -16388,7 +17526,11 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: 'size_t' suffix for literals is a C++2b extension</li>
+<li>warning: alias declaration in this context is a C++2b extension</li>
 <li>warning: an attribute specifier sequence in this position is a C++2b extension</li>
+<li>warning: consteval if is a C++2b extension</li>
+<li>warning: lambda without a parameter clause is a C++2b extension</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2b-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -16418,8 +17560,10 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'decltype' type specifier is incompatible with C++98</li>
 <li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
 <li>warning: 'nullptr' is incompatible with C++98</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
 <li>warning: C++11 attribute syntax is incompatible with C++98</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
 <li>warning: alias declarations are incompatible with C++98</li>
 <li>warning: alignof expressions are incompatible with C++98</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
@@ -16428,6 +17572,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: consecutive right angle brackets are incompatible with C++98 (use '&gt; &gt;')</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
 <li>warning: constexpr if is incompatible with C++ standards before C++17</li>
@@ -16468,6 +17613,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: lambda expressions are incompatible with C++98</li>
 <li>warning: literal operators are incompatible with C++98</li>
 <li>warning: local type %0 as template argument is incompatible with C++98</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
 <li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
 <li>warning: noexcept expressions are incompatible with C++98</li>
@@ -16478,6 +17625,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: passing object of trivial but non-POD type %0 through variadic %select{function|block|method|constructor}1 is incompatible with C++98</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop is incompatible with C++98</li>
@@ -16509,7 +17657,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: use of null pointer as non-type template argument is incompatible with C++98</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: using this character in an identifier is incompatible with C++98</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
 <li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: variable templates are incompatible with C++ standards before C++14</li>
 <li>warning: variadic templates are incompatible with C++98</li>
@@ -16594,10 +17743,14 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
 <li>warning: 'long long' is incompatible with C++98</li>
 <li>warning: 'nullptr' is incompatible with C++98</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
 <li>warning: C++11 attribute syntax is incompatible with C++98</li>
 <li>warning: C++98 requires newline at end of file</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
 <li>warning: alias declarations are incompatible with C++98</li>
 <li>warning: alignof expressions are incompatible with C++98</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
@@ -16613,6 +17766,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: commas at the end of enumerator lists are incompatible with C++98</li>
 <li>warning: consecutive right angle brackets are incompatible with C++98 (use '&gt; &gt;')</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
@@ -16681,6 +17836,10 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: lambda expressions are incompatible with C++98</li>
 <li>warning: literal operators are incompatible with C++98</li>
 <li>warning: local type %0 as template argument is incompatible with C++98</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
 <li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
 <li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
@@ -16697,6 +17856,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: passing object of trivial but non-POD type %0 through variadic %select{function|block|method|constructor}1 is incompatible with C++98</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
@@ -16738,7 +17899,10 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: using this character in an identifier is incompatible with C++98</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
 <li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: variable templates are incompatible with C++ standards before C++14</li>
@@ -16928,11 +18092,16 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
 <li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
 <li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
 </ul>
 <h2>References</h2>
@@ -16964,11 +18133,16 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
 <li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
 <li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
 <li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
 </ul>
 <h2>References</h2>
@@ -16983,7 +18157,10 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2b-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -16997,7 +18174,10 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
 <li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2b-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -17034,6 +18214,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-align" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-cast-function-type</key>
+    <name>clang-diagnostic-cast-function-type</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: cast %diff{from $ to $ |}0,1converts to incompatible function type</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-function-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -17390,7 +18584,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: argument to '#pragma unroll' should not be in parentheses in CUDA C/C++</li>
 <li>warning: ignored 'inline' attribute on kernel function %0</li>
 <li>warning: kernel function %0 is a member function; this may not be accepted by nvcc</li>
-<li>warning: nvcc does not allow '__%0__' to appear after '()' in lambdas</li>
+<li>warning: nvcc does not allow '__%0__' to appear after the parameter list in lambdas</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcuda-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -17404,7 +18598,8 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: Unknown CUDA version. %0 Assuming the latest supported version %1</li>
+<li>warning: CUDA version %0 is only partially supported</li>
+<li>warning: CUDA version%0 is newer than the latest%select{| partially}1 supported version %2</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-cuda-version" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -17620,6 +18815,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: %0 does not support the option '%1'</li>
 <li>warning: %0 is deprecated</li>
 <li>warning: %0 is deprecated: %1</li>
 <li>warning: %0 may be deprecated because the receiver type is unknown</li>
@@ -17632,18 +18828,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
 <li>warning: -O4 is equivalent to -O3</li>
 <li>warning: -fconcepts-ts is deprecated - use '-std=c++20' for Concepts support</li>
-<li>warning: OpenCL version %0 does not support the option '%1'</li>
 <li>warning: Use of 'long' with '__vector' is deprecated</li>
 <li>warning: access declarations are deprecated; use using declarations instead</li>
-<li>warning: argument '%0' is deprecated, use '%1' instead</li>
+<li>warning: argument '%0' is deprecated%select{|, use '%2' instead}1</li>
 <li>warning: comparison between two arrays is deprecated; to compare array addresses, use unary '+' to decay operands to pointers</li>
 <li>warning: compound assignment to object of volatile-qualified type %0 is deprecated</li>
 <li>warning: conversion from string literal to %0 is deprecated</li>
 <li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared copy %select{assignment operator|constructor}1</li>
 <li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared destructor</li>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided copy %select{assignment operator|constructor}1</li>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided destructor</li>
 <li>warning: dynamic exception specifications are deprecated</li>
 <li>warning: implicit capture of 'this' with a capture default of '=' is deprecated</li>
 <li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
+<li>warning: macro %0 has been marked as deprecated%select{|: %2}1</li>
 <li>warning: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated</li>
 <li>warning: property access is using %0 method which is deprecated</li>
 <li>warning: specifying 'uuid' as an ATL attribute is deprecated; use __declspec instead</li>
@@ -17725,6 +18923,7 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared copy %select{assignment operator|constructor}1</li>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided copy %select{assignment operator|constructor}1</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-copy" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -17733,15 +18932,44 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
-    <key>clang-diagnostic-deprecated-copy-dtor</key>
-    <name>clang-diagnostic-deprecated-copy-dtor</name>
+    <key>clang-diagnostic-deprecated-copy-with-dtor</key>
+    <name>clang-diagnostic-deprecated-copy-with-dtor</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared destructor</li>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided destructor</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-copy-dtor" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-copy-with-dtor" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecated-copy-with-user-provided-copy</key>
+    <name>clang-diagnostic-deprecated-copy-with-user-provided-copy</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided copy %select{assignment operator|constructor}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-copy-with-user-provided-copy" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecated-copy-with-user-provided-dtor</key>
+    <name>clang-diagnostic-deprecated-copy-with-user-provided-dtor</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided destructor</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-copy-with-user-provided-dtor" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -17880,6 +19108,20 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-deprecated-pragma</key>
+    <name>clang-diagnostic-deprecated-pragma</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: macro %0 has been marked as deprecated%select{|: %2}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-pragma" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-deprecated-register</key>
     <name>clang-diagnostic-deprecated-register</name>
     <description>
@@ -17965,6 +19207,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdivision-by-zero" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-dllexport-explicit-instantiation-decl</key>
+    <name>clang-diagnostic-dllexport-explicit-instantiation-decl</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: explicit instantiation declaration should not be 'dllexport'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdllexport-explicit-instantiation-decl" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -18418,18 +19674,21 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '%0' qualifier on omitted return type %1 has no effect</li>
 <li>warning: '%0' qualifier on reference type %1 has no effect</li>
 <li>warning: '%0' type qualifier%s1 on return type %plural{1:has|:have}1 no effect</li>
-<li>warning: '-fuse-ld=' taking a path is deprecated. Use '--ld-path=' instead</li>
+<li>warning: '-fuse-ld=' taking a path is deprecated; use '--ld-path=' instead</li>
 <li>warning: ARC %select{unused|__unsafe_unretained|__strong|__weak|__autoreleasing}0 lifetime qualifier on return type is ignored</li>
 <li>warning: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension</li>
 <li>warning: call to function without interrupt attribute could clobber interruptee's VFP registers</li>
 <li>warning: comparison of integers of different signs: %0 and %1</li>
 <li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared copy %select{assignment operator|constructor}1</li>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided copy %select{assignment operator|constructor}1</li>
 <li>warning: empty initialization statement of '%select{if|switch|range-based for}0' has no effect</li>
 <li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
 <li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
 <li>warning: method has no return type specified; defaults to 'id'</li>
 <li>warning: missing field %0 initializer</li>
+<li>warning: parameter %0 set but not used</li>
 <li>warning: performing pointer arithmetic on a null pointer has undefined behavior%select{| if the offset is nonzero}0</li>
+<li>warning: performing pointer subtraction with a null pointer %select{has|may have}0 undefined behavior</li>
 <li>warning: semicolon before method body is ignored</li>
 <li>warning: suspicious concatenation of string literals in an array initialization; did you mean to separate the elements with a comma?</li>
 <li>warning: unused parameter %0</li>
@@ -18493,7 +19752,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: '-fuse-ld=' taking a path is deprecated. Use '--ld-path=' instead</li>
+<li>warning: '-fuse-ld=' taking a path is deprecated; use '--ld-path=' instead</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfuse-ld-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -18511,6 +19770,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfinal-dtor-non-final-class" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-final-macro</key>
+    <name>clang-diagnostic-final-macro</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: macro %0 has been marked as final and should not be %select{undefined|redefined}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfinal-macro" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -18803,6 +20076,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '%0' size argument is too large; destination buffer has size %1, but size argument is %2</li>
 <li>warning: '%0' will always overflow; destination buffer has size %1, but format string expands to at least %2</li>
 <li>warning: '%0' will always overflow; destination buffer has size %1, but size argument is %2</li>
+<li>warning: '%0' will always overflow; destination buffer has size %1, but the source string has length %2 (including NUL byte)</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfortify-source" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -19454,7 +20728,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %0 attribute ignored on a non-definition declaration</li>
 <li>warning: %0 attribute ignored on inline function</li>
 <li>warning: %0 attribute ignored when parsing type</li>
-<li>warning: %0 attribute is deprecated and ignored in OpenCL version %1</li>
+<li>warning: %0 attribute is deprecated and ignored in %1</li>
 <li>warning: %0 attribute is ignored because there exists no call expression inside the statement</li>
 <li>warning: %0 attribute isn't implemented by this Objective-C runtime</li>
 <li>warning: %0 attribute only applies to %1</li>
@@ -19466,6 +20740,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %0 attribute only applies to return values that are pointers or references</li>
 <li>warning: %0 attribute only applies to%select{| constant}1 pointer arguments</li>
 <li>warning: %0 calling convention is not supported %select{for this target|on variadic function|on constructor/destructor|on builtin function}1</li>
+<li>warning: %0 currently has no effect on a using declaration</li>
 <li>warning: %q0 redeclared inline; %1 attribute ignored</li>
 <li>warning: %select{MIPS|MSP430|RISC-V}0 'interrupt' attribute only applies to functions that have %select{no parameters|a 'void' return type}1</li>
 <li>warning: %select{alias|ifunc}1 will not be in section '%0' but in the same section as the %select{aliasee|resolver}2</li>
@@ -19499,7 +20774,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: __weak attribute cannot be specified on an automatic variable when ARC is not enabled</li>
 <li>warning: attribute %0 after definition is ignored</li>
 <li>warning: attribute %0 cannot be applied to %select{functions|Objective-C method}1 without return value</li>
-<li>warning: attribute %0 has no effect when annotating an 'if constexpr' statement</li>
+<li>warning: attribute %0 has no effect when annotating an 'if %select{constexpr|consteval}1' statement</li>
 <li>warning: attribute %0 has no effect when annotating an infinite loop</li>
 <li>warning: attribute %0 ignored, because it cannot be applied to a type</li>
 <li>warning: attribute %0 ignored, because it cannot be applied to omitted return type</li>
@@ -19519,6 +20794,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: inheritance model ignored on %select{primary template|partial specialization}0</li>
 <li>warning: qualifiers after comma in declarator list are ignored</li>
 <li>warning: repeated RISC-V 'interrupt' attribute</li>
+<li>warning: requested alignment is less than minimum alignment of %1 for type %0</li>
 <li>warning: template parameter of a function template with the 'sycl_kernel' attribute cannot be a non-type template parameter</li>
 <li>warning: transparent union definition must contain at least one field; transparent_union attribute ignored</li>
 <li>warning: transparent_union attribute can only be applied to a union definition; attribute ignored</li>
@@ -19587,7 +20863,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '#pragma comment %0' ignored</li>
 <li>warning: '#pragma init_seg' is only supported when targeting a Microsoft environment</li>
 <li>warning: '#pragma optimize' is not supported</li>
-<li>warning: OpenCL extension end directive mismatches begin directive - ignoring</li>
 <li>warning: expected #pragma pack parameter to be '1', '2', '4', '8', or '16'</li>
 <li>warning: expected %select{'enable', 'disable', 'begin' or 'end'|'disable'}0 - ignoring</li>
 <li>warning: expected '#pragma unused' argument to be a variable name</li>
@@ -19607,6 +20882,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: expected string literal in '#pragma %0' - ignoring</li>
 <li>warning: extra tokens at end of '#pragma %0' - ignored</li>
 <li>warning: incorrect use of #pragma clang force_cuda_host_device begin|end</li>
+<li>warning: incorrect use of '#pragma fenv_access (on|off)' - ignored</li>
 <li>warning: incorrect use of '#pragma ms_struct on|off' - ignored</li>
 <li>warning: invalid alignment option in '#pragma %select{align|options align}0' - ignored</li>
 <li>warning: invalid or unsupported rounding mode in '#pragma STDC FENV_ROUND' - ignored</li>
@@ -19648,6 +20924,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-qualifiers" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-ignored-reference-qualifiers</key>
+    <name>clang-diagnostic-ignored-reference-qualifiers</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' qualifier on reference type %1 has no effect</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-reference-qualifiers" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -19721,7 +21011,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: fallthrough annotation in unreachable code</li>
 <li>warning: unannotated fall-through between switch labels</li>
 <li>warning: unannotated fall-through between switch labels in partly-annotated function</li>
 </ul>
@@ -20124,12 +21413,12 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: ignoring extension '%0' because the '%1' architecture does not support it</li>
-<li>warning: no MCU device specified, but '-mhwmult' is set to 'auto', assuming no hardware multiply. Use -mmcu to specify a MSP430 device, or -mhwmult to set hardware multiply type explicitly.</li>
+<li>warning: no MCU device specified, but '-mhwmult' is set to 'auto', assuming no hardware multiply; use '-mmcu' to specify an MSP430 device, or '-mhwmult' to set the hardware multiply type explicitly</li>
 <li>warning: optimization flag '%0' is not supported</li>
 <li>warning: optimization flag '%0' is not supported for target '%1'</li>
 <li>warning: optimization level '%0' is not supported; using '%1%2' instead</li>
-<li>warning: the given MCU does not support hardware multiply, but -mhwmult is set to %0.</li>
-<li>warning: the given MCU supports %0 hardware multiply, but -mhwmult is set to %1.</li>
+<li>warning: the given MCU does not support hardware multiply, but '-mhwmult' is set to %0</li>
+<li>warning: the given MCU supports %0 hardware multiply, but '-mhwmult' is set to %1</li>
 <li>warning: the object size sanitizer has no effect at -O0, but is explicitly enabled: %0</li>
 </ul>
 <h2>References</h2>
@@ -20282,6 +21571,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wlarge-by-value-copy" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-linker-warnings</key>
+    <name>clang-diagnostic-linker-warnings</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: linking module '%0': %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wlinker-warnings" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -20558,6 +21861,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %q0 redeclared without 'dllimport' attribute: 'dllexport' attribute added</li>
 <li>warning: %select{class template|class template partial|variable template|variable template partial|function template|member function|static data member|member class|member enumeration}0 specialization of %1 not in %select{a namespace enclosing %2|class %2 or an enclosing namespace}3 is a Microsoft extension</li>
 <li>warning: %select{|pointer to |reference to }0incomplete type %1 is not allowed in exception specification</li>
+<li>warning: 'abstract' keyword is a Microsoft extension</li>
 <li>warning: 'mutable' on a reference type is a Microsoft extension</li>
 <li>warning: 'sealed' keyword is a Microsoft extension</li>
 <li>warning: 'static' can only be specified inside the class definition</li>
@@ -20601,6 +21905,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-microsoft-abstract</key>
+    <name>clang-diagnostic-microsoft-abstract</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'abstract' keyword is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-abstract" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -21277,6 +22595,20 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-module-lock</key>
+    <name>clang-diagnostic-module-lock</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>remark: locking '%0' to build module '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rmodule-lock" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-most</key>
     <name>clang-diagnostic-most</name>
     <description>
@@ -21321,6 +22653,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: assigning %select{field|instance variable}0 to itself</li>
 <li>warning: base class %0 is uninitialized when used here to access %q1</li>
 <li>warning: bitwise comparison always evaluates to %select{false|true}0</li>
+<li>warning: bitwise negation of a boolean expression%select{;| always evaluates to 'true';}0 did you mean logical negation?</li>
 <li>warning: bitwise or with non-zero value always evaluates to true</li>
 <li>warning: block pointer variable %0 is %select{uninitialized|null}1 when captured by block</li>
 <li>warning: calling '%0' with a nonzero argument is unsafe</li>
@@ -21375,12 +22708,13 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: implicit declaration of function %0 is invalid in C99</li>
 <li>warning: implicitly declaring library function '%0' with type %1</li>
 <li>warning: incomplete format specifier</li>
+<li>warning: initializer order does not match the declaration order</li>
 <li>warning: invalid conversion specifier '%0'</li>
 <li>warning: invalid position specified for %select{field width|field precision}0</li>
 <li>warning: ivar %0 which backs the property is not referenced in this property's accessor</li>
 <li>warning: lambda capture %0 is not %select{used|required to be captured for this use}1</li>
+<li>warning: left operand of comma operator has no effect</li>
 <li>warning: length modifier '%0' results in undefined behavior or no effect with '%1' conversion specifier</li>
-<li>warning: local variable %0 will be copied despite being %select{returned|thrown}1 by name</li>
 <li>warning: loop variable %0 %diff{of type $ binds to a temporary constructed from type $|binds to a temporary constructed from a different type}1,2</li>
 <li>warning: loop variable %0 creates a copy from type %1</li>
 <li>warning: method override for the designated initializer of the superclass %objcinstance0 not found</li>
@@ -21436,6 +22770,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: unused variable %0</li>
 <li>warning: unused variable %0</li>
 <li>warning: use of __private_extern__ on a declaration may not produce external symbol private to the linkage unit and is deprecated</li>
+<li>warning: use of bitwise '%0' with boolean operands</li>
 <li>warning: use of unknown builtin %0</li>
 <li>warning: using '%%P' format specifier without precision</li>
 <li>warning: using '%0' format specifier annotation outside of os_log()/os_trace()</li>
@@ -21445,6 +22780,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: variable %0 is uninitialized when %select{used here|captured by block}1</li>
 <li>warning: variable %0 is uninitialized when passed as a const reference argument here</li>
 <li>warning: variable %0 is uninitialized when used within its own initialization</li>
+<li>warning: variable %0 set but not used</li>
 <li>warning: variable%select{s| %1|s %1 and %2|s %1, %2, and %3|s %1, %2, %3, and %4}0 used in loop condition not modified in loop body</li>
 <li>warning: zero field width in scanf format string is unused</li>
 </ul>
@@ -21463,7 +22799,6 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: explicitly moving variable of type %0 to itself</li>
-<li>warning: local variable %0 will be copied despite being %select{returned|thrown}1 by name</li>
 <li>warning: moving a local object in a return statement prevents copy elision</li>
 <li>warning: moving a temporary object prevents copy elision</li>
 <li>warning: redundant move in return statement</li>
@@ -21814,6 +23149,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnull-pointer-arithmetic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-null-pointer-subtraction</key>
+    <name>clang-diagnostic-null-pointer-subtraction</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: performing pointer subtraction with a null pointer %select{has|may have}0 undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnull-pointer-subtraction" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -22452,12 +23801,27 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-pedantic-core-features</key>
+    <name>clang-diagnostic-pedantic-core-features</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is a core feature in %select{OpenCL C|C++ for OpenCL}1 version %2 but not supported on this target</li>
+<li>warning: OpenCL extension %0 is core feature or supported optional core feature - ignoring</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpedantic-core-features" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-opencl-unsupported-rgba</key>
     <name>clang-diagnostic-opencl-unsupported-rgba</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: vector component name '%0' is an OpenCL version 2.2 feature</li>
+<li>warning: vector component name '%0' is a feature from OpenCL version 3.0 onwards</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopencl-unsupported-rgba" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -22478,8 +23842,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '%0' is not a valid context selector for the context set '%1'; selector ignored</li>
 <li>warning: '%0' is not a valid context set in a `declare variant`; set ignored</li>
 <li>warning: OpenMP loop iteration variable cannot have more than 64 bits size and will be narrowed</li>
+<li>warning: OpenMP offloading target '%0' is similar to target '%1' already specified; will be ignored</li>
 <li>warning: OpenMP only allows an ordered construct with the simd clause nested in a simd construct</li>
-<li>warning: The OpenMP offloading target '%0' is similar to target '%1' already specified - will be ignored.</li>
 <li>warning: Type %0 is not trivially copyable and not guaranteed to be mapped correctly</li>
 <li>warning: Type %0 is not trivially copyable and not guaranteed to be mapped correctly</li>
 <li>warning: aligned clause will be ignored because the requested alignment is not a power of 2</li>
@@ -22495,6 +23859,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: isa trait '%0' is not known to the current target; verify the spelling or consider restricting the context selector with the 'arch' selector further</li>
 <li>warning: more than one 'device_type' clause is specified</li>
 <li>warning: score expressions in the OpenMP context selector need to be constant; %0 is not and will be ignored</li>
+<li>warning: specifying OpenMP directives with [[]] is an OpenMP 5.1 extension</li>
 <li>warning: the context %select{set|selector|property}0 '%1' was used already in the same 'omp declare variant' directive; %select{set|selector|property}0 ignored</li>
 <li>warning: the context property '%0' is not valid for the context selector '%1' and the context set '%2'; property ignored</li>
 <li>warning: the context selector '%0' in context set '%1' requires a context property defined in parentheses; selector ignored</li>
@@ -22507,6 +23872,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenmp" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-openmp-51-extensions</key>
+    <name>clang-diagnostic-openmp-51-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: specifying OpenMP directives with [[]] is an OpenMP 5.1 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenmp-51-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -22572,12 +23951,26 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-pre-openmp-51-compat</key>
+    <name>clang-diagnostic-pre-openmp-51-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: specifying OpenMP directives with [[]] is incompatible with OpenMP standards before OpenMP 5.1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-openmp-51-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-openmp-target</key>
     <name>clang-diagnostic-openmp-target</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: The OpenMP offloading target '%0' is similar to target '%1' already specified - will be ignored.</li>
+<li>warning: OpenMP offloading target '%0' is similar to target '%1' already specified; will be ignored</li>
 <li>warning: Type %0 is not trivially copyable and not guaranteed to be mapped correctly</li>
 <li>warning: declaration is not declared in any declare target region</li>
 <li>warning: declaration marked as declare target after first use, it may lead to incorrect results</li>
@@ -22608,8 +24001,8 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: The '%0' architecture does not support -moutline-atomics; flag ignored</li>
-<li>warning: The '%0' architecture does not support -moutline; flag ignored</li>
+<li>warning: '%0' does not support '-moutline'; flag ignored</li>
+<li>warning: '%0' does not support '-moutline-atomics'; flag ignored</li>
 <li>warning: auto-vectorization requires HVX, use -mhvx to enable it</li>
 <li>warning: ignoring '%0' option as it cannot be used with %select{implicit usage of|}1 -mabicalls and the N64 ABI</li>
 <li>warning: ignoring '-mlong-calls' option as it is not currently supported with %select{|the implicit usage of }0-mabicalls</li>
@@ -22619,6 +24012,21 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woption-ignored" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-ordered-compare-function-pointers</key>
+    <name>clang-diagnostic-ordered-compare-function-pointers</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ordered comparison of function pointers (%0 and %1)</li>
+<li>warning: ordered comparison of function pointers (%0 and %1)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wordered-compare-function-pointers" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -22779,6 +24187,25 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wparentheses-equality" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pedantic-macros</key>
+    <name>clang-diagnostic-pedantic-macros</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 macro redefined</li>
+<li>warning: macro %0 has been marked as deprecated%select{|: %2}1</li>
+<li>warning: macro %0 has been marked as final and should not be %select{undefined|redefined}1</li>
+<li>warning: macro %0 has been marked as unsafe for use in headers%select{|: %2}1</li>
+<li>warning: redefining builtin macro</li>
+<li>warning: undefining builtin macro</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpedantic-macros" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -22972,7 +24399,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '#pragma comment %0' ignored</li>
 <li>warning: '#pragma init_seg' is only supported when targeting a Microsoft environment</li>
 <li>warning: '#pragma optimize' is not supported</li>
-<li>warning: OpenCL extension end directive mismatches begin directive - ignoring</li>
 <li>warning: angle-bracketed include &lt;%0&gt; cannot be aliased to double-quoted include "%1"</li>
 <li>warning: double-quoted include "%0" cannot be aliased to angle-bracketed include &lt;%1&gt;</li>
 <li>warning: expected #pragma pack parameter to be '1', '2', '4', '8', or '16'</li>
@@ -22996,6 +24422,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: expected string literal in '#pragma %0' - ignoring</li>
 <li>warning: extra tokens at end of '#pragma %0' - ignored</li>
 <li>warning: incorrect use of #pragma clang force_cuda_host_device begin|end</li>
+<li>warning: incorrect use of '#pragma fenv_access (on|off)' - ignored</li>
 <li>warning: incorrect use of '#pragma ms_struct on|off' - ignored</li>
 <li>warning: invalid alignment option in '#pragma %select{align|options align}0' - ignored</li>
 <li>warning: invalid or unsupported rounding mode in '#pragma STDC FENV_ROUND' - ignored</li>
@@ -23309,6 +24736,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <ul>
 <li>warning: %select{field|base class}0 %1 will be initialized after %select{field|base}2 %3</li>
 <li>warning: ISO C++ requires field designators to be specified in declaration order; field %1 will be initialized after field %0</li>
+<li>warning: initializer order does not match the declaration order</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreorder" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -23323,6 +24751,7 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: %select{field|base class}0 %1 will be initialized after %select{field|base}2 %3</li>
+<li>warning: initializer order does not match the declaration order</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreorder-ctor" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -23345,6 +24774,20 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-reserved-macro-identifier</key>
+    <name>clang-diagnostic-reserved-macro-identifier</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: macro name is a reserved identifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreserved-macro-identifier" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-reserved-id-macro</key>
     <name>clang-diagnostic-reserved-id-macro</name>
     <description>
@@ -23354,6 +24797,21 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreserved-id-macro" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-reserved-identifier</key>
+    <name>clang-diagnostic-reserved-identifier</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: identifier %0 is reserved because %select{&lt;ERROR&gt;|it starts with '_' at global scope|it starts with '_' and has C language linkage|it starts with '__'|it starts with '_' followed by a capital letter|it contains '__'}1</li>
+<li>warning: macro name is a reserved identifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreserved-identifier" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -23375,6 +24833,20 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-restrict-expansion</key>
+    <name>clang-diagnostic-restrict-expansion</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: macro %0 has been marked as unsafe for use in headers%select{|: %2}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrestrict-expansion" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
     </rule>
   <rule>
     <key>clang-diagnostic-return-stack-address</key>
@@ -23453,7 +24925,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>remark: Generated arguments #%0 in round-trip: %1</li>
+<li>remark: generated arguments #%0 in round-trip: %1</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rround-trip-cc1-args" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -24224,6 +25696,7 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: result of comparison %select{%3|%1}0 %2 %select{%1|%3}0 is always %4</li>
+<li>warning: result of comparison of %select{%3|char expression}0 %2 %select{char expression|%3}0 is always %4, since char is interpreted as unsigned</li>
 <li>warning: result of comparison of %select{%3|unsigned enum expression}0 %2 %select{unsigned enum expression|%3}0 is always %4</li>
 <li>warning: result of comparison of %select{%3|unsigned expression}0 %2 %select{unsigned expression|%3}0 is always %4</li>
 <li>warning: result of comparison of %select{%4|%sub{subst_int_range}1,2}0 %3 %select{%sub{subst_int_range}1,2|%4}0 is always %5</li>
@@ -24316,6 +25789,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-undefined-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-tautological-unsigned-char-zero-compare</key>
+    <name>clang-diagnostic-tautological-unsigned-char-zero-compare</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: result of comparison of %select{%3|char expression}0 %2 %select{char expression|%3}0 is always %4, since char is interpreted as unsigned</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-unsigned-char-zero-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -24460,7 +25947,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: Thread safety beta warning.</li>
+<li>warning: thread safety beta warning</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wthread-safety-beta" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -24519,7 +26006,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: Thread safety verbose warning.</li>
+<li>warning: thread safety verbose warning</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wthread-safety-verbose" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -24551,6 +26038,7 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: result of comparison %select{%3|%1}0 %2 %select{%1|%3}0 is always %4</li>
+<li>warning: result of comparison of %select{%3|char expression}0 %2 %select{char expression|%3}0 is always %4, since char is interpreted as unsigned</li>
 <li>warning: result of comparison of %select{%3|unsigned enum expression}0 %2 %select{unsigned enum expression|%3}0 is always %4</li>
 <li>warning: result of comparison of %select{%3|unsigned expression}0 %2 %select{unsigned expression|%3}0 is always %4</li>
 </ul>
@@ -24728,6 +26216,8 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: \%0 used with no following hex digits; treating as '\' followed by identifier</li>
+<li>warning: empty delimited universal character name; treating as '\' 'u' '{' '}'</li>
+<li>warning: incomplete delimited universal character name; treating as '\' 'u' '{' identifier</li>
 <li>warning: incomplete universal character name; treating as '\' followed by identifier</li>
 <li>warning: universal character name refers to a surrogate character</li>
 <li>warning: universal character names are only valid in C99 or C++</li>
@@ -24975,6 +26465,7 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: code will never be executed</li>
+<li>warning: fallthrough annotation in unreachable code</li>
 <li>warning: loop will run at most once (loop increment never executed)</li>
 </ul>
 <h2>References</h2>
@@ -24992,6 +26483,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'break' will never be executed</li>
 <li>warning: 'return' will never be executed</li>
 <li>warning: code will never be executed</li>
+<li>warning: fallthrough annotation in unreachable code</li>
 <li>warning: loop will run at most once (loop increment never executed)</li>
 </ul>
 <h2>References</h2>
@@ -25010,6 +26502,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunreachable-code-break" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unreachable-code-fallthrough</key>
+    <name>clang-diagnostic-unreachable-code-fallthrough</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: fallthrough annotation in unreachable code</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunreachable-code-fallthrough" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -25152,7 +26658,7 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: debug information option '%0' is not supported for target '%1'</li>
-<li>warning: debug information option '%0' is not supported. It needs DWARF-%2 but target '%1' only provides DWARF-%3.</li>
+<li>warning: debug information option '%0' is not supported; requires DWARF-%2 but target '%1' only provides DWARF-%3</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-target-opt" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -25181,15 +26687,45 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: ignoring temporary created by a constructor declared with %0 attribute: %1</li>
 <li>warning: ivar %0 which backs the property is not referenced in this property's accessor</li>
 <li>warning: lambda capture %0 is not %select{used|required to be captured for this use}1</li>
+<li>warning: left operand of comma operator has no effect</li>
 <li>warning: private field %0 is not used</li>
 <li>warning: unused %select{typedef|type alias}0 %1</li>
 <li>warning: unused function %0</li>
 <li>warning: unused label %0</li>
 <li>warning: unused variable %0</li>
 <li>warning: unused variable %0</li>
+<li>warning: variable %0 set but not used</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unused-but-set-parameter</key>
+    <name>clang-diagnostic-unused-but-set-parameter</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: parameter %0 set but not used</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-but-set-parameter" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unused-but-set-variable</key>
+    <name>clang-diagnostic-unused-but-set-variable</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: variable %0 set but not used</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-but-set-variable" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -25206,6 +26742,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: argument '%0' requires profile-guided optimization information</li>
 <li>warning: argument unused during compilation: '%0'</li>
 <li>warning: ignoring -fdiscard-value-names for LLVM Bitcode</li>
+<li>warning: ignoring -fverify-debuginfo-preserve-export=%0 because -fverify-debuginfo-preserve wasn't enabled</li>
+<li>warning: ignoring invalid /arch: argument '%0'; for %select{64|32}1-bit expected one of %2</li>
 <li>warning: joined argument expects additional value: '%0'</li>
 <li>warning: the flag '%0' has been deprecated and will be ignored</li>
 </ul>
@@ -25434,6 +26972,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: ignoring return value of function declared with %0 attribute: %1</li>
 <li>warning: ignoring temporary created by a constructor declared with %0 attribute</li>
 <li>warning: ignoring temporary created by a constructor declared with %0 attribute: %1</li>
+<li>warning: left operand of comma operator has no effect</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-value" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -25466,6 +27005,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wused-but-marked-unused" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-search-path-usage</key>
+    <name>clang-diagnostic-search-path-usage</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>remark: search path used: '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rsearch-path-usage" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -25693,13 +27246,12 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++98-c++11-compat-pedantic</key>
-    <name>clang-diagnostic-c++98-c++11-compat-pedantic</name>
+    <key>clang-diagnostic-c++98-c++11-compat</key>
+    <name>clang-diagnostic-c++98-c++11-compat</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
 <li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
 <li>warning: digit separators are incompatible with C++ standards before C++14</li>
 <li>warning: generic lambdas are incompatible with C++11</li>
@@ -25712,7 +27264,49 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: variable templates are incompatible with C++ standards before C++14</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pragma-once-outside-header</key>
+    <name>clang-diagnostic-pragma-once-outside-header</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma once in main file</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-once-outside-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pragma-system-header-outside-header</key>
+    <name>clang-diagnostic-pragma-system-header-outside-header</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma system_header ignored in main file</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-system-header-outside-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-disabled-macro-expansion</key>
+    <name>clang-diagnostic-disabled-macro-expansion</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: disabled expansion of recursive macro</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdisabled-macro-expansion" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -25818,6 +27412,31 @@ Derived();             // and so temporary construction is okay</code></pre>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++98-c++11-compat-pedantic</key>
+    <name>clang-diagnostic-c++98-c++11-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-date-time</key>
     <name>clang-diagnostic-date-time</name>
     <description>
@@ -25857,36 +27476,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wheader-guard" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++98-c++11-c++14-compat</key>
-    <name>clang-diagnostic-c++98-c++11-c++14-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
-<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
-<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
-<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
-<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
-<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
-<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
-<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
-<li>warning: inline variables are incompatible with C++ standards before C++17</li>
-<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
-<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
-<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
-<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
-<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
-<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -25994,6 +27583,36 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++98-c++11-c++14-compat</key>
+    <name>clang-diagnostic-c++98-c++11-c++14-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-auto-storage-class</key>
     <name>clang-diagnostic-auto-storage-class</name>
     <description>
@@ -26036,38 +27655,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</key>
-    <name>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
-<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
-<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
-<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
-<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
-<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
-<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
-<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
-<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
-<li>warning: hexadecimal floating literals are incompatible with C++ standards before C++17</li>
-<li>warning: inline variables are incompatible with C++ standards before C++17</li>
-<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
-<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
-<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
-<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
-<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
-<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
     <key>clang-diagnostic-ambiguous-ellipsis</key>
     <name>clang-diagnostic-ambiguous-ellipsis</name>
     <description>
@@ -26096,6 +27683,20 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-cxx-attribute-extension</key>
+    <name>clang-diagnostic-cxx-attribute-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++ does not allow an attribute list to appear here</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcxx-attribute-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-requires-expression</key>
     <name>clang-diagnostic-requires-expression</name>
     <description>
@@ -26119,20 +27720,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstatic-inline-explicit-instantiation" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pedantic-core-features</key>
-    <name>clang-diagnostic-pedantic-core-features</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: OpenCL extension %0 is core feature or supported optional core feature - ignoring</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpedantic-core-features" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -26180,6 +27767,38 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</key>
+    <name>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: hexadecimal floating literals are incompatible with C++ standards before C++17</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-predefined-identifier-outside-function</key>
     <name>clang-diagnostic-predefined-identifier-outside-function</name>
     <description>
@@ -26194,6 +27813,20 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-interrupt-service-routine</key>
+    <name>clang-diagnostic-interrupt-service-routine</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: interrupt service routine should only call a function with attribute 'no_caller_saved_registers'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winterrupt-service-routine" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-redundant-parens</key>
     <name>clang-diagnostic-redundant-parens</name>
     <description>
@@ -26203,40 +27836,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wredundant-parens" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat</key>
-    <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
-<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
-<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
-<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
-<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
-<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
-<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
-<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
-<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
-<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -26340,6 +27939,45 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat</key>
+    <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
+<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
+<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
+<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
+<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-builtin-memcpy-chk-size</key>
     <name>clang-diagnostic-builtin-memcpy-chk-size</name>
     <description>
@@ -26377,42 +28015,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-protocol" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</key>
-    <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
-<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
-<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
-<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
-<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: designated initializers are incompatible with C++ standards before C++20</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
-<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
-<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
-<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
-<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
-<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
-<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -26516,6 +28118,47 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</key>
+    <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
+<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: designated initializers are incompatible with C++ standards before C++20</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
+<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
+<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
+<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-objc-autosynthesis-property-ivar-name-match</key>
     <name>clang-diagnostic-objc-autosynthesis-property-ivar-name-match</name>
     <description>
@@ -26556,28 +28199,6 @@ Derived();             // and so temporary construction is okay</code></pre>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++0x-narrowing</key>
-    <name>clang-diagnostic-c++0x-narrowing</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|constexpr if condition|explicit specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-narrowing" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    <type>CODE_SMELL</type>
-    <remediationFunction>LINEAR</remediationFunction>
-    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>clang-diagnostic-implicit-retain-self</key>
@@ -26622,6 +28243,20 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-redundant-consteval-if</key>
+    <name>clang-diagnostic-redundant-consteval-if</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: consteval if is always true in an %select{unevaluated|immediate}0 context</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wredundant-consteval-if" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-weak-vtables</key>
     <name>clang-diagnostic-weak-vtables</name>
     <description>
@@ -26641,7 +28276,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: explicit template instantiation %0 will emit a vtable in every translation unit</li>
+<li>warning: this warning is no longer in use and will be removed in the next release</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wweak-template-vtables" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -26662,6 +28297,28 @@ Derived();             // and so temporary construction is okay</code></pre>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++0x-narrowing</key>
+    <name>clang-diagnostic-c++0x-narrowing</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-narrowing" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
     </rule>
   <rule>
     <key>clang-diagnostic-injected-class-name</key>
@@ -26717,28 +28374,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-constexpr" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    <type>CODE_SMELL</type>
-    <remediationFunction>LINEAR</remediationFunction>
-    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-narrowing</key>
-    <name>clang-diagnostic-narrowing</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|constexpr if condition|explicit specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnarrowing" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>CRITICAL</severity>
     <type>CODE_SMELL</type>
@@ -26832,6 +28467,28 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-narrowing</key>
+    <name>clang-diagnostic-narrowing</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnarrowing" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
     <key>clang-diagnostic-builtin-assume-aligned-alignment</key>
     <name>clang-diagnostic-builtin-assume-aligned-alignment</name>
     <description>
@@ -26883,104 +28540,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdllimport-static-field-def" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++0x-compat</key>
-    <name>clang-diagnostic-c++0x-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|constexpr if condition|explicit specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
-<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
-<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
-<li>warning: '%0' is a keyword in C++11</li>
-<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
-<li>warning: 'auto' storage class specifier is redundant and incompatible with C++11</li>
-<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
-<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
-<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
-<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
-<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
-<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
-<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
-<li>warning: conversion from string literal to %0 is deprecated</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
-<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
-<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
-<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
-<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: digit separators are incompatible with C++ standards before C++14</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
-<li>warning: explicit instantiation cannot be 'inline'</li>
-<li>warning: explicit instantiation of %0 must occur at global scope</li>
-<li>warning: explicit instantiation of %0 not in a namespace enclosing %1</li>
-<li>warning: explicit instantiation of %q0 must occur in namespace %1</li>
-<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
-<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
-<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: generic lambdas are incompatible with C++11</li>
-<li>warning: identifier after literal will be treated as a reserved user-defined literal suffix in C++11</li>
-<li>warning: identifier after literal will be treated as a user-defined literal suffix in C++11</li>
-<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
-<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
-<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
-<li>warning: inline variables are incompatible with C++ standards before C++17</li>
-<li>warning: integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
-<li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
-<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
-<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
-<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
-<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
-<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
-<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
-<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
-<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
-<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
-<li>warning: use of right-shift operator ('&gt;&gt;') in template argument will require parentheses in C++11</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable templates are incompatible with C++ standards before C++14</li>
-<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    <type>CODE_SMELL</type>
-    <remediationFunction>LINEAR</remediationFunction>
-    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-dllexport-explicit-instantiation-decl</key>
-    <name>clang-diagnostic-dllexport-explicit-instantiation-decl</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: explicit instantiation declaration should not be 'dllexport'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdllexport-explicit-instantiation-decl" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -27070,6 +28629,112 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++0x-compat</key>
+    <name>clang-diagnostic-c++0x-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: '%0' is a keyword in C++11</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'auto' storage class specifier is redundant and incompatible with C++11</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: conversion from string literal to %0 is deprecated</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
+<li>warning: explicit instantiation cannot be 'inline'</li>
+<li>warning: explicit instantiation of %0 must occur at global scope</li>
+<li>warning: explicit instantiation of %0 not in a namespace enclosing %1</li>
+<li>warning: explicit instantiation of %q0 must occur in namespace %1</li>
+<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
+<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: identifier after literal will be treated as a reserved user-defined literal suffix in C++11</li>
+<li>warning: identifier after literal will be treated as a user-defined literal suffix in C++11</li>
+<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
+<li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: use of right-shift operator ('&gt;&gt;') in template argument will require parentheses in C++11</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <type>CODE_SMELL</type>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-ignored-availability-without-sdk-settings</key>
+    <name>clang-diagnostic-ignored-availability-without-sdk-settings</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 availability is ignored without a valid 'SDKSettings.json' in the SDK</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-availability-without-sdk-settings" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-pointer-compare</key>
     <name>clang-diagnostic-pointer-compare</name>
     <description>
@@ -27107,44 +28772,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsizeof-array-div" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++1z-compat</key>
-    <name>clang-diagnostic-c++1z-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
-<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
-<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
-<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
-<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
-<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
-<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
-<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
-<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
-<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
-<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
-<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -27234,6 +28861,52 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++1z-compat</key>
+    <name>clang-diagnostic-c++1z-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
+<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
+<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
+<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
+<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
+<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-invalid-partial-specialization</key>
     <name>clang-diagnostic-invalid-partial-specialization</name>
     <description>
@@ -27289,27 +28962,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtypename-missing" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++2a-compat</key>
-    <name>clang-diagnostic-c++2a-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%0' is a keyword in C++20</li>
-<li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
-<li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: this expression will be parsed as explicit(bool) in C++20</li>
-<li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -27399,6 +29051,30 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++2a-compat</key>
+    <name>clang-diagnostic-c++2a-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' is a keyword in C++20</li>
+<li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
+<li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: this expression will be parsed as explicit(bool) in C++20</li>
+<li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-typedef-redefinition</key>
     <name>clang-diagnostic-typedef-redefinition</name>
     <description>
@@ -27450,28 +29126,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-interface-ivars" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++2a-compat-pedantic</key>
-    <name>clang-diagnostic-c++2a-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%0' is a keyword in C++20</li>
-<li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
-<li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: this expression will be parsed as explicit(bool) in C++20</li>
-<li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -27556,6 +29210,34 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexplicit-ownership-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++2a-compat-pedantic</key>
+    <name>clang-diagnostic-c++2a-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' is a keyword in C++20</li>
+<li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
+<li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: this expression will be parsed as explicit(bool) in C++20</li>
+<li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -27745,20 +29427,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
-    <key>clang-diagnostic-ordered-compare-function-pointers</key>
-    <name>clang-diagnostic-ordered-compare-function-pointers</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ordered comparison of function pointers (%0 and %1)</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wordered-compare-function-pointers" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
     <key>clang-diagnostic-pointer-integer-compare</key>
     <name>clang-diagnostic-pointer-integer-compare</name>
     <description>
@@ -27843,15 +29511,15 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
-    <key>clang-diagnostic-bool-operation</key>
-    <name>clang-diagnostic-bool-operation</name>
+    <key>clang-diagnostic-deprecated-altivec-src-compat</key>
+    <name>clang-diagnostic-deprecated-altivec-src-compat</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: bitwise negation of a boolean expression%select{;| always evaluates to 'true';}0 did you mean logical negation?</li>
+<li>warning: Current handling of vector bool and vector pixel types in this context are deprecated. The default behaviour will soon change to that implied by the '-altivec-compat=xl' option</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbool-operation" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-altivec-src-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -27922,6 +29590,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-implicit-seq-cst" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-gpu-maybe-wrong-side</key>
+    <name>clang-diagnostic-gpu-maybe-wrong-side</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: capture host side class data member by this pointer in device or host device lambda function may result in invalid memory access if this pointer is not accessible on device side</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgpu-maybe-wrong-side" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -28123,6 +29805,20 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-argument-undefined-behaviour</key>
+    <name>clang-diagnostic-argument-undefined-behaviour</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: argument value %0 will result in undefined behaviour</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wargument-undefined-behaviour" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
     </rule>
   <rule>
     <key>clang-diagnostic-nonportable-vector-initialization</key>
@@ -28343,6 +30039,21 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-deprecated-copy-dtor</key>
+    <name>clang-diagnostic-deprecated-copy-dtor</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared destructor</li>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided destructor</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-copy-dtor" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-partial-availability</key>
     <name>clang-diagnostic-partial-availability</name>
     <description>
@@ -28415,7 +30126,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '%0' within '%1'</li>
 <li>warning: '%select{*|.*}0' specified field %select{width|precision}0 is missing a matching 'int' argument</li>
 <li>warning: '&amp;&amp;' within '||'</li>
-<li>warning: '-fuse-ld=' taking a path is deprecated. Use '--ld-path=' instead</li>
+<li>warning: '-fuse-ld=' taking a path is deprecated; use '--ld-path=' instead</li>
 <li>warning: '/*' within block comment</li>
 <li>warning: 'static' function %0 declared in header file should be declared 'static inline'</li>
 <li>warning: 'this' pointer cannot be null in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0</li>
@@ -28432,6 +30143,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: assigning %select{field|instance variable}0 to itself</li>
 <li>warning: base class %0 is uninitialized when used here to access %q1</li>
 <li>warning: bitwise comparison always evaluates to %select{false|true}0</li>
+<li>warning: bitwise negation of a boolean expression%select{;| always evaluates to 'true';}0 did you mean logical negation?</li>
 <li>warning: bitwise or with non-zero value always evaluates to true</li>
 <li>warning: block pointer variable %0 is %select{uninitialized|null}1 when captured by block</li>
 <li>warning: call to function without interrupt attribute could clobber interruptee's VFP registers</li>
@@ -28452,6 +30164,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: data argument not used by format string</li>
 <li>warning: data argument position '%0' exceeds the number of data arguments (%1)</li>
 <li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared copy %select{assignment operator|constructor}1</li>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided copy %select{assignment operator|constructor}1</li>
 <li>warning: designated initializer invoked a non-designated initializer</li>
 <li>warning: designated initializer missing a 'super' call to a designated initializer of the super class</li>
 <li>warning: designated initializer should only invoke a designated initializer on 'super'</li>
@@ -28494,12 +30207,13 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: incomplete format specifier</li>
 <li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
 <li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
+<li>warning: initializer order does not match the declaration order</li>
 <li>warning: invalid conversion specifier '%0'</li>
 <li>warning: invalid position specified for %select{field width|field precision}0</li>
 <li>warning: ivar %0 which backs the property is not referenced in this property's accessor</li>
 <li>warning: lambda capture %0 is not %select{used|required to be captured for this use}1</li>
+<li>warning: left operand of comma operator has no effect</li>
 <li>warning: length modifier '%0' results in undefined behavior or no effect with '%1' conversion specifier</li>
-<li>warning: local variable %0 will be copied despite being %select{returned|thrown}1 by name</li>
 <li>warning: logical not is only applied to the left hand side of this %select{comparison|bitwise operator}0</li>
 <li>warning: loop variable %0 %diff{of type $ binds to a temporary constructed from type $|binds to a temporary constructed from a different type}1,2</li>
 <li>warning: loop variable %0 creates a copy from type %1</li>
@@ -28532,7 +30246,9 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: overflow converting case value to switch condition type (%0 to %1)</li>
 <li>warning: overlapping comparisons always evaluate to %select{false|true}0</li>
 <li>warning: overloaded operator %select{&gt;&gt;|&lt;&lt;}0 has higher precedence than comparison operator</li>
+<li>warning: parameter %0 set but not used</li>
 <li>warning: performing pointer arithmetic on a null pointer has undefined behavior%select{| if the offset is nonzero}0</li>
+<li>warning: performing pointer subtraction with a null pointer %select{has|may have}0 undefined behavior</li>
 <li>warning: position arguments in format strings start counting at 1 (not 0)</li>
 <li>warning: pragma STDC FENV_ROUND is not supported</li>
 <li>warning: pragma diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'</li>
@@ -28569,6 +30285,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: unused variable %0</li>
 <li>warning: unused variable %0</li>
 <li>warning: use of __private_extern__ on a declaration may not produce external symbol private to the linkage unit and is deprecated</li>
+<li>warning: use of bitwise '%0' with boolean operands</li>
 <li>warning: use of unknown builtin %0</li>
 <li>warning: using '%%P' format specifier without precision</li>
 <li>warning: using '%0' format specifier annotation outside of os_log()/os_trace()</li>
@@ -28579,6 +30296,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: variable %0 is uninitialized when %select{used here|captured by block}1</li>
 <li>warning: variable %0 is uninitialized when passed as a const reference argument here</li>
 <li>warning: variable %0 is uninitialized when used within its own initialization</li>
+<li>warning: variable %0 set but not used</li>
 <li>warning: variable%select{s| %1|s %1 and %2|s %1, %2, and %3|s %1, %2, %3, and %4}0 used in loop condition not modified in loop body</li>
 <li>warning: zero field width in scanf format string is unused</li>
 </ul>
@@ -28824,11 +30542,14 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: initialized lambda pack captures are a C++20 extension</li>
 <li>warning: inline nested namespace definition is a C++20 extension</li>
 <li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is a C++20 extension</li>
+<li>warning: member using declaration naming a non-member enumerator is a C++20 extension</li>
 <li>warning: range-based for loop initialization statements are a C++20 extension</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is a C++20 extension</li>
 <li>warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension</li>
 <li>warning: use of the %0 attribute is a C++20 extension</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++20 extension</li>
+<li>warning: using declaration naming a scoped enumerator is a C++20 extension</li>
+<li>warning: using enum declaration is a C++20 extension</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -28846,6 +30567,21 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmsvc-include" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-frame-larger-than=</key>
+    <name>clang-diagnostic-frame-larger-than=</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+<li>warning: stack frame size (%0) exceeds limit (%1) in '%2'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wframe-larger-than=" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -28902,20 +30638,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstack-exhausted" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-div-by-zero</key>
-    <name>clang-diagnostic-div-by-zero</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{remainder|division}0 by zero is undefined</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdiv-by-zero" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -29033,6 +30755,20 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-div-by-zero</key>
+    <name>clang-diagnostic-div-by-zero</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{remainder|division}0 by zero is undefined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdiv-by-zero" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-msvc-not-found</key>
     <name>clang-diagnostic-msvc-not-found</name>
     <description>
@@ -29056,20 +30792,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdarwin-sdk-settings" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++1z-compat-mangling</key>
-    <name>clang-diagnostic-c++1z-compat-mangling</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat-mangling" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -29189,6 +30911,20 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++1z-compat-mangling</key>
+    <name>clang-diagnostic-c++1z-compat-mangling</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat-mangling" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
     <key>clang-diagnostic-language-extension-token</key>
     <name>clang-diagnostic-language-extension-token</name>
     <description>
@@ -29217,30 +30953,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <type>CODE_SMELL</type>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++98-c++11-compat</key>
-    <name>clang-diagnostic-c++98-c++11-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
-<li>warning: digit separators are incompatible with C++ standards before C++14</li>
-<li>warning: generic lambdas are incompatible with C++11</li>
-<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
-<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
-<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
-<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable templates are incompatible with C++ standards before C++14</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
     <key>clang-diagnostic-unicode-homoglyph</key>
     <name>clang-diagnostic-unicode-homoglyph</name>
     <description>
@@ -29264,6 +30976,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-zero-width" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-delimited-escape-sequence-extension</key>
+    <name>clang-diagnostic-delimited-escape-sequence-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: delimited escape sequences are a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdelimited-escape-sequence-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -29338,47 +31064,5 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
     </rule>
-  <rule>
-    <key>clang-diagnostic-pragma-once-outside-header</key>
-    <name>clang-diagnostic-pragma-once-outside-header</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #pragma once in main file</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-once-outside-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pragma-system-header-outside-header</key>
-    <name>clang-diagnostic-pragma-system-header-outside-header</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #pragma system_header ignored in main file</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-system-header-outside-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-disabled-macro-expansion</key>
-    <name>clang-diagnostic-disabled-macro-expansion</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: disabled expansion of recursive macro</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdisabled-macro-expansion" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  
+ 
 </rules>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepositoryTest.java
@@ -37,7 +37,7 @@ public class CxxClangSARuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxClangSARuleRepository.KEY);
-    assertEquals(91, repo.rules().size());
+    assertEquals(92, repo.rules().size());
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
@@ -36,7 +36,7 @@ public class CxxClangTidyRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxClangTidyRuleRepository.KEY);
-    assertEquals(1271, repo.rules().size());
+    assertEquals(1316, repo.rules().size());
   }
 
 }

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -17,7 +17,7 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import cgi
+import html
 import json
 import os
 import re
@@ -30,7 +30,7 @@ from utils_createrules import get_cdata_capable_xml_etree
 
 SEVERITY_MAP = {
 
-    # last update: llvmorg-13-init-4898-g270a336ff462
+    # last update: llvmorg-14-init-8123-ga875e6e1225a (git describe)
     # rule keys are in alphabetical order
 
     "abseil-no-namespace": {"type": "CODE_SMELL", "severity": "INFO"},    
@@ -373,7 +373,7 @@ def create_template_rules(rules):
     <li>Create a new rule in SonarQube by "copying" this rule template and specify the <code>CheckId</code> of your custom rule, a title, a description, and a default severity.</li>
     <li>Enable the newly created rule in your quality profile</li>
   </ol>
-  <li>Relaunch an analysis on your projects, et voilà, your custom rules are executed!</li>
+  <li>Relaunch an analysis on your projects, et voila, your custom rules are executed!</li>
 </ol>"""
     
     rule = et.Element('rule')
@@ -504,7 +504,7 @@ def generate_description(diag_group_name, diagnostics):
             diag_class == "CLASS_REMARK")
         diag_text = diagnostic["Text"]
         diag_class_printable = DIAG_CLASS[diag_class]["printable"]
-        diag_text_escaped = cgi.escape(diag_text)
+        diag_text_escaped = html.escape(diag_text, quote=False)
         html_lines.append("<li>%s: %s</li>" %
                           (diag_class_printable, diag_text_escaped))
     html_lines.append("</ul>")

--- a/cxx-sensors/src/tools/generate_clangtidy_resources.cmd
+++ b/cxx-sensors/src/tools/generate_clangtidy_resources.cmd
@@ -1,0 +1,68 @@
+@ECHO OFF
+CLS
+
+REM customize paths for your local system
+SET SCRIPT_DIR=%~dp0
+SET PANDOC_DIR=C:\Program Files\Pandoc\
+SET PYTHON_DIR=C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python37_64\
+SET LLVM_DIR=C:\Development\git\llvm-project\
+
+REM verify paths
+IF NOT EXIST "%PANDOC_DIR%" (
+   ECHO Invalid PANDOC_DIR setting
+   GOTO ERROR
+)
+
+IF NOT EXIST "%PYTHON_DIR%" (
+   ECHO Invalid PYTHON_DIR setting
+   GOTO ERROR
+)
+
+IF NOT EXIST "%LLVM_DIR%" (
+   ECHO Invalid LLVM_DIR setting
+   GOTO ERROR
+)
+
+IF NOT EXIST "%LLVM_DIR%build\Release\bin" (
+   ECHO You have to build LLVM first
+   GOTO ERROR
+)
+
+REM tool versions
+"%PANDOC_DIR%pandoc.exe" -v
+"%PYTHON_DIR%python.exe" -V
+"%LLVM_DIR%build\Release\bin\llvm-tblgen.exe" --version
+git --version
+ECHO LLVM recent tag:
+PUSHD "%LLVM_DIR%"
+git describe
+POPD
+ECHO.
+
+REM GENERATION OF RULES FROM CLANG-TIDY DOCUMENTATION (RST FILES)
+ECHO generate the new version of the rules file...
+"%PYTHON_DIR%python.exe" "%SCRIPT_DIR%clangtidy_createrules.py" rules "%LLVM_DIR%clang-tools-extra\docs\clang-tidy\checks" > "%SCRIPT_DIR%clangtidy_new.xml"
+ECHO compare the new version with the old one, extend the old XML...
+"%PYTHON_DIR%python.exe" "%SCRIPT_DIR%utils_createrules.py" comparerules "%SCRIPT_DIR%\..\main\resources\clangtidy.xml" "%SCRIPT_DIR%clangtidy_new.xml" > "%SCRIPT_DIR%clangtidy-comparison.md"
+
+REM GENERATION OF RULES FROM CLANG DIAGNOSTICS
+ECHO generate the list of diagnostics...
+PUSHD "%LLVM_DIR%clang\include\clang\Basic"
+"%LLVM_DIR%build\Release\bin\llvm-tblgen.exe" -dump-json "%LLVM_DIR%clang\include\clang\Basic\Diagnostic.td" > "%SCRIPT_DIR%diagnostic.json"
+POPD
+ECHO generate the new version of the diagnostics file...
+"%PYTHON_DIR%python.exe" "%SCRIPT_DIR%clangtidy_createrules.py" diagnostics "%SCRIPT_DIR%diagnostic.json" > "%SCRIPT_DIR%diagnostic_new.xml"
+ECHO compare the new version with the old one, extend the old XML...
+"%PYTHON_DIR%python.exe" "%SCRIPT_DIR%utils_createrules.py" comparerules "%SCRIPT_DIR%\..\main\resources\clangtidy.xml" "%SCRIPT_DIR%diagnostic_new.xml" > "%SCRIPT_DIR%diagnostic-comparison.md"
+
+REM exit
+GOTO END
+:ERROR
+ECHO.
+ECHO execution failed
+EXIT /B 1
+
+:END
+ECHO.
+ECHO finished succesfully
+EXIT /B 0


### PR DESCRIPTION
* tag: llvmorg-14-init-8123-ga875e6e1225a
* new clang tidy rules:
  * altera-id-dependent-backward-branch
  * bugprone-easily-swappable-parameters
  * bugprone-implicit-widening-of-multiplication-result
  * bugprone-suspicious-memory-comparison
  * bugprone-unhandled-exception-at-new
  * cert-exp42-c
  * cert-flp37-c
  * cppcoreguidelines-virtual-class-destructor
  * readability-data-pointer
  * readability-identifier-length
  * readability-suspicious-call-argument
* new clang diagnostic rules:
  * clang-diagnostic-aix-compat
  * clang-diagnostic-argument-undefined-behaviour
  * clang-diagnostic-attribute-warning
  * clang-diagnostic-bitwise-instead-of-logical
  * clang-diagnostic-cast-function-type
  * clang-diagnostic-cxx-attribute-extension
  * clang-diagnostic-delimited-escape-sequence-extension
  * clang-diagnostic-deprecated-altivec-src-compat
  * clang-diagnostic-deprecated-copy-with-dtor
  * clang-diagnostic-deprecated-copy-with-user-provided-copy
  * clang-diagnostic-deprecated-copy-with-user-provided-dtor
  * clang-diagnostic-deprecated-pragma
  * clang-diagnostic-final-macro
  * clang-diagnostic-frame-larger-than
  * clang-diagnostic-gpu-maybe-wrong-side
  * clang-diagnostic-ignored-availability-without-sdk-settings
  * clang-diagnostic-ignored-reference-qualifiers
  * clang-diagnostic-interrupt-service-routine
  * clang-diagnostic-linker-warnings
  * clang-diagnostic-microsoft-abstract
  * clang-diagnostic-module-lock
  * clang-diagnostic-null-pointer-subtraction
  * clang-diagnostic-openmp-51-extensions
  * clang-diagnostic-pedantic-macros
  * clang-diagnostic-pre-openmp-51-compat
  * clang-diagnostic-redundant-consteval-if
  * clang-diagnostic-reserved-identifier
  * clang-diagnostic-reserved-macro-identifier
  * clang-diagnostic-restrict-expansion
  * clang-diagnostic-search-path-usage
  * clang-diagnostic-tautological-unsigned-char-zero-compare
  * clang-diagnostic-unreachable-code-fallthrough
  * clang-diagnostic-unused-but-set-parameter
  * clang-diagnostic-unused-but-set-variable
* new clang-sa rules:
  * cplusplus.StringChecker

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2270)
<!-- Reviewable:end -->
