### PR TITLE
Cleanup deprecated code in 8.9 to make plugin run on 9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ jdk:
 env:
   - SONARLABEL=sonarqube-7.9.6 SONARAPI=SqApi79
   - SONARLABEL=sonarqube-8.9.2.46101 SONARAPI=SqApi79
+  - SONARLABEL=sonarqube-9.1.0.47736 SONARAPI=SqApi79
 
 addons:
   # shorten the VM hostname with the new workaround

--- a/cxx-checks/pom.xml
+++ b/cxx-checks/pom.xml
@@ -42,6 +42,11 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.sonarsource.sonarqube</groupId>
+      <artifactId>sonar-plugin-api-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.sslr</groupId>
       <artifactId>sslr-testing-harness</artifactId>
       <scope>test</scope>

--- a/cxx-sensors/pom.xml
+++ b/cxx-sensors/pom.xml
@@ -29,6 +29,15 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.sonarqube</groupId>
+      <artifactId>sonar-plugin-api-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-testing-harness</artifactId>
       <scope>test</scope>

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/StaxParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/StaxParser.java
@@ -63,12 +63,9 @@ public class StaxParser {
    */
   public StaxParser(XmlStreamHandler streamHandler, boolean isoControlCharsAwareParser) {
     this.streamHandler = streamHandler;
-    var xmlFactory = XMLInputFactory.newInstance();
-    if (xmlFactory instanceof WstxInputFactory) {
-      var wstxInputfactory = (WstxInputFactory) xmlFactory;
-      wstxInputfactory.configureForLowMemUsage();
-      wstxInputfactory.getConfig().setUndeclaredEntityResolver(new UndeclaredEntitiesXMLResolver());
-    }
+    WstxInputFactory xmlFactory = new WstxInputFactory();
+    xmlFactory.configureForLowMemUsage();
+    xmlFactory.getConfig().setUndeclaredEntityResolver(new UndeclaredEntitiesXMLResolver());
     xmlFactory.setProperty(XMLInputFactory.IS_VALIDATING, Boolean.FALSE);
     xmlFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
     xmlFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.FALSE);

--- a/cxx-squid-bridge/src/main/java/org/sonar/cxx/squidbridge/annotations/AnnotationBasedProfileBuilder.java
+++ b/cxx-squid-bridge/src/main/java/org/sonar/cxx/squidbridge/annotations/AnnotationBasedProfileBuilder.java
@@ -23,7 +23,6 @@
  */
 package org.sonar.cxx.squidbridge.annotations;
 
-import org.sonar.api.profiles.ProfileDefinition;
 import org.sonar.api.profiles.RulesProfile;
 import org.sonar.api.rules.RuleFinder;
 import org.sonar.api.utils.AnnotationUtils;
@@ -31,8 +30,7 @@ import org.sonar.api.utils.ValidationMessages;
 
 /**
  * Utility class to build an instance of {@link RulesProfile} based on a list of classes annotated
- * with {@link ActivatedByDefault}. It can be used to implement the <code>createProfile</code>
- * method of {@link ProfileDefinition}.
+ * with {@link ActivatedByDefault}.
  *
  * @since 2.5
  */

--- a/cxx-squid-bridge/src/main/java/org/sonar/cxx/squidbridge/annotations/SqaleSubCharacteristic.java
+++ b/cxx-squid-bridge/src/main/java/org/sonar/cxx/squidbridge/annotations/SqaleSubCharacteristic.java
@@ -27,15 +27,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.sonar.api.server.rule.RulesDefinition.SubCharacteristics;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Deprecated(forRemoval = true)
 public @interface SqaleSubCharacteristic {
 
-  /**
-   * @see SubCharacteristics
-   */
   public String value();
 
 }

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/annotations/AnnotationBasedRulesDefinitionTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/annotations/AnnotationBasedRulesDefinitionTest.java
@@ -33,7 +33,6 @@ import org.sonar.api.server.rule.*;
 import org.sonar.api.server.rule.RulesDefinition.NewRepository;
 import org.sonar.api.server.rule.RulesDefinition.Param;
 import org.sonar.api.server.rule.RulesDefinition.Repository;
-import org.sonar.api.server.rule.RulesDefinition.SubCharacteristics;
 import org.sonar.check.Cardinality;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
@@ -190,7 +189,6 @@ public class AnnotationBasedRulesDefinitionTest {
   public void class_with_sqale_constant_remediation() throws Exception {
 
     @Rule(key = "key1", name = "name1", description = "description1")
-    @SqaleSubCharacteristic(SubCharacteristics.CPU_EFFICIENCY)
     @SqaleConstantRemediation("10min")
     class RuleClass {
     }
@@ -203,7 +201,6 @@ public class AnnotationBasedRulesDefinitionTest {
   public void class_with_sqale_linear_remediation() throws Exception {
 
     @Rule(key = "key1", name = "name1", description = "description1")
-    @SqaleSubCharacteristic(SubCharacteristics.CPU_EFFICIENCY)
     @SqaleLinearRemediation(coeff = "2h", effortToFixDescription = "Effort to test one uncovered condition")
     class RuleClass {
     }
@@ -216,7 +213,6 @@ public class AnnotationBasedRulesDefinitionTest {
   public void class_with_sqale_linear_with_offset_remediation() throws Exception {
 
     @Rule(key = "key1", name = "name1", description = "description1")
-    @SqaleSubCharacteristic(SubCharacteristics.CPU_EFFICIENCY)
     @SqaleLinearWithOffsetRemediation(coeff = "5min", offset = "1h",
                                       effortToFixDescription = "Effort to test one uncovered condition")
     class RuleClass {
@@ -229,7 +225,6 @@ public class AnnotationBasedRulesDefinitionTest {
   @Test
   public void class_with_several_sqale_remediation_annotations() throws Exception {
     @Rule(key = "key1", name = "name1", description = "description1")
-    @SqaleSubCharacteristic(SubCharacteristics.CPU_EFFICIENCY)
     @SqaleConstantRemediation("10min")
     @SqaleLinearRemediation(coeff = "2h", effortToFixDescription = "Effort to test one uncovered condition")
     class RuleClass {
@@ -242,7 +237,6 @@ public class AnnotationBasedRulesDefinitionTest {
   @Test
   public void invalid_sqale_annotation() throws Exception {
     @Rule(key = "key1", name = "name1", description = "description1")
-    @SqaleSubCharacteristic(SubCharacteristics.CPU_EFFICIENCY)
     @SqaleConstantRemediation("xxx")
     class MyInvalidRuleClass {
     }
@@ -275,7 +269,6 @@ public class AnnotationBasedRulesDefinitionTest {
   @Test
   public void load_method_with_class_with_sqale_annotations() throws Exception {
     @Rule(key = "key1", name = "name1", description = "description1")
-    @SqaleSubCharacteristic(SubCharacteristics.CPU_EFFICIENCY)
     @SqaleConstantRemediation("10min")
     class RuleClass {
     }
@@ -286,9 +279,9 @@ public class AnnotationBasedRulesDefinitionTest {
   private void assertRemediation(RulesDefinition.Rule rule, Type type, String coeff, String offset, String effortDesc) {
     DebtRemediationFunction remediationFunction = rule.debtRemediationFunction();
     assertThat(remediationFunction.type()).isEqualTo(type);
-    assertThat(remediationFunction.coefficient()).isEqualTo(coeff);
-    assertThat(remediationFunction.offset()).isEqualTo(offset);
-    assertThat(rule.effortToFixDescription()).isEqualTo(effortDesc);
+    assertThat(remediationFunction.gapMultiplier()).isEqualTo(coeff);
+    assertThat(remediationFunction.baseEffort()).isEqualTo(offset);
+    assertThat(rule.gapDescription()).isEqualTo(effortDesc);
   }
 
   private void assertParam(Param param, String expectedKey, String expectedDescription) {

--- a/cxx-squid/pom.xml
+++ b/cxx-squid/pom.xml
@@ -54,6 +54,11 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.sonarsource.sonarqube</groupId>
+      <artifactId>sonar-plugin-api-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.sslr</groupId>
       <artifactId>sslr-testing-harness</artifactId>
       <scope>test</scope>

--- a/cxx-sslr-toolkit/pom.xml
+++ b/cxx-sslr-toolkit/pom.xml
@@ -85,7 +85,7 @@
               <rules>
                 <requireFilesSize>
                   <maxsize>13000000</maxsize>
-                  <minsize>8000000</minsize>
+                  <minsize>7000000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>
                   </files>

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
     <animal.sniffer.skip>true</animal.sniffer.skip>
     <aggregate.report.dir>integration-tests/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
     <!-- versions -->
-    <sonar.version>7.9</sonar.version>
+    <sonar.version>8.9.3.48735</sonar.version>
     <java.version>11</java.version>
     <maven.compiler.version>3.8.1</maven.compiler.version>
     <sslr.version>1.24.0.633</sslr.version>
@@ -275,6 +275,12 @@
         <artifactId>sonar-plugin-api</artifactId>
         <version>${sonar.version}</version>
         <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.sonarsource.sonarqube</groupId>
+        <artifactId>sonar-plugin-api-impl</artifactId>
+        <version>${sonar.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>

--- a/sonar-cxx-plugin/pom.xml
+++ b/sonar-cxx-plugin/pom.xml
@@ -58,6 +58,11 @@
       <artifactId>gson</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.sonarsource.sonarqube</groupId>
+      <artifactId>sonar-plugin-api-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.sslr</groupId>
       <artifactId>sslr-testing-harness</artifactId>
       <scope>test</scope>
@@ -80,6 +85,15 @@
   </dependencies>
 
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonarsource.sonar-packaging-maven-plugin</groupId>
+        <artifactId>sonar-packaging-maven-plugin</artifactId>
+        <configuration>
+          <sonarQubeMinVersion>${sonarQubeMinVersion}</sonarQubeMinVersion>
+        </configuration>
+      </plugin>
+    </plugins>
     <resources>
       <resource>
         <directory>src/main/resources</directory>

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxFileLinesContextTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxFileLinesContextTest.java
@@ -37,7 +37,7 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.issue.NoSonarFilter;
+import org.sonar.api.batch.sensor.issue.internal.DefaultNoSonarFilter;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
@@ -59,7 +59,7 @@ public class CxxFileLinesContextTest {
     var inputFile = TestUtils.buildInputFile(baseDir, "ncloc.cc");
     context.fileSystem().add(inputFile);
 
-    var sensor = new CxxSquidSensor(fileLinesContextFactory, checkFactory, new NoSonarFilter(), null);
+    var sensor = new CxxSquidSensor(fileLinesContextFactory, checkFactory, new DefaultNoSonarFilter(), null);
     sensor.execute(context);
   }
 

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxHighlighterTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxHighlighterTest.java
@@ -34,7 +34,7 @@ import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.highlighting.TypeOfText;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.issue.NoSonarFilter;
+import org.sonar.api.batch.sensor.issue.internal.DefaultNoSonarFilter;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
 
@@ -57,7 +57,7 @@ public class CxxHighlighterTest {
     context = SensorContextTester.create(baseDir);
     context.fileSystem().add(inputFile);
 
-    sensor = new CxxSquidSensor(fileLinesContextFactory, checkFactory, new NoSonarFilter(), null);
+    sensor = new CxxSquidSensor(fileLinesContextFactory, checkFactory, new DefaultNoSonarFilter(), null);
     sensor.execute(context);
   }
 

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxSquidSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxSquidSensorTest.java
@@ -34,8 +34,8 @@ import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.cpd.internal.TokensLine;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.issue.internal.DefaultNoSonarFilter;
 import org.sonar.api.config.internal.MapSettings;
-import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
@@ -54,7 +54,7 @@ public class CxxSquidSensorTest {
     FileLinesContext fileLinesContext = mock(FileLinesContext.class);
     when(fileLinesContextFactory.createFor(Mockito.any(InputFile.class))).thenReturn(fileLinesContext);
 
-    sensor = new CxxSquidSensor(fileLinesContextFactory, checkFactory, new NoSonarFilter(), null);
+    sensor = new CxxSquidSensor(fileLinesContextFactory, checkFactory, new DefaultNoSonarFilter(), null);
   }
 
   @Test


### PR DESCRIPTION
I needed the plugin running on latest sonar 9.1 without errors (#2241)

I've updated targeted version to latest LTS - 8.9.3.4875 and fixed compilation problems (internal code used in tests moved to sonar-plugin-api-impl dependency, missing gson dependency in one place, `org.sonar.api.issue.NoSonarFilter` now abstarct class - replaced usage in tests with `org.sonar.api.batch.sensor.issue.internal.DefaultNoSonarFilter`).

Then I moved to fix deprecated functions in 8.9, that are missing in 9.1 - most were simply renamed, the only significant change is that [org.sonar.api.server.rule.RulesDefinition.NewRule.setDebtSubCharacteristic](https://javadocs.sonarsource.org/8.9.3.48735/org/sonar/api/server/rule/RulesDefinition.NewRule.html#setDebtSubCharacteristic(java.lang.String)) is gone in 9.1 without replacement (it's documented to do nothing in 8.9), so I removed the call, marked `@SqualeSubCharacteristic`, which was used to set it, as deprecated and fixed logic to check for `@Squale*Remediation` annotations instead

The plugin runs on 9.1 and builds with passing tests targeting 8.9.3.4875

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2274)
<!-- Reviewable:end -->
