### PR TITLE
fix parsing error with right angle bracket detection

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -713,7 +713,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
     ).skipIfOneChild();
 
     b.rule(cudaKernel).is(
-      b.sequence("<<", "<", b.optional(expressionList), ">", ">>") // CUDA
+      b.sequence("<<", "<", b.optional(expressionList), ">>", ">") // CUDA
     );
 
     b.rule(typeIdEnclosed).is( // todo

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/StatementTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/StatementTest.java
@@ -72,6 +72,28 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
+  public void expressionStatement_reallife() {
+    setRootRule(CxxGrammarImpl.expressionStatement);
+
+    assertThatParser()
+      // fix #2286: use expressionStatement with ; at the end to reset RightAngleBracketsChannel after each matches
+      .matches("a() < 0 || c >= 1;")
+      .matches("a() < 0 || c > 1;")
+      .matches("a() < 0 || c >> 1;");
+  }
+
+  @Test
+  public void selectionStatement_reallife() {
+    setRootRule(CxxGrammarImpl.selectionStatement);
+
+    assertThatParser()
+      // fix #2286
+      .matches("if(a() < 0 || c >= 1) {}")
+      .matches("if(a() < 0 || c > 1) {}")
+      .matches("if(a() < 0 || c >> 1) {}");
+  }
+
+  @Test
   public void labeledStatement() {
     setRootRule(CxxGrammarImpl.labeledStatement);
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/TemplatesTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/TemplatesTest.java
@@ -199,7 +199,13 @@ public class TemplatesTest extends ParserBaseTestHelper {
       .matches("A<(X>Y)>")
       .matches("A<(X<Y)>")
       .matches("vector<std::vector<bool>>")
-      .matches("Y<X<(6>>1)>>");
+      .matches("Y<X<(6>1)>>")
+      .matches("Y<X<(6<1)>>")
+      .matches("Y<X<(6>=1)>>")
+      .matches("Y<X<(6<=1)>>")
+      .matches("Y<X<(6>>1)>>")
+      .matches("Y<X<(6<<1)>>")
+      .matches("Y<X<(6<=>1)>>");
   }
 
   @Test


### PR DESCRIPTION
- close #2286

```C++
void check() {
    a() < 0 || c >= 1;
    a() < 0 || c > 1;
    a() < 0 || c >> 1;

    if(a() < 0 || c >= 1) {}
    if(a() < 0 || c > 1) {}
    if(a() < 0 || c >> 1) {}

    Y<X<(6<1)>>;
    Y<X<(6>=1)>>;
    Y<X<(6<=1)>>;
    Y<X<(6>>1)>>;
    Y<X<(6<<1)>>;
    Y<X<(6<=>1)>>;
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2291)
<!-- Reviewable:end -->
