### PR TITLE
UndocumentedApi: support unnamed-enum

### DIFF
--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
@@ -98,7 +98,7 @@ public class CxxPublicApiVisitorTest {
 
   @Test
   public void unnamed_enum() throws IOException {
-    assertThat(verifyPublicApiOfFile("src/test/resources/metrics/unnamed_enum.h")).isEqualTo(tuple(1, 1));
+    assertThat(verifyPublicApiOfFile("src/test/resources/metrics/unnamed_enum.h")).isEqualTo(tuple(8, 0));
   }
 
   @Test

--- a/cxx-squid/src/test/resources/metrics/unnamed_enum.h
+++ b/cxx-squid/src/test/resources/metrics/unnamed_enum.h
@@ -1,3 +1,39 @@
-enum /*anonymous enum*/ {
+// enum ...
+
+/** doc */
+enum named_enum_1 {
 };
 
+enum /*unnamed-enum*/ {
+};
+
+/** doc */
+enum named_enum_2 : int {
+};
+
+enum /*unnamed-enum*/ : int {
+};
+
+// typedef ...
+
+/** doc */
+typedef enum named_enum_3 {
+} type_name_1;
+
+/** doc */
+typedef enum named_enum_4 : int {
+} type_name_2;
+
+/** doc */
+typedef enum /*unnamed-enum*/ {
+} type_name_3;
+
+typedef enum /*unnamed-enum*/ {
+} type_name_4; ///< doc
+
+/** doc */
+typedef enum /*unnamed-enum*/ : int {
+} type_name_5;
+
+typedef enum /*unnamed-enum*/ : int {
+} type_name_6; ///< doc


### PR DESCRIPTION
samples with valid documentation:
```C++
enum /*unnamed-enum*/ {
};

enum /*unnamed-enum*/ : int {
};

/** doc */
typedef enum /*unnamed-enum*/ {
} type_name_3;

typedef enum /*unnamed-enum*/ {
} type_name_4; ///< doc

/** doc */
typedef enum /*unnamed-enum*/ : int {
} type_name_5;

typedef enum /*unnamed-enum*/ : int {
} type_name_6; ///< doc
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2277)
<!-- Reviewable:end -->
