### PR TITLE
Parsing error when using template type parameter with assignment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
   - openjdk11
 env:
   - SONARLABEL=sonarqube-7.9.6 SONARAPI=SqApi79
-  - SONARLABEL=sonarqube-8.9.2.46101 SONARAPI=SqApi79
+  - SONARLABEL=sonarqube-8.9.7.52159 SONARAPI=SqApi79
 
 addons:
   # shorten the VM hostname with the new workaround

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,30 +24,28 @@ cache:
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
+      
+      Remove-Item "*.zip"
+       
       if ((Test-Path -Path "C:\maven" )) {
         Remove-Item -Recurse -Force "C:\maven"
       }
+      if ((Test-Path -Path "C:\maven" )) {
+        Remove-Item -Recurse -Force "C:\sonar-scanner"
+      }
+      if ((Test-Path -Path "C:\maven" )) {
+        Remove-Item -Recurse -Force "C:\sonarqube"
+      }
+      
+  - curl -fsSL -o C:/maven-bin.zip https://dlcdn.apache.org/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.zip
+  - curl -fsSL -o C:/sonar-scanner-dist.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.6.2.2472.zip
+  - curl -fsSL -o C:/sonarqube.zip https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-8.9.7.52159.zip
 
-      (new-object System.Net.WebClient).DownloadFile(
-        'https://dlcdn.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.zip',
-        'C:\maven-bin.zip'
-      )
+  - ps: |
       [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
-
-      if (!(Test-Path -Path "C:\sonar-scanner" )) {
-        (new-object System.Net.WebClient).DownloadFile(
-          'https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.6.2.2472.zip',
-          'C:\sonar-scanner-dist.zip'
-        )
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonar-scanner-dist.zip", "C:\sonar-scanner")
-      }
-      if (!(Test-Path -Path "C:\sonarqube" )) {
-        (new-object System.Net.WebClient).DownloadFile(
-          'https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-8.9.2.46101.zip',
-          'C:\sonarqube-8.9.2.46101.zip'
-        )
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonarqube-8.9.2.46101.zip", "C:\sonarqube")
-      }
+      [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonar-scanner-dist.zip", "C:\sonar-scanner")
+      [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sonarqube.zip", "C:\sonarqube")
+     
   - ps: |
       If ($env:Platform -Match "x86") {
         $env:PCRE_PLATFORM="Win32"
@@ -62,10 +60,10 @@ install:
         $env:VCVARS_PLATFORM="amd64"
         $env:LANG_PLATFORM="-x64"
       }
-  - cmd: SET PATH=C:\maven\apache-maven-3.8.3\bin;%JAVA_HOME%\bin;C:\sonar-scanner\sonar-scanner-4.6.2.2472\bin;%PATH%
-  - cmd: SET M2_HOME=C:\maven\apache-maven-3.8.3
-  - cmd: SET MAVEN_HOME=C:\maven\apache-maven-3.8.3
-  - cmd: SET SONARHOME=C:\sonarqube\sonarqube-8.9.2.46101
+  - cmd: SET PATH=C:\maven\apache-maven-3.8.4\bin;%JAVA_HOME%\bin;C:\sonar-scanner\sonar-scanner-4.6.2.2472\bin;%PATH%
+  - cmd: SET M2_HOME=C:\maven\apache-maven-3.8.4
+  - cmd: SET MAVEN_HOME=C:\maven\apache-maven-3.8.4
+  - cmd: SET SONARHOME=C:\sonarqube\sonarqube-8.9.7.52159
   - cmd: SET TestDataFolder=C:\projects\sonar-cxx\integration-tests\testdata
   - cmd: SET
 
@@ -107,4 +105,4 @@ on_failure:
   - ps: Get-ChildItem cxx-checks\target\surefire-reports\*.txt | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   - ps: Get-ChildItem sonar-cxx-plugin\target\surefire-reports\*.txt | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   - ps: Get-ChildItem *.log | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-  - ps: Get-ChildItem C:\sonarqube\sonarqube-8.9.2.46101\logs\* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+  - ps: Get-ChildItem C:\sonarqube\sonarqube-8.9.7.52159\logs\* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -2185,6 +2185,8 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
             b.sequence(b.optional(IDENTIFIER), "=", typeId), // C++
             // syntax sugar to handle type traits providing type name (e.g. std::enable_if_t<>=0, std::enable_if_t<>*=nullptr)
             b.sequence(b.optional("*"), "=", LITERAL),
+            // syntax sugar in case type is an identifier, e.g. 'size_t s = 0' (PEG conflict with parameterDeclaration)
+            b.sequence(IDENTIFIER, "=", initializerClause),
             b.sequence(b.optional("..."), b.optional(IDENTIFIER)) // C++ (PEG: different order)
           )
         )

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/TemplatesTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/TemplatesTest.java
@@ -71,7 +71,11 @@ public class TemplatesTest extends ParserBaseTestHelper {
   public void templateHead_reallife() {
     setRootRule(CxxGrammarImpl.templateHead);
 
-    assertThatParser().matches("template<typename T> requires Addable<T>");
+    assertThatParser()
+      .matches("template<typename T> requires Addable<T>")
+      // issue #2317
+      .matches("template <typename T, size_t s = sizeof(T)*2 >")
+      .matches("template <typename T, size_t s = 1>2 >");
   }
 
   @Test
@@ -126,7 +130,12 @@ public class TemplatesTest extends ParserBaseTestHelper {
       .matches("template<typename = float> typename = foo::foo")
       // parameter-declaration
       .matches("auto ... vs")
-      .matches("auto** pp0");
+      .matches("auto** pp0")
+      // issue #2317
+      .matches("size_t s = 15")
+      .matches("size_t s = sizeof(T)*2")
+      .matches("values v = v::ok")
+      .matches("T::type n = 0");
   }
 
   @Test


### PR DESCRIPTION
- close #2317

There is a PEG issue with the order of
```
template-parameter:
   type-parameter
   parameter-declaration
```
`type-parameter type-constraint` rule matches in case of non integral data type.

Samples:
```C++
template <typename T, size_t s = 15 > void f() {}
template <typename T, size_t s = sizeof(T)*2 > void f() {}
template <typename T, size_t s = 1>2 > void f() {}
template <values v = v::ok> void f() {}
template<class T, T::type n = 0> class X;
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2321)
<!-- Reviewable:end -->
