### PR TITLE
Fix parsing error with right angle bracket detection

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/channels/RightAngleBracketsChannel.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/channels/RightAngleBracketsChannel.java
@@ -53,7 +53,9 @@ public class RightAngleBracketsChannel extends Channel<Lexer> {
 
     switch (ch) {
       case '(':
-        parentheseLevel++;
+        if (angleBracketLevel > 0) {
+          parentheseLevel++;
+        }
         break;
       case ')':
         if (parentheseLevel > 0) {

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/ExpressionTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/ExpressionTest.java
@@ -337,6 +337,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
       .matches("::foo()")
       .matches("obj.foo<int>()")
       .matches("typeid(int)")
+      .matches("f(std::shared_ptr<A<int>>(p))") // fix #2286
       // C++/CLI
       .matches("G::typeid")
       .matches("int::typeid")


### PR DESCRIPTION
- https://github.com/SonarOpenCommunity/sonar-cxx/blob/master/cxx-squid/dox/Right_Angle_Brackets_N1757_05-0017.html
- close #2318

Sample:
```C++
auto foo(A<int>* p)  {
    auto a = f(std::shared_ptr<A<int>>(p));
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2319)
<!-- Reviewable:end -->
