### PR TITLE
C++14: add type traits helper support

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -2185,7 +2185,13 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
         b.sequence( // C++ (PEG: different order) todo one up
           typeConstraint,
           b.firstOf(
-            b.sequence(b.optional(IDENTIFIER), "=", typeId), // C++
+            b.sequence(
+              b.optional(IDENTIFIER), "=",
+              b.firstOf(
+                typeId, // C++
+                initializerClause // syntax sugar to handle type traits providing type name (e.g. std::enable_if_t<>=0)
+              )
+            ),
             b.sequence(b.optional("..."), b.optional(IDENTIFIER)) // C++ (PEG: different order)
           )
         )

--- a/cxx-squid/src/test/resources/parser/own/C++14/type-traits-helper.cc
+++ b/cxx-squid/src/test/resources/parser/own/C++14/type-traits-helper.cc
@@ -1,0 +1,7 @@
+// C++14 type traits helper were added (issue #2305)
+
+// using types trait with/without helper with/without default value
+template <typename T, typename std::enable_if  <std::is_base_of<BaseT, T>::value, int>::type  = 0> class A {};
+template <typename T, typename std::enable_if  <std::is_base_of<BaseT, T>::value, int>::type>      class B {};
+template <typename T,          std::enable_if_t<std::is_base_of<BaseT, T>::value, int>        = 0> class C {};
+template <typename T,          std::enable_if_t<std::is_base_of<BaseT, T>::value, int>>            class D {};


### PR DESCRIPTION
- supporting type traits helper as typeParameter (e.g. std::enable_if_t)
- close #2305

```C++
template <typename T, typename std::enable_if  <std::is_base_of<BaseT, T>::value, int>::type = 0> class A {};
template <typename T,          std::enable_if_t<std::is_base_of<BaseT, T>::value, int>       = 0> class C {};
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2306)
<!-- Reviewable:end -->
