### PR TITLE
cxx 2.1.x remove technical debt

### DIFF
--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/CheckListTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/CheckListTest.java
@@ -22,10 +22,10 @@ package org.sonar.cxx.checks;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class CheckListTest {
+class CheckListTest {
 
   @Test
-  public void count() {
+  void count() {
     assertThat(CheckList.getChecks()).hasSize(27);
   }
 }

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/api/UndocumentedApiCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/api/UndocumentedApiCheckTest.java
@@ -28,13 +28,13 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifierRule;
 
-public class UndocumentedApiCheckTest {
+class UndocumentedApiCheckTest {
 
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
   @SuppressWarnings("squid:S2699")
   @Test
-  public void detected() throws UnsupportedEncodingException, IOException {
+  void detected() throws UnsupportedEncodingException, IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/checks/UndocumentedApiCheck/no_doc.h", ".");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile(), new UndocumentedApiCheck());
 
@@ -94,7 +94,7 @@ public class UndocumentedApiCheckTest {
   }
 
   @Test
-  public void docStyle1() throws UnsupportedEncodingException, IOException {
+  void docStyle1() throws UnsupportedEncodingException, IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/checks/UndocumentedApiCheck/doc_style1.h", ".");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile(), new UndocumentedApiCheck());
 
@@ -110,7 +110,7 @@ public class UndocumentedApiCheckTest {
   }
 
   @Test
-  public void docStyle2() throws UnsupportedEncodingException, IOException {
+  void docStyle2() throws UnsupportedEncodingException, IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/checks/UndocumentedApiCheck/doc_style2.h", ".");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile(), new UndocumentedApiCheck());
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/error/ParsingErrorCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/error/ParsingErrorCheckTest.java
@@ -28,7 +28,7 @@ import org.sonar.cxx.config.CxxSquidConfiguration;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class ParsingErrorCheckTest {
+class ParsingErrorCheckTest {
 
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/error/ParsingErrorRecoveryCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/error/ParsingErrorRecoveryCheckTest.java
@@ -28,7 +28,7 @@ import org.sonar.cxx.config.CxxSquidConfiguration;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class ParsingErrorRecoveryCheckTest {
+class ParsingErrorRecoveryCheckTest {
 
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/file/FileEncodingCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/file/FileEncodingCheckTest.java
@@ -30,7 +30,7 @@ import org.sonar.cxx.config.CxxSquidConfiguration;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class FileEncodingCheckTest {
+class FileEncodingCheckTest {
 
   private final FileEncodingCheck check = new FileEncodingCheck();
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/file/MissingNewLineAtEndOfFileCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/file/MissingNewLineAtEndOfFileCheckTest.java
@@ -27,7 +27,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class MissingNewLineAtEndOfFileCheckTest {
+class MissingNewLineAtEndOfFileCheckTest {
 
   private final MissingNewLineAtEndOfFileCheck check = new MissingNewLineAtEndOfFileCheck();
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/file/TabCharacterCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/file/TabCharacterCheckTest.java
@@ -27,7 +27,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class TabCharacterCheckTest {
+class TabCharacterCheckTest {
 
   private final TabCharacterCheck check = new TabCharacterCheck();
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/ClassComplexityCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/ClassComplexityCheckTest.java
@@ -32,10 +32,10 @@ import org.sonar.cxx.utils.CxxReportIssue;
 import org.sonar.cxx.utils.CxxReportLocation;
 import org.sonar.cxx.visitors.MultiLocatitionSquidCheck;
 
-public class ClassComplexityCheckTest {
+class ClassComplexityCheckTest {
 
   @Test
-  public void test() throws UnsupportedEncodingException, IOException {
+  void test() throws UnsupportedEncodingException, IOException {
     var check = new ClassComplexityCheck();
     check.setMaxComplexity(5);
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FileComplexityCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FileComplexityCheckTest.java
@@ -32,10 +32,10 @@ import org.sonar.cxx.utils.CxxReportIssue;
 import org.sonar.cxx.utils.CxxReportLocation;
 import org.sonar.cxx.visitors.MultiLocatitionSquidCheck;
 
-public class FileComplexityCheckTest {
+class FileComplexityCheckTest {
 
   @Test
-  public void check() throws UnsupportedEncodingException, IOException {
+  void check() throws UnsupportedEncodingException, IOException {
     var check = new FileComplexityCheck();
     check.setMaxComplexity(1);
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FunctionCognitiveComplexityCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FunctionCognitiveComplexityCheckTest.java
@@ -32,10 +32,10 @@ import org.sonar.cxx.utils.CxxReportIssue;
 import org.sonar.cxx.utils.CxxReportLocation;
 import org.sonar.cxx.visitors.MultiLocatitionSquidCheck;
 
-public class FunctionCognitiveComplexityCheckTest {
+class FunctionCognitiveComplexityCheckTest {
 
   @Test
-  public void check() throws UnsupportedEncodingException, IOException {
+  void check() throws UnsupportedEncodingException, IOException {
     var check = new FunctionCognitiveComplexityCheck();
     check.setMaxComplexity(5);
     var tester = CxxFileTesterHelper.create("src/test/resources/checks/FunctionCognitiveComplexity.cc", ".");

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FunctionComplexityCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/FunctionComplexityCheckTest.java
@@ -29,10 +29,10 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.utils.CxxReportLocation;
 import org.sonar.cxx.visitors.MultiLocatitionSquidCheck;
 
-public class FunctionComplexityCheckTest {
+class FunctionComplexityCheckTest {
 
   @Test
-  public void check() throws UnsupportedEncodingException, IOException {
+  void check() throws UnsupportedEncodingException, IOException {
     var check = new FunctionComplexityCheck();
     check.setMaxComplexity(5);
     var tester = CxxFileTesterHelper.create("src/test/resources/checks/FunctionComplexity.cc", ".");

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/TooLongLineCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/TooLongLineCheckTest.java
@@ -27,7 +27,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class TooLongLineCheckTest {
+class TooLongLineCheckTest {
 
   private final TooLongLineCheck check = new TooLongLineCheck();
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/TooManyLinesOfCodeInFileCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/TooManyLinesOfCodeInFileCheckTest.java
@@ -27,7 +27,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class TooManyLinesOfCodeInFileCheckTest {
+class TooManyLinesOfCodeInFileCheckTest {
 
   private final TooManyLinesOfCodeInFileCheck check = new TooManyLinesOfCodeInFileCheck();
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/TooManyLinesOfCodeInFunctionCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/TooManyLinesOfCodeInFunctionCheckTest.java
@@ -28,7 +28,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class TooManyLinesOfCodeInFunctionCheckTest {
+class TooManyLinesOfCodeInFunctionCheckTest {
 
   private final TooManyLinesOfCodeInFunctionCheck check = new TooManyLinesOfCodeInFunctionCheck();
   private final MapSettings settings = new MapSettings();

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/TooManyParametersCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/TooManyParametersCheckTest.java
@@ -27,7 +27,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class TooManyParametersCheckTest {
+class TooManyParametersCheckTest {
 
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/TooManyStatementsPerLineCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/metrics/TooManyStatementsPerLineCheckTest.java
@@ -28,7 +28,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class TooManyStatementsPerLineCheckTest {
+class TooManyStatementsPerLineCheckTest {
 
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion
@@ -51,7 +51,7 @@ public class TooManyStatementsPerLineCheckTest {
   }
 
   @Test
-  public void testDefaultExcludeCaseBreak() {
+  void testDefaultExcludeCaseBreak() {
     var check = new TooManyStatementsPerLineCheck();
     assertThat(check.excludeCaseBreak).isFalse();
   }

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/naming/ClassNameCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/naming/ClassNameCheckTest.java
@@ -25,7 +25,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class ClassNameCheckTest {
+class ClassNameCheckTest {
 
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/naming/FileNameCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/naming/FileNameCheckTest.java
@@ -27,7 +27,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifierRule;
 
-public class FileNameCheckTest {
+class FileNameCheckTest {
 
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
   private final FileNameCheck check = new FileNameCheck();

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/naming/FunctionNameCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/naming/FunctionNameCheckTest.java
@@ -25,7 +25,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class FunctionNameCheckTest {
+class FunctionNameCheckTest {
 
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/naming/MethodNameCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/naming/MethodNameCheckTest.java
@@ -25,7 +25,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class MethodNameCheckTest {
+class MethodNameCheckTest {
 
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/CommentRegularExpressionCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/CommentRegularExpressionCheckTest.java
@@ -27,7 +27,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class CommentRegularExpressionCheckTest {
+class CommentRegularExpressionCheckTest {
 
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/FileHeaderCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/FileHeaderCheckTest.java
@@ -28,7 +28,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class FileHeaderCheckTest {
+class FileHeaderCheckTest {
 
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/FileRegularExpressionCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/FileRegularExpressionCheckTest.java
@@ -29,7 +29,7 @@ import org.sonar.cxx.config.CxxSquidConfiguration;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class FileRegularExpressionCheckTest {
+class FileRegularExpressionCheckTest {
 
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/FixmeTagPresenceCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/FixmeTagPresenceCheckTest.java
@@ -27,7 +27,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifierRule;
 
-public class FixmeTagPresenceCheckTest {
+class FixmeTagPresenceCheckTest {
 
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/LineRegularExpressionCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/LineRegularExpressionCheckTest.java
@@ -27,7 +27,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class LineRegularExpressionCheckTest {
+class LineRegularExpressionCheckTest {
 
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/NoSonarCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/NoSonarCheckTest.java
@@ -27,7 +27,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class NoSonarCheckTest {
+class NoSonarCheckTest {
 
   private final NoSonarCheck check = new NoSonarCheck();
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/TodoTagPresenceCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/regex/TodoTagPresenceCheckTest.java
@@ -27,7 +27,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifierRule;
 
-public class TodoTagPresenceCheckTest {
+class TodoTagPresenceCheckTest {
 
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 

--- a/cxx-checks/src/test/java/org/sonar/cxx/checks/xpath/XPathCheckTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/checks/xpath/XPathCheckTest.java
@@ -27,7 +27,7 @@ import org.sonar.cxx.checks.CxxFileTesterHelper;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifier;
 
-public class XPathCheckTest {
+class XPathCheckTest {
 
   @Test
   @SuppressWarnings("squid:S2699") // ... verify contains the assertion

--- a/cxx-checks/src/test/java/org/sonar/cxx/tag/TagTest.java
+++ b/cxx-checks/src/test/java/org/sonar/cxx/tag/TagTest.java
@@ -23,10 +23,10 @@ import java.lang.reflect.Constructor;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class TagTest {
+class TagTest {
 
   @Test
-  public void private_constructor() throws Exception {
+  void private_constructor() throws Exception {
     Constructor<Tag> constructor = Tag.class.getDeclaredConstructor();
     assertThat(constructor.canAccess(null)).isFalse();
     constructor.setAccessible(true);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/postjobs/FinalReportTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/postjobs/FinalReportTest.java
@@ -42,7 +42,7 @@ import org.sonar.cxx.CxxAstScanner;
 import org.sonar.cxx.preprocessor.CxxPreprocessor;
 import org.sonar.cxx.visitors.CxxParseErrorLoggerVisitor;
 
-public class FinalReportTest {
+class FinalReportTest {
 
   @RegisterExtension
   public LogTesterJUnit5 logTester = new LogTesterJUnit5();
@@ -55,7 +55,7 @@ public class FinalReportTest {
   }
 
   @Test
-  public void finalReportTest() throws IOException {
+  void finalReportTest() throws IOException {
     var dir = "src/test/resources/org/sonar/cxx/postjobs";
     var context = SensorContextTester.create(new File(dir));
     InputFile inputFile = createInputFile(dir + "/syntaxerror.cc", ".", Charset.defaultCharset());

--- a/cxx-sensors/src/test/java/org/sonar/cxx/prejobs/XlstSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/prejobs/XlstSensorTest.java
@@ -34,7 +34,7 @@ import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class XlstSensorTest {
+class XlstSensorTest {
 
   @RegisterExtension
   public LogTesterJUnit5 logTester = new LogTesterJUnit5();
@@ -53,20 +53,20 @@ public class XlstSensorTest {
   }
 
   @Test
-  public void noLoggingIfNotUsed() {
+  void noLoggingIfNotUsed() {
     var context = SensorContextTester.create(fs.baseDir());
 
     var sensor = new XlstSensor();
     logTester.clear();
     sensor.execute(context);
 
-    assertThat(logTester.logs(LoggerLevel.ERROR).isEmpty()).isTrue();
-    assertThat(logTester.logs(LoggerLevel.WARN).isEmpty()).isTrue();
-    assertThat(logTester.logs(LoggerLevel.INFO).isEmpty()).isTrue();
+    assertThat(logTester.logs(LoggerLevel.ERROR)).isEmpty();
+    assertThat(logTester.logs(LoggerLevel.WARN)).isEmpty();
+    assertThat(logTester.logs(LoggerLevel.INFO)).isEmpty();
   }
 
   @Test
-  public void shouldReportNothingWhenNoReportFound() {
+  void shouldReportNothingWhenNoReportFound() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(XlstSensor.OTHER_XSLT_KEY + "1" + XlstSensor.STYLESHEET_KEY, "notexistingpath");
     settings.setProperty(XlstSensor.OTHER_XSLT_KEY + "2" + XlstSensor.STYLESHEET_KEY, "notexistingpath");
@@ -84,7 +84,7 @@ public class XlstSensorTest {
   }
 
   @Test
-  public void shouldNotCreateMessage() {
+  void shouldNotCreateMessage() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(XlstSensor.OTHER_XSLT_KEY + "1" + XlstSensor.STYLESHEET_KEY, "something");
     context.setSettings(settings);
@@ -97,7 +97,7 @@ public class XlstSensorTest {
   }
 
   @Test
-  public void shouldCreateMissingStylesheetMessage() {
+  void shouldCreateMissingStylesheetMessage() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(XlstSensor.OTHER_XSLT_KEY + "1" + XlstSensor.STYLESHEET_KEY, "");
     settings.setProperty(XlstSensor.OTHER_XSLT_KEY + "1" + XlstSensor.OUTPUT_KEY, "outputs");
@@ -113,7 +113,7 @@ public class XlstSensorTest {
   }
 
   @Test
-  public void shouldCreateEmptyInputsMessage() {
+  void shouldCreateEmptyInputsMessage() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(XlstSensor.OTHER_XSLT_KEY + "1" + XlstSensor.STYLESHEET_KEY, "something");
     settings.setProperty(XlstSensor.OTHER_XSLT_KEY + "1" + XlstSensor.INPUT_KEY, "");
@@ -129,7 +129,7 @@ public class XlstSensorTest {
   }
 
   @Test
-  public void shouldCreateEmptyOutputsMessage() {
+  void shouldCreateEmptyOutputsMessage() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(XlstSensor.OTHER_XSLT_KEY + "1" + XlstSensor.STYLESHEET_KEY, "something");
     settings.setProperty(XlstSensor.OTHER_XSLT_KEY + "1" + XlstSensor.INPUT_KEY, "something");
@@ -146,7 +146,7 @@ public class XlstSensorTest {
   }
 
   @Test
-  public void shouldTransformReportExternalXlst()
+  void shouldTransformReportExternalXlst()
     throws java.io.IOException, javax.xml.transform.TransformerException {
     var context = SensorContextTester.create(fs.baseDir());
     var stylesheetFile = "prejobs" + File.separator + "xslt-stylesheet.xslt";
@@ -170,7 +170,7 @@ public class XlstSensorTest {
   }
 
   @Test
-  public void shouldTransformReportInternalXlst()
+  void shouldTransformReportInternalXlst()
     throws java.io.IOException, javax.xml.transform.TransformerException {
     var context = SensorContextTester.create(fs.baseDir());
     var stylesheetFile = "cppunit-1.x-to-junit-1.0.xsl";

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepositoryTest.java
@@ -26,10 +26,10 @@ import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 
-public class CxxClangSARuleRepositoryTest {
+class CxxClangSARuleRepositoryTest {
 
   @Test
-  public void createRulesTest() {
+  void createRulesTest() {
     var def = new CxxClangSARuleRepository(
       mock(ServerFileSystem.class), new RulesDefinitionXmlLoader());
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSASensorTest.java
@@ -37,7 +37,7 @@ import org.sonar.api.config.internal.MapSettings;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxClangSASensorTest {
+class CxxClangSASensorTest {
 
   private DefaultFileSystem fs;
   private final MapSettings settings = new MapSettings();
@@ -49,7 +49,7 @@ public class CxxClangSASensorTest {
   }
 
   @Test
-  public void shouldIgnoreIssuesIfResourceNotFound() {
+  void shouldIgnoreIssuesIfResourceNotFound() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxClangSASensor.REPORT_PATH_KEY, "clangsa-reports/clangsa-empty.plist");
     context.setSettings(settings);
@@ -61,7 +61,7 @@ public class CxxClangSASensorTest {
   }
 
   @Test
-  public void shouldReportCorrectViolations() {
+  void shouldReportCorrectViolations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxClangSASensor.REPORT_PATH_KEY, "clangsa-reports/clangsa-report.plist");
     context.setSettings(settings);
@@ -87,7 +87,7 @@ public class CxxClangSASensorTest {
   }
 
   @Test
-  public void shouldReportCorrectFlows() {
+  void shouldReportCorrectFlows() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxClangSASensor.REPORT_PATH_KEY,
                          "clangsa-reports/clangsa-report.plist");
@@ -150,7 +150,7 @@ public class CxxClangSASensorTest {
   }
 
   @Test
-  public void invalidReportReportsNoIssues() {
+  void invalidReportReportsNoIssues() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxClangSASensor.REPORT_PATH_KEY, "clangsa-reports/clangsa-reportXYZ.plist");
     context.setSettings(settings);
@@ -165,7 +165,7 @@ public class CxxClangSASensorTest {
   }
 
   @Test
-  public void sensorDescriptor() {
+  void sensorDescriptor() {
     var descriptor = new DefaultSensorDescriptor();
     var sensor = new CxxClangSASensor();
     sensor.describe(descriptor);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
@@ -26,17 +26,17 @@ import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 
-public class CxxClangTidyRuleRepositoryTest {
+class CxxClangTidyRuleRepositoryTest {
 
   @Test
-  public void createRulesTest() {
+  void createRulesTest() {
     var def = new CxxClangTidyRuleRepository(mock(ServerFileSystem.class), new RulesDefinitionXmlLoader());
 
     var context = new RulesDefinition.Context();
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxClangTidyRuleRepository.KEY);
-    assertThat(repo.rules().size()).isEqualTo(1340);
+    assertThat(repo.rules()).hasSize(1340);
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidySensorTest.java
@@ -34,7 +34,7 @@ import org.sonar.api.config.internal.MapSettings;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxClangTidySensorTest {
+class CxxClangTidySensorTest {
 
   private DefaultFileSystem fs;
   private final MapSettings settings = new MapSettings();
@@ -47,7 +47,7 @@ public class CxxClangTidySensorTest {
   }
 
   @Test
-  public void shouldIgnoreIssuesIfResourceNotFound() {
+  void shouldIgnoreIssuesIfResourceNotFound() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(
       CxxClangTidySensor.REPORT_PATH_KEY,
@@ -62,7 +62,7 @@ public class CxxClangTidySensorTest {
   }
 
   @Test
-  public void shouldReportDefaultRuleId() {
+  void shouldReportDefaultRuleId() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(
       CxxClangTidySensor.REPORT_PATH_KEY,
@@ -89,7 +89,7 @@ public class CxxClangTidySensorTest {
   }
 
   @Test
-  public void shouldReportSameIssueInSameLineWithDifferentColumn() {
+  void shouldReportSameIssueInSameLineWithDifferentColumn() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(
       CxxClangTidySensor.REPORT_PATH_KEY,
@@ -123,7 +123,7 @@ public class CxxClangTidySensorTest {
   }
 
   @Test
-  public void shouldRemoveDuplicateIssues() {
+  void shouldRemoveDuplicateIssues() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(
       CxxClangTidySensor.REPORT_PATH_KEY,
@@ -152,7 +152,7 @@ public class CxxClangTidySensorTest {
   }
 
   @Test
-  public void shouldReportLineIfColumnIsInvalid() {
+  void shouldReportLineIfColumnIsInvalid() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(
       CxxClangTidySensor.REPORT_PATH_KEY,
@@ -179,7 +179,7 @@ public class CxxClangTidySensorTest {
   }
 
   @Test
-  public void shouldReportIssuesInFirstAndLastColumn() {
+  void shouldReportIssuesInFirstAndLastColumn() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(
       CxxClangTidySensor.REPORT_PATH_KEY,
@@ -200,13 +200,13 @@ public class CxxClangTidySensorTest {
     assertThat(context.allIssues()).hasSize(2);
     var issuesList = new ArrayList<Issue>(context.allIssues());
     assertThat(issuesList.get(0).ruleKey().rule()).isEqualTo("first-column");
-    assertThat(issuesList.get(0).primaryLocation().textRange().start().lineOffset()).isEqualTo(0);
+    assertThat(issuesList.get(0).primaryLocation().textRange().start().lineOffset()).isZero();
     assertThat(issuesList.get(1).ruleKey().rule()).isEqualTo("last-column");
     assertThat(issuesList.get(1).primaryLocation().textRange().start().lineOffset()).isEqualTo(9);
   }
 
   @Test
-  public void shouldReportAliasRuleIds() {
+  void shouldReportAliasRuleIds() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(
       CxxClangTidySensor.REPORT_PATH_KEY,
@@ -235,7 +235,7 @@ public class CxxClangTidySensorTest {
   }
 
   @Test
-  public void shouldReportErrors() {
+  void shouldReportErrors() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(
       CxxClangTidySensor.REPORT_PATH_KEY,
@@ -257,7 +257,7 @@ public class CxxClangTidySensorTest {
   }
 
   @Test
-  public void shouldReportFatalErrors() {
+  void shouldReportFatalErrors() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(
       CxxClangTidySensor.REPORT_PATH_KEY,
@@ -279,7 +279,7 @@ public class CxxClangTidySensorTest {
   }
 
   @Test
-  public void shouldReportWarnings() {
+  void shouldReportWarnings() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(
       CxxClangTidySensor.REPORT_PATH_KEY,
@@ -301,7 +301,7 @@ public class CxxClangTidySensorTest {
   }
 
   @Test
-  public void shouldReportNodiscard() {
+  void shouldReportNodiscard() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(
       CxxClangTidySensor.REPORT_PATH_KEY,
@@ -323,7 +323,7 @@ public class CxxClangTidySensorTest {
   }
 
   @Test
-  public void shouldReportFlow() {
+  void shouldReportFlow() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(
       CxxClangTidySensor.REPORT_PATH_KEY,
@@ -349,7 +349,7 @@ public class CxxClangTidySensorTest {
   }
 
   @Test
-  public void invalidReportReportsNoIssues() {
+  void invalidReportReportsNoIssues() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(
       CxxClangTidySensor.REPORT_PATH_KEY,
@@ -371,7 +371,7 @@ public class CxxClangTidySensorTest {
   }
 
   @Test
-  public void sensorDescriptor() {
+  void sensorDescriptor() {
     var descriptor = new DefaultSensorDescriptor();
     var sensor = new CxxClangTidySensor();
     sensor.describe(descriptor);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensorTest.java
@@ -34,7 +34,7 @@ import org.sonar.api.utils.log.LogTesterJUnit5;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxCompilerSensorTest {
+class CxxCompilerSensorTest {
 
   @RegisterExtension
   public LogTesterJUnit5 logTester = new LogTesterJUnit5();
@@ -54,7 +54,7 @@ public class CxxCompilerSensorTest {
   }
 
   @Test
-  public void testFileNotFound() {
+  void testFileNotFound() {
     var report = new File("");
     sensor.setRegex("(?<test>.*)");
     sensor.testExecuteReport(report);
@@ -63,7 +63,7 @@ public class CxxCompilerSensorTest {
   }
 
   @Test
-  public void testRegexEmpty() {
+  void testRegexEmpty() {
     var report = new File("");
     sensor.testExecuteReport(report);
     var log = logTester.logs().toString();
@@ -71,7 +71,7 @@ public class CxxCompilerSensorTest {
   }
 
   @Test
-  public void testRegexInvalid() {
+  void testRegexInvalid() {
     var report = new File(fs.baseDir(), "compiler-reports/VC-report.vclog");
     sensor.setRegex("(?<test>*)");
     sensor.testExecuteReport(report);
@@ -80,7 +80,7 @@ public class CxxCompilerSensorTest {
   }
 
   @Test
-  public void testRegexNamedGroupMissing() {
+  void testRegexNamedGroupMissing() {
     var report = new File(fs.baseDir(), "compiler-reports/VC-report.vclog");
     sensor.setRegex(".*");
     sensor.testExecuteReport(report);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccRuleRepositoryTest.java
@@ -26,10 +26,10 @@ import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 
-public class CxxCompilerGccRuleRepositoryTest {
+class CxxCompilerGccRuleRepositoryTest {
 
   @Test
-  public void createGccRulesTest() {
+  void createGccRulesTest() {
     var def = new CxxCompilerGccRuleRepository(
       mock(ServerFileSystem.class),
       new RulesDefinitionXmlLoader());

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensorTest.java
@@ -32,7 +32,7 @@ import org.sonar.api.batch.sensor.issue.Issue;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxCompilerGccSensorTest {
+class CxxCompilerGccSensorTest {
 
   private DefaultFileSystem fs;
   private final MapSettings settings = new MapSettings();
@@ -43,7 +43,7 @@ public class CxxCompilerGccSensorTest {
   }
 
   @Test
-  public void sensorDescriptorGcc() {
+  void sensorDescriptorGcc() {
     var descriptor = new DefaultSensorDescriptor();
     var sensor = new CxxCompilerGccSensor();
     sensor.describe(descriptor);
@@ -56,7 +56,7 @@ public class CxxCompilerGccSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectGccViolations() {
+  void shouldReportCorrectGccViolations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCompilerGccSensor.REPORT_PATH_KEY, "compiler-reports/build.gcclog");
     context.setSettings(settings);
@@ -71,7 +71,7 @@ public class CxxCompilerGccSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectGccViolationsWithOrWithoutIds() {
+  void shouldReportCorrectGccViolationsWithOrWithoutIds() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCompilerGccSensor.REPORT_PATH_KEY, "compiler-reports/build-warning-without-id.gcclog");
     context.setSettings(settings);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcRuleRepositoryTest.java
@@ -26,10 +26,10 @@ import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 
-public class CxxCompilerVcRuleRepositoryTest {
+class CxxCompilerVcRuleRepositoryTest {
 
   @Test
-  public void createVcRulesTest() {
+  void createVcRulesTest() {
     var def = new CxxCompilerVcRuleRepository(
       mock(ServerFileSystem.class),
       new RulesDefinitionXmlLoader());

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcSensorTest.java
@@ -31,7 +31,7 @@ import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxCompilerVcSensorTest {
+class CxxCompilerVcSensorTest {
 
   private DefaultFileSystem fs;
   private final MapSettings settings = new MapSettings();
@@ -42,7 +42,7 @@ public class CxxCompilerVcSensorTest {
   }
 
   @Test
-  public void sensorDescriptorVc() {
+  void sensorDescriptorVc() {
     var descriptor = new DefaultSensorDescriptor();
     var sensor = new CxxCompilerVcSensor();
     sensor.describe(descriptor);
@@ -55,7 +55,7 @@ public class CxxCompilerVcSensorTest {
   }
 
   @Test
-  public void shouldReportACorrectVcViolations() {
+  void shouldReportACorrectVcViolations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCompilerVcSensor.REPORT_PATH_KEY,
                          "compiler-reports/BuildLog.htm");
@@ -72,7 +72,7 @@ public class CxxCompilerVcSensorTest {
   }
 
   @Test
-  public void shouldReportBCorrectVcViolations() {
+  void shouldReportBCorrectVcViolations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCompilerVcSensor.REPORT_PATH_KEY, "compiler-reports/VC-report.vclog");
     settings.setProperty(CxxCompilerVcSensor.REPORT_ENCODING_DEF, StandardCharsets.UTF_8.name());

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxBullseyeCoverageSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxBullseyeCoverageSensorTest.java
@@ -32,7 +32,7 @@ import org.sonar.cxx.sensors.coverage.bullseye.CxxCoverageBullseyeSensor;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxBullseyeCoverageSensorTest {
+class CxxBullseyeCoverageSensorTest {
 
   private static final Logger LOG = Loggers.get(CxxBullseyeCoverageSensorTest.class);
   private DefaultFileSystem fs;
@@ -45,7 +45,7 @@ public class CxxBullseyeCoverageSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectCoverage() {
+  void shouldReportCorrectCoverage() {
     var coverageReport = "coverage-reports/bullseye/coverage-result-bullseye.xml";
     var context = SensorContextTester.create(fs.baseDir());
 
@@ -126,7 +126,7 @@ public class CxxBullseyeCoverageSensorTest {
   }
 
   @Test
-  public void shouldParseTopLevelFiles() {
+  void shouldParseTopLevelFiles() {
     // read top level folder name from report file
     var coverageReport = "coverage-reports/bullseye/bullseye-coverage-report-data-in-root-node-win.xml";
     var context = SensorContextTester.create(fs.baseDir());
@@ -160,7 +160,7 @@ public class CxxBullseyeCoverageSensorTest {
   }
 
   @Test
-  public void shouldReportAllProbes() {
+  void shouldReportAllProbes() {
 
     var coverageReport = "coverage-reports/bullseye/bullseye-coverage-Linux-V8.9.60.xml";
     var context = SensorContextTester.create(fs.baseDir());
@@ -234,7 +234,7 @@ public class CxxBullseyeCoverageSensorTest {
   }
 
   @Test
-  public void shouldIgnoreBlocks() {
+  void shouldIgnoreBlocks() {
 
     // report contains a block tag => ignore
     var coverageReport = "coverage-reports/bullseye/bullseye-coverage-Windows-V8.20.2.xml";

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxCoberturaSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxCoberturaSensorTest.java
@@ -41,7 +41,7 @@ import org.sonar.cxx.sensors.coverage.cobertura.CxxCoverageCoberturaSensor;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxCoberturaSensorTest {
+class CxxCoberturaSensorTest {
 
   @RegisterExtension
   public LogTesterJUnit5 logTester = new LogTesterJUnit5();
@@ -56,7 +56,7 @@ public class CxxCoberturaSensorTest {
   }
 
   @Test
-  public void testPathJoin() {
+  void testPathJoin() {
     var empty = Paths.get("");
     String result;
     /*
@@ -155,7 +155,7 @@ public class CxxCoberturaSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectCoverageForAllTypesOfCoverage() {
+  void shouldReportCorrectCoverageForAllTypesOfCoverage() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageCoberturaSensor.REPORT_PATH_KEY,
                          "coverage-reports/cobertura/coverage-result-cobertura.xml");
@@ -186,7 +186,7 @@ public class CxxCoberturaSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectCoverageSQ62() {
+  void shouldReportCorrectCoverageSQ62() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageCoberturaSensor.REPORT_PATH_KEY,
                          "coverage-reports/cobertura/coverage-result-cobertura.xml");
@@ -209,7 +209,7 @@ public class CxxCoberturaSensorTest {
   }
 
   @Test
-  public void shouldReportNoCoverageSaved() {
+  void shouldReportNoCoverageSaved() {
     var context = SensorContextTester.create(fs.baseDir());
     final String reportPathsValue = "coverage-reports/cobertura/specific-cases/does-not-exist.xml";
     settings.setProperty(CxxCoverageCoberturaSensor.REPORT_PATH_KEY, reportPathsValue);
@@ -225,7 +225,7 @@ public class CxxCoberturaSensorTest {
   }
 
   @Test
-  public void shouldNotCrashWhenProcessingReportsContainingBigNumberOfHits() {
+  void shouldNotCrashWhenProcessingReportsContainingBigNumberOfHits() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageCoberturaSensor.REPORT_PATH_KEY,
                          "coverage-reports/cobertura/specific-cases/cobertura-bignumberofhits.xml");
@@ -238,7 +238,7 @@ public class CxxCoberturaSensorTest {
   }
 
   @Test
-  public void shouldReportNoCoverageWhenReportEmpty() {
+  void shouldReportNoCoverageWhenReportEmpty() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageCoberturaSensor.REPORT_PATH_KEY,
                          "coverage-reports/cobertura/specific-cases/coverage-result-cobertura-empty.xml");
@@ -260,7 +260,7 @@ public class CxxCoberturaSensorTest {
   }
 
   @Test
-  public void shouldReportNoCoverageWhenReportInvalid() {
+  void shouldReportNoCoverageWhenReportInvalid() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxReportSensor.ERROR_RECOVERY_KEY, true);
     settings.setProperty(CxxCoverageCoberturaSensor.REPORT_PATH_KEY,

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxMSCoverageSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxMSCoverageSensorTest.java
@@ -31,7 +31,7 @@ import org.sonar.api.config.internal.MapSettings;
 import org.sonar.cxx.sensors.coverage.vs.CxxCoverageVisualStudioSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxMSCoverageSensorTest {
+class CxxMSCoverageSensorTest {
 
   private DefaultFileSystem fs;
   private SensorContextTester context;
@@ -43,7 +43,7 @@ public class CxxMSCoverageSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectCoverage() {
+  void shouldReportCorrectCoverage() {
     context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageVisualStudioSensor.REPORT_PATH_KEY, "coverage-reports/MSCoverage/MSCoverage.xml");
     context.setSettings(settings);
@@ -72,7 +72,7 @@ public class CxxMSCoverageSensorTest {
   }
 
   @Test
-  public void shouldReportCoverageWhenVisualStudioCase() {
+  void shouldReportCoverageWhenVisualStudioCase() {
     SensorContextTester context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageVisualStudioSensor.REPORT_PATH_KEY,
                          "coverage-reports/MSCoverage/coverage-result-visual-studio.xml");
@@ -109,7 +109,7 @@ public class CxxMSCoverageSensorTest {
   }
 
   @Test
-  public void shouldReadFaultyReportAndNotCrash() {
+  void shouldReadFaultyReportAndNotCrash() {
     context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageVisualStudioSensor.REPORT_PATH_KEY, "coverage-reports/MSCoverage/faulty.xml");
     context.setSettings(settings);
@@ -128,7 +128,7 @@ public class CxxMSCoverageSensorTest {
   }
 
   @Test
-  public void shouldConsumeEmptyReport() {
+  void shouldConsumeEmptyReport() {
     context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageVisualStudioSensor.REPORT_PATH_KEY, "coverage-reports/MSCoverage/empty-report.xml");
     context.setSettings(settings);
@@ -145,7 +145,7 @@ public class CxxMSCoverageSensorTest {
   }
 
   @Test
-  public void sensorDescriptor() {
+  void sensorDescriptor() {
     context = SensorContextTester.create(fs.baseDir());
     var descriptor = new DefaultSensorDescriptor();
     var sensor = new CxxCoverageVisualStudioSensor();

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxTestwellCtcTxtParserTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxTestwellCtcTxtParserTest.java
@@ -30,7 +30,7 @@ import org.sonar.cxx.sensors.coverage.ctc.CxxCoverageTestwellCtcTxtSensor;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxTestwellCtcTxtParserTest {
+class CxxTestwellCtcTxtParserTest {
 
   private DefaultFileSystem fs;
   private SensorContextTester context;
@@ -43,7 +43,7 @@ public class CxxTestwellCtcTxtParserTest {
   }
 
   @Test
-  public void shouldReportCoveredLines() {
+  void shouldReportCoveredLines() {
     context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageTestwellCtcTxtSensor.REPORT_PATH_KEY,
                          "coverage-reports/TestwellCTC/report_small_v8.txt");
@@ -64,7 +64,7 @@ public class CxxTestwellCtcTxtParserTest {
   }
 
   @Test
-  public void shouldReportCoveredConditionsOne() {
+  void shouldReportCoveredConditionsOne() {
     context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageTestwellCtcTxtSensor.REPORT_PATH_KEY,
                          "coverage-reports/TestwellCTC/report_small_v8.txt");
@@ -85,7 +85,7 @@ public class CxxTestwellCtcTxtParserTest {
   }
 
   @Test
-  public void shouldReportCoveredConditionsTwo() {
+  void shouldReportCoveredConditionsTwo() {
     context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageTestwellCtcTxtSensor.REPORT_PATH_KEY,
                          "coverage-reports/TestwellCTC/report_small_v8.txt");
@@ -106,7 +106,7 @@ public class CxxTestwellCtcTxtParserTest {
   }
 
   @Test
-  public void shouldConsumeLargeReportCoveredLines() {
+  void shouldConsumeLargeReportCoveredLines() {
     context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageTestwellCtcTxtSensor.REPORT_PATH_KEY,
                          "coverage-reports/TestwellCTC/report_big.txt");
@@ -131,7 +131,7 @@ public class CxxTestwellCtcTxtParserTest {
   }
 
   @Test
-  public void shouldConsumeLargeReportCoveredConditions() {
+  void shouldConsumeLargeReportCoveredConditions() {
     context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageTestwellCtcTxtSensor.REPORT_PATH_KEY,
                          "coverage-reports/TestwellCTC/report_big.txt");
@@ -156,7 +156,7 @@ public class CxxTestwellCtcTxtParserTest {
   }
 
   @Test
-  public void shouldConsumeLargeReportConditions() {
+  void shouldConsumeLargeReportConditions() {
     context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageTestwellCtcTxtSensor.REPORT_PATH_KEY,
                          "coverage-reports/TestwellCTC/report_big.txt");
@@ -181,7 +181,7 @@ public class CxxTestwellCtcTxtParserTest {
   }
 
   @Test
-  public void shouldConsumeEmptyReport() {
+  void shouldConsumeEmptyReport() {
     context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCoverageTestwellCtcTxtSensor.REPORT_PATH_KEY,
                          "coverage-reports/TestwellCTC/report_empty.txt");

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
@@ -26,10 +26,10 @@ import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 
-public class CxxCppCheckRuleRepositoryTest {
+class CxxCppCheckRuleRepositoryTest {
 
   @Test
-  public void createRulesTest() {
+  void createRulesTest() {
     var def = new CxxCppCheckRuleRepository(
       mock(ServerFileSystem.class), new RulesDefinitionXmlLoader());
 
@@ -37,7 +37,7 @@ public class CxxCppCheckRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxCppCheckRuleRepository.KEY);
-    assertThat(repo.rules().size()).isEqualTo(666);
+    assertThat(repo.rules()).hasSize(666);
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckSensorTest.java
@@ -31,7 +31,7 @@ import org.sonar.api.config.internal.MapSettings;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxCppCheckSensorTest {
+class CxxCppCheckSensorTest {
 
   private DefaultFileSystem fs;
   private final MapSettings settings = new MapSettings();
@@ -43,7 +43,7 @@ public class CxxCppCheckSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectViolations() {
+  void shouldReportCorrectViolations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCppCheckSensor.REPORT_PATH_KEY, "cppcheck-reports/cppcheck-result-*.xml");
     context.setSettings(settings);
@@ -60,7 +60,7 @@ public class CxxCppCheckSensorTest {
   }
 
   @Test
-  public void shouldReportProjectLevelViolationsV2() {
+  void shouldReportProjectLevelViolationsV2() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCppCheckSensor.REPORT_PATH_KEY,
                          "cppcheck-reports/cppcheck-result-projectlevelviolation-V2.xml");
@@ -81,7 +81,7 @@ public class CxxCppCheckSensorTest {
   }
 
   @Test
-  public void shouldIgnoreAViolationWhenTheResourceCouldntBeFoundV1() {
+  void shouldIgnoreAViolationWhenTheResourceCouldntBeFoundV1() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCppCheckSensor.REPORT_PATH_KEY, "cppcheck-reports/cppcheck-result-SAMPLE-V1.xml");
     context.setSettings(settings);
@@ -93,7 +93,7 @@ public class CxxCppCheckSensorTest {
   }
 
   @Test
-  public void shouldIgnoreAViolationWhenTheResourceCouldntBeFoundV2() {
+  void shouldIgnoreAViolationWhenTheResourceCouldntBeFoundV2() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxCppCheckSensor.REPORT_PATH_KEY, "cppcheck-reports/cppcheck-result-SAMPLE-V2.xml");
     context.setSettings(settings);
@@ -105,7 +105,7 @@ public class CxxCppCheckSensorTest {
   }
 
   @Test
-  public void shouldThrowExceptionWhenRecoveryIsDisabled() {
+  void shouldThrowExceptionWhenRecoveryIsDisabled() {
     IllegalStateException thrown = catchThrowableOfType(() -> {
       var context = SensorContextTester.create(fs.baseDir());
       settings.setProperty(CxxReportSensor.ERROR_RECOVERY_KEY, false);
@@ -119,7 +119,7 @@ public class CxxCppCheckSensorTest {
   }
 
   @Test
-  public void sensorDescriptor() {
+  void sensorDescriptor() {
     var descriptor = new DefaultSensorDescriptor();
     var sensor = new CxxCppCheckSensor();
     sensor.describe(descriptor);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/CxxDrMemoryRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/CxxDrMemoryRuleRepositoryTest.java
@@ -28,10 +28,10 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.Rule;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 
-public class CxxDrMemoryRuleRepositoryTest {
+class CxxDrMemoryRuleRepositoryTest {
 
   @Test
-  public void createRulesTest() {
+  void createRulesTest() {
     var def = new CxxDrMemoryRuleRepository(
       mock(ServerFileSystem.class),
       new RulesDefinitionXmlLoader());
@@ -41,7 +41,7 @@ public class CxxDrMemoryRuleRepositoryTest {
 
     RulesDefinition.Repository repo = context.repository(CxxDrMemoryRuleRepository.KEY);
     List<Rule> rules = repo.rules();
-    assertThat(rules.size()).isEqualTo(9);
+    assertThat(rules).hasSize(9);
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/CxxDrMemorySensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/CxxDrMemorySensorTest.java
@@ -30,7 +30,7 @@ import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxDrMemorySensorTest {
+class CxxDrMemorySensorTest {
 
   private DefaultFileSystem fs;
 
@@ -40,7 +40,7 @@ public class CxxDrMemorySensorTest {
   }
 
   @Test
-  public void shouldIgnoreAViolationWhenTheResourceCouldntBeFoundV1() {
+  void shouldIgnoreAViolationWhenTheResourceCouldntBeFoundV1() {
     var context = SensorContextTester.create(fs.baseDir());
     context.settings().setProperty(CxxDrMemorySensor.REPORT_PATH_KEY,
                                    "drmemory-reports/drmemory-result-SAMPLE-V1.txt");
@@ -56,7 +56,7 @@ public class CxxDrMemorySensorTest {
   }
 
   @Test
-  public void sensorDescriptor() {
+  void sensorDescriptor() {
     var descriptor = new DefaultSensorDescriptor();
     var sensor = new CxxDrMemorySensor();
     sensor.describe(descriptor);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/DrMemoryParserTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/DrMemoryParserTest.java
@@ -27,15 +27,15 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sensors.drmemory.DrMemoryParser.DrMemoryError;
 
-public class DrMemoryParserTest {
+class DrMemoryParserTest {
 
   @Test
-  public void shouldParseTheWholeFile() throws IOException {
+  void shouldParseTheWholeFile() throws IOException {
     ClassLoader classLoader = getClass().getClassLoader();
     var file = new File(classLoader.getResource("org/sonar/cxx/sensors/reports-project/drmemory-reports/results.txt")
       .getFile());
     List<DrMemoryError> drMemoryErrors = DrMemoryParser.parse(file, StandardCharsets.UTF_8.name());
-    assertThat(drMemoryErrors.size()).isEqualTo(733);
+    assertThat(drMemoryErrors).hasSize(733);
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/infer/CxxInferRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/infer/CxxInferRuleRepositoryTest.java
@@ -26,10 +26,10 @@ import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 
-public class CxxInferRuleRepositoryTest {
+class CxxInferRuleRepositoryTest {
 
   @Test
-  public void createRulesTest() {
+  void createRulesTest() {
     var def = new CxxInferRuleRepository(
       mock(ServerFileSystem.class), new RulesDefinitionXmlLoader());
 
@@ -37,7 +37,7 @@ public class CxxInferRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxInferRuleRepository.KEY);
-    assertThat(repo.rules().size()).isEqualTo(164);
+    assertThat(repo.rules()).hasSize(164);
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/infer/CxxInferSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/infer/CxxInferSensorTest.java
@@ -31,7 +31,7 @@ import org.sonar.api.config.internal.MapSettings;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxInferSensorTest {
+class CxxInferSensorTest {
 
   private DefaultFileSystem fs;
   private final MapSettings settings = new MapSettings();
@@ -43,7 +43,7 @@ public class CxxInferSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectViolations() {
+  void shouldReportCorrectViolations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxInferSensor.REPORT_PATH_KEY, "infer-reports/infer-result-sample.json");
     context.setSettings(settings);
@@ -88,7 +88,7 @@ public class CxxInferSensorTest {
   }
 
   @Test
-  public void shouldIgnoreAViolationWhenTheResourceCouldntBeFound() {
+  void shouldIgnoreAViolationWhenTheResourceCouldntBeFound() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxInferSensor.REPORT_PATH_KEY, "infer-reports/infer-result-sample.json");
     context.setSettings(settings);
@@ -100,7 +100,7 @@ public class CxxInferSensorTest {
   }
 
   @Test
-  public void shouldThrowExceptionWhenRecoveryIsDisabled() {
+  void shouldThrowExceptionWhenRecoveryIsDisabled() {
     IllegalStateException thrown = catchThrowableOfType(() -> {
       var context = SensorContextTester.create(fs.baseDir());
       settings.setProperty(CxxReportSensor.ERROR_RECOVERY_KEY, false);
@@ -114,7 +114,7 @@ public class CxxInferSensorTest {
   }
 
   @Test
-  public void sensorDescriptor() {
+  void sensorDescriptor() {
     var descriptor = new DefaultSensorDescriptor();
     var sensor = new CxxInferSensor();
     sensor.describe(descriptor);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/infer/InferParserTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/infer/InferParserTest.java
@@ -23,10 +23,10 @@ import com.google.gson.Gson;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class InferParserTest {
+class InferParserTest {
 
   @Test
-  public void shouldParseImportantInformation() {
+  void shouldParseImportantInformation() {
     var expected = new InferParser.InferIssue();
     expected.setBugType("TotoType");
     expected.setFile("path/to/toto.c");
@@ -38,7 +38,7 @@ public class InferParserTest {
     var gson = new Gson();
     InferParser.InferIssue value = gson.fromJson(json, InferParser.InferIssue.class);
 
-    assertThat(value.toString()).isEqualTo(expected.toString());
+    assertThat(value).hasToString(expected.toString());
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherRepositoryTest.java
@@ -25,7 +25,7 @@ import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 
-public class CxxOtherRepositoryTest {
+class CxxOtherRepositoryTest {
 
   private final MapSettings settings = new MapSettings();
 
@@ -77,7 +77,7 @@ public class CxxOtherRepositoryTest {
                                     + "</rules>";
 
   @Test
-  public void verifyTemplateRuleIsFound() {
+  void verifyTemplateRuleIsFound() {
     settings.setProperty(CxxOtherSensor.RULES_KEY, "");
     var def = new CxxOtherRepository(settings.asConfig(), new RulesDefinitionXmlLoader());
 
@@ -89,7 +89,7 @@ public class CxxOtherRepositoryTest {
   }
 
   @Test
-  public void createNonEmptyRulesTest() {
+  void createNonEmptyRulesTest() {
     settings.setProperty(CxxOtherSensor.RULES_KEY, profile1);
     var def = new CxxOtherRepository(settings.asConfig(), new RulesDefinitionXmlLoader());
 
@@ -101,7 +101,7 @@ public class CxxOtherRepositoryTest {
   }
 
   @Test
-  public void createNullRulesTest() {
+  void createNullRulesTest() {
     settings.setProperty(CxxOtherSensor.RULES_KEY, "");
     var def = new CxxOtherRepository(settings.asConfig(), new RulesDefinitionXmlLoader());
 
@@ -113,7 +113,7 @@ public class CxxOtherRepositoryTest {
   }
 
   @Test
-  public void verifyRuleValuesTest() {
+  void verifyRuleValuesTest() {
     settings.setProperty(CxxOtherSensor.RULES_KEY, profile2);
     var def = new CxxOtherRepository(settings.asConfig(), new RulesDefinitionXmlLoader());
 
@@ -131,7 +131,7 @@ public class CxxOtherRepositoryTest {
   }
 
   @Test
-  public void verifyRulesWithSameKey() {
+  void verifyRulesWithSameKey() {
     settings.setProperty(CxxOtherSensor.RULES_KEY, profile2 + "," + profile3);
     var def = new CxxOtherRepository(settings.asConfig(), new RulesDefinitionXmlLoader());
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherSensorTest.java
@@ -33,7 +33,7 @@ import org.sonar.api.utils.log.LogTesterJUnit5;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxOtherSensorTest {
+class CxxOtherSensorTest {
 
   @RegisterExtension
   public LogTesterJUnit5 logTester = new LogTesterJUnit5();
@@ -48,7 +48,7 @@ public class CxxOtherSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectViolations() {
+  void shouldReportCorrectViolations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxOtherSensor.REPORT_PATH_KEY, "externalrules-reports/externalrules-result-ok.xml");
     context.setSettings(settings);
@@ -65,7 +65,7 @@ public class CxxOtherSensorTest {
   }
 
   @Test
-  public void shouldReportFileLevelViolations() {
+  void shouldReportFileLevelViolations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxOtherSensor.REPORT_PATH_KEY,
                          "externalrules-reports/externalrules-result-filelevelviolation.xml");
@@ -81,7 +81,7 @@ public class CxxOtherSensorTest {
   }
 
   @Test
-  public void shouldReportProjectLevelViolations() {
+  void shouldReportProjectLevelViolations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxOtherSensor.REPORT_PATH_KEY,
                          "externalrules-reports/externalrules-result-projectlevelviolation.xml");
@@ -94,7 +94,7 @@ public class CxxOtherSensorTest {
   }
 
   @Test
-  public void shouldThrowExceptionWhenReportEmpty() {
+  void shouldThrowExceptionWhenReportEmpty() {
     var context = SensorContextTester.create(fs.baseDir());
 
     IllegalStateException thrown = catchThrowableOfType(() -> {
@@ -110,7 +110,7 @@ public class CxxOtherSensorTest {
   }
 
   @Test
-  public void shouldReportNoViolationsIfNoReportFound() {
+  void shouldReportNoViolationsIfNoReportFound() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxOtherSensor.REPORT_PATH_KEY, "externalrules-reports/noreport.xml");
     context.setSettings(settings);
@@ -122,7 +122,7 @@ public class CxxOtherSensorTest {
   }
 
   @Test
-  public void shouldThrowInCaseOfATrashyReport() {
+  void shouldThrowInCaseOfATrashyReport() {
     IllegalStateException thrown = catchThrowableOfType(() -> {
       var context = SensorContextTester.create(fs.baseDir());
       settings.setProperty(CxxReportSensor.ERROR_RECOVERY_KEY, false);
@@ -136,7 +136,7 @@ public class CxxOtherSensorTest {
   }
 
   @Test
-  public void shouldReportOnlyOneViolationAndRemoveDuplicates() {
+  void shouldReportOnlyOneViolationAndRemoveDuplicates() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxOtherSensor.REPORT_PATH_KEY, "externalrules-reports/externalrules-with-duplicates.xml");
     context.setSettings(settings);
@@ -151,7 +151,7 @@ public class CxxOtherSensorTest {
   }
 
   @Test
-  public void sensorDescriptor() {
+  void sensorDescriptor() {
     var descriptor = new DefaultSensorDescriptor();
     sensor = new CxxOtherSensor();
     sensor.describe(descriptor);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/pclint/CxxPCLintRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/pclint/CxxPCLintRuleRepositoryTest.java
@@ -26,17 +26,17 @@ import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 
-public class CxxPCLintRuleRepositoryTest {
+class CxxPCLintRuleRepositoryTest {
 
   @Test
-  public void createRulesTest() {
+  void createRulesTest() {
     var def = new CxxPCLintRuleRepository(mock(ServerFileSystem.class), new RulesDefinitionXmlLoader());
 
     var context = new RulesDefinition.Context();
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxPCLintRuleRepository.KEY);
-    assertThat(repo.rules().size()).isEqualTo(1920);
+    assertThat(repo.rules()).hasSize(1920);
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/pclint/CxxPCLintSensorTest.java
@@ -33,7 +33,7 @@ import org.sonar.api.config.internal.MapSettings;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxPCLintSensorTest {
+class CxxPCLintSensorTest {
 
   private DefaultFileSystem fs;
   private final MapSettings settings = new MapSettings();
@@ -45,7 +45,7 @@ public class CxxPCLintSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectViolations() {
+  void shouldReportCorrectViolations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxPCLintSensor.REPORT_PATH_KEY, "pclint-reports/pclint-result-SAMPLE.xml");
     context.setSettings(settings);
@@ -64,7 +64,7 @@ public class CxxPCLintSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectMisra2004Violations() {
+  void shouldReportCorrectMisra2004Violations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxPCLintSensor.REPORT_PATH_KEY, "pclint-reports/pclint-result-MISRA2004-SAMPLE1.xml");
     context.setSettings(settings);
@@ -79,7 +79,7 @@ public class CxxPCLintSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectMisra2004PcLint9Violations() {
+  void shouldReportCorrectMisra2004PcLint9Violations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxPCLintSensor.REPORT_PATH_KEY, "pclint-reports/pclint-result-MISRA2004-SAMPLE2.xml");
     context.setSettings(settings);
@@ -94,7 +94,7 @@ public class CxxPCLintSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectMisraCppViolations() {
+  void shouldReportCorrectMisraCppViolations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxPCLintSensor.REPORT_PATH_KEY, "pclint-reports/pclint-result-MISRACPP.xml");
     context.setSettings(settings);
@@ -112,7 +112,7 @@ public class CxxPCLintSensorTest {
   }
 
   @Test
-  public void shouldNotSaveIssuesWhenMisra2004DescIsWrong() {
+  void shouldNotSaveIssuesWhenMisra2004DescIsWrong() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxPCLintSensor.REPORT_PATH_KEY, "pclint-reports/incorrect-pclint-MISRA2004-desc.xml");
     context.setSettings(settings);
@@ -127,7 +127,7 @@ public class CxxPCLintSensorTest {
   }
 
   @Test
-  public void shouldNotSaveAnythingWhenMisra2004RuleDoNotExist() {
+  void shouldNotSaveAnythingWhenMisra2004RuleDoNotExist() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxPCLintSensor.REPORT_PATH_KEY,
                          "pclint-reports/incorrect-pclint-MISRA2004-rule-do-not-exist.xml");
@@ -143,7 +143,7 @@ public class CxxPCLintSensorTest {
   }
 
   @Test
-  public void shouldNotRemapMisra1998Rules() {
+  void shouldNotRemapMisra1998Rules() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxPCLintSensor.REPORT_PATH_KEY, "pclint-reports/pclint-result-MISRA1998-SAMPLE.xml");
     context.setSettings(settings);
@@ -158,7 +158,7 @@ public class CxxPCLintSensorTest {
   }
 
   @Test
-  public void shouldReportProjectLevelViolations() {
+  void shouldReportProjectLevelViolations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxPCLintSensor.REPORT_PATH_KEY, "pclint-reports/pclint-result-projectlevelviolation.xml");
     context.setSettings(settings);
@@ -170,7 +170,7 @@ public class CxxPCLintSensorTest {
   }
 
   @Test
-  public void shouldThrowExceptionInvalidChar() {
+  void shouldThrowExceptionInvalidChar() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxPCLintSensor.REPORT_PATH_KEY, "pclint-reports/pclint-result-invalid-char.xml");
     context.setSettings(settings);
@@ -178,11 +178,11 @@ public class CxxPCLintSensorTest {
     var sensor = new CxxPCLintSensor();
     sensor.execute(context);
 
-    assertThat(context.allIssues().size()).isZero();
+    assertThat(context.allIssues()).isEmpty();
   }
 
   @Test
-  public void sensorDescriptor() {
+  void sensorDescriptor() {
     var descriptor = new DefaultSensorDescriptor();
     var sensor = new CxxPCLintSensor();
     sensor.describe(descriptor);
@@ -195,7 +195,7 @@ public class CxxPCLintSensorTest {
   }
 
   @Test
-  public void loadSupplementalMsg() {
+  void loadSupplementalMsg() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxPCLintSensor.REPORT_PATH_KEY, "pclint-reports/pclint-result-with-supplemental.xml");
     context.setSettings(settings);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/rats/CxxRatsRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/rats/CxxRatsRuleRepositoryTest.java
@@ -26,10 +26,10 @@ import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 
-public class CxxRatsRuleRepositoryTest {
+class CxxRatsRuleRepositoryTest {
 
   @Test
-  public void createRulesTest() {
+  void createRulesTest() {
     var def = new CxxRatsRuleRepository(mock(ServerFileSystem.class), new RulesDefinitionXmlLoader());
 
     var context = new RulesDefinition.Context();

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/rats/CxxRatsSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/rats/CxxRatsSensorTest.java
@@ -31,7 +31,7 @@ import org.sonar.api.config.internal.MapSettings;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxRatsSensorTest {
+class CxxRatsSensorTest {
 
   private CxxRatsSensor sensor;
   private DefaultFileSystem fs;
@@ -43,7 +43,7 @@ public class CxxRatsSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectViolations() {
+  void shouldReportCorrectViolations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxReportSensor.ERROR_RECOVERY_KEY, true);
     settings.setProperty(CxxRatsSensor.REPORT_PATH_KEY, "rats-reports/rats-result-*.xml");
@@ -61,7 +61,7 @@ public class CxxRatsSensorTest {
   }
 
   @Test
-  public void sensorDescriptor() {
+  void sensorDescriptor() {
     var descriptor = new DefaultSensorDescriptor();
     sensor = new CxxRatsSensor();
     sensor.describe(descriptor);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/CxxUnitTestResultsAggregatorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/CxxUnitTestResultsAggregatorTest.java
@@ -36,13 +36,13 @@ import static org.mockito.Mockito.when;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.config.internal.MapSettings;
 
-public class CxxUnitTestResultsAggregatorTest {
+class CxxUnitTestResultsAggregatorTest {
 
   private final String key1 = UnitTestConfiguration.VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY;
   private final String key3 = UnitTestConfiguration.NUNIT_TEST_RESULTS_PROPERTY_KEY;
 
   @Test
-  public void hasUnitTestResultsProperty() {
+  void hasUnitTestResultsProperty() {
 
     Configuration config = mock(Configuration.class);
 
@@ -64,7 +64,7 @@ public class CxxUnitTestResultsAggregatorTest {
   }
 
   @Test
-  public void aggregate() {
+  void aggregate() {
     WildcardPatternFileProvider wildcardPatternFileProvider = mock(WildcardPatternFileProvider.class);
     var config = new MapSettings();
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/CxxUnitTestResultsImportSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/CxxUnitTestResultsImportSensorTest.java
@@ -38,13 +38,13 @@ import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.measures.CoreMetrics;
 
-public class CxxUnitTestResultsImportSensorTest {
+class CxxUnitTestResultsImportSensorTest {
 
   @TempDir
   File tempDir;
 
   @Test
-  public void sensorDescriptor() {
+  void sensorDescriptor() {
     var descriptor = new DefaultSensorDescriptor();
     var sensor = new CxxUnitTestResultsImportSensor(mock(CxxUnitTestResultsAggregator.class));
     sensor.describe(descriptor);
@@ -56,7 +56,7 @@ public class CxxUnitTestResultsImportSensorTest {
   }
 
   @Test
-  public void analyze() throws Exception {
+  void analyze() throws Exception {
     var context = SensorContextTester.create(tempDir);
     UnitTestResults results = mock(UnitTestResults.class);
     when(results.tests()).thenReturn(42);
@@ -90,7 +90,7 @@ public class CxxUnitTestResultsImportSensorTest {
   }
 
   @Test
-  public void should_not_save_metrics_with_empty_results() throws Exception {
+  void should_not_save_metrics_with_empty_results() throws Exception {
     var context = SensorContextTester.create(tempDir);
 
     CxxUnitTestResultsAggregator unitTestResultsAggregator = mock(CxxUnitTestResultsAggregator.class);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/NUnitTestResultsFileParserTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/NUnitTestResultsFileParserTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.mock;
 import org.sonar.api.utils.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
 
-public class NUnitTestResultsFileParserTest {
+class NUnitTestResultsFileParserTest {
 
   private static final String REPORT_PATH
                                 = "src/test/resources/org/sonar/cxx/sensors/reports-project/xunit-reports/nunit/";
@@ -40,7 +40,7 @@ public class NUnitTestResultsFileParserTest {
   public LogTesterJUnit5 logTester = new LogTesterJUnit5();
 
   @Test
-  public void no_counters() {
+  void no_counters() {
     ParseErrorException thrown = catchThrowableOfType(() -> {
       new NUnitTestResultsFileParser().accept(new File(REPORT_PATH + "no_counters.xml"), mock(UnitTestResults.class));
     }, ParseErrorException.class);
@@ -49,7 +49,7 @@ public class NUnitTestResultsFileParserTest {
   }
 
   @Test
-  public void wrong_passed_number() {
+  void wrong_passed_number() {
     ParseErrorException thrown = catchThrowableOfType(() -> {
       new NUnitTestResultsFileParser().accept(new File(REPORT_PATH + "invalid_total.xml"), mock(UnitTestResults.class));
     }, ParseErrorException.class);
@@ -58,7 +58,7 @@ public class NUnitTestResultsFileParserTest {
   }
 
   @Test
-  public void valid() throws Exception {
+  void valid() throws Exception {
     var results = new UnitTestResults();
     new NUnitTestResultsFileParser().accept(new File(REPORT_PATH + "valid.xml"), results);
 
@@ -71,7 +71,7 @@ public class NUnitTestResultsFileParserTest {
   }
 
   @Test
-  public void valid_comma_in_double() throws Exception {
+  void valid_comma_in_double() throws Exception {
     var results = new UnitTestResults();
     new NUnitTestResultsFileParser().accept(new File(REPORT_PATH + "valid_comma_in_double.xml"), results);
 
@@ -79,7 +79,7 @@ public class NUnitTestResultsFileParserTest {
   }
 
   @Test
-  public void valid_no_execution_time() throws Exception {
+  void valid_no_execution_time() throws Exception {
     var results = new UnitTestResults();
     new NUnitTestResultsFileParser().accept(new File(REPORT_PATH + "valid_no_execution_time.xml"), results);
 
@@ -92,7 +92,7 @@ public class NUnitTestResultsFileParserTest {
   }
 
   @Test
-  public void empty() {
+  void empty() {
     var results = new UnitTestResults();
     new NUnitTestResultsFileParser().accept(new File(REPORT_PATH + "empty.xml"), results);
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/VisualStudioTestResultsFileParserTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/VisualStudioTestResultsFileParserTest.java
@@ -28,12 +28,12 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 
-public class VisualStudioTestResultsFileParserTest {
+class VisualStudioTestResultsFileParserTest {
 
   private static final String REPORT_PATH = "src/test/resources/org/sonar/cxx/sensors/reports-project/MSTest-reports/";
 
   @Test
-  public void no_counters() {
+  void no_counters() {
     IllegalArgumentException thrown = catchThrowableOfType(() -> {
       new VisualStudioTestResultsFileParser().accept(new File(REPORT_PATH + "no_counters.trx"),
                                                      mock(UnitTestResults.class));
@@ -43,7 +43,7 @@ public class VisualStudioTestResultsFileParserTest {
   }
 
   @Test
-  public void wrong_passed_number() {
+  void wrong_passed_number() {
     ParseErrorException thrown = catchThrowableOfType(() -> {
       new VisualStudioTestResultsFileParser().accept(new File(REPORT_PATH + "wrong_passed_number.trx"),
                                                      mock(UnitTestResults.class));
@@ -53,7 +53,7 @@ public class VisualStudioTestResultsFileParserTest {
   }
 
   @Test
-  public void valid() throws Exception {
+  void valid() throws Exception {
     var results = new UnitTestResults();
     new VisualStudioTestResultsFileParser().accept(new File(REPORT_PATH + "valid.trx"), results);
 
@@ -66,7 +66,7 @@ public class VisualStudioTestResultsFileParserTest {
   }
 
   @Test
-  public void valid_missing_attributes() throws Exception {
+  void valid_missing_attributes() throws Exception {
     var results = new UnitTestResults();
     new VisualStudioTestResultsFileParser().accept(new File(REPORT_PATH + "valid_missing_attributes.trx"), results);
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/WildcardPatternFileProviderTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/WildcardPatternFileProviderTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class WildcardPatternFileProviderTest {
+class WildcardPatternFileProviderTest {
 
   @TempDir
   File tempDir;
@@ -71,7 +71,7 @@ public class WildcardPatternFileProviderTest {
   }
 
   @Test
-  public void absolute_paths() {
+  void absolute_paths() {
     assertThat(listFiles(new File(tempDir, "foo.txt").getAbsolutePath()))
       .containsOnly(new File(tempDir, "foo.txt"));
 
@@ -82,13 +82,13 @@ public class WildcardPatternFileProviderTest {
   }
 
   @Test
-  public void absolute_paths_with_current_and_parent_folder_access() {
+  void absolute_paths_with_current_and_parent_folder_access() {
     assertThat(listFiles(new File(tempDir, path("a", "..", ".", "foo.txt")).getAbsolutePath()))
       .containsOnly(new File(tempDir, path("a", "..", ".", "foo.txt")));
   }
 
   @Test
-  public void absolute_paths_with_wildcards() {
+  void absolute_paths_with_wildcards() {
     assertThat(listFiles(new File(tempDir, "*.txt").getAbsolutePath()))
       .containsOnly(new File(tempDir, "foo.txt"), new File(tempDir, "bar.txt"));
 
@@ -122,7 +122,7 @@ public class WildcardPatternFileProviderTest {
   }
 
   @Test
-  public void relative_paths() {
+  void relative_paths() {
     assertThat(listFiles("foo.txt", tempDir))
       .containsOnly(new File(tempDir, "foo.txt"));
 
@@ -133,7 +133,7 @@ public class WildcardPatternFileProviderTest {
   }
 
   @Test
-  public void relative_paths_with_current_and_parent_folder_access() {
+  void relative_paths_with_current_and_parent_folder_access() {
     assertThat(listFiles(path("..", "foo.txt"), new File(tempDir, "a")))
       .containsOnly(new File(new File(tempDir, "a"), path("..", "foo.txt")));
 
@@ -145,7 +145,7 @@ public class WildcardPatternFileProviderTest {
   }
 
   @Test
-  public void relative_paths_with_wildcards() {
+  void relative_paths_with_wildcards() {
     assertThat(listFiles("*.txt", tempDir))
       .containsOnly(new File(tempDir, "foo.txt"), new File(tempDir, "bar.txt"));
 
@@ -179,7 +179,7 @@ public class WildcardPatternFileProviderTest {
   }
 
   @Test
-  public void should_fail_with_current_folder_access_after_wildcard() {
+  void should_fail_with_current_folder_access_after_wildcard() {
     IllegalArgumentException thrown = catchThrowableOfType(() -> {
       listFiles(new File(tempDir, path("?", ".", "foo.txt")).getAbsolutePath());
     }, IllegalArgumentException.class);
@@ -187,7 +187,7 @@ public class WildcardPatternFileProviderTest {
   }
 
   @Test
-  public void should_fail_with_parent_folder_access_after_wildcard() {
+  void should_fail_with_parent_folder_access_after_wildcard() {
     IllegalArgumentException thrown = catchThrowableOfType(() -> {
       listFiles(path("*", "..", "foo.txt"), tempDir);
     }, IllegalArgumentException.class);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/XmlParserHelperTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/XmlParserHelperTest.java
@@ -28,12 +28,12 @@ import java.io.IOException;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class XmlParserHelperTest {
+class XmlParserHelperTest {
 
   private static final String REPORT_PATH = "src/test/resources/org/sonar/cxx/sensors/reports-project/MSTest-reports/";
 
   @Test
-  public void invalid_prolog() throws IOException {
+  void invalid_prolog() throws IOException {
     IllegalStateException e = catchThrowableOfType(() -> {
       try (var helper = new XmlParserHelper(new File(REPORT_PATH + "invalid_prolog.txt"))) {
         helper.nextStartTag();
@@ -44,7 +44,7 @@ public class XmlParserHelperTest {
   }
 
   @Test
-  public void nextStartOrEndTag() {
+  void nextStartOrEndTag() {
     var xml = new XmlParserHelper(new File(REPORT_PATH + "valid.xml"));
     assertThat(xml.nextStartOrEndTag()).isEqualTo("<foo>");
     assertThat(xml.nextStartOrEndTag()).isEqualTo("<bar>");
@@ -60,7 +60,7 @@ public class XmlParserHelperTest {
   }
 
   @Test
-  public void getDoubleAttribute() {
+  void getDoubleAttribute() {
     var xml = new XmlParserHelper(new File(REPORT_PATH + "valid.xml"));
     xml.nextStartTag();
     assertThat(xml.getDoubleAttribute("myDouble")).isEqualTo(0.123);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/xunit/CxxXunitSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/xunit/CxxXunitSensorTest.java
@@ -31,7 +31,7 @@ import org.sonar.api.measures.CoreMetrics;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxXunitSensorTest {
+class CxxXunitSensorTest {
 
   private FileSystem fs;
   private final MapSettings settings = new MapSettings();
@@ -43,7 +43,7 @@ public class CxxXunitSensorTest {
   }
 
   @Test
-  public void shouldReportNothingWhenNoReportFound() {
+  void shouldReportNothingWhenNoReportFound() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxXunitSensor.REPORT_PATH_KEY, "notexistingpath");
     context.setSettings(settings);
@@ -55,7 +55,7 @@ public class CxxXunitSensorTest {
   }
 
   @Test
-  public void shouldReadXunitReport() {
+  void shouldReadXunitReport() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxXunitSensor.REPORT_PATH_KEY, "xunit-reports/xunit-result-SAMPLE_with_fileName.xml");
     context.setSettings(settings);
@@ -75,7 +75,7 @@ public class CxxXunitSensorTest {
   }
 
   @Test
-  public void shouldThrowWhenGivenInvalidTime() {
+  void shouldThrowWhenGivenInvalidTime() {
     IllegalStateException thrown = catchThrowableOfType(() -> {
       var context = SensorContextTester.create(fs.baseDir());
       settings.setProperty(CxxXunitSensor.REPORT_PATH_KEY, "xunit-reports/invalid-time-xunit-report.xml");
@@ -88,7 +88,7 @@ public class CxxXunitSensorTest {
   }
 
   @Test
-  public void sensorDescriptor() {
+  void sensorDescriptor() {
     var descriptor = new DefaultSensorDescriptor();
     var sensor = new CxxXunitSensor();
     sensor.describe(descriptor);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/xunit/TestCaseTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/xunit/TestCaseTest.java
@@ -22,10 +22,10 @@ package org.sonar.cxx.sensors.tests.xunit;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class TestCaseTest {
+class TestCaseTest {
 
   @Test
-  public void rendersRightDetails() {
+  void rendersRightDetails() {
     var testCase = new TestCase("testCaseName", 1, "ok", "stack", "msg", "classname", "filename", "testSuiteName");
     assertThat(testCase.getClassname()).isEqualTo("classname");
     assertThat(testCase.getFullname()).isEqualTo("testSuiteName:testCaseName");

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/xunit/TestFileTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/xunit/TestFileTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TestFileTest {
+class TestFileTest {
 
   private TestFile testFile;
 
@@ -35,16 +35,16 @@ public class TestFileTest {
   }
 
   @Test
-  public void newBornTestFileShouldHaveVirginStatistics() {
-    assertThat(testFile.getTests()).isEqualTo(0);
-    assertThat(testFile.getErrors()).isEqualTo(0);
-    assertThat(testFile.getFailures()).isEqualTo(0);
-    assertThat(testFile.getSkipped()).isEqualTo(0);
-    assertThat(testFile.getExecutionTime()).isEqualTo(0);
+  void newBornTestFileShouldHaveVirginStatistics() {
+    assertThat(testFile.getTests()).isZero();
+    assertThat(testFile.getErrors()).isZero();
+    assertThat(testFile.getFailures()).isZero();
+    assertThat(testFile.getSkipped()).isZero();
+    assertThat(testFile.getExecutionTime()).isZero();
   }
 
   @Test
-  public void addingTestCaseShouldIncrementStatistics() {
+  void addingTestCaseShouldIncrementStatistics() {
     int testBefore = testFile.getTests();
     long timeBefore = testFile.getExecutionTime();
 
@@ -57,7 +57,7 @@ public class TestFileTest {
   }
 
   @Test
-  public void addingAnErroneousTestCaseShouldIncrementErrorStatistic() {
+  void addingAnErroneousTestCaseShouldIncrementErrorStatistic() {
     int errorsBefore = testFile.getErrors();
     TestCase error = mock(TestCase.class);
     when(error.isError()).thenReturn(true);
@@ -68,7 +68,7 @@ public class TestFileTest {
   }
 
   @Test
-  public void addingAFailedTestCaseShouldIncrementFailedStatistic() {
+  void addingAFailedTestCaseShouldIncrementFailedStatistic() {
     int failedBefore = testFile.getFailures();
     TestCase failedTC = mock(TestCase.class);
     when(failedTC.isFailure()).thenReturn(true);
@@ -79,7 +79,7 @@ public class TestFileTest {
   }
 
   @Test
-  public void addingASkippedTestCaseShouldIncrementSkippedStatistic() {
+  void addingASkippedTestCaseShouldIncrementSkippedStatistic() {
     int skippedBefore = testFile.getSkipped();
     TestCase skippedTC = mock(TestCase.class);
     when(skippedTC.isSkipped()).thenReturn(true);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/xunit/XunitReportParserTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/xunit/XunitReportParserTest.java
@@ -31,14 +31,14 @@ import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sensors.utils.StaxParser;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class XunitReportParserTest {
+class XunitReportParserTest {
 
   private XunitReportParser parserHandler = new XunitReportParser("");
   private StaxParser parser = new StaxParser(parserHandler, false);
   private final String pathPrefix = "/org/sonar/cxx/sensors/reports-project/xunit-reports/";
 
   @Test
-  public void testParse() throws javax.xml.stream.XMLStreamException {
+  void testParse() throws javax.xml.stream.XMLStreamException {
 
     var ioMap = new TreeMap<String, Integer>();
 
@@ -66,7 +66,7 @@ public class XunitReportParserTest {
   }
 
   @Test
-  public void shouldThrowWhenGivenInvalidTime() {
+  void shouldThrowWhenGivenInvalidTime() {
     javax.xml.stream.XMLStreamException thrown = catchThrowableOfType(() -> {
       parserHandler = new XunitReportParser("");
       parser = new StaxParser(parserHandler, false);
@@ -77,7 +77,7 @@ public class XunitReportParserTest {
   }
 
   @Test
-  public void testFilePaths() throws javax.xml.stream.XMLStreamException {
+  void testFilePaths() throws javax.xml.stream.XMLStreamException {
     parserHandler = new XunitReportParser("");
     parser = new StaxParser(parserHandler, false);
     File report = TestUtils.loadResource(pathPrefix + "xunit-result-SAMPLE-inconsistent-case.xml");

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxMetricsTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxMetricsTest.java
@@ -25,16 +25,16 @@ import org.junit.jupiter.api.Test;
 import org.sonar.api.measures.Metric;
 import org.sonar.cxx.CxxMetrics;
 
-public class CxxMetricsTest {
+class CxxMetricsTest {
 
   @Test
-  public void getMetricsTest() {
+  void getMetricsTest() {
     List<Metric> list = CxxMetrics.getMetrics();
     assertThat(list).hasSize(12);
   }
 
   @Test
-  public void getMetricTest() {
+  void getMetricTest() {
     Metric<Integer> metric0 = CxxMetrics.getMetric(CxxMetrics.PUBLIC_API_KEY);
     assertThat(metric0).isNotNull();
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportPatternMatchingTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportPatternMatchingTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
 
-public class CxxReportPatternMatchingTest {
+class CxxReportPatternMatchingTest {
 
   private static final String REPORT_PATH_KEY = "sonar.cxx.cppcheck.reportPaths";
 
@@ -63,7 +63,7 @@ public class CxxReportPatternMatchingTest {
   }
 
   @Test
-  public void getReports_patternMatching() throws java.io.IOException, java.lang.InterruptedException {
+  void getReports_patternMatching() throws java.io.IOException, java.lang.InterruptedException {
     String pattern, expected, allpaths;
     List<File> reports;
     for (var example : examples) {

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportSensorTest.java
@@ -28,7 +28,7 @@ import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
 
-public class CxxReportSensorTest {
+class CxxReportSensorTest {
 
   private final String VALID_REPORT_PATH = "cppcheck-reports/cppcheck-result-*.xml";
   private final String VALID_REPORT_PATH_LIST = "cppcheck-reports/*empty.xml, cppcheck-reports/*V2.xml";
@@ -49,13 +49,13 @@ public class CxxReportSensorTest {
   }
 
   @Test
-  public void shouldntThrowWhenInstantiating() {
+  void shouldntThrowWhenInstantiating() {
     var sensor = new CxxReportSensorImpl(settings);
     assertThat(sensor).isNotNull();
   }
 
   @Test
-  public void getReports_shouldFindNothingIfNoKey() {
+  void getReports_shouldFindNothingIfNoKey() {
     settings.setProperty(REPORT_PATH_PROPERTY_KEY, INVALID_REPORT_PATH);
 
     var context = SensorContextTester.create(baseDir);
@@ -65,7 +65,7 @@ public class CxxReportSensorTest {
   }
 
   @Test
-  public void getReports_shouldFindNothingIfNoPath() {
+  void getReports_shouldFindNothingIfNoPath() {
     settings.setProperty(REPORT_PATH_PROPERTY_KEY, "");
     var context = SensorContextTester.create(baseDir);
     context.setSettings(settings);
@@ -74,7 +74,7 @@ public class CxxReportSensorTest {
   }
 
   @Test
-  public void getReports_shouldFindNothingIfInvalidPath() {
+  void getReports_shouldFindNothingIfInvalidPath() {
     settings.setProperty(REPORT_PATH_PROPERTY_KEY, INVALID_REPORT_PATH);
     var context = SensorContextTester.create(baseDir);
     context.setSettings(settings);
@@ -83,7 +83,7 @@ public class CxxReportSensorTest {
   }
 
   @Test
-  public void getReports_shouldFindSomething() {
+  void getReports_shouldFindSomething() {
     settings.setProperty(REPORT_PATH_PROPERTY_KEY, VALID_REPORT_PATH);
     var context = SensorContextTester.create(baseDir);
     context.setSettings(settings);
@@ -95,7 +95,7 @@ public class CxxReportSensorTest {
   }
 
   @Test
-  public void getReports_shouldFindSomethingList() {
+  void getReports_shouldFindSomethingList() {
     settings.setProperty(REPORT_PATH_PROPERTY_KEY, VALID_REPORT_PATH_LIST);
     var context = SensorContextTester.create(baseDir);
     context.setSettings(settings);

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportSensor_getReports_Test.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/CxxReportSensor_getReports_Test.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
 
-public class CxxReportSensor_getReports_Test {
+class CxxReportSensor_getReports_Test {
 
   private static final String REPORT_PATH_KEY = "sonar.cxx.cppcheck.reportPaths";
 
@@ -39,7 +39,7 @@ public class CxxReportSensor_getReports_Test {
   private final MapSettings settings = new MapSettings();
 
   @Test
-  public void testAbsoluteInsideBasedir() throws IOException {
+  void testAbsoluteInsideBasedir() throws IOException {
     var absReportFile = new File(tempDir, "path/to/report.xml").getAbsoluteFile();
     FileUtils.touch(absReportFile);
 
@@ -52,7 +52,7 @@ public class CxxReportSensor_getReports_Test {
   }
 
   @Test
-  public void testAbsoluteOutsideBasedir() {
+  void testAbsoluteOutsideBasedir() {
     File absReportsProject = TestUtils.loadResource("/org/sonar/cxx/sensors/reports-project").getAbsoluteFile();
     var absReportFile = new File(absReportsProject, "cppcheck-reports/cppcheck-result-SAMPLE-V2.xml");
 
@@ -65,7 +65,7 @@ public class CxxReportSensor_getReports_Test {
   }
 
   @Test
-  public void testAbsoluteOutsideBasedirWithGlobbing() {
+  void testAbsoluteOutsideBasedirWithGlobbing() {
     File absReportsProject = TestUtils.loadResource("/org/sonar/cxx/sensors/reports-project").getAbsoluteFile();
     var absReportFile = new File(absReportsProject, "cppcheck-reports/cppcheck-result-SAMPLE-*.xml");
 
@@ -78,7 +78,7 @@ public class CxxReportSensor_getReports_Test {
   }
 
   @Test
-  public void testAbsoluteOutsideBasedirAndRelative() throws IOException {
+  void testAbsoluteOutsideBasedirAndRelative() throws IOException {
     File absReportsProject = TestUtils.loadResource("/org/sonar/cxx/sensors/reports-project").getAbsoluteFile();
     var absReportFile = new File(absReportsProject, "cppcheck-reports/cppcheck-result-SAMPLE-V2.xml");
 
@@ -94,7 +94,7 @@ public class CxxReportSensor_getReports_Test {
   }
 
   @Test
-  public void testAbsoluteOutsideBasedirWithGlobbingAndRelativeWithGlobbing() throws IOException {
+  void testAbsoluteOutsideBasedirWithGlobbingAndRelativeWithGlobbing() throws IOException {
     File absReportsProject = TestUtils.loadResource("/org/sonar/cxx/sensors/reports-project").getAbsoluteFile();
     var absReportFile = new File(absReportsProject, "cppcheck-reports/cppcheck-result-SAMPLE-*.xml");
 
@@ -115,7 +115,7 @@ public class CxxReportSensor_getReports_Test {
   }
 
   @Test
-  public void testAbsoluteOutsideBasedirWithGlobbingAndNestedRelativeWithGlobbing() throws IOException {
+  void testAbsoluteOutsideBasedirWithGlobbingAndNestedRelativeWithGlobbing() throws IOException {
     File absReportsProject = TestUtils.loadResource("/org/sonar/cxx/sensors/reports-project").getAbsoluteFile();
     var absReportFile = new File(absReportsProject, "cppcheck-reports/cppcheck-result-SAMPLE-*.xml");
 
@@ -135,7 +135,7 @@ public class CxxReportSensor_getReports_Test {
   }
 
   @Test
-  public void testRelativeBackticksOutsideBasedirThenBackInside() throws IOException {
+  void testRelativeBackticksOutsideBasedirThenBackInside() throws IOException {
     FileUtils.touch(new File(tempDir, "path/to/supercoolreport.xml"));
     FileUtils.touch(new File(tempDir, "path/to/a/report.xml"));
     FileUtils.touch(new File(tempDir, "path/to/some/reports/1.xml"));
@@ -150,7 +150,7 @@ public class CxxReportSensor_getReports_Test {
   }
 
   @Test
-  public void testRelativeExcessiveBackticks() throws IOException {
+  void testRelativeExcessiveBackticks() throws IOException {
     FileUtils.touch(new File(tempDir, "path/to/supercoolreport.xml"));
 
     // Might be valid if java.io.tmpdir is nested excessively deep -- not likely
@@ -162,7 +162,7 @@ public class CxxReportSensor_getReports_Test {
     context.setSettings(settings);
 
     List<File> reports = CxxUtils.getFiles(context, REPORT_PATH_KEY);
-    assertThat(reports.size()).isZero();
+    assertThat(reports).isEmpty();
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/CxxValgrindRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/CxxValgrindRuleRepositoryTest.java
@@ -31,19 +31,19 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxValgrindRuleRepositoryTest {
+class CxxValgrindRuleRepositoryTest {
 
   @Test
-  public void shouldContainProperNumberOfRules() {
+  void shouldContainProperNumberOfRules() {
     var def = new CxxValgrindRuleRepository(mock(ServerFileSystem.class), new RulesDefinitionXmlLoader());
     var context = new RulesDefinition.Context();
     def.define(context);
     RulesDefinition.Repository repo = context.repository(CxxValgrindRuleRepository.KEY);
-    assertThat(repo.rules().size()).isEqualTo(16);
+    assertThat(repo.rules()).hasSize(16);
   }
 
   @Test
-  public void containsValidFormatInExtensionRulesOldFormat() {
+  void containsValidFormatInExtensionRulesOldFormat() {
     ServerFileSystem filesystem = mock(ServerFileSystem.class);
     var extensionFile = new ArrayList<File>();
     extensionFile.add(TestUtils.loadResource("/org/sonar/cxx/sensors/rules-repository/CustomRulesOldFormat.xml"));
@@ -55,11 +55,11 @@ public class CxxValgrindRuleRepositoryTest {
     var context = new RulesDefinition.Context();
     def.define(context);
     RulesDefinition.Repository repo = context.repository(repositoryKey);
-    assertThat(repo.rules().size()).isEqualTo(18);
+    assertThat(repo.rules()).hasSize(18);
   }
 
   @Test
-  public void containsValidFormatInExtensionRulesNewFormat() {
+  void containsValidFormatInExtensionRulesNewFormat() {
     ServerFileSystem filesystem = mock(ServerFileSystem.class);
     var extensionFile = new ArrayList<File>();
     extensionFile.add(TestUtils.loadResource("/org/sonar/cxx/sensors/rules-repository/CustomRulesNewFormat.xml"));
@@ -71,7 +71,7 @@ public class CxxValgrindRuleRepositoryTest {
     var context = new RulesDefinition.Context();
     def.define(context);
     RulesDefinition.Repository repo = context.repository(repositoryKey);
-    assertThat(repo.rules().size()).isEqualTo(17);
+    assertThat(repo.rules()).hasSize(17);
   }
 
   @Test //@todo check if new behaviour is ok: Exception is replaced by error message in LOG file
@@ -87,7 +87,7 @@ public class CxxValgrindRuleRepositoryTest {
     var context = new RulesDefinition.Context();
     def.define(context);
     RulesDefinition.Repository repo = context.repository(repositoryKey);
-    assertThat(repo.rules().size()).isEqualTo(16);
+    assertThat(repo.rules()).hasSize(16);
   }
 
   @Test //@todo check if new behaviour is ok: Exception is replaced by error message in LOG file
@@ -103,7 +103,7 @@ public class CxxValgrindRuleRepositoryTest {
     var context = new RulesDefinition.Context();
     def.define(context);
     RulesDefinition.Repository repo = context.repository(repositoryKey);
-    assertThat(repo.rules().size()).isEqualTo(16);
+    assertThat(repo.rules()).hasSize(16);
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/CxxValgrindSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/CxxValgrindSensorTest.java
@@ -34,7 +34,7 @@ import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxValgrindSensorTest {
+class CxxValgrindSensorTest {
 
   private DefaultFileSystem fs;
   private CxxValgrindSensor sensor;
@@ -46,7 +46,7 @@ public class CxxValgrindSensorTest {
   }
 
   @Test
-  public void shouldNotThrowWhenGivenValidData() {
+  void shouldNotThrowWhenGivenValidData() {
     var context = SensorContextTester.create(fs.baseDir());
     sensor.execute(context);
 
@@ -54,7 +54,7 @@ public class CxxValgrindSensorTest {
   }
 
   @Test
-  public void shouldSaveViolationIfErrorIsInside() {
+  void shouldSaveViolationIfErrorIsInside() {
     var context = SensorContextTester.create(fs.baseDir());
     context.fileSystem().add(
       TestInputFileBuilder.create("myProjectKey", "dir/file")
@@ -70,7 +70,7 @@ public class CxxValgrindSensorTest {
   }
 
   @Test
-  public void shouldNotSaveViolationIfErrorIsOutside() {
+  void shouldNotSaveViolationIfErrorIsOutside() {
     var context = SensorContextTester.create(fs.baseDir());
     sensor.execute(context); // set context
     var valgrindErrors = new HashSet<ValgrindError>();
@@ -81,7 +81,7 @@ public class CxxValgrindSensorTest {
   }
 
   @Test
-  public void sensorDescriptor() {
+  void sensorDescriptor() {
     var descriptor = new DefaultSensorDescriptor();
     sensor.describe(descriptor);
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/ValgrindErrorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/ValgrindErrorTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ValgrindErrorTest {
+class ValgrindErrorTest {
 
   private ValgrindError error;
   private ValgrindError equalError;
@@ -38,36 +38,36 @@ public class ValgrindErrorTest {
   }
 
   @Test
-  public void errorDoesntEqualsNull() {
+  void errorDoesntEqualsNull() {
     assertThat(error).isNotNull();
   }
 
   @Test
-  public void errorDoesntEqualsMiscObject() {
+  void errorDoesntEqualsMiscObject() {
     assertThat(error).isNotEqualTo("string");
   }
 
   @Test
-  public void errorEqualityIsReflexive() {
+  void errorEqualityIsReflexive() {
     assertThat(error).isEqualTo(error);
     assertThat(otherError).isEqualTo(otherError);
     assertThat(equalError).isEqualTo(equalError);
   }
 
   @Test
-  public void errorEqualityWorksAsExpected() {
+  void errorEqualityWorksAsExpected() {
     assertThat(error).isEqualTo(equalError);
     assertThat(error).isNotEqualTo(otherError);
   }
 
   @Test
-  public void errorHashWorksAsExpected() {
+  void errorHashWorksAsExpected() {
     assertThat(error).hasSameHashCodeAs(equalError);
     assertThat(error.hashCode()).isNotEqualTo(otherError.hashCode());
   }
 
   @Test
-  public void getKindWorks() {
+  void getKindWorks() {
     var KIND = "kind";
     assertThat(KIND).isEqualTo(new ValgrindError(KIND, "", Collections.singletonList(new ValgrindStack())).getKind());
   }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/ValgrindFrameTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/ValgrindFrameTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ValgrindFrameTest {
+class ValgrindFrameTest {
 
   private ValgrindFrame frame;
   private ValgrindFrame equalFrame;
@@ -38,36 +38,36 @@ public class ValgrindFrameTest {
   }
 
   @Test
-  public void frameDoesntEqualsNull() {
+  void frameDoesntEqualsNull() {
     assertThat(frame).isNotNull();
   }
 
   @Test
-  public void frameDoesntEqualsMiscObject() {
+  void frameDoesntEqualsMiscObject() {
     assertThat(frame).isNotEqualTo("string");
   }
 
   @Test
-  public void frameEqualityIsReflexive() {
+  void frameEqualityIsReflexive() {
     assertThat(frame).isEqualTo(frame);
     assertThat(otherFrame).isEqualTo(otherFrame);
     assertThat(equalFrame).isEqualTo(equalFrame);
   }
 
   @Test
-  public void frameEqualityWorksAsExpected() {
+  void frameEqualityWorksAsExpected() {
     assertThat(frame).isEqualTo(equalFrame);
     assertThat(frame).isNotEqualTo(otherFrame);
   }
 
   @Test
-  public void frameHashWorksAsExpected() {
+  void frameHashWorksAsExpected() {
     assertThat(frame).hasSameHashCodeAs(equalFrame);
     assertThat(frame.hashCode()).isNotEqualTo(otherFrame.hashCode());
   }
 
   @Test
-  public void stringRepresentationShouldResembleValgrindsStandard() {
+  void stringRepresentationShouldResembleValgrindsStandard() {
     var ioMap = new HashMap<String, ValgrindFrame>();
 
     ioMap.put("0xDEADBEAF: main() (main.cc:1)",
@@ -86,7 +86,7 @@ public class ValgrindFrameTest {
               new ValgrindFrame(null, null, null, null, null, ""));
 
     for (var entry : ioMap.entrySet()) {
-      assertThat(entry.getValue().toString()).isEqualTo(entry.getKey());
+      assertThat(entry.getValue()).hasToString(entry.getKey());
     }
   }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/ValgrindReportParserTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/ValgrindReportParserTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class ValgrindReportParserTest {
+class ValgrindReportParserTest {
 
   private ValgrindReportParser parser;
 
@@ -37,36 +37,36 @@ public class ValgrindReportParserTest {
   }
 
   @Test
-  public void shouldParseCorrectNumberOfErrors() throws javax.xml.stream.XMLStreamException {
+  void shouldParseCorrectNumberOfErrors() throws javax.xml.stream.XMLStreamException {
     File absReportsProject = TestUtils.loadResource("/org/sonar/cxx/sensors/reports-project").getAbsoluteFile();
     var absReportFile = new File(absReportsProject, "valgrind-reports/valgrind-result-SAMPLE_1.xml");
     Set<ValgrindError> valgrindErrors = parser.parse(absReportFile);
-    assertThat(valgrindErrors.size()).isEqualTo(13);
+    assertThat(valgrindErrors).hasSize(13);
   }
 
   @Test
-  public void parseAnErrorWithMultipleStacks() throws javax.xml.stream.XMLStreamException {
+  void parseAnErrorWithMultipleStacks() throws javax.xml.stream.XMLStreamException {
     File absReportsProject = TestUtils.loadResource("/org/sonar/cxx/sensors/reports-project").getAbsoluteFile();
     var absReportFile = new File(absReportsProject, "valgrind-reports/valgrind-result-SAMPLE_2.xml");
     Set<ValgrindError> valgrindErrors = parser.parse(absReportFile);
     // single <error>
-    assertThat(valgrindErrors.size()).isEqualTo(1);
+    assertThat(valgrindErrors).hasSize(1);
 
     ValgrindError error = valgrindErrors.iterator().next();
     // merge <what> and <auxwhat>
     assertThat(error.getText())
       .isEqualTo("Invalid write of size 4: Address 0xd820468 is 0 bytes after a block of size 40 alloc'd");
     // <error> contains two <stack> entries
-    assertThat(error.getStacks().size()).isEqualTo(2);
+    assertThat(error.getStacks()).hasSize(2);
   }
 
   @Test
-  public void parseAnErrorWithMultipleAuxwhat() throws javax.xml.stream.XMLStreamException {
+  void parseAnErrorWithMultipleAuxwhat() throws javax.xml.stream.XMLStreamException {
     File absReportsProject = TestUtils.loadResource("/org/sonar/cxx/sensors/reports-project").getAbsoluteFile();
     var absReportFile = new File(absReportsProject, "valgrind-reports/valgrind-result-SAMPLE_3.xml");
     Set<ValgrindError> valgrindErrors = parser.parse(absReportFile);
     // single <error>
-    assertThat(valgrindErrors.size()).isEqualTo(1);
+    assertThat(valgrindErrors).hasSize(1);
 
     ValgrindError error = valgrindErrors.iterator().next();
     // merge <what>, <auxwhat> and one more <auxwhat>
@@ -74,11 +74,11 @@ public class ValgrindReportParserTest {
     // https://github.com/pathscale/valgrind-mmt/blob/master/docs/internals/xml-output.txt
     assertThat(error.getText()).isEqualTo("Invalid write of size 4: Details0; Details1");
     // <error> contains one <stack> entry
-    assertThat(error.getStacks().size()).isEqualTo(1);
+    assertThat(error.getStacks()).hasSize(1);
   }
 
   @Test
-  public void shouldThrowWhenGivenAnIncompleteReport_1() {
+  void shouldThrowWhenGivenAnIncompleteReport_1() {
     javax.xml.stream.XMLStreamException thrown = catchThrowableOfType(() -> {
       File absReportsProject = TestUtils.loadResource("/org/sonar/cxx/sensors/reports-project").getAbsoluteFile();
       var absReportFile = new File(absReportsProject, "valgrind-reports/incorrect-valgrind-result_1.xml");
@@ -90,7 +90,7 @@ public class ValgrindReportParserTest {
   }
 
   @Test
-  public void shouldThrowWhenGivenAnIncompleteReport_2() {
+  void shouldThrowWhenGivenAnIncompleteReport_2() {
     javax.xml.stream.XMLStreamException thrown = catchThrowableOfType(() -> {
       File absReportsProject = TestUtils.loadResource("/org/sonar/cxx/sensors/reports-project").getAbsoluteFile();
       var absReportFile = new File(absReportsProject, "valgrind-reports/incorrect-valgrind-result_2.xml");
@@ -102,7 +102,7 @@ public class ValgrindReportParserTest {
   }
 
   @Test
-  public void shouldThrowWhenGivenAnIncompleteReport_3() {
+  void shouldThrowWhenGivenAnIncompleteReport_3() {
     javax.xml.stream.XMLStreamException thrown = catchThrowableOfType(() -> {
       File absReportsProject = TestUtils.loadResource("/org/sonar/cxx/sensors/reports-project").getAbsoluteFile();
       var absReportFile = new File(absReportsProject, "valgrind-reports/incorrect-valgrind-result_3.xml");

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/ValgrindStackTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/ValgrindStackTest.java
@@ -25,7 +25,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ValgrindStackTest {
+class ValgrindStackTest {
 
   private final ValgrindStack stack = new ValgrindStack();
   private final ValgrindStack equalStack = new ValgrindStack();
@@ -48,36 +48,36 @@ public class ValgrindStackTest {
   }
 
   @Test
-  public void stackDoesntEqualsNull() {
+  void stackDoesntEqualsNull() {
     assertThat(stack).isNotNull();
   }
 
   @Test
-  public void stackDoesntEqualsMiscObject() {
+  void stackDoesntEqualsMiscObject() {
     assertThat(stack).isNotEqualTo("string");
   }
 
   @Test
-  public void stackEqualityIsReflexive() {
+  void stackEqualityIsReflexive() {
     assertThat(stack).isEqualTo(stack);
     assertThat(otherStack).isEqualTo(otherStack);
     assertThat(equalStack).isEqualTo(equalStack);
   }
 
   @Test
-  public void stackEqualityWorksAsExpected() {
+  void stackEqualityWorksAsExpected() {
     assertThat(stack).isEqualTo(equalStack);
     assertThat(stack).isNotEqualTo(otherStack);
   }
 
   @Test
-  public void stackHashWorksAsExpected() {
+  void stackHashWorksAsExpected() {
     assertThat(stack).hasSameHashCodeAs(equalStack);
     assertThat(stack.hashCode()).isNotEqualTo(otherStack.hashCode());
   }
 
   @Test
-  public void stringRepresentationShouldResembleValgrindsStandard() {
+  void stringRepresentationShouldResembleValgrindsStandard() {
     var frame0 = new ValgrindFrame("0xDEADBEAF", "libX.so", "main()", null, "main.cc", "1");
     var stack0 = new ValgrindStack();
     stack0.addFrame(frame0);
@@ -89,18 +89,18 @@ public class ValgrindStackTest {
 
     var softly = new SoftAssertions();
     softly.assertThat(new ValgrindStack().toString()).isEmpty();
-    softly.assertThat(stack0.toString()).isEqualTo(frame0.toString());
-    softly.assertThat(stack1.toString()).isEqualTo(frame1.toString() + "\n" + frame0.toString());
+    softly.assertThat(stack0).hasToString(frame0.toString());
+    softly.assertThat(stack1).hasToString(frame1.toString() + "\n" + frame0.toString());
     softly.assertAll();
   }
 
   @Test
-  public void getLastOwnFrame_returnsNullOnEmptyStack() {
+  void getLastOwnFrame_returnsNullOnEmptyStack() {
     assertThat(new ValgrindStack().getLastOwnFrame("somepath")).isNull();
   }
 
   @Test
-  public void getLastOwnFrame_returnsNullIfNoOwnFrameThere() {
+  void getLastOwnFrame_returnsNullIfNoOwnFrameThere() {
     var frame = new ValgrindFrame(null, null, null, null, null, "1");
     var stack = new ValgrindStack();
     stack.addFrame(frame);
@@ -109,7 +109,7 @@ public class ValgrindStackTest {
   }
 
   @Test
-  public void getLastOwnFrame_returnsTheOwnFrame1() {
+  void getLastOwnFrame_returnsTheOwnFrame1() {
     var BASE_DIR = new File("our", "path");
     var OWN_PATH = new File(BASE_DIR, "subdir");
 
@@ -123,7 +123,7 @@ public class ValgrindStackTest {
   }
 
   @Test
-  public void getLastOwnFrame_returnsTheOwnFrame2() {
+  void getLastOwnFrame_returnsTheOwnFrame2() {
     var BASE_DIR = new File("our/path/.");
     var OWN_PATH = new File("our/../our/./path/subdir");
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxRuleRepositoryTest.java
@@ -26,10 +26,10 @@ import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 
-public class CxxVeraxxRuleRepositoryTest {
+class CxxVeraxxRuleRepositoryTest {
 
   @Test
-  public void createRulesTest() {
+  void createRulesTest() {
     var def = new CxxVeraxxRuleRepository(mock(ServerFileSystem.class), new RulesDefinitionXmlLoader());
 
     var context = new RulesDefinition.Context();

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxSensorTest.java
@@ -31,7 +31,7 @@ import org.sonar.api.config.internal.MapSettings;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
-public class CxxVeraxxSensorTest {
+class CxxVeraxxSensorTest {
 
   private DefaultFileSystem fs;
   private final MapSettings settings = new MapSettings();
@@ -43,7 +43,7 @@ public class CxxVeraxxSensorTest {
   }
 
   @Test
-  public void shouldReportCorrectViolations() {
+  void shouldReportCorrectViolations() {
     var context = SensorContextTester.create(fs.baseDir());
     settings.setProperty(CxxVeraxxSensor.REPORT_PATH_KEY, "vera++-reports/vera++-result-*.xml");
     context.setSettings(settings);
@@ -68,7 +68,7 @@ public class CxxVeraxxSensorTest {
   }
 
   @Test
-  public void sensorDescriptor() {
+  void sensorDescriptor() {
     var descriptor = new DefaultSensorDescriptor();
     var sensor = new CxxVeraxxSensor();
     sensor.describe(descriptor);

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/annotations/AnnotationBasedProfileBuilderTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/annotations/AnnotationBasedProfileBuilderTest.java
@@ -37,7 +37,7 @@ import org.sonar.api.rules.RulePriority;
 import org.sonar.api.utils.ValidationMessages;
 import org.sonar.check.Rule;
 
-public class AnnotationBasedProfileBuilderTest {
+class AnnotationBasedProfileBuilderTest {
 
   private static final String KEY1 = "key1";
   private static final String REPO_KEY = "repo1";
@@ -57,7 +57,7 @@ public class AnnotationBasedProfileBuilderTest {
   }
 
   @Test
-  public void should_add_a_rule_with_the_annotation() throws Exception {
+  void should_add_a_rule_with_the_annotation() throws Exception {
     @ActivatedByDefault
     @Rule(key = KEY1)
     class RuleActivatedByDefault {
@@ -67,12 +67,12 @@ public class AnnotationBasedProfileBuilderTest {
     assertThat(profile.getActiveRules()).hasSize(1);
     var activeRule = profile.getActiveRules().get(0);
     assertThat(activeRule.getRule()).isEqualTo(rule);
-    assertThat(activeRule.getSeverity().toString()).isEqualTo(Severity.MINOR);
+    assertThat(activeRule.getSeverity()).hasToString(Severity.MINOR);
     assertThat(messages.getWarnings()).isEmpty();
   }
 
   @Test
-  public void should_not_add_a_rule_without_the_annotation() throws Exception {
+  void should_not_add_a_rule_without_the_annotation() throws Exception {
     @Rule(key = KEY1)
     class RuleNotActivatedByDefault {
     }
@@ -83,7 +83,7 @@ public class AnnotationBasedProfileBuilderTest {
   }
 
   @Test
-  public void unknown_rule_key() throws Exception {
+  void unknown_rule_key() throws Exception {
     @ActivatedByDefault
     @Rule(key = "unknownKey")
     class RuleActivatedByDefaultWithUnknownKey {
@@ -96,7 +96,7 @@ public class AnnotationBasedProfileBuilderTest {
   }
 
   @Test
-  public void should_ignore_class_without_rule_annotation() throws Exception {
+  void should_ignore_class_without_rule_annotation() throws Exception {
     @ActivatedByDefault
     class ClassWithoutRuleAnnotation {
     }

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/annotations/AnnotationBasedRulesDefinitionTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/annotations/AnnotationBasedRulesDefinitionTest.java
@@ -36,7 +36,7 @@ import org.sonar.check.Cardinality;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
 
-public class AnnotationBasedRulesDefinitionTest {
+class AnnotationBasedRulesDefinitionTest {
 
   private static final String REPO_KEY = "repoKey";
   private static final String LANGUAGE_KEY_WITH_RESOURCE_BUNDLE = "languageKey";
@@ -44,12 +44,12 @@ public class AnnotationBasedRulesDefinitionTest {
   private final RulesDefinition.Context context = new RulesDefinition.Context();
 
   @Test
-  public void no_class_to_add() throws Exception {
+  void no_class_to_add() throws Exception {
     assertThat(buildRepository(false).rules()).isEmpty();
   }
 
   @Test
-  public void class_without_rule_annotation() throws Exception {
+  void class_without_rule_annotation() throws Exception {
     class NotRuleClass {
     }
     IllegalArgumentException thrown = catchThrowableOfType(() -> {
@@ -59,7 +59,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void rule_annotation_data() throws Exception {
+  void rule_annotation_data() throws Exception {
 
     @Rule(key = "key1", name = "name1", description = "description1", tags = "mytag")
     class RuleClass {
@@ -84,7 +84,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void rule_without_explicit_key() throws Exception {
+  void rule_without_explicit_key() throws Exception {
     IllegalArgumentException thrown = catchThrowableOfType(() -> {
       buildSingleRuleRepository(RuleClassWithoutAnnotationDefinedKey.class);
     }, IllegalArgumentException.class);
@@ -92,7 +92,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void rule_without_explicit_key_can_be_acceptable() throws Exception {
+  void rule_without_explicit_key_can_be_acceptable() throws Exception {
     Repository repository = buildRepository(LANGUAGE_KEY_WITH_RESOURCE_BUNDLE, false, false,
                                             RuleClassWithoutAnnotationDefinedKey.class);
     var rule = repository.rules().get(0);
@@ -101,7 +101,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void external_names_and_descriptions() throws Exception {
+  void external_names_and_descriptions() throws Exception {
 
     @Rule(key = "ruleWithExternalInfo")
     class RuleClass {
@@ -122,7 +122,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void no_name_and_no_resource_bundle() throws Exception {
+  void no_name_and_no_resource_bundle() throws Exception {
     @Rule(key = "ruleWithExternalInfo")
     class RuleClass {
     }
@@ -133,7 +133,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void rule_template() throws Exception {
+  void rule_template() throws Exception {
     @Rule(key = "key1", name = "name1", description = "description1")
     @NoSqale
     @RuleTemplate
@@ -145,7 +145,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void cardinality_single() throws Exception {
+  void cardinality_single() throws Exception {
     @Rule(key = "key1", name = "name1", description = "description1", cardinality = Cardinality.SINGLE)
     class RuleClass {
     }
@@ -155,7 +155,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void cardinality_multiple() throws Exception {
+  void cardinality_multiple() throws Exception {
     @Rule(key = "key1", name = "name1", description = "description1", cardinality = Cardinality.MULTIPLE)
     class RuleClass {
     }
@@ -166,7 +166,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void class_without_sqale_annotation() throws Exception {
+  void class_without_sqale_annotation() throws Exception {
     @Rule(key = "key1", name = "name1", description = "description1")
     class RuleClass {
     }
@@ -177,7 +177,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void class_with_nosqale_annotation() throws Exception {
+  void class_with_nosqale_annotation() throws Exception {
 
     @Rule(key = "key1", name = "name1", description = "description1")
     @NoSqale
@@ -189,7 +189,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void class_with_sqale_constant_remediation() throws Exception {
+  void class_with_sqale_constant_remediation() throws Exception {
 
     @Rule(key = "key1", name = "name1", description = "description1")
     @SqaleConstantRemediation("10min")
@@ -201,7 +201,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void class_with_sqale_linear_remediation() throws Exception {
+  void class_with_sqale_linear_remediation() throws Exception {
 
     @Rule(key = "key1", name = "name1", description = "description1")
     @SqaleLinearRemediation(coeff = "2h", effortToFixDescription = "Effort to test one uncovered condition")
@@ -213,7 +213,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void class_with_sqale_linear_with_offset_remediation() throws Exception {
+  void class_with_sqale_linear_with_offset_remediation() throws Exception {
 
     @Rule(key = "key1", name = "name1", description = "description1")
     @SqaleLinearWithOffsetRemediation(coeff = "5min", offset = "1h",
@@ -226,7 +226,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void class_with_several_sqale_remediation_annotations() throws Exception {
+  void class_with_several_sqale_remediation_annotations() throws Exception {
     @Rule(key = "key1", name = "name1", description = "description1")
     @SqaleConstantRemediation("10min")
     @SqaleLinearRemediation(coeff = "2h", effortToFixDescription = "Effort to test one uncovered condition")
@@ -239,7 +239,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void invalid_sqale_annotation() throws Exception {
+  void invalid_sqale_annotation() throws Exception {
     @Rule(key = "key1", name = "name1", description = "description1")
     @SqaleConstantRemediation("xxx")
     class MyInvalidRuleClass {
@@ -253,7 +253,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void rule_not_created_by_RulesDefinitionAnnotationLoader() throws Exception {
+  void rule_not_created_by_RulesDefinitionAnnotationLoader() throws Exception {
     @Rule
     class RuleClass {
     }
@@ -266,7 +266,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void load_method_with_class_without_sqale_annotation() throws Exception {
+  void load_method_with_class_without_sqale_annotation() throws Exception {
     @Rule(key = "key1", name = "name1", description = "description1")
     class RuleClass {
     }
@@ -277,7 +277,7 @@ public class AnnotationBasedRulesDefinitionTest {
   }
 
   @Test
-  public void load_method_with_class_with_sqale_annotations() throws Exception {
+  void load_method_with_class_with_sqale_annotations() throws Exception {
     @Rule(key = "key1", name = "name1", description = "description1")
     @SqaleConstantRemediation("10min")
     class RuleClass {

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/api/CheckMessageTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/api/CheckMessageTest.java
@@ -26,17 +26,17 @@ package org.sonar.cxx.squidbridge.api;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class CheckMessageTest {
+class CheckMessageTest {
 
   @Test
-  public void testFormatDefaultMessage() {
+  void testFormatDefaultMessage() {
     var message = new CheckMessage(null, "Value is {0,number,integer}, expected value is {1,number,integer}.",
                                3, 7);
     assertThat(message.formatDefaultMessage()).isEqualTo("Value is 3, expected value is 7.");
   }
 
   @Test
-  public void testNotFormatMessageWithoutParameters() {
+  void testNotFormatMessageWithoutParameters() {
     var message = new CheckMessage(null, "public void main(){."); // This message can't be used as a pattern by the MessageFormat
     // class
     assertThat(message.formatDefaultMessage()).isEqualTo("public void main(){.");

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/api/SourceCodeTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/api/SourceCodeTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class SourceCodeTest {
+class SourceCodeTest {
 
   private SourceProject prj;
   private SourcePackage pac;
@@ -50,31 +50,31 @@ public class SourceCodeTest {
   }
 
   @Test
-  public void testAddChild() {
+  void testAddChild() {
     prj.addChild(pac);
     assertThat(pac.getParent()).isEqualTo(prj);
     assertThat(prj.getChildren()).contains(pac);
   }
 
   @Test
-  public void testEqualsAndHashCode() {
+  void testEqualsAndHashCode() {
     assertThat(prj).isNotEqualTo(pac);
     assertThat(prj.hashCode()).isNotEqualTo(pac.hashCode());
     assertThat(prj).isNotEqualTo(new Object());
 
     SourceCode samePac = new SourcePackage("org.sonar");
     assertThat(pac).isEqualTo(samePac);
-    assertThat(pac.hashCode()).isEqualTo(samePac.hashCode());
+    assertThat(pac).hasSameHashCodeAs(samePac);
   }
 
   @Test
-  public void testContains() {
+  void testContains() {
     assertThat(prj.hasChild(pac)).isTrue();
     assertThat(prj.hasChild(cla)).isTrue();
   }
 
   @Test
-  public void testIsType() {
+  void testIsType() {
     var pacFrom = new SourcePackage("org.from");
     assertThat(pacFrom).isNotExactlyInstanceOf(SourceCode.class);
     assertThat(pacFrom).isNotExactlyInstanceOf(SourceClass.class);
@@ -82,7 +82,7 @@ public class SourceCodeTest {
   }
 
   @Test
-  public void testGetParentByType() {
+  void testGetParentByType() {
     var pacFrom = new SourcePackage("org.from");
     var fileFrom = new SourceFile("org.from.From.java", "From.java");
     var classFrom = new SourceClass("org.from.From", "From");
@@ -92,7 +92,7 @@ public class SourceCodeTest {
   }
 
   @Test
-  public void testGetAncestorByType() {
+  void testGetAncestorByType() {
     var file = new SourceFile("org.from.From.java", "From.java");
     var class1 = new SourceClass("org.from.From", "From");
     var class2 = new SourceClass("org.from.From$Foo", "From$Foo");
@@ -109,14 +109,14 @@ public class SourceCodeTest {
   }
 
   @Test
-  public void testHasAmongParents() {
+  void testHasAmongParents() {
     assertThat(cla.hasAmongParents(prj)).isTrue();
     assertThat(cla.hasAmongParents(pac)).isTrue();
     assertThat(prj.hasAmongParents(cla)).isFalse();
   }
 
   @Test
-  public void getCheckMessages() {
+  void getCheckMessages() {
     SourceCode foo = new SourceFile("Foo.java");
     assertThat(foo.getCheckMessages()).hasSize(0);
 

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/api/SourceFileTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/api/SourceFileTest.java
@@ -28,10 +28,10 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class SourceFileTest {
+class SourceFileTest {
 
   @Test
-  public void testGetStartAtLine() {
+  void testGetStartAtLine() {
     var file = new SourceFile("com/sonarsource/Toto.java");
     assertThat(file.getStartAtLine()).isEqualTo(1);
     file = new SourceFile("com/sonarsource/Toto.java", "Toto.java");
@@ -39,7 +39,7 @@ public class SourceFileTest {
   }
 
   @Test
-  public void testHasNoSon() {
+  void testHasNoSon() {
     var file = new SourceFile("com/sonarsource/Toto.java");
     Set<Integer> noSonarTagLines = new HashSet<>();
     noSonarTagLines.add(23);

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/api/SourceMethodTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/api/SourceMethodTest.java
@@ -26,10 +26,10 @@ package org.sonar.cxx.squidbridge.api;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class SourceMethodTest {
+class SourceMethodTest {
 
   @Test
-  public void testSquidMethodSquidClassString() {
+  void testSquidMethodSquidClassString() {
     SourceMethod squidMethod = new SourceMethod(new SourceClass("org.sonar.Squid"), "scan:23", 23);
     assertThat(squidMethod.getKey()).isEqualTo("org.sonar.Squid#scan:23");
     assertThat(squidMethod.getStartAtLine()).isEqualTo(23);

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractCommentRegularExpressionCheckTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractCommentRegularExpressionCheckTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 
-public class AbstractCommentRegularExpressionCheckTest {
+class AbstractCommentRegularExpressionCheckTest {
 
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
@@ -51,7 +51,7 @@ public class AbstractCommentRegularExpressionCheckTest {
   private final Check check = new Check();
 
   @Test
-  public void empty() {
+  void empty() {
     check.regularExpression = "";
     check.message = "Empty regular expression.";
 
@@ -59,7 +59,7 @@ public class AbstractCommentRegularExpressionCheckTest {
   }
 
   @Test
-  public void case_insensitive() {
+  void case_insensitive() {
     check.regularExpression = "(?i).*TODO.*";
     check.message = "Avoid TODO.";
 
@@ -70,7 +70,7 @@ public class AbstractCommentRegularExpressionCheckTest {
   }
 
   @Test
-  public void case_sensitive() {
+  void case_sensitive() {
     check.regularExpression = ".*TODO.*";
     check.message = "Avoid TODO.";
 
@@ -79,7 +79,7 @@ public class AbstractCommentRegularExpressionCheckTest {
   }
 
   @Test
-  public void wrong_regular_expression() {
+  void wrong_regular_expression() {
     check.regularExpression = "*";
     IllegalStateException thrown = catchThrowableOfType(() -> {
       scanFile("/checks/commentRegularExpression.mc", check);

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractFileComplexityCheckTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractFileComplexityCheckTest.java
@@ -30,7 +30,7 @@ import org.sonar.cxx.squidbridge.measures.MetricDef;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 import org.sonar.cxx.squidbridge.test.miniC.MiniCAstScanner.MiniCMetrics;
 
-public class AbstractFileComplexityCheckTest {
+class AbstractFileComplexityCheckTest {
 
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
@@ -53,14 +53,14 @@ public class AbstractFileComplexityCheckTest {
   private final Check check = new Check();
 
   @Test
-  public void fileComplexityEqualsMaximum() {
+  void fileComplexityEqualsMaximum() {
     check.maximumFileComplexity = 5;
 
     checkMessagesVerifier.verify(scanFile("/checks/complexity5.mc", check).getCheckMessages());
   }
 
   @Test
-  public void fileComplexityGreaterMaximum() {
+  void fileComplexityGreaterMaximum() {
     check.maximumFileComplexity = 4;
 
     checkMessagesVerifier.verify(scanFile("/checks/complexity5.mc", check).getCheckMessages())
@@ -68,7 +68,7 @@ public class AbstractFileComplexityCheckTest {
   }
 
   @Test
-  public void wrong_parameter() {
+  void wrong_parameter() {
     check.maximumFileComplexity = 0;
     IllegalArgumentException thrown = catchThrowableOfType(() -> {
       scanFile("/checks/complexity5.mc", check);

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractLineLengthCheckTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractLineLengthCheckTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 
-public class AbstractLineLengthCheckTest {
+class AbstractLineLengthCheckTest {
 
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
@@ -46,13 +46,13 @@ public class AbstractLineLengthCheckTest {
   private final Check check = new Check();
 
   @Test
-  public void lineLengthWithDefaultLength() {
+  void lineLengthWithDefaultLength() {
     checkMessagesVerifier.verify(scanFile("/checks/line_length.mc", check).getCheckMessages())
       .next().atLine(3).withMessage("The line length is greater than 80 authorized.");
   }
 
   @Test
-  public void lineLengthWithSpecificLength() {
+  void lineLengthWithSpecificLength() {
     check.maximumLineLength = 7;
 
     checkMessagesVerifier.verify(scanFile("/checks/line_length.mc", check).getCheckMessages())
@@ -61,7 +61,7 @@ public class AbstractLineLengthCheckTest {
   }
 
   @Test
-  public void wrong_parameter() {
+  void wrong_parameter() {
     check.maximumLineLength = 0;
     IllegalArgumentException thrown = catchThrowableOfType(() -> {
       scanFile("/checks/line_length.mc", check);

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractNamingCheckTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractNamingCheckTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 import static org.assertj.core.api.Assertions.*;
 
-public class AbstractNamingCheckTest {
+class AbstractNamingCheckTest {
 
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
@@ -72,7 +72,7 @@ public class AbstractNamingCheckTest {
   private final Check check = new Check();
 
   @Test
-  public void detected() {
+  void detected() {
     check.regularExpression = "[a-z]+";
     checkMessagesVerifier.verify(scanFile("/checks/naming.mc", check).getCheckMessages())
       .next().atLine(5).withMessage("\"BAD\" is a bad name.")
@@ -80,7 +80,7 @@ public class AbstractNamingCheckTest {
   }
 
   @Test
-  public void wrong_regular_expression() {
+  void wrong_regular_expression() {
     check.regularExpression = "*";
     IllegalStateException thrown = catchThrowableOfType(() -> {
       scanFile("/checks/naming.mc", check);

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractNoSonarCheckTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractNoSonarCheckTest.java
@@ -27,7 +27,7 @@ import com.sonar.cxx.sslr.api.Grammar;
 import org.junit.jupiter.api.Test;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 
-public class AbstractNoSonarCheckTest {
+class AbstractNoSonarCheckTest {
 
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
@@ -35,7 +35,7 @@ public class AbstractNoSonarCheckTest {
   }
 
   @Test
-  public void singleLineCommentsSyntax() {
+  void singleLineCommentsSyntax() {
     checkMessagesVerifier.verify(scanFile("/checks/no_sonar.mc", new Check()).getCheckMessages())
       .next().atLine(5).withMessage("Is NOSONAR usage acceptable or does it hide a real quality flaw?")
       .next().atLine(6)

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractOneStatementPerLineCheckTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractOneStatementPerLineCheckTest.java
@@ -30,7 +30,7 @@ import com.sonar.cxx.sslr.test.minic.MiniCGrammar;
 import org.junit.jupiter.api.Test;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 
-public class AbstractOneStatementPerLineCheckTest {
+class AbstractOneStatementPerLineCheckTest {
 
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
@@ -49,7 +49,7 @@ public class AbstractOneStatementPerLineCheckTest {
   }
 
   @Test
-  public void detected() {
+  void detected() {
     checkMessagesVerifier.verify(scanFile("/checks/one_statement_per_line.mc", new Check()).getCheckMessages())
       .next().atLine(7).withMessage(
       "At most one statement is allowed per line, but 2 statements were found on this line.");

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractParseErrorCheckTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractParseErrorCheckTest.java
@@ -27,7 +27,7 @@ import com.sonar.cxx.sslr.api.Grammar;
 import org.junit.jupiter.api.Test;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 
-public class AbstractParseErrorCheckTest {
+class AbstractParseErrorCheckTest {
 
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
@@ -37,7 +37,7 @@ public class AbstractParseErrorCheckTest {
   private final Check check = new Check();
 
   @Test
-  public void parseError() {
+  void parseError() {
     checkMessagesVerifier.verify(scanFile("/checks/parse_error.mc", check).getCheckMessages())
       .next().atLine(3);
   }

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractSingleLineCommentsSyntaxCheckTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractSingleLineCommentsSyntaxCheckTest.java
@@ -27,7 +27,7 @@ import com.sonar.cxx.sslr.api.Grammar;
 import org.junit.jupiter.api.Test;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 
-public class AbstractSingleLineCommentsSyntaxCheckTest {
+class AbstractSingleLineCommentsSyntaxCheckTest {
 
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
@@ -41,7 +41,7 @@ public class AbstractSingleLineCommentsSyntaxCheckTest {
   }
 
   @Test
-  public void singleLineCommentsSyntax() {
+  void singleLineCommentsSyntax() {
     checkMessagesVerifier.verify(scanFile("/checks/single_line_comments_syntax.mc", new Check()).getCheckMessages())
       .next().atLine(1).withMessage("This single line comment should use the single line comment syntax \"//\"")
       .next().atLine(15);

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractXPathCheckTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/AbstractXPathCheckTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 
-public class AbstractXPathCheckTest {
+class AbstractXPathCheckTest {
 
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
@@ -52,7 +52,7 @@ public class AbstractXPathCheckTest {
   private final Check check = new Check();
 
   @Test
-  public void emptyXPathCheck() {
+  void emptyXPathCheck() {
     check.xpath = "";
     check.message = "Empty XPath check.";
 
@@ -60,7 +60,7 @@ public class AbstractXPathCheckTest {
   }
 
   @Test
-  public void booleanXPathCheckWithResults() {
+  void booleanXPathCheckWithResults() {
     check.xpath = "count(//VARIABLE_DEFINITION) > 0";
     check.message = "Boolean XPath rule with results.";
 
@@ -69,7 +69,7 @@ public class AbstractXPathCheckTest {
   }
 
   @Test
-  public void booleanXPathCheckWithoutResults() {
+  void booleanXPathCheckWithoutResults() {
     check.xpath = "count(//variableDefinition) > 2";
     check.message = "Boolean XPath rule without results.";
 
@@ -77,7 +77,7 @@ public class AbstractXPathCheckTest {
   }
 
   @Test
-  public void astNodesXpathCheck() {
+  void astNodesXpathCheck() {
     check.xpath = "//VARIABLE_DEFINITION";
     check.message = "No variable definitions allowed!";
 
@@ -87,14 +87,14 @@ public class AbstractXPathCheckTest {
   }
 
   @Test
-  public void parse_error() {
+  void parse_error() {
     check.xpath = "//VARIABLE_DEFINITION";
 
     checkMessagesVerifier.verify(scanFile("/checks/parse_error.mc", check).getCheckMessages());
   }
 
   @Test
-  public void wrong_xpath() {
+  void wrong_xpath() {
     check.xpath = "//";
     IllegalStateException thrown = catchThrowableOfType(() -> {
       scanFile("/checks/xpath.mc", check);

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/CheckMessagesVerifierRuleTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/CheckMessagesVerifierRuleTest.java
@@ -31,16 +31,16 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import org.sonar.cxx.squidbridge.api.CheckMessage;
 
-public class CheckMessagesVerifierRuleTest {
+class CheckMessagesVerifierRuleTest {
 
   @Test
-  public void shouldNotFailIfNothingToVerify() {
+  void shouldNotFailIfNothingToVerify() {
     var rule = new CheckMessagesVerifierRule();
     rule.verify();
   }
 
   @Test
-  public void shouldNotFailIfVerificationsWereSuccessful() {
+  void shouldNotFailIfVerificationsWereSuccessful() {
     var rule = new CheckMessagesVerifierRule();
     rule.verify(Collections.EMPTY_LIST);
     rule.verify(Collections.EMPTY_LIST);
@@ -48,7 +48,7 @@ public class CheckMessagesVerifierRuleTest {
   }
 
   @Test
-  public void shouldFailIfFirstVerificationFailed() {
+  void shouldFailIfFirstVerificationFailed() {
     AssertionError thrown = catchThrowableOfType(() -> {
       Collection<CheckMessage> messages = Arrays.asList(mock(CheckMessage.class));
       var rule = new CheckMessagesVerifierRule();
@@ -62,7 +62,7 @@ public class CheckMessagesVerifierRuleTest {
   }
 
   @Test
-  public void shouldFailIfSecondVerificationFailed() {
+  void shouldFailIfSecondVerificationFailed() {
     AssertionError thrown = catchThrowableOfType(() -> {
       Collection<CheckMessage> messages = Arrays.asList(mock(CheckMessage.class));
       var rule = new CheckMessagesVerifierRule();

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/CheckMessagesVerifierTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/CheckMessagesVerifierTest.java
@@ -34,10 +34,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import org.sonar.cxx.squidbridge.api.CheckMessage;
 
-public class CheckMessagesVerifierTest {
+class CheckMessagesVerifierTest {
 
   @Test
-  public void next() {
+  void next() {
     AssertionError thrown = catchThrowableOfType(() -> {
       CheckMessagesVerifier.verify(Collections.EMPTY_LIST)
         .next();
@@ -48,7 +48,7 @@ public class CheckMessagesVerifierTest {
   }
 
   @Test
-  public void noMore() {
+  void noMore() {
     AssertionError thrown = catchThrowableOfType(() -> {
       Collection<CheckMessage> messages = Arrays.asList(mockCheckMessage(1, "foo"));
       CheckMessagesVerifier.verify(messages)
@@ -60,7 +60,7 @@ public class CheckMessagesVerifierTest {
   }
 
   @Test
-  public void line() {
+  void line() {
     AssertionError thrown = catchThrowableOfType(() -> {
       Collection<CheckMessage> messages = Arrays.asList(mockCheckMessage(1, "foo"));
       CheckMessagesVerifier.verify(messages)
@@ -72,7 +72,7 @@ public class CheckMessagesVerifierTest {
   }
 
   @Test
-  public void line_withoutHasNext() {
+  void line_withoutHasNext() {
     IllegalStateException thrown = catchThrowableOfType(() -> {
       Collection<CheckMessage> messages = Arrays.asList(mockCheckMessage(1, "foo"));
       CheckMessagesVerifier.verify(messages)
@@ -84,7 +84,7 @@ public class CheckMessagesVerifierTest {
   }
 
   @Test
-  public void withMessage() {
+  void withMessage() {
     AssertionError thrown = catchThrowableOfType(() -> {
       Collection<CheckMessage> messages = Arrays.asList(mockCheckMessage(1, "foo"));
       CheckMessagesVerifier.verify(messages)
@@ -96,7 +96,7 @@ public class CheckMessagesVerifierTest {
   }
 
   @Test
-  public void withMessage_withoutHasNext() {
+  void withMessage_withoutHasNext() {
     IllegalStateException thrown = catchThrowableOfType(() -> {
       Collection<CheckMessage> messages = Arrays.asList(mockCheckMessage(1, "foo"));
       CheckMessagesVerifier.verify(messages)
@@ -108,7 +108,7 @@ public class CheckMessagesVerifierTest {
   }
 
   @Test
-  public void withMessageContaining() {
+  void withMessageContaining() {
     AssertionError thrown = catchThrowableOfType(() -> {
       Collection<CheckMessage> messages = Arrays.asList(mockCheckMessage(1, "foo"));
       CheckMessagesVerifier.verify(messages)
@@ -120,7 +120,7 @@ public class CheckMessagesVerifierTest {
   }
 
   @Test
-  public void withCost() {
+  void withCost() {
     AssertionError thrown = catchThrowableOfType(() -> {
       Collection<CheckMessage> messages = Arrays.asList(mockCheckMessage(1, "foo", 0d));
       CheckMessagesVerifier.verify(messages)
@@ -132,7 +132,7 @@ public class CheckMessagesVerifierTest {
   }
 
   @Test
-  public void ok() {
+  void ok() {
     Collection<CheckMessage> messages = Arrays.asList(
       mockCheckMessage(null, "b"),
       mockCheckMessage(2, "a", 1d),

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/ChecksHelperTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/ChecksHelperTest.java
@@ -26,10 +26,10 @@ package org.sonar.cxx.squidbridge.checks;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class ChecksHelperTest {
+class ChecksHelperTest {
 
   @Test
-  public void private_constructor() throws Exception {
+  void private_constructor() throws Exception {
     var constructor = ChecksHelper.class.getDeclaredConstructor();
     assertThat(constructor.isAccessible()).isFalse();
     constructor.setAccessible(true);

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/ResourceParser.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/ResourceParser.java
@@ -41,7 +41,7 @@ public class ResourceParser {
       throw new IllegalArgumentException("The file located under \"" + filePath + "\" was not found.");
     }
     scanner.scanFile(file);
-    assertThat(scanner.getIndex().search(new QueryByType(SourceFile.class)).size()).isEqualTo(1);
+    assertThat(scanner.getIndex().search(new QueryByType(SourceFile.class))).hasSize(1);
     return (SourceFile) scanner.getIndex().search(new QueryByType(SourceFile.class)).iterator().next();
   }
 

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/SquidCheckTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/checks/SquidCheckTest.java
@@ -26,10 +26,10 @@ package org.sonar.cxx.squidbridge.checks;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class SquidCheckTest {
+class SquidCheckTest {
 
   @Test
-  public void test_getKey() {
+  void test_getKey() {
     var squidCheck = new SquidCheck() {
     };
     assertThat(squidCheck.getKey()).isNull();

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/indexer/SquidIndexTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/indexer/SquidIndexTest.java
@@ -33,7 +33,7 @@ import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.api.SourcePackage;
 import org.sonar.cxx.squidbridge.api.SourceProject;
 
-public class SquidIndexTest {
+class SquidIndexTest {
 
   private SquidIndex indexer;
   private SourceProject project;
@@ -58,7 +58,7 @@ public class SquidIndexTest {
   }
 
   @Test
-  public void searchSingleResource() {
+  void searchSingleResource() {
     SourceCode squidClass = indexer.search("org.sonar.squid.Squid");
     assertThat(squidClass).isEqualTo(new SourceClass("org.sonar.squid.Squid", "Squid"));
     SourceCode javaNCSSClass = indexer.search("org.sonar.squid.JavaNCSS");
@@ -66,32 +66,32 @@ public class SquidIndexTest {
   }
 
   @Test
-  public void searchByType() {
+  void searchByType() {
     Collection<SourceCode> resources = indexer.search(new QueryByType(SourceFile.class));
-    assertThat(resources.size()).isEqualTo(2);
+    assertThat(resources).hasSize(2);
     resources = indexer.search(new QueryByType(SourceClass.class));
-    assertThat(resources.size()).isEqualTo(1);
-    assertThat(resources.contains(classSquid)).isTrue();
+    assertThat(resources).hasSize(1);
+    assertThat(resources).contains(classSquid);
   }
 
   @Test
-  public void searchByName() {
+  void searchByName() {
     Collection<SourceCode> resources = indexer.search(new QueryByName("Squid.java"));
-    assertThat(resources.size()).isEqualTo(1);
-    assertThat(resources.contains(fileSquid)).isTrue();
+    assertThat(resources).hasSize(1);
+    assertThat(resources).contains(fileSquid);
   }
 
   @Test
-  public void searchByParent() {
+  void searchByParent() {
     Collection<SourceCode> resources = indexer.search(new QueryByParent(packSquid));
-    assertThat(resources.size()).isEqualTo(3);
+    assertThat(resources).hasSize(3);
   }
 
   @Test
-  public void searchByParentAndByType() {
+  void searchByParentAndByType() {
     Collection<SourceCode> resources = indexer.search(new QueryByParent(packSquid), new QueryByType(SourceClass.class));
-    assertThat(resources.size()).isEqualTo(1);
-    assertThat(resources.contains(classSquid)).isTrue();
+    assertThat(resources).hasSize(1);
+    assertThat(resources).contains(classSquid);
   }
 
 }

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/metrics/CommentsVisitorTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/metrics/CommentsVisitorTest.java
@@ -30,33 +30,33 @@ import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFileIgnoreHeaderComments;
 import org.sonar.cxx.squidbridge.test.miniC.MiniCAstScanner.MiniCMetrics;
 
-public class CommentsVisitorTest {
+class CommentsVisitorTest {
 
   @Test
-  public void empty() {
+  void empty() {
     SourceFile sourceFile = scanFile("/metrics/comments_none.mc");
 
-    assertThat(sourceFile.getInt(MiniCMetrics.COMMENT_LINES)).isEqualTo(0);
+    assertThat(sourceFile.getInt(MiniCMetrics.COMMENT_LINES)).isZero();
 
-    assertThat(sourceFile.getNoSonarTagLines().size()).isEqualTo(0);
+    assertThat(sourceFile.getNoSonarTagLines()).isEmpty();
   }
 
   @Test
-  public void comments() {
+  void comments() {
     SourceFile sourceFile = scanFile("/metrics/comments.mc");
 
     assertThat(sourceFile.getInt(MiniCMetrics.COMMENT_LINES)).isEqualTo(3);
 
-    assertThat(sourceFile.getNoSonarTagLines().size()).isEqualTo(2);
+    assertThat(sourceFile.getNoSonarTagLines()).hasSize(2);
     assertThat(sourceFile.getNoSonarTagLines()).containsOnly(5, 6);
   }
 
   @Test
-  public void headerComments() {
+  void headerComments() {
     SourceFile sourceFile = scanFileIgnoreHeaderComments("/metrics/header_comments.mc");
 
     assertThat(sourceFile.getInt(MiniCMetrics.COMMENT_LINES)).isEqualTo(1);
-    assertThat(sourceFile.getNoSonarTagLines().size()).isEqualTo(0);
+    assertThat(sourceFile.getNoSonarTagLines()).isEmpty();
   }
 
 }

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/metrics/ComplexityVisitorTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/metrics/ComplexityVisitorTest.java
@@ -29,10 +29,10 @@ import org.sonar.cxx.squidbridge.api.SourceFile;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 import org.sonar.cxx.squidbridge.test.miniC.MiniCAstScanner.MiniCMetrics;
 
-public class ComplexityVisitorTest {
+class ComplexityVisitorTest {
 
   @Test
-  public void counter() {
+  void counter() {
     SourceFile sourceFile = scanFile("/metrics/complexity.mc");
 
     assertThat(sourceFile.getInt(MiniCMetrics.COMPLEXITY)).isEqualTo(4);

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/metrics/CounterVisitorTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/metrics/CounterVisitorTest.java
@@ -29,10 +29,10 @@ import org.sonar.cxx.squidbridge.api.SourceFile;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 import org.sonar.cxx.squidbridge.test.miniC.MiniCAstScanner.MiniCMetrics;
 
-public class CounterVisitorTest {
+class CounterVisitorTest {
 
   @Test
-  public void counter() {
+  void counter() {
     SourceFile sourceFile = scanFile("/metrics/counter.mc");
 
     assertThat(sourceFile.getInt(MiniCMetrics.COMPLEXITY)).isEqualTo(4);

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/metrics/LinesOfCodeVisitorTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/metrics/LinesOfCodeVisitorTest.java
@@ -29,10 +29,10 @@ import org.sonar.cxx.squidbridge.api.SourceFile;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 import org.sonar.cxx.squidbridge.test.miniC.MiniCAstScanner.MiniCMetrics;
 
-public class LinesOfCodeVisitorTest {
+class LinesOfCodeVisitorTest {
 
   @Test
-  public void linesOfCode() {
+  void linesOfCode() {
     SourceFile sourceFile = scanFile("/metrics/lines_of_code.mc");
 
     assertThat(sourceFile.getInt(MiniCMetrics.LINES_OF_CODE)).isEqualTo(3);

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/metrics/LinesVisitorTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/metrics/LinesVisitorTest.java
@@ -29,10 +29,10 @@ import org.sonar.cxx.squidbridge.api.SourceFile;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 import org.sonar.cxx.squidbridge.test.miniC.MiniCAstScanner.MiniCMetrics;
 
-public class LinesVisitorTest {
+class LinesVisitorTest {
 
   @Test
-  public void linesOfCode() {
+  void linesOfCode() {
     SourceFile sourceFile = scanFile("/metrics/lines.mc");
 
     assertThat(sourceFile.getInt(MiniCMetrics.LINES)).isEqualTo(19);

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/metrics/ResourceParser.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/metrics/ResourceParser.java
@@ -52,7 +52,7 @@ public class ResourceParser {
       throw new IllegalArgumentException("The file located under \"" + filePath + "\" was not found.");
     }
     scanner.scanFile(file);
-    assertThat(scanner.getIndex().search(new QueryByType(SourceFile.class)).size()).isEqualTo(1);
+    assertThat(scanner.getIndex().search(new QueryByType(SourceFile.class))).hasSize(1);
     return (SourceFile) scanner.getIndex().search(new QueryByType(SourceFile.class)).iterator().next();
   }
 

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/rules/ExternalDescriptionLoaderTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/rules/ExternalDescriptionLoaderTest.java
@@ -30,7 +30,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.NewRepository;
 import org.sonar.api.server.rule.RulesDefinition.Repository;
 
-public class ExternalDescriptionLoaderTest {
+class ExternalDescriptionLoaderTest {
 
   private static final String REPO_KEY = "repoKey";
   private static final String LANGUAGE_KEY = "languageKey";
@@ -39,21 +39,21 @@ public class ExternalDescriptionLoaderTest {
   private final NewRepository repository = context.createRepository(REPO_KEY, LANGUAGE_KEY);
 
   @Test
-  public void existing_rule_description() throws Exception {
+  void existing_rule_description() throws Exception {
     repository.createRule("ruleWithExternalInfo").setName("name1");
     var rule = buildRepository().rule("ruleWithExternalInfo");
     assertThat(rule.htmlDescription()).isEqualTo("description for ruleWithExternalInfo");
   }
 
   @Test
-  public void rule_with_non_external_description() throws Exception {
+  void rule_with_non_external_description() throws Exception {
     repository.createRule("ruleWithoutExternalInfo").setName("name1").setHtmlDescription("my description");
     var rule = buildRepository().rule("ruleWithoutExternalInfo");
     assertThat(rule.htmlDescription()).isEqualTo("my description");
   }
 
   @Test
-  public void rule_without_description() {
+  void rule_without_description() {
     IllegalStateException thrown = catchThrowableOfType(() -> {
       repository.createRule("ruleWithoutExternalInfo").setName("name1");
       buildRepository().rule("ruleWithoutExternalInfo");
@@ -62,7 +62,7 @@ public class ExternalDescriptionLoaderTest {
   }
 
   @Test
-  public void invalid_url() {
+  void invalid_url() {
     IllegalStateException thrown = catchThrowableOfType(() -> {
       var loader = new ExternalDescriptionLoader(repository, LANGUAGE_KEY);
       var rule = repository.createRule("ruleWithoutExternalInfo").setName("name1");

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/rules/PropertyFileLoaderTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/rules/PropertyFileLoaderTest.java
@@ -34,7 +34,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.NewRepository;
 import org.sonar.api.server.rule.RulesDefinition.Repository;
 
-public class PropertyFileLoaderTest {
+class PropertyFileLoaderTest {
 
   private static final String PARAM_KEY = "param1";
   private static final String RULE_KEY = "rule1";
@@ -43,7 +43,7 @@ public class PropertyFileLoaderTest {
   private final NewRepository repository = context.createRepository("repoKey", "languageKey");
 
   @Test
-  public void rule_and_parameter_defined_in_property_file() throws Exception {
+  void rule_and_parameter_defined_in_property_file() throws Exception {
     var newRule = repository.createRule(RULE_KEY);
     newRule.setHtmlDescription("desc");
     newRule.createParam(PARAM_KEY);
@@ -54,7 +54,7 @@ public class PropertyFileLoaderTest {
   }
 
   @Test
-  public void rule_and_parameter_not_defined_in_property_file() throws Exception {
+  void rule_and_parameter_not_defined_in_property_file() throws Exception {
     var newRule = repository.createRule(RULE_KEY);
     newRule.setName("ruleName1");
     newRule.setHtmlDescription("desc");
@@ -67,7 +67,7 @@ public class PropertyFileLoaderTest {
   }
 
   @Test
-  public void should_fail_if_resource_is_not_found() {
+  void should_fail_if_resource_is_not_found() {
     IllegalArgumentException thrown = catchThrowableOfType(() -> {
       PropertyFileLoader.loadNames(repository, "/rules/unknown.properties");
     }, IllegalArgumentException.class);
@@ -75,7 +75,7 @@ public class PropertyFileLoaderTest {
   }
 
   @Test
-  public void should_fail_if_resource_has_invalid_format() {
+  void should_fail_if_resource_has_invalid_format() {
     IllegalArgumentException thrown = catchThrowableOfType(() -> {
       InputStream stream = mock(InputStream.class);
       doThrow(new IOException()).when(stream).read((byte[]) any());

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/test/miniC/fakeChecks/FakeCommentCheckTest.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/test/miniC/fakeChecks/FakeCommentCheckTest.java
@@ -31,7 +31,7 @@ import org.sonar.cxx.squidbridge.checks.CheckMessagesVerifierRule;
 import org.sonar.cxx.squidbridge.checks.SquidCheck;
 import static org.sonar.cxx.squidbridge.metrics.ResourceParser.scanFile;
 
-public class FakeCommentCheckTest {
+class FakeCommentCheckTest {
 
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
@@ -48,7 +48,7 @@ public class FakeCommentCheckTest {
   }
 
   @Test
-  public void testFakeCommentCheck() {
+  void testFakeCommentCheck() {
     checkMessagesVerifier.verify(scanFile("/fakeChecks/fakeComment.mc", new FakeCommentCheck()).getCheckMessages())
       .next().atLine(6);
   }

--- a/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/test/miniC/fakeChecks/ResourceParser.java
+++ b/cxx-squid-bridge/src/test/java/org/sonar/cxx/squidbridge/test/miniC/fakeChecks/ResourceParser.java
@@ -41,7 +41,7 @@ public class ResourceParser {
       throw new IllegalArgumentException("The file located under \"" + filePath + "\" was not found.");
     }
     scanner.scanFile(file);
-    assertThat(scanner.getIndex().search(new QueryByType(SourceFile.class)).size()).isEqualTo(1);
+    assertThat(scanner.getIndex().search(new QueryByType(SourceFile.class))).hasSize(1);
     return (SourceFile) scanner.getIndex().search(new QueryByType(SourceFile.class)).iterator().next();
   }
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/AggregateMeasureComputerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/AggregateMeasureComputerTest.java
@@ -29,7 +29,7 @@ import org.sonar.api.ce.measure.test.TestMeasureComputerContext;
 import org.sonar.api.ce.measure.test.TestMeasureComputerDefinition.MeasureComputerDefinitionBuilderImpl;
 import org.sonar.api.ce.measure.test.TestSettings;
 
-public class AggregateMeasureComputerTest {
+class AggregateMeasureComputerTest {
 
   private static TestMeasureComputerContext createContext(AggregateMeasureComputer aggregator, Component component) {
     return new TestMeasureComputerContext(component, new TestSettings(),
@@ -39,13 +39,13 @@ public class AggregateMeasureComputerTest {
   }
 
   @Test
-  public void metricsNumber() {
+  void metricsNumber() {
     var aggregator = new AggregateMeasureComputer();
     assertThat(aggregator.getAggregatedMetrics()).hasSize(7);
   }
 
   @Test
-  public void ignoreFiles() {
+  void ignoreFiles() {
     var aggregator = new AggregateMeasureComputer();
 
     var file = new TestComponent("file", Type.FILE, new FileAttributesImpl("cxx", false));
@@ -58,7 +58,7 @@ public class AggregateMeasureComputerTest {
   }
 
   @Test
-  public void ignoreAlreadyAggregatedMetric() {
+  void ignoreAlreadyAggregatedMetric() {
     var aggregator = new AggregateMeasureComputer();
 
     var module = new TestComponent("module0", Type.MODULE, null);
@@ -72,7 +72,7 @@ public class AggregateMeasureComputerTest {
   }
 
   @Test
-  public void ignoreIfNothingToAggregate() {
+  void ignoreIfNothingToAggregate() {
     var aggregator = new AggregateMeasureComputer();
 
     var module = new TestComponent("module0", Type.MODULE, null);
@@ -84,7 +84,7 @@ public class AggregateMeasureComputerTest {
   }
 
   @Test
-  public void aggregate() {
+  void aggregate() {
     var aggregator = new AggregateMeasureComputer();
 
     var module = new TestComponent("module0", Type.MODULE, null);

--- a/cxx-squid/src/test/java/org/sonar/cxx/CxxAstScannerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/CxxAstScannerTest.java
@@ -33,10 +33,10 @@ import org.sonar.cxx.squidbridge.api.SourceFile;
 import org.sonar.cxx.squidbridge.api.SourceProject;
 import org.sonar.cxx.squidbridge.indexer.QueryByType;
 
-public class CxxAstScannerTest {
+class CxxAstScannerTest {
 
   @Test
-  public void files() throws UnsupportedEncodingException, IOException {
+  void files() throws UnsupportedEncodingException, IOException {
 
     var tester = CxxFileTesterHelper.create("src/test/resources/metrics/trivial.cc", ".", "");
     CxxFileTesterHelper.add(tester, "src/test/resources/metrics/trivial.cc", "");
@@ -51,7 +51,7 @@ public class CxxAstScannerTest {
   }
 
   @Test
-  public void comments() throws UnsupportedEncodingException, IOException {
+  void comments() throws UnsupportedEncodingException, IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/metrics/comments.cc", ".", "");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile());
     var softly = new SoftAssertions();
@@ -61,14 +61,14 @@ public class CxxAstScannerTest {
   }
 
   @Test
-  public void lines() throws UnsupportedEncodingException, IOException {
+  void lines() throws UnsupportedEncodingException, IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/metrics/classes.cc", ".", "");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile());
     assertThat(file.getInt(CxxMetric.LINES)).isEqualTo(7);
   }
 
   @Test
-  public void lines_of_code() throws UnsupportedEncodingException, IOException {
+  void lines_of_code() throws UnsupportedEncodingException, IOException {
 
     var tester = CxxFileTesterHelper.create("src/test/resources/metrics/classes.cc", ".", "");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile());
@@ -76,56 +76,56 @@ public class CxxAstScannerTest {
   }
 
   @Test
-  public void statements() throws UnsupportedEncodingException, IOException {
+  void statements() throws UnsupportedEncodingException, IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/metrics/statements.cc", ".", "");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile());
     assertThat(file.getInt(CxxMetric.STATEMENTS)).isEqualTo(4);
   }
 
   @Test
-  public void functions() throws UnsupportedEncodingException, IOException {
+  void functions() throws UnsupportedEncodingException, IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/metrics/functions.cc", ".", "");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile());
     assertThat(file.getInt(CxxMetric.FUNCTIONS)).isEqualTo(2);
   }
 
   @Test
-  public void classes() throws UnsupportedEncodingException, IOException {
+  void classes() throws UnsupportedEncodingException, IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/metrics/classes.cc", ".", "");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile());
     assertThat(file.getInt(CxxMetric.CLASSES)).isEqualTo(2);
   }
 
   @Test
-  public void complexity() throws UnsupportedEncodingException, IOException {
+  void complexity() throws UnsupportedEncodingException, IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/metrics/complexity.cc", ".", "");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile());
     assertThat(file.getInt(CxxMetric.COMPLEXITY)).isEqualTo(14);
   }
 
   @Test
-  public void complexity_alternative() throws UnsupportedEncodingException, IOException {
+  void complexity_alternative() throws UnsupportedEncodingException, IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/metrics/complexity_alternative.cc", ".", "");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile());
     assertThat(file.getInt(CxxMetric.COMPLEXITY)).isEqualTo(14);
   }
 
   @Test
-  public void complexity_macro() throws UnsupportedEncodingException, IOException {
+  void complexity_macro() throws UnsupportedEncodingException, IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/metrics/complexity_macro.cc", ".", "");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile());
     assertThat(file.getInt(CxxMetric.COMPLEXITY)).isEqualTo(1);
   }
 
   @Test
-  public void error_recovery_declaration() throws UnsupportedEncodingException, IOException {
+  void error_recovery_declaration() throws UnsupportedEncodingException, IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/parser/bad/error_recovery_declaration.cc", ".", "");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile());
     assertThat(file.getInt(CxxMetric.FUNCTIONS)).isEqualTo(2);
   }
 
   @Test
-  public void nosonar_comments() throws UnsupportedEncodingException, IOException {
+  void nosonar_comments() throws UnsupportedEncodingException, IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/metrics/nosonar.cc", ".", "");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile());
     assertThat(file.getNoSonarTagLines()).containsOnly(3, 6, 9, 11);

--- a/cxx-squid/src/test/java/org/sonar/cxx/DensityMeasureComputerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/DensityMeasureComputerTest.java
@@ -28,7 +28,7 @@ import org.sonar.api.ce.measure.test.TestMeasureComputerContext;
 import org.sonar.api.ce.measure.test.TestMeasureComputerDefinition.MeasureComputerDefinitionBuilderImpl;
 import org.sonar.api.ce.measure.test.TestSettings;
 
-public class DensityMeasureComputerTest {
+class DensityMeasureComputerTest {
 
   private static TestMeasureComputerContext createContext(DensityMeasureComputer computer) {
     var component = new TestComponent("file", Type.FILE, new FileAttributesImpl("cxx", false));
@@ -38,14 +38,14 @@ public class DensityMeasureComputerTest {
   }
 
   @Test
-  public void metricsNumber() {
+  void metricsNumber() {
     var computer = new DensityMeasureComputer();
     assertThat(computer.getInputMetrics()).hasSize(8);
     assertThat(computer.getOutputMetrics()).hasSize(5);
   }
 
   @Test
-  public void ignoreMissingValue() {
+  void ignoreMissingValue() {
     var computer = new DensityMeasureComputer();
     TestMeasureComputerContext context = createContext(computer);
 
@@ -56,7 +56,7 @@ public class DensityMeasureComputerTest {
   }
 
   @Test
-  public void ignoreMissingTotal() {
+  void ignoreMissingTotal() {
     var computer = new DensityMeasureComputer();
     TestMeasureComputerContext context = createContext(computer);
 
@@ -67,7 +67,7 @@ public class DensityMeasureComputerTest {
   }
 
   @Test
-  public void ignoreMissingBoth() {
+  void ignoreMissingBoth() {
     var computer = new DensityMeasureComputer();
     TestMeasureComputerContext context = createContext(computer);
 
@@ -77,7 +77,7 @@ public class DensityMeasureComputerTest {
   }
 
   @Test
-  public void ignoreAlreadyCalculated() {
+  void ignoreAlreadyCalculated() {
     var computer = new DensityMeasureComputer();
     TestMeasureComputerContext context = createContext(computer);
 
@@ -91,7 +91,7 @@ public class DensityMeasureComputerTest {
   }
 
   @Test
-  public void calculatePercent() {
+  void calculatePercent() {
     var computer = new DensityMeasureComputer();
     TestMeasureComputerContext context = createContext(computer);
 
@@ -104,7 +104,7 @@ public class DensityMeasureComputerTest {
   }
 
   @Test
-  public void calculateRemainingPercent() {
+  void calculateRemainingPercent() {
     var computer = new DensityMeasureComputer();
     TestMeasureComputerContext context = createContext(computer);
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/api/CxxMetricTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/api/CxxMetricTest.java
@@ -22,10 +22,10 @@ package org.sonar.cxx.api;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
-public class CxxMetricTest {
+class CxxMetricTest {
 
   @Test
-  public void test() {
+  void test() {
     var softly = new SoftAssertions();
     softly.assertThat(CxxMetric.values()).hasSize(21);
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/config/CxxSquidConfigurationTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/config/CxxSquidConfigurationTest.java
@@ -31,12 +31,12 @@ import static org.assertj.core.api.Assertions.*;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
-public class CxxSquidConfigurationTest {
+class CxxSquidConfigurationTest {
 
   private static final String VC_CHARSET = "UTF8";
 
   @Test
-  public void testEmptyDb() {
+  void testEmptyDb() {
     var db = new CxxSquidConfiguration();
     Optional<String> value = db.get("level", "key");
 
@@ -46,7 +46,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void emptySingleValue() {
+  void emptySingleValue() {
     var db = new CxxSquidConfiguration();
     db.add("a", "b", "c");
     Optional<String> value = db.get("d", "e");
@@ -57,7 +57,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void identifierSingleValue() {
+  void identifierSingleValue() {
     var db = new CxxSquidConfiguration();
     db.add(CxxSquidConfiguration.GLOBAL, "key", "value");
     Optional<String> value = db.get(CxxSquidConfiguration.GLOBAL, "key");
@@ -69,7 +69,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void identifierMultiValue() {
+  void identifierMultiValue() {
     var db = new CxxSquidConfiguration();
     db.add(CxxSquidConfiguration.GLOBAL, "key", "value1");
     db.add(CxxSquidConfiguration.GLOBAL, "key", "value2");
@@ -85,7 +85,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void identifierParentSingleValue() {
+  void identifierParentSingleValue() {
     var db = new CxxSquidConfiguration();
     db.add(CxxSquidConfiguration.PREDEFINED_MACROS, "key", "value1");
     db.add("a/b/c", "key", "value2");
@@ -98,7 +98,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void fileSingleValue() {
+  void fileSingleValue() {
     var db = new CxxSquidConfiguration();
     db.add("a/b/c", "key", "value");
     Optional<String> value = db.get("a/b/c", "key");
@@ -110,7 +110,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void fileMultiValue1() {
+  void fileMultiValue1() {
     var db = new CxxSquidConfiguration();
     db.add("a/b/c", "key", "value1");
     db.add("a/b/c", "key", "value2");
@@ -126,7 +126,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void fileMultiValue2() {
+  void fileMultiValue2() {
     var db = new CxxSquidConfiguration();
     db.add("a/b/c", "key", new String[]{"value1", "value2", "value3"});
     List<String> values = db.getValues("a/b/c", "key");
@@ -140,7 +140,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void fileMultiValue3() {
+  void fileMultiValue3() {
     var db = new CxxSquidConfiguration();
     db.add("a/b/c", "key", Arrays.asList("value1", "value2", "value3"));
     List<String> values = db.getValues("a/b/c", "key");
@@ -154,7 +154,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void fileParentSingleValue() {
+  void fileParentSingleValue() {
     var db = new CxxSquidConfiguration();
     db.add(CxxSquidConfiguration.PREDEFINED_MACROS, "key", "value1");
     db.add(CxxSquidConfiguration.SONAR_PROJECT_PROPERTIES, "key", "value2");
@@ -168,7 +168,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void fileParentMultiValue() {
+  void fileParentMultiValue() {
     var db = new CxxSquidConfiguration();
     db.add(CxxSquidConfiguration.PREDEFINED_MACROS, "key", "value1");
     db.add(CxxSquidConfiguration.SONAR_PROJECT_PROPERTIES, "key", "value2");
@@ -193,7 +193,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void testSpecialCharInValue() {
+  void testSpecialCharInValue() {
     var db = new CxxSquidConfiguration();
     db.add("a/b/c", "key", "<>&'\"");
     Optional<String> value = db.get("a/b/c", "key");
@@ -205,7 +205,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void testKeys() {
+  void testKeys() {
     var db = new CxxSquidConfiguration();
     db.add("a/b/c", "key1", "value1");
     db.add("a/b/c", "key2", "value2");
@@ -225,7 +225,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void testChildrenValues() {
+  void testChildrenValues() {
     var db = new CxxSquidConfiguration();
     db.add("a/b/c", "key", "value1");
     db.add("c/d/e", "key", "value2");
@@ -247,7 +247,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void testLevelValues() {
+  void testLevelValues() {
     var db = new CxxSquidConfiguration();
     db.add(CxxSquidConfiguration.GLOBAL, "key", "value1");
     db.add(CxxSquidConfiguration.SONAR_PROJECT_PROPERTIES, "key", "value2");
@@ -260,7 +260,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void testPathNames() {
+  void testPathNames() {
     var db = new CxxSquidConfiguration();
     db.add("/a/b/c.cpp", "key1", "value1");
     db.add("c:\\a\\b\\c.cpp", "key2", "value2");
@@ -284,7 +284,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void testBoolean() {
+  void testBoolean() {
     var db = new CxxSquidConfiguration();
     db.add("level", "key1", "True");
     db.add("level", "key2", "False");
@@ -302,7 +302,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void testInt() {
+  void testInt() {
     var db = new CxxSquidConfiguration();
     db.add("level", "key", "1");
     Optional<Integer> value = db.getInt("level", "key");
@@ -314,7 +314,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void testLong() {
+  void testLong() {
     var db = new CxxSquidConfiguration();
     db.add("level", "key", String.valueOf(Long.MAX_VALUE));
     Optional<Long> value = db.getLong("level", "key");
@@ -326,7 +326,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void testFloat() {
+  void testFloat() {
     var db = new CxxSquidConfiguration();
     db.add("level", "key", String.valueOf(Float.MAX_VALUE));
     Optional<Float> value = db.getFloat("level", "key");
@@ -338,7 +338,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void testDouble() {
+  void testDouble() {
     var db = new CxxSquidConfiguration();
     db.add("level", "key", String.valueOf(Double.MAX_VALUE));
     Optional<Double> value = db.getDouble("level", "key");
@@ -350,7 +350,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void testToString() {
+  void testToString() {
     var db = new CxxSquidConfiguration();
     db.add("global1", "key1", "value1");
     db.add("global1", "key1", "value2");
@@ -372,17 +372,17 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void emptyValueShouldReturnNoDirsOrDefines() {
+  void emptyValueShouldReturnNoDirsOrDefines() {
     var squidConfig = new CxxSquidConfiguration();
     squidConfig.readMsBuildFiles(new ArrayList<>(), VC_CHARSET);
     var softly = new SoftAssertions();
-    softly.assertThat(getIncludeDirectories(squidConfig).size()).isZero();
-    softly.assertThat(getDefines(squidConfig).size()).isZero();
+    softly.assertThat(getIncludeDirectories(squidConfig)).isEmpty();
+    softly.assertThat(getDefines(squidConfig)).isEmpty();
     softly.assertAll();
   }
 
   @Test
-  public void emptyValueShouldUseIncludeDirsIfSet() {
+  void emptyValueShouldUseIncludeDirsIfSet() {
     var squidConfig = new CxxSquidConfiguration();
     squidConfig.add(CxxSquidConfiguration.SONAR_PROJECT_PROPERTIES, CxxSquidConfiguration.INCLUDE_DIRECTORIES,
                     new String[]{"dir1", "dir2"});
@@ -391,7 +391,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void correctlyCreatesConfiguration1() {
+  void correctlyCreatesConfiguration1() {
     var squidConfig = new CxxSquidConfiguration(".");
     var files = new ArrayList<File>();
     files.add(new File("src/test/resources/msbuild/vc++13.txt"));
@@ -404,14 +404,14 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void shouldHandleSpecificCommonOptionsCorrectly() {
+  void shouldHandleSpecificCommonOptionsCorrectly() {
     var squidConfig = new CxxSquidConfiguration(".");
     var files = new ArrayList<File>();
     files.add(new File("src/test/resources/msbuild/platformCommon.txt"));
     squidConfig.readMsBuildFiles(files, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(getIncludeDirectories(squidConfig).size()).isZero();
+    softly.assertThat(getIncludeDirectories(squidConfig)).isEmpty();
     List<String> defines = getDefines(squidConfig);
     softly.assertThat(defines).hasSize(20 + 5);
     ValidateDefaultAsserts(softly, defines);
@@ -436,7 +436,7 @@ public class CxxSquidConfigurationTest {
     squidConfig.readMsBuildFiles(files, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(getIncludeDirectories(squidConfig).size()).isZero();
+    softly.assertThat(getIncludeDirectories(squidConfig)).isEmpty();
     List<String> defines = getDefines(squidConfig);
     softly.assertThat(defines).hasSize(3);
     ValidateDefaultAsserts(softly, defines);
@@ -445,13 +445,13 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void shouldHandleSpecificCommonx64OptionsCorrectly() {
+  void shouldHandleSpecificCommonx64OptionsCorrectly() {
     var squidConfig = new CxxSquidConfiguration(".");
     var files = new ArrayList<File>();
     files.add(new File("src/test/resources/msbuild/platformCommonX64.txt"));
     squidConfig.readMsBuildFiles(files, VC_CHARSET);
 
-    assertThat(getIncludeDirectories(squidConfig).size()).isZero();
+    assertThat(getIncludeDirectories(squidConfig)).isEmpty();
     List<String> defines = getDefines(squidConfig);
 
     var softly = new SoftAssertions();
@@ -467,14 +467,14 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void shouldHandleSpecificV100OptionsCorrectly() {
+  void shouldHandleSpecificV100OptionsCorrectly() {
     var squidConfig = new CxxSquidConfiguration(".");
     var files = new ArrayList<File>();
     files.add(new File("src/test/resources/msbuild/platformToolsetv100.txt"));
     squidConfig.readMsBuildFiles(files, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(getIncludeDirectories(squidConfig).size()).isZero();
+    softly.assertThat(getIncludeDirectories(squidConfig)).isEmpty();
     List<String> defines = getDefines(squidConfig);
     softly.assertThat(defines).hasSize(12 + 6);
     ValidateDefaultAsserts(softly, defines);
@@ -486,14 +486,14 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void shouldHandleSpecificV110OptionsCorrectly() {
+  void shouldHandleSpecificV110OptionsCorrectly() {
     var squidConfig = new CxxSquidConfiguration(".");
     var files = new ArrayList<File>();
     files.add(new File("src/test/resources/msbuild/platformToolsetv110.txt"));
     squidConfig.readMsBuildFiles(files, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(getIncludeDirectories(squidConfig).size()).isZero();
+    softly.assertThat(getIncludeDirectories(squidConfig)).isEmpty();
     List<String> defines = getDefines(squidConfig);
     softly.assertThat(defines).hasSize(13 + 5);
     ValidateDefaultAsserts(softly, defines);
@@ -509,14 +509,14 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void shouldHandleSpecificV120OptionsCorrectly() {
+  void shouldHandleSpecificV120OptionsCorrectly() {
     var squidConfig = new CxxSquidConfiguration(".");
     var files = new ArrayList<File>();
     files.add(new File("src/test/resources/msbuild/platformToolsetv120.txt"));
     squidConfig.readMsBuildFiles(files, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(getIncludeDirectories(squidConfig).size()).isZero();
+    softly.assertThat(getIncludeDirectories(squidConfig)).isEmpty();
     List<String> defines = getDefines(squidConfig);
     softly.assertThat(defines).hasSize(15 + 6);
     ValidateDefaultAsserts(softly, defines);
@@ -535,14 +535,14 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void shouldHandleSpecificV140OptionsCorrectly() {
+  void shouldHandleSpecificV140OptionsCorrectly() {
     var squidConfig = new CxxSquidConfiguration(".");
     var files = new ArrayList<File>();
     files.add(new File("src/test/resources/msbuild/platformToolsetv140.txt"));
     squidConfig.readMsBuildFiles(files, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(getIncludeDirectories(squidConfig).size()).isZero();
+    softly.assertThat(getIncludeDirectories(squidConfig)).isEmpty();
     List<String> defines = getDefines(squidConfig);
     assertThat(defines).hasSize(15 + 6);
     ValidateDefaultAsserts(softly, defines);
@@ -560,7 +560,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void shouldHandleTFSAgentV141OptionsCorrectly() {
+  void shouldHandleTFSAgentV141OptionsCorrectly() {
     var squidConfig = new CxxSquidConfiguration(".");
     var files = new ArrayList<File>();
     files.add(new File("src/test/resources/msbuild/TFS-agent-msvc14.txt"));
@@ -581,7 +581,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void shouldHandleTFSAgentV141mpOptionsCorrectly() {
+  void shouldHandleTFSAgentV141mpOptionsCorrectly() {
     var squidConfig = new CxxSquidConfiguration(".");
     var files = new ArrayList<File>();
     files.add(new File("src/test/resources/msbuild/TFS-agent-msvc14-mp.txt"));
@@ -602,14 +602,14 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void shouldHandleSpecificV141x86OptionsCorrectly() {
+  void shouldHandleSpecificV141x86OptionsCorrectly() {
     var squidConfig = new CxxSquidConfiguration(".");
     var files = new ArrayList<File>();
     files.add(new File("src/test/resources/msbuild/platformToolsetv141x86.txt"));
     squidConfig.readMsBuildFiles(files, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(getIncludeDirectories(squidConfig).size()).isZero();
+    softly.assertThat(getIncludeDirectories(squidConfig)).isEmpty();
     List<String> defines = getDefines(squidConfig);
     assertThat(defines).hasSize(15 + 12);
     ValidateDefaultAsserts(softly, defines);
@@ -623,14 +623,14 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void shouldHandleSpecificV141x64OptionsCorrectly() {
+  void shouldHandleSpecificV141x64OptionsCorrectly() {
     var squidConfig = new CxxSquidConfiguration(".");
     var files = new ArrayList<File>();
     files.add(new File("src/test/resources/msbuild/platformToolsetv141x64.txt"));
     squidConfig.readMsBuildFiles(files, VC_CHARSET);
 
     var softly = new SoftAssertions();
-    softly.assertThat(getIncludeDirectories(squidConfig).size()).isZero();
+    softly.assertThat(getIncludeDirectories(squidConfig)).isEmpty();
     List<String> defines = getDefines(squidConfig);
     assertThat(defines).hasSize(15 + 14);
     ValidateDefaultAsserts(softly, defines);
@@ -644,7 +644,7 @@ public class CxxSquidConfigurationTest {
   }
 
   @Test
-  public void shouldHandleBuildLog() {
+  void shouldHandleBuildLog() {
     var squidConfig = new CxxSquidConfiguration(".");
     var files = new ArrayList<File>();
     files.add(new File("src/test/resources/msbuild/ParallelBuildLog.txt"));

--- a/cxx-squid/src/test/java/org/sonar/cxx/config/JsonCompilationDatabaseTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/config/JsonCompilationDatabaseTest.java
@@ -27,10 +27,10 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class JsonCompilationDatabaseTest {
+class JsonCompilationDatabaseTest {
 
   @Test
-  public void testGlobalSettings() throws Exception {
+  void testGlobalSettings() throws Exception {
     var squidConfig = new CxxSquidConfiguration();
 
     var file = new File("src/test/resources/jsondb/compile_commands.json");
@@ -52,7 +52,7 @@ public class JsonCompilationDatabaseTest {
   }
 
   @Test
-  public void testExtensionSettings() throws Exception {
+  void testExtensionSettings() throws Exception {
     var squidConfig = new CxxSquidConfiguration();
     var file = new File("src/test/resources/jsondb/compile_commands.json");
     var jsonDb = new JsonCompilationDatabase(squidConfig);
@@ -76,7 +76,7 @@ public class JsonCompilationDatabaseTest {
   }
 
   @Test
-  public void testCommandSettings() throws Exception {
+  void testCommandSettings() throws Exception {
     var squidConfig = new CxxSquidConfiguration();
 
     var file = new File("src/test/resources/jsondb/compile_commands.json");
@@ -105,7 +105,7 @@ public class JsonCompilationDatabaseTest {
   }
 
   @Test
-  public void testArgumentParser() throws Exception {
+  void testArgumentParser() throws Exception {
     var squidConfig = new CxxSquidConfiguration();
 
     var file = new File("src/test/resources/jsondb/compile_commands.json");
@@ -142,7 +142,7 @@ public class JsonCompilationDatabaseTest {
   }
 
   @Test
-  public void testArgumentSettings() throws Exception {
+  void testArgumentSettings() throws Exception {
     var squidConfig = new CxxSquidConfiguration();
 
     var file = new File("src/test/resources/jsondb/compile_commands.json");
@@ -171,7 +171,7 @@ public class JsonCompilationDatabaseTest {
   }
 
   @Test
-  public void testRelativeDirectorySettings() throws Exception {
+  void testRelativeDirectorySettings() throws Exception {
     var squidConfig = new CxxSquidConfiguration();
 
     var file = new File("src/test/resources/jsondb/compile_commands.json");
@@ -194,7 +194,7 @@ public class JsonCompilationDatabaseTest {
   }
 
   @Test
-  public void testArgumentAsListSettings() throws Exception {
+  void testArgumentAsListSettings() throws Exception {
     var squidConfig = new CxxSquidConfiguration();
 
     var file = new File("src/test/resources/jsondb/compile_commands.json");
@@ -223,7 +223,7 @@ public class JsonCompilationDatabaseTest {
   }
 
   @Test
-  public void testUnknownUnitSettings() throws Exception {
+  void testUnknownUnitSettings() throws Exception {
     var squidConfig = new CxxSquidConfiguration();
 
     var file = new File("src/test/resources/jsondb/compile_commands.json");
@@ -247,7 +247,7 @@ public class JsonCompilationDatabaseTest {
   }
 
   @Test
-  public void testInvalidJson() {
+  void testInvalidJson() {
     JsonMappingException thrown = catchThrowableOfType(() -> {
       var squidConfig = new CxxSquidConfiguration();
       var file = new File("src/test/resources/jsondb/invalid.json");
@@ -258,7 +258,7 @@ public class JsonCompilationDatabaseTest {
   }
 
   @Test
-  public void testFileNotFound() {
+  void testFileNotFound() {
     FileNotFoundException thrown = catchThrowableOfType(() -> {
       var squidConfig = new CxxSquidConfiguration();
       var file = new File("src/test/resources/jsondb/not-found.json");

--- a/cxx-squid/src/test/java/org/sonar/cxx/config/MsBuildTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/config/MsBuildTest.java
@@ -34,7 +34,7 @@ import org.sonar.api.internal.apachecommons.lang.SystemUtils;
  *
  * @author rudolfgrauberger
  */
-public class MsBuildTest {
+class MsBuildTest {
 
   public static final String REFERENCE_DETAILED_LOG = "src/test/resources/msbuild/msbuild-detailed-en.txt";
   public static final String UNIQUE_FILE = "C:\\Development\\Source\\Cpp\\Dummy\\src\\main.cpp";
@@ -46,7 +46,7 @@ public class MsBuildTest {
   }
 
   @Test
-  public void relativeIncludesFromReferenceLog() {
+  void relativeIncludesFromReferenceLog() {
 
     List<String> includes = getIncludesForReferenceLogFile();
 
@@ -63,7 +63,7 @@ public class MsBuildTest {
   }
 
   @Test
-  public void relativeIncludesVS2019ReferenceLog() {
+  void relativeIncludesVS2019ReferenceLog() {
 
     var REFERENCE_LOG = "src/test/resources/msbuild/msbuild-azure-devops-en.txt";
     List<String> includes = getIncludesForUniqueFile(REFERENCE_LOG);
@@ -76,7 +76,7 @@ public class MsBuildTest {
   }
 
   @Test
-  public void relativeIncludesFromGermanLog() {
+  void relativeIncludesFromGermanLog() {
 
     List<String> refIncludes = getIncludesForReferenceLogFile();
     List<String> includes = getIncludesForUniqueFile("src/test/resources/msbuild/msbuild-detailed-de.txt");
@@ -88,7 +88,7 @@ public class MsBuildTest {
   }
 
   @Test
-  public void relativeIncludesFromFrenchLog() {
+  void relativeIncludesFromFrenchLog() {
 
     List<String> refIncludes = getIncludesForReferenceLogFile();
     List<String> includes = getIncludesForUniqueFile("src/test/resources/msbuild/msbuild-detailed-fr.txt");

--- a/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerIncludeTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerIncludeTest.java
@@ -37,10 +37,10 @@ import org.sonar.cxx.preprocessor.JoinStringsPreprocessor;
 import org.sonar.cxx.utils.TestUtils;
 import org.sonar.cxx.squidbridge.SquidAstVisitorContext;
 
-public class CxxLexerIncludeTest {
+class CxxLexerIncludeTest {
 
   @Test
-  public void quoted_include_without_IncludeDirectories() {
+  void quoted_include_without_IncludeDirectories() {
     // Quoted form / preprocessor include file search order:
     // 1) In the same directory as the file that contains the #include statement.
 
@@ -49,7 +49,7 @@ public class CxxLexerIncludeTest {
   }
 
   @Test
-  public void quoted_include_with_IncludeDirectories1() {
+  void quoted_include_with_IncludeDirectories1() {
     // Quoted form / preprocessor include file search order:
     // 1) In the same directory as the file that contains the #include statement.
 
@@ -58,7 +58,7 @@ public class CxxLexerIncludeTest {
   }
 
   @Test
-  public void quoted_include_with_IncludeDirectories2() {
+  void quoted_include_with_IncludeDirectories2() {
     // Quoted form / preprocessor include file search order:
     // 2) In the directories of the currently opened include files, in the reverse order in which they were opened.
     // The search begins in the directory of the parent include file and continues upward through the directories of
@@ -69,7 +69,7 @@ public class CxxLexerIncludeTest {
   }
 
   @Test
-  public void quoted_include_with_IncludeDirectories3a() {
+  void quoted_include_with_IncludeDirectories3a() {
     // Quoted form / preprocessor include file search order:
     // 3) Along the path that's specified by each /I compiler option.
 
@@ -78,7 +78,7 @@ public class CxxLexerIncludeTest {
   }
 
   @Test
-  public void quoted_include_with_IncludeDirectories3b() {
+  void quoted_include_with_IncludeDirectories3b() {
     // Quoted form / preprocessor include file search order:
     // 3) Along the path that's specified by each /I compiler option.
 
@@ -87,7 +87,7 @@ public class CxxLexerIncludeTest {
   }
 
   @Test
-  public void bracket_include_without_IncludeDirectories() {
+  void bracket_include_without_IncludeDirectories() {
     // Angle-bracket form / preprocessor include file search order:
     // 1) Along the path that's specified by each /I compiler option (IncludeDirectories).
 
@@ -96,7 +96,7 @@ public class CxxLexerIncludeTest {
   }
 
   @Test
-  public void bracket_include_with_IncludeDirectories1a() {
+  void bracket_include_with_IncludeDirectories1a() {
     // Angle-bracket form / preprocessor include file search order:
     // 1) Along the path that's specified by each /I compiler option (IncludeDirectories).
 
@@ -105,7 +105,7 @@ public class CxxLexerIncludeTest {
   }
 
   @Test
-  public void bracket_include_with_IncludeDirectories1b() {
+  void bracket_include_with_IncludeDirectories1b() {
     // Angle-bracket form / preprocessor include file search order:
     // 1) Along the path that's specified by each /I compiler option (IncludeDirectories).
 
@@ -114,7 +114,7 @@ public class CxxLexerIncludeTest {
   }
 
   @Test
-  public void bracket_include_with_IncludeDirectories1c() {
+  void bracket_include_with_IncludeDirectories1c() {
     // Angle-bracket form / preprocessor include file search order:
     // 1) Along the path that's specified by each /I compiler option (IncludeDirectories).
 
@@ -123,7 +123,7 @@ public class CxxLexerIncludeTest {
   }
 
   @Test
-  public void compilation_database_settings_propagated() {
+  void compilation_database_settings_propagated() {
     // test: are compilation database settings propagated in case of nested includes
 
     List<String> defines = Arrays.asList("GLOBAL 1");
@@ -132,7 +132,7 @@ public class CxxLexerIncludeTest {
   }
 
   @Test
-  public void bracket_import_with_IncludeDirectories() {
+  void bracket_import_with_IncludeDirectories() {
     // Angle-bracket form / preprocessor include file search order:
     // 1) Along the path that's specified by each /I compiler option (IncludeDirectories).
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerTest.java
@@ -41,7 +41,7 @@ import org.sonar.cxx.preprocessor.CxxPreprocessor;
 import org.sonar.cxx.preprocessor.JoinStringsPreprocessor;
 import org.sonar.cxx.squidbridge.SquidAstVisitorContext;
 
-public class CxxLexerTest {
+class CxxLexerTest {
 
   private Lexer lexer;
 
@@ -61,7 +61,7 @@ public class CxxLexerTest {
    * @throws URISyntaxException
    */
   @Test
-  public void comments_cxx() {
+  void comments_cxx() {
     var softly = new SoftAssertions();
     softly.assertThat(lexer.lex("//\n new line")).as("comment c++: empty").anySatisfy(token
       -> assertThat(token).isValue("new").hasTrivia().isTrivia("//").isComment().isTriviaLine(1));
@@ -78,7 +78,7 @@ public class CxxLexerTest {
    * C++ Standard, Section 2.8 "Comments"
    */
   @Test
-  public void comments_c() {
+  void comments_c() {
     var softly = new SoftAssertions();
     softly.assertThat(lexer.lex("/**/")).as("comment c: empty").anySatisfy(token
       -> assertThat(token).isValue("EOF").hasTrivia().isTrivia("/**/").isComment().isTriviaLine(1));
@@ -97,7 +97,7 @@ public class CxxLexerTest {
    * C++ Standard, Section 2.14.2 "Integer literals"
    */
   @Test
-  public void decimal_integer_literals() {
+  void decimal_integer_literals() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       LiteralValuesBuilder.builder("0").tokenValue("0").tokenType(CxxTokenType.NUMBER).build(),
       LiteralValuesBuilder.builder("7").tokenValue("7").tokenType(CxxTokenType.NUMBER).build(),
@@ -144,7 +144,7 @@ public class CxxLexerTest {
    * C++ Standard, Section 2.14.2 "Integer literals"
    */
   @Test
-  public void octal_integer_literals() {
+  void octal_integer_literals() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       // Octal integer
       LiteralValuesBuilder.builder("07").tokenValue("07").tokenType(CxxTokenType.NUMBER).build(),
@@ -191,7 +191,7 @@ public class CxxLexerTest {
    * C++ Standard, Section 2.14.2 "Integer literals"
    */
   @Test
-  public void hex_integer_literals() {
+  void hex_integer_literals() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       // Hex integer
       LiteralValuesBuilder.builder("0x7").tokenValue("0x7").tokenType(CxxTokenType.NUMBER).build(),
@@ -238,7 +238,7 @@ public class CxxLexerTest {
    * C++ Standard, Section 2.14.2 "Integer literals"
    */
   @Test
-  public void bin_integer_literals() {
+  void bin_integer_literals() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       // bin integer
       LiteralValuesBuilder.builder("0b0").tokenValue("0b0").tokenType(CxxTokenType.NUMBER).build(),
@@ -255,7 +255,7 @@ public class CxxLexerTest {
    * C++ Standard, Section 2.14.2 "Integer literals"
    */
   @Test
-  public void hex_integer_literals_bigX() {
+  void hex_integer_literals_bigX() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       // Hex integer (big X)
       LiteralValuesBuilder.builder("0X7").tokenValue("0X7").tokenType(CxxTokenType.NUMBER).build(),
@@ -302,7 +302,7 @@ public class CxxLexerTest {
    * C++ Standard, Section 2.14.2 "Integer literals"
    */
   @Test
-  public void bin_integer_literals_bigB() {
+  void bin_integer_literals_bigB() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       // Binary literal (big B)
       LiteralValuesBuilder.builder("0B1").tokenValue("0B1").tokenType(CxxTokenType.NUMBER).build(),
@@ -349,7 +349,7 @@ public class CxxLexerTest {
    * C++ Standard, Section 2.14.4 "Floating literals"
    */
   @Test
-  public void floating_point_literals() {
+  void floating_point_literals() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       LiteralValuesBuilder.builder("3.14").tokenValue("3.14").tokenType(CxxTokenType.NUMBER).build(),
       LiteralValuesBuilder.builder("10.").tokenValue("10.").tokenType(CxxTokenType.NUMBER).build(),
@@ -404,7 +404,7 @@ public class CxxLexerTest {
    * C++ Standard, Section 2.13.8 "User-defined literals"
    */
   @Test
-  public void user_defined_literals() {
+  void user_defined_literals() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       LiteralValuesBuilder.builder("12_w").tokenValue("12_w").tokenType(CxxTokenType.NUMBER).build(),
       LiteralValuesBuilder.builder("1.2_w").tokenValue("1.2_w").tokenType(CxxTokenType.NUMBER).build(),
@@ -425,7 +425,7 @@ public class CxxLexerTest {
    * C++ Standard, Section 2.13 ff "digit separators"
    */
   @Test
-  public void digit_separators() {
+  void digit_separators() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       LiteralValuesBuilder.builder("1'000'000").tokenValue("1'000'000").tokenType(CxxTokenType.NUMBER).build(),
       LiteralValuesBuilder.builder("0b0100'1100'0110").tokenValue("0b0100'1100'0110").tokenType(CxxTokenType.NUMBER)
@@ -450,7 +450,7 @@ public class CxxLexerTest {
    * C++ Standard, Section 2.14.6 "Boolean literals"
    */
   @Test
-  public void boolean_literals() {
+  void boolean_literals() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       LiteralValuesBuilder.builder("true").tokenValue("true").tokenType(CxxKeyword.TRUE).build(),
       LiteralValuesBuilder.builder("false").tokenValue("false").tokenType(CxxKeyword.FALSE).build()
@@ -465,7 +465,7 @@ public class CxxLexerTest {
    * C++ Standard, Section 2.14.7 "Pointer literals"
    */
   @Test
-  public void pointer_literals() {
+  void pointer_literals() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       LiteralValuesBuilder.builder("nullptr").tokenValue("nullptr").tokenType(CxxTokenType.NUMBER).build()
     ));
@@ -479,7 +479,7 @@ public class CxxLexerTest {
    * C++ Standard, Character literals
    */
   @Test
-  public void character_literals() {
+  void character_literals() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       LiteralValuesBuilder.builder("''").tokenValue("''").tokenType(CxxTokenType.CHARACTER).build(), // char: empty
       LiteralValuesBuilder.builder("u8''").tokenValue("u8''").tokenType(CxxTokenType.CHARACTER).build(), // char: prefix u8
@@ -506,7 +506,7 @@ public class CxxLexerTest {
    * C++ Standard, String literals
    */
   @Test
-  public void string_literals() {
+  void string_literals() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       LiteralValuesBuilder.builder("\"\"").tokenValue("\"\"").tokenType(CxxTokenType.STRING).build(), // string: empty
       LiteralValuesBuilder.builder("u8\"\"").tokenValue("u8\"\"").tokenType(CxxTokenType.STRING).build(), // string: prefix u8
@@ -529,7 +529,7 @@ public class CxxLexerTest {
   }
 
   @Test
-  public void rawstring_literals() {
+  void rawstring_literals() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       LiteralValuesBuilder.builder("R\"(...)\"").tokenValue("R\"(...)\"").tokenType(CxxTokenType.STRING).build(), // raw string: empty
       LiteralValuesBuilder.builder("uR\"(...)\"").tokenValue("uR\"(...)\"").tokenType(CxxTokenType.STRING).build(), // raw string: prefix u
@@ -575,7 +575,7 @@ public class CxxLexerTest {
   }
 
   @Test
-  public void operators_and_delimiters() {
+  void operators_and_delimiters() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       LiteralValuesBuilder.builder(":").tokenValue(":").tokenType(CxxPunctuator.COLON).build(),
       LiteralValuesBuilder.builder("=").tokenValue("=").tokenType(CxxPunctuator.ASSIGN).build(),
@@ -588,7 +588,7 @@ public class CxxLexerTest {
   }
 
   @Test
-  public void keywords_and_identifiers() {
+  void keywords_and_identifiers() {
     var values = new ArrayList<LiteralValuesBuilder>(Arrays.asList(
       LiteralValuesBuilder.builder("return").tokenValue("return").tokenType(CxxKeyword.RETURN).build(),
       LiteralValuesBuilder.builder("identifier").tokenValue("identifier").tokenType(GenericTokenType.IDENTIFIER)
@@ -605,7 +605,7 @@ public class CxxLexerTest {
   }
 
   @Test
-  public void blank_lines() {
+  void blank_lines() {
     var softly = new SoftAssertions();
     softly.assertThat(lexer.lex("    // comment\\n")).hasSize(1);
     softly.assertThat(lexer.lex("    \n")).hasSize(1);

--- a/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithPreprocessingTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithPreprocessingTest.java
@@ -48,7 +48,7 @@ import org.sonar.cxx.preprocessor.JoinStringsPreprocessor;
 import org.sonar.cxx.preprocessor.SourceCodeProvider;
 import org.sonar.cxx.squidbridge.SquidAstVisitorContext;
 
-public class CxxLexerWithPreprocessingTest {
+class CxxLexerWithPreprocessingTest {
 
   private static Lexer lexer;
   private final SquidAstVisitorContext<Grammar> context;
@@ -63,7 +63,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void escaping_newline() {
+  void escaping_newline() {
     var softly = new SoftAssertions();
     softly.assertThat(lexer.lex("line\\\r\nline")).as("dos style").noneMatch(token
       -> token.getValue().contentEquals("\\") && token.getType().equals(GenericTokenType.UNKNOWN_CHAR));
@@ -76,7 +76,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void joining_strings() {
+  void joining_strings() {
     var softly = new SoftAssertions();
     softly.assertThat(lexer.lex("\"string\"")).anySatisfy(token
       -> assertThat(token).isValue("\"string\"").hasType(CxxTokenType.STRING));
@@ -89,7 +89,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_objectlike_macros() {
+  void expanding_objectlike_macros() {
     List<Token> tokens = lexer.lex("#define lala \"haha\"\nlala");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(2);
@@ -98,7 +98,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_functionlike_macros() {
+  void expanding_functionlike_macros() {
     List<Token> tokens = lexer.lex("#define plus(a, b) a + b\n plus(1, 2)");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(4);
@@ -107,7 +107,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_functionlike_macros_with_varargs() {
+  void expanding_functionlike_macros_with_varargs() {
     List<Token> tokens = lexer.lex("#define wrapper(...) __VA_ARGS__\n wrapper(1, 2)");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(4);
@@ -117,7 +117,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_functionlike_macros_withnamed_varargs() {
+  void expanding_functionlike_macros_withnamed_varargs() {
     List<Token> tokens = lexer.lex("#define wrapper(args...) args\n wrapper(1, 2)");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(4);
@@ -127,7 +127,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_functionlike_macros_with_empty_varargs() {
+  void expanding_functionlike_macros_with_empty_varargs() {
     List<Token> tokens = lexer.lex("#define wrapper(...) (__VA_ARGS__)\n wrapper()");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(3);
@@ -137,7 +137,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_macro_with_empty_parameter_list() {
+  void expanding_macro_with_empty_parameter_list() {
     List<Token> tokens = lexer.lex("#define M() 0\n M()");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(2);
@@ -146,7 +146,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_functionlike_macros_withextraparantheses() {
+  void expanding_functionlike_macros_withextraparantheses() {
     List<Token> tokens = lexer.lex("#define neg(a) -a\n neg((1))");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(5);
@@ -155,7 +155,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_hashoperator() {
+  void expanding_hashoperator() {
     List<Token> tokens = lexer.lex("#define str(a) # a\n str(x)");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(2);
@@ -164,7 +164,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_hashhash_operator() {
+  void expanding_hashhash_operator() {
     List<Token> tokens = lexer.lex("#define concat(a,b) a ## b\n concat(x,y)");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(2); // xy + EOF
@@ -173,7 +173,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_hashhash_operator_withoutparams() {
+  void expanding_hashhash_operator_withoutparams() {
     List<Token> tokens = lexer.lex("#define hashhash c ## c\n hashhash");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(2); // cc + EOF
@@ -182,7 +182,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_sequenceof_hashhash_operators() {
+  void expanding_sequenceof_hashhash_operators() {
     List<Token> tokens = lexer.lex("#define concat(a,b) a ## ## ## b\n concat(x,y)");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(2); // xy + EOF
@@ -191,7 +191,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_many_hashhash_operators() {
+  void expanding_many_hashhash_operators() {
     List<Token> tokens = lexer.lex("#define concat(a,b) c ## c ## c ## c\n concat(x,y)");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(2); // cccc + EOF
@@ -201,7 +201,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void hashhash_arguments_with_whitespace_before_comma() {
+  void hashhash_arguments_with_whitespace_before_comma() {
     // The blank behind FOO finds its way into the expansion.
     // This leads to expression evaluation errors. Found in boost.
     // Problem: cannot find defined behaviour in the C++ Standard for
@@ -220,7 +220,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_hashhash_operator_sampleFromCPPStandard() {
+  void expanding_hashhash_operator_sampleFromCPPStandard() {
     // TODO: think about implementing this behavior. This is a sample from the standard, which is
     // not working yet. Because the current implementation throws away all 'irrelevant'
     // preprocessor directives too early, I guess.
@@ -239,7 +239,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_hashoperator_quoting1() {
+  void expanding_hashoperator_quoting1() {
     List<Token> tokens = lexer.lex("#define str(a) # a\n str(\"x\")");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(2);
@@ -249,7 +249,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_chained_macros() {
+  void expanding_chained_macros() {
     List<Token> tokens = lexer.lex("#define M1 \"a\"\n"
                                      + "#define M2 M1\n"
                                      + "M2");
@@ -260,7 +260,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_chained_macros2() {
+  void expanding_chained_macros2() {
     List<Token> tokens = lexer.lex("#define M1 \"a\"\n"
                                      + "#define M2 foo(M1)\n"
                                      + "M2");
@@ -272,7 +272,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void expanding_chained_macros3() {
+  void expanding_chained_macros3() {
     List<Token> tokens = lexer.lex("#define M1(a) \"a\"\n"
                                      + "#define M2 foo(M1)\n"
                                      + "M2");
@@ -284,7 +284,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void joining_strings_after_macro_expansion() {
+  void joining_strings_after_macro_expansion() {
     List<Token> tokens = lexer.lex("#define Y \"hello, \" \n"
                                      + "#define X Y \"world\" \n"
                                      + "X");
@@ -296,7 +296,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void joining_strings_after_macro_expansion2() {
+  void joining_strings_after_macro_expansion2() {
     List<Token> tokens = lexer.lex("#define M \"A\" \"B\" \"C\" \n"
                                      + "#define N M \n"
                                      + "N");
@@ -307,7 +307,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void joining_strings_after_macro_expansion3() {
+  void joining_strings_after_macro_expansion3() {
     List<Token> tokens = lexer.lex("#define M \"B\" \n"
                                      + "\"A\" M");
     var softly = new SoftAssertions();
@@ -317,7 +317,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void preserving_whitespace() {
+  void preserving_whitespace() {
     List<Token> tokens = lexer.lex("#define CODE(x) x\n"
                                      + "CODE(new B())");
     var softly = new SoftAssertions();
@@ -328,13 +328,13 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void bodyless_defines() {
+  void bodyless_defines() {
     assertThat(lexer.lex("#define M\n" + "M")).noneMatch(token -> token.getValue().contentEquals("M"))
       .noneMatch(token -> token.getType().equals(GenericTokenType.IDENTIFIER));
   }
 
   @Test
-  public void external_define() {
+  void external_define() {
     var squidConfig = new CxxSquidConfiguration();
     squidConfig.add(CxxSquidConfiguration.SONAR_PROJECT_PROPERTIES, CxxSquidConfiguration.DEFINES,
                     "M body");
@@ -350,7 +350,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void external_defines_with_params() {
+  void external_defines_with_params() {
     var squidConfig = new CxxSquidConfiguration();
     squidConfig.add(CxxSquidConfiguration.SONAR_PROJECT_PROPERTIES, CxxSquidConfiguration.DEFINES,
                     "minus(a, b) a - b");
@@ -365,7 +365,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void using_keyword_as_macro_name() {
+  void using_keyword_as_macro_name() {
     List<Token> tokens = lexer.lex("#define new new_debug\n"
                                      + "new");
     var softly = new SoftAssertions();
@@ -376,7 +376,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void using_keyword_as_macro_parameter() {
+  void using_keyword_as_macro_parameter() {
     List<Token> tokens = lexer.lex("#define macro(new) new\n"
                                      + "macro(a)");
     var softly = new SoftAssertions();
@@ -386,7 +386,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void using_macro_name_as_macro_identifier() {
+  void using_macro_name_as_macro_identifier() {
     List<Token> tokens = lexer.lex("#define X(a) a X(a)\n"
                                      + "X(new)");
     var softly = new SoftAssertions();
@@ -397,7 +397,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void using_keyword_as_macro_argument() {
+  void using_keyword_as_macro_argument() {
     List<Token> tokens = lexer.lex("#define X(a) a\n"
                                      + "X(new)");
     var softly = new SoftAssertions();
@@ -407,7 +407,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void includes_are_working() throws IOException {
+  void includes_are_working() throws IOException {
     SourceCodeProvider scp = mock(SourceCodeProvider.class);
     when(scp.getSourceCodeFile(anyString(), eq(false))).thenReturn(new File("file"));
     when(scp.getSourceCode(any(File.class), any(Charset.class))).thenReturn("#define A B\n");
@@ -427,14 +427,14 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void macro_replacement_in_includes_is_working() {
+  void macro_replacement_in_includes_is_working() {
     List<Token> tokens = lexer.lex("#define A \"B\"\n"
                                      + "#include A\n");
     assertThat(tokens).hasSize(1); // EOF
   }
 
   @Test
-  public void conditional_compilation_ifdef_undefined() {
+  void conditional_compilation_ifdef_undefined() {
     List<Token> tokens = lexer.lex("#ifdef LALA\n"
                                      + "111\n"
                                      + "#else\n"
@@ -449,7 +449,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void conditional_compilation_ifdef_defined() {
+  void conditional_compilation_ifdef_defined() {
     List<Token> tokens = lexer.lex("#define LALA\n"
                                      + "#ifdef LALA\n"
                                      + "  111\n"
@@ -465,7 +465,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void conditional_compilation_ifndef_undefined() {
+  void conditional_compilation_ifndef_undefined() {
     List<Token> tokens = lexer.lex("#ifndef LALA\n"
                                      + "111\n"
                                      + "#else\n"
@@ -479,7 +479,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void conditional_compilation_ifndef_defined() {
+  void conditional_compilation_ifndef_defined() {
     List<Token> tokens = lexer.lex("#define X\n"
                                      + "#ifndef X\n"
                                      + "  111\n"
@@ -494,7 +494,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void conditional_compilation_ifdef_nested() {
+  void conditional_compilation_ifdef_nested() {
     List<Token> tokens = lexer.lex("#define B\n"
                                      + "#ifdef A\n"
                                      + "  a\n"
@@ -516,7 +516,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void conditional_compilation_if_false() {
+  void conditional_compilation_if_false() {
     List<Token> tokens = lexer.lex("#if 0\n"
                                      + "  a\n"
                                      + "#else\n"
@@ -531,7 +531,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void conditional_compilation_if_true() {
+  void conditional_compilation_if_true() {
     List<Token> tokens = lexer.lex("#if 1\n"
                                      + "  a\n"
                                      + "#else\n"
@@ -545,7 +545,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void conditional_compilation_if_identifier_true() {
+  void conditional_compilation_if_identifier_true() {
     List<Token> tokens = lexer.lex("#define LALA 1\n"
                                      + "#if LALA\n"
                                      + "  a\n"
@@ -560,7 +560,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void conditional_compilation_if_identifier_false() {
+  void conditional_compilation_if_identifier_false() {
     List<Token> tokens = lexer.lex("#if LALA\n"
                                      + "  a\n"
                                      + "#else\n"
@@ -575,7 +575,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void nested_ifs() {
+  void nested_ifs() {
     List<Token> tokens = lexer.lex("#if 0\n"
                                      + "  #if 1\n"
                                      + "    b\n"
@@ -596,7 +596,7 @@ public class CxxLexerWithPreprocessingTest {
   // Proper separation of parameterized macros and macros expand to a string enclosed
   // in parentheses
   @Test
-  public void macro_expanding_to_parantheses() {
+  void macro_expanding_to_parantheses() {
     // a macro is identified as 'functionlike' if and only if the parentheses
     // aren't separated from the identifier by whitespace. Otherwise, the parentheses
     // belong to the replacement string
@@ -606,7 +606,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void assume_true_if_cannot_evaluate_if_expression() {
+  void assume_true_if_cannot_evaluate_if_expression() {
     List<Token> tokens = lexer.lex("#if (\"\")\n"
                                      + "  a\n"
                                      + "#else\n"
@@ -619,13 +619,13 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void ignore_irrelevant_preprocessor_directives() {
+  void ignore_irrelevant_preprocessor_directives() {
     List<Token> tokens = lexer.lex("#pragma lala\n");
     assertThat(tokens).hasSize(1); // EOF
   }
 
   @Test
-  public void overwriteGlobalMacro() {
+  void overwriteGlobalMacro() {
     var squidConfig = new CxxSquidConfiguration();
     squidConfig.add(CxxSquidConfiguration.GLOBAL, CxxSquidConfiguration.DEFINES, "macro globalvalue");
     var cxxpp = new CxxPreprocessor(context, squidConfig);
@@ -645,7 +645,7 @@ public class CxxLexerWithPreprocessingTest {
    * Test the expansion of default macros. Document the reference value of __LINE__ == 1
    */
   @Test
-  public void defaultMacros() {
+  void defaultMacros() {
     var squidConfig = new CxxSquidConfiguration();
     var cxxpp = new CxxPreprocessor(context, squidConfig);
 
@@ -668,7 +668,7 @@ public class CxxLexerWithPreprocessingTest {
    * </code>
    */
   @Test
-  public void configuredDefinesOverrideDefaultMacros() {
+  void configuredDefinesOverrideDefaultMacros() {
     var squidConfig = new CxxSquidConfiguration();
     squidConfig.add(CxxSquidConfiguration.GLOBAL, CxxSquidConfiguration.DEFINES, "__LINE__ 123");
     var cxxpp = new CxxPreprocessor(context, squidConfig);
@@ -694,7 +694,7 @@ public class CxxLexerWithPreprocessingTest {
    * </code>
    */
   @Test
-  public void forcedIncludesOverrideConfiguredDefines() throws IOException {
+  void forcedIncludesOverrideConfiguredDefines() throws IOException {
     String forceIncludePath = "/home/user/force.h";
     var forceIncludeFile = new File(forceIncludePath);
 
@@ -724,7 +724,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void elif_expression() {
+  void elif_expression() {
     List<Token> tokens = lexer.lex("#if 0\n"
                                      + "  if\n"
                                      + "#elif 1\n"
@@ -739,7 +739,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void continued_preprocessor_directive() {
+  void continued_preprocessor_directive() {
     // continuations mask only one succeeding newline
     List<Token> tokens = lexer.lex("#define M macrobody\\\n"
                                      + "\n"
@@ -752,7 +752,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void misc_preprocessor_lines() {
+  void misc_preprocessor_lines() {
     // a line which begins with a hash is a preprocessor line
     // it doesn't have any meaning in our context and should be just ignored
 
@@ -764,7 +764,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void undef_works() {
+  void undef_works() {
     List<Token> tokens = lexer.lex("#define a b\n"
                                      + "#undef a\n"
                                      + "a\n");
@@ -775,7 +775,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void function_like_macros_in_if_expressions() {
+  void function_like_macros_in_if_expressions() {
     List<Token> tokens = lexer.lex("#define A() 0\n"
                                      + "#define B() 0\n"
                                      + "#if A() & B()\n"
@@ -791,7 +791,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void proper_expansion_of_function_like_macros_in_if_expressions() {
+  void proper_expansion_of_function_like_macros_in_if_expressions() {
     List<Token> tokens = lexer.lex("#define A() 0 ## 1\n"
                                      + "#if A()\n"
                                      + "truecase\n"
@@ -806,7 +806,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void problem_with_chained_defined_expressions() {
+  void problem_with_chained_defined_expressions() {
     List<Token> tokens = lexer.lex("#define _C_\n"
                                      + "#if !defined(_A_) && !defined(_B_) && !defined(_C_)\n"
                                      + "truecase\n"
@@ -821,7 +821,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void problem_evaluating_elif_expressions() {
+  void problem_evaluating_elif_expressions() {
     List<Token> tokens = lexer.lex("#define foo(a) 1\n"
                                      + "#if 0\n"
                                      + "body\n"
@@ -838,7 +838,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void built_in_macros() {
+  void built_in_macros() {
     List<Token> tokens = lexer.lex("__DATE__");
     var softly = new SoftAssertions();
     softly.assertThat(tokens).hasSize(2); // date + EOF
@@ -847,7 +847,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void dont_look_at_subsequent_clauses_if_elif() {
+  void dont_look_at_subsequent_clauses_if_elif() {
     // When a if clause has been evaluated to true, dont look at
     // subsequent elif clauses
     List<Token> tokens = lexer.lex("#define A 1\n"
@@ -864,7 +864,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void dont_look_at_subsequent_clauses_elif_elif() {
+  void dont_look_at_subsequent_clauses_elif_elif() {
     List<Token> tokens = lexer.lex("#define SDS_ARCH_darwin_15_i86\n"
                                      + "#ifdef SDS_ARCH_freebsd_61_i86\n"
                                      + "   case1\n"
@@ -898,7 +898,7 @@ public class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  public void string_problem_1903() {
+  void string_problem_1903() {
     List<Token> tokens = lexer.lex("void f1() {}\n"
                                      + "#define BROKEN_DEFINE \" /a/path/*\"\n"
                                      + "void f2() {}");

--- a/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexer_PreprocessorDisabled_Test.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexer_PreprocessorDisabled_Test.java
@@ -28,7 +28,7 @@ import static org.sonar.cxx.lexer.LexerAssert.assertThat;
 import org.sonar.cxx.parser.CxxLexer;
 import org.sonar.cxx.parser.CxxTokenType;
 
-public class CxxLexer_PreprocessorDisabled_Test {
+class CxxLexer_PreprocessorDisabled_Test {
 
   private Lexer lexer;
 
@@ -38,7 +38,7 @@ public class CxxLexer_PreprocessorDisabled_Test {
   }
 
   @Test
-  public void preprocessor_directives() {
+  void preprocessor_directives() {
     var softly = new SoftAssertions();
     softly.assertThat(lexer.lex("#include <iostream>")).anySatisfy(token -> assertThat(token).isValue(
       "#include <iostream>").hasType(CxxTokenType.PREPROCESSOR));
@@ -61,14 +61,14 @@ public class CxxLexer_PreprocessorDisabled_Test {
   }
 
   @Test
-  public void preprocessor_continued_define() {
+  void preprocessor_continued_define() {
     assertThat(lexer.lex("#define M\\\n"
                            + "0")).anySatisfy(token -> assertThat(token).isValue("#define M 0").hasType(
       CxxTokenType.PREPROCESSOR));
   }
 
   @Test
-  public void preprocessor_directive_with_comment() {
+  void preprocessor_directive_with_comment() {
     var softly = new SoftAssertions();
     softly.assertThat(lexer.lex("#define A B*/\n")).anySatisfy(token -> assertThat(token)
       .isValue("#define A B*/")

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/AssemblerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/AssemblerTest.java
@@ -24,14 +24,14 @@ import org.junit.jupiter.api.Test;
 public class AssemblerTest extends ParserBaseTestHelper {
 
   @Test
-  public void asmIsoStandard() {
+  void asmIsoStandard() {
     setRootRule(CxxGrammarImpl.asmDeclaration);
     assertThatParser()
       .matches("asm(\"mov eax, num\");");
   }
 
   @Test
-  public void asmGcc() {
+  void asmGcc() {
     setRootRule(CxxGrammarImpl.asmDeclaration);
     assertThatParser()
       .matches("asm(\"mov eax, num\");")
@@ -42,7 +42,7 @@ public class AssemblerTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void asmVcAssemblyInstruction1() {
+  void asmVcAssemblyInstruction1() {
     setRootRule(CxxGrammarImpl.asmDeclaration);
     assertThatParser()
       .matches("__asm mov eax, num ;")
@@ -50,7 +50,7 @@ public class AssemblerTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void asmVcAssemblyInstructionList1() {
+  void asmVcAssemblyInstructionList1() {
     setRootRule(CxxGrammarImpl.asmDeclaration);
     assertThatParser()
       .matches("__asm { mov eax, num }")
@@ -58,7 +58,7 @@ public class AssemblerTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void asmVcAssemblyInstructionList2() {
+  void asmVcAssemblyInstructionList2() {
     setRootRule(CxxGrammarImpl.asmDeclaration);
     assertThatParser()
       .matches("__asm { mov eax, num };")
@@ -66,7 +66,7 @@ public class AssemblerTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void asmVcAssemblyInstructionList3() {
+  void asmVcAssemblyInstructionList3() {
     setRootRule(CxxGrammarImpl.asmDeclaration);
     assertThatParser()
       .matches(
@@ -86,7 +86,7 @@ public class AssemblerTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void asmGccLabel() {
+  void asmGccLabel() {
     setRootRule(CxxGrammarImpl.asmLabel);
     assertThatParser()
       .matches("asm (\"myfoo\")")
@@ -94,7 +94,7 @@ public class AssemblerTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void asmGccLabel_reallife() {
+  void asmGccLabel_reallife() {
     setRootRule(CxxGrammarImpl.simpleDeclaration);
 
     assertThatParser()

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/AttributeTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/AttributeTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class AttributeTest extends ParserBaseTestHelper {
 
   @Test
-  public void classSpecifier_reallife() {
+  void classSpecifier_reallife() {
     setRootRule(CxxGrammarImpl.attributeSpecifierSeq);
 
     assertThatParser()

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/AttributedAtlTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/AttributedAtlTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class AttributedAtlTest extends ParserBaseTestHelper {
 
   @Test
-  public void vcAtlDeclaration() {
+  void vcAtlDeclaration() {
     setRootRule(CxxGrammarImpl.declaration);
 
     assertThatParser()
@@ -32,7 +32,7 @@ public class AttributedAtlTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void vcAtlEnum() {
+  void vcAtlEnum() {
     setRootRule(CxxGrammarImpl.enumSpecifier);
 
     assertThatParser()
@@ -40,7 +40,7 @@ public class AttributedAtlTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void vcAtlClass() {
+  void vcAtlClass() {
     setRootRule(CxxGrammarImpl.classSpecifier);
 
     assertThatParser()
@@ -49,7 +49,7 @@ public class AttributedAtlTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void vcAtlMember() {
+  void vcAtlMember() {
     setRootRule(CxxGrammarImpl.memberSpecification);
 
     assertThatParser()
@@ -57,7 +57,7 @@ public class AttributedAtlTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void vcAtlRealWorldExample() {
+  void vcAtlRealWorldExample() {
     setRootRule(CxxGrammarImpl.translationUnit);
 
     assertThatParser()

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/BalancedTokensTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/BalancedTokensTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class BalancedTokensTest extends ParserBaseTestHelper {
 
   @Test
-  public void attributeSpecifierSeq() {
+  void attributeSpecifierSeq() {
     setRootRule(CxxGrammarImpl.attributeSpecifierSeq);
     mockRule(CxxGrammarImpl.attributeSpecifier);
 
@@ -38,7 +38,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void attributeSpecifierSeq_reallife() {
+  void attributeSpecifierSeq_reallife() {
     setRootRule(CxxGrammarImpl.attributeSpecifierSeq);
 
     assertThatParser()
@@ -48,7 +48,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void attributeSpecifier() {
+  void attributeSpecifier() {
     setRootRule(CxxGrammarImpl.attributeSpecifier);
 
     mockRule(CxxGrammarImpl.attributeList);
@@ -62,7 +62,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void attributeSpecifier_reallife() {
+  void attributeSpecifier_reallife() {
     setRootRule(CxxGrammarImpl.attributeSpecifier);
 
     assertThatParser()
@@ -70,7 +70,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void alignmentSpecifier() {
+  void alignmentSpecifier() {
     setRootRule(CxxGrammarImpl.alignmentSpecifier);
 
     mockRule(CxxGrammarImpl.typeId);
@@ -87,7 +87,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void attributeUsingPrefix() {
+  void attributeUsingPrefix() {
     setRootRule(CxxGrammarImpl.attributeUsingPrefix);
     mockRule(CxxGrammarImpl.attributeNamespace);
 
@@ -96,7 +96,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void attributeList() {
+  void attributeList() {
     setRootRule(CxxGrammarImpl.attributeList);
     mockRule(CxxGrammarImpl.attribute);
 
@@ -113,7 +113,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void attributeList_reallife() {
+  void attributeList_reallife() {
     setRootRule(CxxGrammarImpl.attributeList);
 
     assertThatParser()
@@ -125,7 +125,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void attribute() {
+  void attribute() {
     setRootRule(CxxGrammarImpl.attribute);
 
     mockRule(CxxGrammarImpl.attributeToken);
@@ -137,7 +137,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void attribute_reallife() {
+  void attribute_reallife() {
     setRootRule(CxxGrammarImpl.attribute);
 
     assertThatParser()
@@ -147,7 +147,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void attributeToken() {
+  void attributeToken() {
     setRootRule(CxxGrammarImpl.attributeToken);
     mockRule(CxxGrammarImpl.attributeScopedToken);
 
@@ -157,7 +157,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void attributeScopedToken() {
+  void attributeScopedToken() {
     setRootRule(CxxGrammarImpl.attributeScopedToken);
     mockRule(CxxGrammarImpl.attributeNamespace);
 
@@ -166,7 +166,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void attributeScopedToken_reallife() {
+  void attributeScopedToken_reallife() {
     setRootRule(CxxGrammarImpl.attributeScopedToken);
 
     assertThatParser()
@@ -174,7 +174,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void attributeNamespace() {
+  void attributeNamespace() {
     setRootRule(CxxGrammarImpl.attributeNamespace);
 
     assertThatParser()
@@ -182,7 +182,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void attributeArgumentClause() {
+  void attributeArgumentClause() {
     setRootRule(CxxGrammarImpl.attributeArgumentClause);
     mockRule(CxxGrammarImpl.balancedTokenSeq);
 
@@ -191,7 +191,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void attributeArgumentClause_reallife() {
+  void attributeArgumentClause_reallife() {
     setRootRule(CxxGrammarImpl.attributeArgumentClause);
 
     assertThatParser()
@@ -199,7 +199,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void balancedTokenSeq() {
+  void balancedTokenSeq() {
     setRootRule(CxxGrammarImpl.balancedTokenSeq);
     mockRule(CxxGrammarImpl.balancedToken);
 
@@ -210,7 +210,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void balancedTokenSeq_reallife() {
+  void balancedTokenSeq_reallife() {
     setRootRule(CxxGrammarImpl.balancedTokenSeq);
 
     assertThatParser()
@@ -218,7 +218,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void balancedToken() {
+  void balancedToken() {
     setRootRule(CxxGrammarImpl.balancedToken);
     mockRule(CxxGrammarImpl.balancedTokenSeq);
 
@@ -230,7 +230,7 @@ public class BalancedTokensTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void balancedToken_reallife() {
+  void balancedToken_reallife() {
     setRootRule(CxxGrammarImpl.balancedToken);
 
     assertThatParser()

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/ClassesTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/ClassesTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class ClassesTest extends ParserBaseTestHelper {
 
   @Test
-  public void className_reallife() {
+  void className_reallife() {
     setRootRule(CxxGrammarImpl.className);
 
     assertThatParser()
@@ -32,7 +32,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void classSpecifier_reallife() {
+  void classSpecifier_reallife() {
     setRootRule(CxxGrammarImpl.classSpecifier);
 
     assertThatParser()
@@ -42,7 +42,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void classHead() {
+  void classHead() {
     setRootRule(CxxGrammarImpl.classHead);
 
     mockRule(CxxGrammarImpl.classKey);
@@ -62,7 +62,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void classHeadName() {
+  void classHeadName() {
     setRootRule(CxxGrammarImpl.classHeadName);
 
     mockRule(CxxGrammarImpl.nestedNameSpecifier);
@@ -74,7 +74,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void memberSpecification() {
+  void memberSpecification() {
     setRootRule(CxxGrammarImpl.memberSpecification);
 
     mockRule(CxxGrammarImpl.memberDeclaration);
@@ -88,7 +88,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void memberSpecification_reallife() {
+  void memberSpecification_reallife() {
     setRootRule(CxxGrammarImpl.memberSpecification);
 
     assertThatParser()
@@ -99,7 +99,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void memberDeclaration() {
+  void memberDeclaration() {
     setRootRule(CxxGrammarImpl.memberDeclaration);
 
     mockRule(CxxGrammarImpl.attributeSpecifierSeq);
@@ -144,7 +144,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void memberDeclaration_reallife() {
+  void memberDeclaration_reallife() {
     setRootRule(CxxGrammarImpl.memberDeclaration);
 
     assertThatParser()
@@ -179,7 +179,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   ;
 
   @Test
-  public void memberDeclaratorList() {
+  void memberDeclaratorList() {
     setRootRule(CxxGrammarImpl.memberDeclaratorList);
 
     mockRule(CxxGrammarImpl.memberDeclarator);
@@ -190,7 +190,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void memberDeclaratorList_reallife() {
+  void memberDeclaratorList_reallife() {
     setRootRule(CxxGrammarImpl.memberDeclaratorList);
 
     assertThatParser()
@@ -198,7 +198,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void memberDeclarator() {
+  void memberDeclarator() {
     setRootRule(CxxGrammarImpl.memberDeclarator);
 
     mockRule(CxxGrammarImpl.declarator);
@@ -225,7 +225,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void memberDeclarator_reallife() {
+  void memberDeclarator_reallife() {
     setRootRule(CxxGrammarImpl.memberDeclarator);
 
     assertThatParser()
@@ -234,7 +234,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void virtSpecifierSeq() {
+  void virtSpecifierSeq() {
     setRootRule(CxxGrammarImpl.virtSpecifierSeq);
 
     mockRule(CxxGrammarImpl.virtSpecifier);
@@ -245,7 +245,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void virtSpecifierSeq_reallife() {
+  void virtSpecifierSeq_reallife() {
     setRootRule(CxxGrammarImpl.virtSpecifierSeq);
 
     assertThatParser()
@@ -256,7 +256,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void cliFunctionModifier_reallife() {
+  void cliFunctionModifier_reallife() {
     setRootRule(CxxGrammarImpl.cliFunctionModifier);
 
     assertThatParser()
@@ -266,7 +266,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void virtSpecifier() {
+  void virtSpecifier() {
     setRootRule(CxxGrammarImpl.virtSpecifier);
 
     assertThatParser()
@@ -275,7 +275,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void baseSpecifierList() {
+  void baseSpecifierList() {
     setRootRule(CxxGrammarImpl.baseSpecifierList);
 
     mockRule(CxxGrammarImpl.baseSpecifier);
@@ -289,7 +289,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void baseSpecifier() {
+  void baseSpecifier() {
     setRootRule(CxxGrammarImpl.baseSpecifier);
 
     mockRule(CxxGrammarImpl.classOrDecltype);
@@ -306,7 +306,7 @@ public class ClassesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void classOrDecltype() {
+  void classOrDecltype() {
     setRootRule(CxxGrammarImpl.classOrDecltype);
 
     mockRule(CxxGrammarImpl.nestedNameSpecifier);

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/CxxKeywordTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/CxxKeywordTest.java
@@ -22,10 +22,10 @@ package org.sonar.cxx.parser;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
-public class CxxKeywordTest {
+class CxxKeywordTest {
 
   @Test
-  public void test() {
+  void test() {
     var softly = new SoftAssertions();
     softly.assertThat(CxxKeyword.values()).hasSize(91);
     softly.assertThat(CxxKeyword.keywordValues()).hasSize(CxxKeyword.values().length);

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/CxxParserTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/CxxParserTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 import org.sonar.cxx.config.CxxSquidConfiguration;
 import org.sonar.cxx.squidbridge.SquidAstVisitorContext;
 
-public class CxxParserTest {
+class CxxParserTest {
 
   private final String errSources = "/parser/bad/error_recovery_declaration.cc";
   private final String[] goodFiles = {"own", "VC", "GCC", "cli", "cuda", "examples"};
@@ -56,7 +56,7 @@ public class CxxParserTest {
   }
 
   @Test
-  public void testParsingCppSourceFiles() {
+  void testParsingCppSourceFiles() {
     var map = new HashMap<String, Integer>() {
       private static final long serialVersionUID = 6029310517902718597L;
 
@@ -109,7 +109,7 @@ public class CxxParserTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testPreproccessorParsingSourceFiles() {
+  void testPreproccessorParsingSourceFiles() {
     var includes = Arrays.asList(
       "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\INCLUDE",
       "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\ATLMFC\\INCLUDE",
@@ -147,7 +147,7 @@ public class CxxParserTest {
   }
 
   @Test
-  public void testParseErrorRecoveryDisabled() {
+  void testParseErrorRecoveryDisabled() {
     Parser<Grammar> p = createParser(null, false, null);
 
     // The error recovery works, if:
@@ -159,7 +159,7 @@ public class CxxParserTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testParseErrorRecoveryEnabled() {
+  void testParseErrorRecoveryEnabled() {
     var map = new HashMap<String, Integer>() {
       private static final long serialVersionUID = 3433381506274827684L;
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/CxxPunctuatorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/CxxPunctuatorTest.java
@@ -24,10 +24,10 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 
-public class CxxPunctuatorTest {
+class CxxPunctuatorTest {
 
   @Test
-  public void test() {
+  void test() {
     var softly = new SoftAssertions();
     softly.assertThat(CxxPunctuator.values()).hasSize(50);
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/CxxTokenTypeTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/CxxTokenTypeTest.java
@@ -22,10 +22,10 @@ package org.sonar.cxx.parser;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
-public class CxxTokenTypeTest {
+class CxxTokenTypeTest {
 
   @Test
-  public void test() {
+  void test() {
     var softly = new SoftAssertions();
     softly.assertThat(CxxTokenType.values()).hasSize(5);
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/DeclarationsTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/DeclarationsTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class DeclarationsTest extends ParserBaseTestHelper {
 
   @Test
-  public void declarationSeq() {
+  void declarationSeq() {
     setRootRule(CxxGrammarImpl.declarationSeq);
 
     mockRule(CxxGrammarImpl.declaration);
@@ -35,7 +35,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void declaration() {
+  void declaration() {
     setRootRule(CxxGrammarImpl.declaration);
 
     mockRule(CxxGrammarImpl.blockDeclaration);
@@ -69,7 +69,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void declaration_reallife() {
+  void declaration_reallife() {
     setRootRule(CxxGrammarImpl.declaration);
 
     assertThatParser()
@@ -106,7 +106,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void aliasDeclaration() {
+  void aliasDeclaration() {
     setRootRule(CxxGrammarImpl.aliasDeclaration);
 
     mockRule(CxxGrammarImpl.attributeSpecifierSeq);
@@ -118,7 +118,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void simpleDeclaration() {
+  void simpleDeclaration() {
     setRootRule(CxxGrammarImpl.simpleDeclaration);
 
     mockRule(CxxGrammarImpl.attributeSpecifierSeq);
@@ -141,7 +141,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void simpleDeclaration_reallife() {
+  void simpleDeclaration_reallife() {
     setRootRule(CxxGrammarImpl.simpleDeclaration);
 
     assertThatParser()
@@ -188,7 +188,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void staticAssertDeclaration() {
+  void staticAssertDeclaration() {
     setRootRule(CxxGrammarImpl.staticAssertDeclaration);
 
     mockRule(CxxGrammarImpl.constantExpression);
@@ -198,7 +198,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void declSpecifier() {
+  void declSpecifier() {
     setRootRule(CxxGrammarImpl.declSpecifier);
 
     mockRule(CxxGrammarImpl.storageClassSpecifier);
@@ -218,7 +218,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void declSpecifier_reallife() {
+  void declSpecifier_reallife() {
     setRootRule(CxxGrammarImpl.declSpecifier);
 
     assertThatParser()
@@ -254,7 +254,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void typeSpecifier_reallife() {
+  void typeSpecifier_reallife() {
     setRootRule(CxxGrammarImpl.typeSpecifier);
 
     assertThatParser()
@@ -263,7 +263,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void typeSpecifierSeq() {
+  void typeSpecifierSeq() {
     setRootRule(CxxGrammarImpl.typeSpecifierSeq);
 
     mockRule(CxxGrammarImpl.typeSpecifier);
@@ -277,7 +277,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void typeSpecifierSeq_reallife() {
+  void typeSpecifierSeq_reallife() {
     setRootRule(CxxGrammarImpl.typeSpecifierSeq);
 
     assertThatParser()
@@ -286,7 +286,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void definingTypeSpecifier() {
+  void definingTypeSpecifier() {
     setRootRule(CxxGrammarImpl.definingTypeSpecifier);
 
     mockRule(CxxGrammarImpl.typeSpecifier);
@@ -300,7 +300,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void definingTypeSpecifierSeq() {
+  void definingTypeSpecifierSeq() {
     setRootRule(CxxGrammarImpl.definingTypeSpecifierSeq);
 
     mockRule(CxxGrammarImpl.definingTypeSpecifier);
@@ -314,7 +314,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void simpleTypeSpecifier() {
+  void simpleTypeSpecifier() {
     setRootRule(CxxGrammarImpl.simpleTypeSpecifier);
 
     mockRule(CxxGrammarImpl.typeName);
@@ -350,7 +350,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void simpleTypeSpecifier_reallife() {
+  void simpleTypeSpecifier_reallife() {
     setRootRule(CxxGrammarImpl.simpleTypeSpecifier);
 
     assertThatParser()
@@ -358,7 +358,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void typeName() {
+  void typeName() {
     setRootRule(CxxGrammarImpl.typeName);
 
     mockRule(CxxGrammarImpl.className);
@@ -372,7 +372,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void typeName_reallife() {
+  void typeName_reallife() {
     setRootRule(CxxGrammarImpl.typeName);
 
     assertThatParser()
@@ -380,7 +380,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void decltypeSpecifier() {
+  void decltypeSpecifier() {
     setRootRule(CxxGrammarImpl.decltypeSpecifier);
 
     mockRule(CxxGrammarImpl.expression);
@@ -391,7 +391,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void placeholderTypeSpecifier() {
+  void placeholderTypeSpecifier() {
     setRootRule(CxxGrammarImpl.placeholderTypeSpecifier);
 
     mockRule(CxxGrammarImpl.className);
@@ -404,7 +404,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void elaboratedTypeSpecifier() {
+  void elaboratedTypeSpecifier() {
     setRootRule(CxxGrammarImpl.elaboratedTypeSpecifier);
 
     mockRule(CxxGrammarImpl.classKey);
@@ -425,7 +425,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void elaboratedTypeSpecifier_reallife() {
+  void elaboratedTypeSpecifier_reallife() {
     setRootRule(CxxGrammarImpl.elaboratedTypeSpecifier);
 
     assertThatParser()
@@ -433,7 +433,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void enumSpecifier() {
+  void enumSpecifier() {
     setRootRule(CxxGrammarImpl.enumSpecifier);
 
     mockRule(CxxGrammarImpl.enumHead);
@@ -447,7 +447,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void enumSpecifier_reallife() {
+  void enumSpecifier_reallife() {
     setRootRule(CxxGrammarImpl.enumSpecifier);
 
     assertThatParser()
@@ -469,7 +469,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void enumHead() {
+  void enumHead() {
     setRootRule(CxxGrammarImpl.enumHead);
 
     mockRule(CxxGrammarImpl.enumKey);
@@ -489,7 +489,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void enumHeadName() {
+  void enumHeadName() {
     setRootRule(CxxGrammarImpl.enumHeadName);
 
     mockRule(CxxGrammarImpl.nestedNameSpecifier);
@@ -500,7 +500,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void opaqueEnumDeclaration() {
+  void opaqueEnumDeclaration() {
     setRootRule(CxxGrammarImpl.opaqueEnumDeclaration);
 
     mockRule(CxxGrammarImpl.enumKey);
@@ -516,7 +516,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void enumKey() {
+  void enumKey() {
     setRootRule(CxxGrammarImpl.enumKey);
 
     assertThatParser()
@@ -526,7 +526,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void enumBase() {
+  void enumBase() {
     setRootRule(CxxGrammarImpl.enumBase);
     mockRule(CxxGrammarImpl.typeSpecifierSeq);
 
@@ -535,7 +535,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void enumeratorList() {
+  void enumeratorList() {
     setRootRule(CxxGrammarImpl.enumeratorList);
 
     mockRule(CxxGrammarImpl.enumeratorDefinition);
@@ -546,7 +546,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void enumeratorDefinition() {
+  void enumeratorDefinition() {
     setRootRule(CxxGrammarImpl.enumeratorDefinition);
 
     mockRule(CxxGrammarImpl.enumerator);
@@ -558,7 +558,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void enumerator() {
+  void enumerator() {
     setRootRule(CxxGrammarImpl.enumerator);
     mockRule(CxxGrammarImpl.attributeSpecifierSeq);
 
@@ -568,7 +568,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void namespaceDefinition() {
+  void namespaceDefinition() {
     setRootRule(CxxGrammarImpl.namespaceDefinition);
 
     mockRule(CxxGrammarImpl.namedNamespaceDefinition);
@@ -582,7 +582,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void enclosingNamespaceSpecifier() {
+  void enclosingNamespaceSpecifier() {
     setRootRule(CxxGrammarImpl.enclosingNamespaceSpecifier);
 
     assertThatParser()
@@ -594,7 +594,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void namespaceDefinition_reallife() {
+  void namespaceDefinition_reallife() {
     setRootRule(CxxGrammarImpl.namespaceDefinition);
 
     assertThatParser()
@@ -605,7 +605,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void usingDeclaration() {
+  void usingDeclaration() {
     setRootRule(CxxGrammarImpl.usingDeclaration);
     mockRule(CxxGrammarImpl.usingDeclaratorList);
 
@@ -614,7 +614,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void usingDeclaratorList() {
+  void usingDeclaratorList() {
     setRootRule(CxxGrammarImpl.usingDeclaratorList);
     mockRule(CxxGrammarImpl.usingDeclarator);
 
@@ -627,7 +627,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void usingDeclarator() {
+  void usingDeclarator() {
     setRootRule(CxxGrammarImpl.usingDeclarator);
 
     mockRule(CxxGrammarImpl.nestedNameSpecifier);
@@ -639,7 +639,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void usingDirective() {
+  void usingDirective() {
     setRootRule(CxxGrammarImpl.usingDirective);
 
     assertThatParser()
@@ -647,7 +647,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void linkageSpecification() {
+  void linkageSpecification() {
     setRootRule(CxxGrammarImpl.linkageSpecification);
 
     mockRule(CxxGrammarImpl.declaration);
@@ -659,7 +659,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void propertyDeclaration() {
+  void propertyDeclaration() {
     setRootRule(CxxGrammarImpl.cliPropertyDefinition);
 
     mockRule(CxxGrammarImpl.cliAttributes);
@@ -692,7 +692,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void accessorSpecificationDeclaration() {
+  void accessorSpecificationDeclaration() {
     setRootRule(CxxGrammarImpl.cliAccessorSpecification);
 
     mockRule(CxxGrammarImpl.cliAccessorDeclaration);
@@ -707,7 +707,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void eventDeclaration() {
+  void eventDeclaration() {
     setRootRule(CxxGrammarImpl.cliEventDefinition);
 
     mockRule(CxxGrammarImpl.cliAttributes);
@@ -725,7 +725,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void eventTypeDeclaration() {
+  void eventTypeDeclaration() {
     setRootRule(CxxGrammarImpl.cliEventType);
 
     mockRule(CxxGrammarImpl.nestedNameSpecifier);
@@ -742,7 +742,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void cliAttributesDefinition() {
+  void cliAttributesDefinition() {
     setRootRule(CxxGrammarImpl.cliAttributes);
 
     mockRule(CxxGrammarImpl.typeName);
@@ -760,7 +760,7 @@ public class DeclarationsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void cliAttributesDefinition_reallife() {
+  void cliAttributesDefinition_reallife() {
     setRootRule(CxxGrammarImpl.cliAttributes);
 
     assertThatParser()

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/DeclaratorsTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/DeclaratorsTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class DeclaratorsTest extends ParserBaseTestHelper {
 
   @Test
-  public void initDeclarator() {
+  void initDeclarator() {
     setRootRule(CxxGrammarImpl.initDeclarator);
 
     mockRule(CxxGrammarImpl.declarator);
@@ -41,7 +41,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void initDeclaratorList() {
+  void initDeclaratorList() {
     setRootRule(CxxGrammarImpl.initDeclaratorList);
 
     mockRule(CxxGrammarImpl.initDeclarator);
@@ -52,7 +52,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void initDeclaratorList_reallife() {
+  void initDeclaratorList_reallife() {
     setRootRule(CxxGrammarImpl.initDeclaratorList);
 
     assertThatParser()
@@ -61,7 +61,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void initDeclarator_reallife() {
+  void initDeclarator_reallife() {
     setRootRule(CxxGrammarImpl.initDeclarator);
 
     assertThatParser()
@@ -70,7 +70,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void declarator() {
+  void declarator() {
     setRootRule(CxxGrammarImpl.declarator);
 
     mockRule(CxxGrammarImpl.ptrDeclarator);
@@ -84,7 +84,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void declarator_reallife() {
+  void declarator_reallife() {
     setRootRule(CxxGrammarImpl.declarator);
 
     assertThatParser()
@@ -99,7 +99,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void noptrDeclarator() {
+  void noptrDeclarator() {
     setRootRule(CxxGrammarImpl.noptrDeclarator);
 
     mockRule(CxxGrammarImpl.declaratorId);
@@ -121,7 +121,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void noptrDeclarator_reallife() {
+  void noptrDeclarator_reallife() {
     setRootRule(CxxGrammarImpl.noptrDeclarator);
 
     assertThatParser()
@@ -129,7 +129,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void parametersAndQualifiers() {
+  void parametersAndQualifiers() {
     setRootRule(CxxGrammarImpl.parametersAndQualifiers);
 
     mockRule(CxxGrammarImpl.parameterDeclarationClause);
@@ -147,7 +147,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void parametersAndQualifiers_reallife() {
+  void parametersAndQualifiers_reallife() {
     setRootRule(CxxGrammarImpl.parametersAndQualifiers);
 
     assertThatParser()
@@ -156,7 +156,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void ptrDeclarator() {
+  void ptrDeclarator() {
     setRootRule(CxxGrammarImpl.ptrDeclarator);
 
     mockRule(CxxGrammarImpl.noptrDeclarator);
@@ -170,7 +170,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void ptrDeclarator_reallife() {
+  void ptrDeclarator_reallife() {
     setRootRule(CxxGrammarImpl.ptrDeclarator);
 
     assertThatParser()
@@ -179,7 +179,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void ptrOperator() {
+  void ptrOperator() {
     setRootRule(CxxGrammarImpl.ptrOperator);
 
     mockRule(CxxGrammarImpl.attributeSpecifierSeq);
@@ -200,7 +200,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void ptrOperator_reallife() {
+  void ptrOperator_reallife() {
     setRootRule(CxxGrammarImpl.ptrOperator);
 
     assertThatParser()
@@ -208,7 +208,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void cvQualifierSeq() {
+  void cvQualifierSeq() {
     setRootRule(CxxGrammarImpl.cvQualifierSeq);
 
     mockRule(CxxGrammarImpl.cvQualifier);
@@ -219,7 +219,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void declaratorId() {
+  void declaratorId() {
     setRootRule(CxxGrammarImpl.declaratorId);
 
     mockRule(CxxGrammarImpl.idExpression);
@@ -230,7 +230,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void declaratorId_reallife() {
+  void declaratorId_reallife() {
     setRootRule(CxxGrammarImpl.declaratorId);
 
     assertThatParser()
@@ -239,7 +239,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void typeId() {
+  void typeId() {
     setRootRule(CxxGrammarImpl.typeId);
 
     mockRule(CxxGrammarImpl.typeSpecifierSeq);
@@ -251,7 +251,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void typeId_reallife() {
+  void typeId_reallife() {
     setRootRule(CxxGrammarImpl.typeId);
 
     assertThatParser()
@@ -264,7 +264,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void definingTypeId() {
+  void definingTypeId() {
     setRootRule(CxxGrammarImpl.definingTypeId);
 
     mockRule(CxxGrammarImpl.definingTypeSpecifierSeq);
@@ -276,7 +276,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void abstractDeclarator() {
+  void abstractDeclarator() {
     setRootRule(CxxGrammarImpl.abstractDeclarator);
 
     mockRule(CxxGrammarImpl.ptrAbstractDeclarator);
@@ -293,7 +293,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void ptrAbstractDeclarator() {
+  void ptrAbstractDeclarator() {
     setRootRule(CxxGrammarImpl.ptrAbstractDeclarator);
 
     mockRule(CxxGrammarImpl.noptrAbstractDeclarator);
@@ -308,7 +308,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void noptrAbstractDeclarator() {
+  void noptrAbstractDeclarator() {
     setRootRule(CxxGrammarImpl.noptrAbstractDeclarator);
 
     mockRule(CxxGrammarImpl.parametersAndQualifiers);
@@ -327,7 +327,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void abstractPackDeclarator() {
+  void abstractPackDeclarator() {
     setRootRule(CxxGrammarImpl.abstractPackDeclarator);
 
     mockRule(CxxGrammarImpl.noptrAbstractPackDeclarator);
@@ -340,7 +340,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void noptrAbstractPackDeclarator() {
+  void noptrAbstractPackDeclarator() {
     setRootRule(CxxGrammarImpl.noptrAbstractPackDeclarator);
 
     mockRule(CxxGrammarImpl.parametersAndQualifiers);
@@ -356,7 +356,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void parameterDeclarationList() {
+  void parameterDeclarationList() {
     setRootRule(CxxGrammarImpl.parameterDeclarationList);
 
     mockRule(CxxGrammarImpl.parameterDeclaration);
@@ -367,7 +367,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void parameterDeclarationList_reallife() {
+  void parameterDeclarationList_reallife() {
     setRootRule(CxxGrammarImpl.parameterDeclarationList);
 
     assertThatParser()
@@ -376,7 +376,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void parameterDeclarationClause() {
+  void parameterDeclarationClause() {
     setRootRule(CxxGrammarImpl.parameterDeclarationClause);
 
     mockRule(CxxGrammarImpl.parameterDeclarationList);
@@ -390,7 +390,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void parameterDeclarationClause_reallife() {
+  void parameterDeclarationClause_reallife() {
     setRootRule(CxxGrammarImpl.parameterDeclarationClause);
 
     assertThatParser()
@@ -399,7 +399,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void parameterDeclaration() {
+  void parameterDeclaration() {
     setRootRule(CxxGrammarImpl.parameterDeclaration);
 
     mockRule(CxxGrammarImpl.attributeSpecifierSeq);
@@ -422,7 +422,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void parameterDeclaration_reallife() {
+  void parameterDeclaration_reallife() {
     setRootRule(CxxGrammarImpl.parameterDeclaration);
 
     assertThatParser()
@@ -440,7 +440,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void functionDefinition() {
+  void functionDefinition() {
     setRootRule(CxxGrammarImpl.functionDefinition);
 
     mockRule(CxxGrammarImpl.attributeSpecifierSeq);
@@ -461,7 +461,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void functionDefinition_reallife() {
+  void functionDefinition_reallife() {
     setRootRule(CxxGrammarImpl.functionDefinition);
 
     assertThatParser()
@@ -487,7 +487,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void functionBody() {
+  void functionBody() {
     setRootRule(CxxGrammarImpl.functionBody);
 
     mockRule(CxxGrammarImpl.compoundStatement);
@@ -503,7 +503,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void functionBody_reallife() {
+  void functionBody_reallife() {
     setRootRule(CxxGrammarImpl.functionBody);
 
     assertThatParser()
@@ -513,7 +513,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void initializer_reallife() {
+  void initializer_reallife() {
     setRootRule(CxxGrammarImpl.initializer);
 
     assertThatParser()
@@ -522,7 +522,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void initializerClause_reallife() {
+  void initializerClause_reallife() {
     setRootRule(CxxGrammarImpl.initializerClause);
 
     assertThatParser()
@@ -531,7 +531,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void initializerClause() {
+  void initializerClause() {
     setRootRule(CxxGrammarImpl.initializerClause);
 
     mockRule(CxxGrammarImpl.assignmentExpression);
@@ -545,7 +545,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void initializerList() {
+  void initializerList() {
     setRootRule(CxxGrammarImpl.initializerList);
 
     mockRule(CxxGrammarImpl.initializerClause);
@@ -558,7 +558,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void initializerList_reallife() {
+  void initializerList_reallife() {
     setRootRule(CxxGrammarImpl.initializerList);
 
     assertThatParser()
@@ -566,7 +566,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void designatedInitializerList() {
+  void designatedInitializerList() {
     setRootRule(CxxGrammarImpl.designatedInitializerList);
 
     mockRule(CxxGrammarImpl.designatedInitializerClause);
@@ -577,7 +577,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void designatedInitializerClause_reallife() {
+  void designatedInitializerClause_reallife() {
     setRootRule(CxxGrammarImpl.designatedInitializerClause);
 
     assertThatParser()
@@ -591,7 +591,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void designator() {
+  void designator() {
     setRootRule(CxxGrammarImpl.designator);
 
     mockRule(CxxGrammarImpl.constantExpression);
@@ -608,7 +608,7 @@ public class DeclaratorsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void bracedInitList() {
+  void bracedInitList() {
     setRootRule(CxxGrammarImpl.bracedInitList);
 
     mockRule(CxxGrammarImpl.initializerList);

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/ExceptionHandlingTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/ExceptionHandlingTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class ExceptionHandlingTest extends ParserBaseTestHelper {
 
   @Test
-  public void exceptionDeclaration() {
+  void exceptionDeclaration() {
     setRootRule(CxxGrammarImpl.exceptionDeclaration);
 
     mockRule(CxxGrammarImpl.typeSpecifierSeq);
@@ -41,7 +41,7 @@ public class ExceptionHandlingTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void exceptionSpecification_reallife() {
+  void exceptionSpecification_reallife() {
     setRootRule(CxxGrammarImpl.noexceptSpecifier);
 
     assertThatParser()
@@ -50,7 +50,7 @@ public class ExceptionHandlingTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void typeIdList() {
+  void typeIdList() {
     setRootRule(CxxGrammarImpl.typeIdList);
 
     mockRule(CxxGrammarImpl.typeId);
@@ -64,7 +64,7 @@ public class ExceptionHandlingTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void noexceptSpecification() {
+  void noexceptSpecification() {
     setRootRule(CxxGrammarImpl.noexceptSpecifier);
 
     mockRule(CxxGrammarImpl.constantExpression);

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/ExpressionTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/ExpressionTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class ExpressionTest extends ParserBaseTestHelper {
 
   @Test
-  public void primaryExpression() {
+  void primaryExpression() {
     setRootRule(CxxGrammarImpl.primaryExpression);
 
     mockRule(CxxGrammarImpl.LITERAL);
@@ -46,7 +46,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void primaryExpression_reallife() {
+  void primaryExpression_reallife() {
     setRootRule(CxxGrammarImpl.primaryExpression);
 
     assertThatParser()
@@ -56,7 +56,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void foldExpression() {
+  void foldExpression() {
     setRootRule(CxxGrammarImpl.foldExpression);
 
     mockRule(CxxGrammarImpl.castExpression);
@@ -69,7 +69,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void requiresExpression() {
+  void requiresExpression() {
     setRootRule(CxxGrammarImpl.requiresExpression);
 
     mockRule(CxxGrammarImpl.requirementParameterList);
@@ -81,7 +81,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void requirementParameterList() {
+  void requirementParameterList() {
     setRootRule(CxxGrammarImpl.requirementParameterList);
 
     mockRule(CxxGrammarImpl.parameterDeclarationClause);
@@ -92,7 +92,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void requirementBody() {
+  void requirementBody() {
     setRootRule(CxxGrammarImpl.requirementBody);
 
     mockRule(CxxGrammarImpl.requirementSeq);
@@ -102,7 +102,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void requirementSeq() {
+  void requirementSeq() {
     setRootRule(CxxGrammarImpl.requirementSeq);
 
     mockRule(CxxGrammarImpl.requirement);
@@ -114,7 +114,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void requirement() {
+  void requirement() {
     setRootRule(CxxGrammarImpl.requirement);
 
     mockRule(CxxGrammarImpl.simpleRequirement);
@@ -130,7 +130,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void simpleRequirement() {
+  void simpleRequirement() {
     setRootRule(CxxGrammarImpl.simpleRequirement);
 
     mockRule(CxxGrammarImpl.expression);
@@ -140,7 +140,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void typeRequirement() {
+  void typeRequirement() {
     setRootRule(CxxGrammarImpl.typeRequirement);
 
     mockRule(CxxGrammarImpl.nestedNameSpecifier);
@@ -152,7 +152,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void compoundRequirement() {
+  void compoundRequirement() {
     setRootRule(CxxGrammarImpl.compoundRequirement);
 
     mockRule(CxxGrammarImpl.expression);
@@ -175,7 +175,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void nestedRequirement() {
+  void nestedRequirement() {
     setRootRule(CxxGrammarImpl.nestedRequirement);
 
     mockRule(CxxGrammarImpl.constraintExpression);
@@ -185,7 +185,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void idExpression_reallife() {
+  void idExpression_reallife() {
     setRootRule(CxxGrammarImpl.idExpression);
 
     assertThatParser()
@@ -195,7 +195,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void unqualifiedId() {
+  void unqualifiedId() {
     setRootRule(CxxGrammarImpl.unqualifiedId);
 
     mockRule(CxxGrammarImpl.operatorFunctionId);
@@ -216,7 +216,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void unqualifiedId_reallife() {
+  void unqualifiedId_reallife() {
     setRootRule(CxxGrammarImpl.unqualifiedId);
 
     assertThatParser()
@@ -225,7 +225,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void qualifiedId() {
+  void qualifiedId() {
     setRootRule(CxxGrammarImpl.qualifiedId);
 
     mockRule(CxxGrammarImpl.nestedNameSpecifier);
@@ -237,7 +237,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void qualifiedId_reallife() {
+  void qualifiedId_reallife() {
     setRootRule(CxxGrammarImpl.qualifiedId);
 
     assertThatParser()
@@ -245,7 +245,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void nestedNameSpecifier() {
+  void nestedNameSpecifier() {
     setRootRule(CxxGrammarImpl.nestedNameSpecifier);
 
     mockRule(CxxGrammarImpl.typeName);
@@ -284,7 +284,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void postfixExpression() {
+  void postfixExpression() {
     setRootRule(CxxGrammarImpl.postfixExpression);
 
     mockRule(CxxGrammarImpl.primaryExpression);
@@ -327,7 +327,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void postfixExpression_reallife() {
+  void postfixExpression_reallife() {
     setRootRule(CxxGrammarImpl.postfixExpression);
 
     assertThatParser()
@@ -346,7 +346,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void expressionList_reallife() {
+  void expressionList_reallife() {
     setRootRule(CxxGrammarImpl.expressionList);
 
     assertThatParser()
@@ -354,7 +354,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void unaryExpression() {
+  void unaryExpression() {
     setRootRule(CxxGrammarImpl.unaryExpression);
 
     mockRule(CxxGrammarImpl.postfixExpression);
@@ -376,7 +376,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void unaryExpression_reallife() {
+  void unaryExpression_reallife() {
     setRootRule(CxxGrammarImpl.unaryExpression);
 
     assertThatParser()
@@ -385,7 +385,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void newExpression() {
+  void newExpression() {
     setRootRule(CxxGrammarImpl.newExpression);
 
     mockRule(CxxGrammarImpl.newPlacement);
@@ -399,7 +399,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void newExpression_reallife() {
+  void newExpression_reallife() {
     setRootRule(CxxGrammarImpl.newExpression);
 
     assertThatParser()
@@ -418,7 +418,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void newDeclarator() {
+  void newDeclarator() {
     setRootRule(CxxGrammarImpl.newDeclarator);
 
     mockRule(CxxGrammarImpl.ptrOperator);
@@ -433,7 +433,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void noptrNewDeclarator() {
+  void noptrNewDeclarator() {
     setRootRule(CxxGrammarImpl.noptrNewDeclarator);
 
     mockRule(CxxGrammarImpl.expression);
@@ -448,7 +448,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void newInitializer() {
+  void newInitializer() {
     setRootRule(CxxGrammarImpl.newInitializer);
 
     mockRule(CxxGrammarImpl.expressionList);
@@ -461,7 +461,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void deleteExpression() {
+  void deleteExpression() {
     setRootRule(CxxGrammarImpl.deleteExpression);
 
     mockRule(CxxGrammarImpl.castExpression);
@@ -472,7 +472,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void expression() {
+  void expression() {
     setRootRule(CxxGrammarImpl.expression);
     mockRule(CxxGrammarImpl.assignmentExpression);
 
@@ -483,7 +483,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void expression_reallife() {
+  void expression_reallife() {
     setRootRule(CxxGrammarImpl.expression);
 
     assertThatParser()
@@ -506,7 +506,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void assignmentExpression() {
+  void assignmentExpression() {
     setRootRule(CxxGrammarImpl.assignmentExpression);
 
     mockRule(CxxGrammarImpl.conditionalExpression);
@@ -524,7 +524,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void assignmentExpression_reallife() {
+  void assignmentExpression_reallife() {
     setRootRule(CxxGrammarImpl.assignmentExpression);
 
     assertThatParser()
@@ -535,7 +535,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void logicalOrExpression() {
+  void logicalOrExpression() {
     setRootRule(CxxGrammarImpl.logicalOrExpression);
     mockRule(CxxGrammarImpl.logicalAndExpression);
 
@@ -546,7 +546,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void logicalOrExpression_reallife() {
+  void logicalOrExpression_reallife() {
     setRootRule(CxxGrammarImpl.logicalOrExpression);
 
     assertThatParser()
@@ -554,7 +554,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void conditionalExpression() {
+  void conditionalExpression() {
     setRootRule(CxxGrammarImpl.conditionalExpression);
 
     mockRule(CxxGrammarImpl.logicalOrExpression);
@@ -567,7 +567,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void constantExpression() {
+  void constantExpression() {
     setRootRule(CxxGrammarImpl.constantExpression);
 
     mockRule(CxxGrammarImpl.conditionalExpression);
@@ -577,7 +577,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void constantExpression_reallife() {
+  void constantExpression_reallife() {
     setRootRule(CxxGrammarImpl.constantExpression);
 
     assertThatParser()
@@ -585,7 +585,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void logicalAndExpression() {
+  void logicalAndExpression() {
     setRootRule(CxxGrammarImpl.logicalAndExpression);
     mockRule(CxxGrammarImpl.inclusiveOrExpression);
 
@@ -596,7 +596,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void inclusiveOrExpression() {
+  void inclusiveOrExpression() {
     setRootRule(CxxGrammarImpl.inclusiveOrExpression);
     mockRule(CxxGrammarImpl.exclusiveOrExpression);
 
@@ -607,7 +607,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void exclusiveOrExpression() {
+  void exclusiveOrExpression() {
     setRootRule(CxxGrammarImpl.exclusiveOrExpression);
     mockRule(CxxGrammarImpl.andExpression);
 
@@ -618,7 +618,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void andExpression() {
+  void andExpression() {
     setRootRule(CxxGrammarImpl.andExpression);
     mockRule(CxxGrammarImpl.equalityExpression);
 
@@ -629,7 +629,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void equalityExpression() {
+  void equalityExpression() {
     setRootRule(CxxGrammarImpl.equalityExpression);
     mockRule(CxxGrammarImpl.relationalExpression);
 
@@ -641,7 +641,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void relationalExpression() {
+  void relationalExpression() {
     setRootRule(CxxGrammarImpl.relationalExpression);
     mockRule(CxxGrammarImpl.compareExpression);
 
@@ -654,7 +654,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void shiftExpression() {
+  void shiftExpression() {
     setRootRule(CxxGrammarImpl.shiftExpression);
     mockRule(CxxGrammarImpl.additiveExpression);
 
@@ -665,7 +665,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void compareExpression() {
+  void compareExpression() {
     setRootRule(CxxGrammarImpl.compareExpression);
     mockRule(CxxGrammarImpl.shiftExpression);
 
@@ -675,7 +675,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void additiveExpression() {
+  void additiveExpression() {
     setRootRule(CxxGrammarImpl.additiveExpression);
     mockRule(CxxGrammarImpl.multiplicativeExpression);
 
@@ -686,7 +686,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void multiplicativeExpression() {
+  void multiplicativeExpression() {
     setRootRule(CxxGrammarImpl.multiplicativeExpression);
     mockRule(CxxGrammarImpl.pmExpression);
 
@@ -698,7 +698,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void multiplicativeExpression_reallive() {
+  void multiplicativeExpression_reallive() {
     setRootRule(CxxGrammarImpl.multiplicativeExpression);
 
     assertThatParser()
@@ -706,7 +706,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void pmExpression() {
+  void pmExpression() {
     setRootRule(CxxGrammarImpl.pmExpression);
     mockRule(CxxGrammarImpl.castExpression);
 
@@ -717,7 +717,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void castExpression() {
+  void castExpression() {
     setRootRule(CxxGrammarImpl.pmExpression);
 
     mockRule(CxxGrammarImpl.unaryExpression);
@@ -733,7 +733,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void castExpression_reallife() {
+  void castExpression_reallife() {
     setRootRule(CxxGrammarImpl.castExpression);
 
     assertThatParser()
@@ -754,7 +754,7 @@ public class ExpressionTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void yieldExpression() {
+  void yieldExpression() {
     setRootRule(CxxGrammarImpl.yieldExpression);
 
     mockRule(CxxGrammarImpl.assignmentExpression);

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/FileInputTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/FileInputTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class FileInputTest extends ParserBaseTestHelper {
 
   @Test
-  public void translationUnit() {
+  void translationUnit() {
     setRootRule(CxxGrammarImpl.translationUnit);
 
     mockRule(CxxGrammarImpl.declaration);

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/LamdaExpressionsTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/LamdaExpressionsTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 public class LamdaExpressionsTest extends ParserBaseTestHelper {
 
   @Test
-  public void lambdaExpression() {
+  void lambdaExpression() {
     setRootRule(CxxGrammarImpl.lambdaExpression);
 
     mockRule(CxxGrammarImpl.lambdaIntroducer);
@@ -44,7 +44,7 @@ public class LamdaExpressionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void lambdaExpression_reallife() {
+  void lambdaExpression_reallife() {
     setRootRule(CxxGrammarImpl.lambdaExpression);
 
     assertThatParser()
@@ -78,7 +78,7 @@ public class LamdaExpressionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void lambdaIntroducer() {
+  void lambdaIntroducer() {
     setRootRule(CxxGrammarImpl.lambdaIntroducer);
     mockRule(CxxGrammarImpl.lambdaCapture);
 
@@ -88,7 +88,7 @@ public class LamdaExpressionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void lambdaIntroducer_reallife() {
+  void lambdaIntroducer_reallife() {
     setRootRule(CxxGrammarImpl.lambdaIntroducer);
 
     assertThatParser()
@@ -101,7 +101,7 @@ public class LamdaExpressionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void lambdaCapture() {
+  void lambdaCapture() {
     setRootRule(CxxGrammarImpl.lambdaCapture);
 
     mockRule(CxxGrammarImpl.captureDefault);
@@ -114,7 +114,7 @@ public class LamdaExpressionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void captureDefault() {
+  void captureDefault() {
     setRootRule(CxxGrammarImpl.captureDefault);
 
     assertThatParser()
@@ -123,7 +123,7 @@ public class LamdaExpressionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void captureList() {
+  void captureList() {
     setRootRule(CxxGrammarImpl.captureList);
     mockRule(CxxGrammarImpl.capture);
 
@@ -133,7 +133,7 @@ public class LamdaExpressionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void capture() {
+  void capture() {
     setRootRule(CxxGrammarImpl.capture);
 
     mockRule(CxxGrammarImpl.simpleCapture);
@@ -145,7 +145,7 @@ public class LamdaExpressionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void simpleCapture() {
+  void simpleCapture() {
     setRootRule(CxxGrammarImpl.simpleCapture);
 
     assertThatParser()
@@ -158,7 +158,7 @@ public class LamdaExpressionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void initCapture() {
+  void initCapture() {
     setRootRule(CxxGrammarImpl.initCapture);
     mockRule(CxxGrammarImpl.initializer);
 
@@ -170,7 +170,7 @@ public class LamdaExpressionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void initCapture_reallife() {
+  void initCapture_reallife() {
     setRootRule(CxxGrammarImpl.initCapture);
 
     assertThatParser()
@@ -182,7 +182,7 @@ public class LamdaExpressionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void lambdaDeclarator() {
+  void lambdaDeclarator() {
     setRootRule(CxxGrammarImpl.lambdaDeclarator);
 
     mockRule(CxxGrammarImpl.parameterDeclarationClause);

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/ModuleTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/ModuleTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class ModuleTest extends ParserBaseTestHelper {
 
   @Test
-  public void translationUnit() {
+  void translationUnit() {
     setRootRule(CxxGrammarImpl.translationUnit);
 
     mockRule(CxxGrammarImpl.globalModuleFragment);
@@ -45,7 +45,7 @@ public class ModuleTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void translationUnit_reallife() {
+  void translationUnit_reallife() {
     setRootRule(CxxGrammarImpl.translationUnit);
 
     assertThatParser()
@@ -58,7 +58,7 @@ public class ModuleTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void moduleDeclaration() {
+  void moduleDeclaration() {
     setRootRule(CxxGrammarImpl.moduleDeclaration);
 
     mockRule(CxxGrammarImpl.moduleName);
@@ -73,7 +73,7 @@ public class ModuleTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void moduleDeclaration_reallife() {
+  void moduleDeclaration_reallife() {
     setRootRule(CxxGrammarImpl.moduleDeclaration);
 
     assertThatParser()
@@ -83,7 +83,7 @@ public class ModuleTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void moduleName() {
+  void moduleName() {
     setRootRule(CxxGrammarImpl.moduleName);
 
     mockRule(CxxGrammarImpl.moduleNameQualifier);
@@ -94,7 +94,7 @@ public class ModuleTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void modulePartition() {
+  void modulePartition() {
     setRootRule(CxxGrammarImpl.modulePartition);
 
     mockRule(CxxGrammarImpl.moduleNameQualifier);
@@ -105,7 +105,7 @@ public class ModuleTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void moduleNameQualifier() {
+  void moduleNameQualifier() {
     setRootRule(CxxGrammarImpl.moduleNameQualifier);
 
     assertThatParser()
@@ -114,7 +114,7 @@ public class ModuleTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void exportDeclaration() {
+  void exportDeclaration() {
     setRootRule(CxxGrammarImpl.exportDeclaration);
 
     mockRule(CxxGrammarImpl.declaration);
@@ -129,7 +129,7 @@ public class ModuleTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void exportDeclaration_reallife() {
+  void exportDeclaration_reallife() {
     setRootRule(CxxGrammarImpl.exportDeclaration);
 
     assertThatParser()
@@ -139,7 +139,7 @@ public class ModuleTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void moduleImportDeclaration() {
+  void moduleImportDeclaration() {
     setRootRule(CxxGrammarImpl.moduleImportDeclaration);
 
     mockRule(CxxGrammarImpl.moduleName);
@@ -154,7 +154,7 @@ public class ModuleTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void moduleImportDeclaration_reallife() {
+  void moduleImportDeclaration_reallife() {
     setRootRule(CxxGrammarImpl.moduleImportDeclaration);
 
     assertThatParser()
@@ -163,7 +163,7 @@ public class ModuleTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void globalModuleFragment() {
+  void globalModuleFragment() {
     setRootRule(CxxGrammarImpl.globalModuleFragment);
 
     mockRule(CxxGrammarImpl.declarationSeq);
@@ -174,7 +174,7 @@ public class ModuleTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void privateModuleFragment() {
+  void privateModuleFragment() {
     setRootRule(CxxGrammarImpl.privateModuleFragment);
 
     mockRule(CxxGrammarImpl.declarationSeq);

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/OverloadingTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/OverloadingTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class OverloadingTest extends ParserBaseTestHelper {
 
   @Test
-  public void operatorFunctionId_reallife() {
+  void operatorFunctionId_reallife() {
     setRootRule(CxxGrammarImpl.operatorFunctionId);
 
     assertThatParser()
@@ -32,7 +32,7 @@ public class OverloadingTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void operator() {
+  void operator() {
     setRootRule(CxxGrammarImpl.operator);
 
     assertThatParser()
@@ -46,7 +46,7 @@ public class OverloadingTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void literalOperatorId_reallife() {
+  void literalOperatorId_reallife() {
     setRootRule(CxxGrammarImpl.literalOperatorId);
 
     assertThatParser()

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/PreprocessorDirectivesTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/PreprocessorDirectivesTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
 
   @Test
-  public void preprocessorDirectives() {
+  void preprocessorDirectives() {
     assertThat(parse(
       "#define IDX 10\n"
         + "array[IDX];"))
@@ -33,7 +33,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void hashhash_related_parsing_problem1() {
+  void hashhash_related_parsing_problem1() {
     assertThat(parse(
       "#define CASES CASE(00)\n"
         + "#define CASE(n) case 0x##n:\n"
@@ -47,7 +47,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void hashhash_related_parsing_problem2() {
+  void hashhash_related_parsing_problem2() {
     assertThat(parse(
       "#define paster( n ) printf_s( \"token\" #n \" = %d\", token##n )\n"
         + "int token9 = 9;"
@@ -58,7 +58,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void object_like_macros() {
+  void object_like_macros() {
     assertThat(parse(
       "#define BUFFER_SIZE 1024\n"
         + "foo = (char *) malloc (BUFFER_SIZE);"))
@@ -95,7 +95,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void function_like_macros() {
+  void function_like_macros() {
     assertThat(parse(
       "#define lang_init() c_init()\n"
         + "lang_init();"))
@@ -115,7 +115,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void complex_macro_rescanning() {
+  void complex_macro_rescanning() {
     assertThat(parse(
       "#define lang_init std_init\n"
         + "#define std_init() c_init()\n"
@@ -149,7 +149,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void macro_arguments() {
+  void macro_arguments() {
     assertThat(parse(
       "#define min(X, Y)  ((X) < (Y) ? (X) : (Y))\n"
         + "int i = min(a + 28, *p);"))
@@ -162,7 +162,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void variadic_macros() {
+  void variadic_macros() {
     assertThat(parse(
       "#define eprintf(...) fprintf (stderr, __VA_ARGS__)\n"
         + "eprintf(\"%s:%d: \", input_file, lineno);"))
@@ -239,7 +239,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void va_opt_macros() {
+  void va_opt_macros() {
     // C++20 : Replacement-list may contain the token sequence __VA_OPT__ ( content ),
     // which is replaced by content if __VA_ARGS__ is non-empty, and expands to nothing otherwise.
 
@@ -269,7 +269,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void stringification() {
+  void stringification() {
     // default use case
     assertThat(parse(
       "#define make_string(x) #x\n"
@@ -341,7 +341,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void concatenation() {
+  void concatenation() {
     assertThat(parse(
       "#define A t ## 1\n"
         + "int i = A;"))
@@ -365,7 +365,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void undef() {
+  void undef() {
     assertThat(parse(
       "#define FOO 4\n"
         + "#undef FOO\n"
@@ -382,7 +382,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void redefining_macros() {
+  void redefining_macros() {
     assertThat(parse(
       "#define FOO 1\n"
         + "#define FOO 2\n"
@@ -391,7 +391,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void prescan() {
+  void prescan() {
     assertThat(parse(
       "#define AFTERX(x) X_ ## x\n"
         + "#define XAFTERX(x) AFTERX(x)\n"
@@ -412,7 +412,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void self_referential_macros() {
+  void self_referential_macros() {
     assertThat(parse(
       "#define EPERM EPERM\n"
         + "a = EPERM;"))
@@ -431,7 +431,7 @@ public class PreprocessorDirectivesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void has_include() {
+  void has_include() {
     assertThat(parse(
       "#if __has_include\n"
         + "#   define OK 1\n"

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/SpecialMemberFunctionsTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/SpecialMemberFunctionsTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class SpecialMemberFunctionsTest extends ParserBaseTestHelper {
 
   @Test
-  public void ctorInitializer_reallife() {
+  void ctorInitializer_reallife() {
     setRootRule(CxxGrammarImpl.ctorInitializer);
 
     assertThatParser()
@@ -32,7 +32,7 @@ public class SpecialMemberFunctionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void memInitializerList() {
+  void memInitializerList() {
     setRootRule(CxxGrammarImpl.memInitializerList);
 
     mockRule(CxxGrammarImpl.memInitializer);
@@ -45,7 +45,7 @@ public class SpecialMemberFunctionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void memInitializer() {
+  void memInitializer() {
     setRootRule(CxxGrammarImpl.memInitializer);
 
     mockRule(CxxGrammarImpl.memInitializerId);
@@ -59,7 +59,7 @@ public class SpecialMemberFunctionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void memInitializer_reallife() {
+  void memInitializer_reallife() {
     setRootRule(CxxGrammarImpl.memInitializer);
 
     assertThatParser()
@@ -67,7 +67,7 @@ public class SpecialMemberFunctionsTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void memInitializerId_reallife() {
+  void memInitializerId_reallife() {
     setRootRule(CxxGrammarImpl.memInitializerId);
 
     assertThatParser()

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/StatementTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/StatementTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class StatementTest extends ParserBaseTestHelper {
 
   @Test
-  public void statement() {
+  void statement() {
     setRootRule(CxxGrammarImpl.statement);
 
     mockRule(CxxGrammarImpl.labeledStatement);
@@ -50,7 +50,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void statement_reallife() {
+  void statement_reallife() {
     setRootRule(CxxGrammarImpl.statement);
 
     assertThatParser()
@@ -72,7 +72,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void expressionStatement_reallife() {
+  void expressionStatement_reallife() {
     setRootRule(CxxGrammarImpl.expressionStatement);
 
     assertThatParser()
@@ -83,7 +83,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void selectionStatement_reallife() {
+  void selectionStatement_reallife() {
     setRootRule(CxxGrammarImpl.selectionStatement);
 
     assertThatParser()
@@ -94,7 +94,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void labeledStatement() {
+  void labeledStatement() {
     setRootRule(CxxGrammarImpl.labeledStatement);
 
     mockRule(CxxGrammarImpl.attributeSpecifierSeq);
@@ -114,7 +114,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void statementSeq() {
+  void statementSeq() {
     setRootRule(CxxGrammarImpl.statementSeq);
 
     mockRule(CxxGrammarImpl.statement);
@@ -125,7 +125,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void selectionStatement() {
+  void selectionStatement() {
     setRootRule(CxxGrammarImpl.selectionStatement);
 
     mockRule(CxxGrammarImpl.statement);
@@ -146,7 +146,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void switchStatement_reallife() {
+  void switchStatement_reallife() {
     setRootRule(CxxGrammarImpl.selectionStatement);
 
     assertThatParser()
@@ -156,7 +156,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void ifStatement_reallife() {
+  void ifStatement_reallife() {
     setRootRule(CxxGrammarImpl.selectionStatement);
 
     assertThatParser()
@@ -164,7 +164,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void condition() {
+  void condition() {
     setRootRule(CxxGrammarImpl.condition);
 
     mockRule(CxxGrammarImpl.attributeSpecifierSeq);
@@ -183,7 +183,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void condition_reallife() {
+  void condition_reallife() {
     setRootRule(CxxGrammarImpl.condition);
 
     assertThatParser()
@@ -193,7 +193,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void iterationStatement() {
+  void iterationStatement() {
     setRootRule(CxxGrammarImpl.iterationStatement);
 
     mockRule(CxxGrammarImpl.condition);
@@ -214,7 +214,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void iterationStatement_reallife() {
+  void iterationStatement_reallife() {
     setRootRule(CxxGrammarImpl.iterationStatement);
 
     assertThatParser()
@@ -247,7 +247,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void forInitStatement_reallife() {
+  void forInitStatement_reallife() {
     setRootRule(CxxGrammarImpl.initStatement);
 
     assertThatParser()
@@ -255,7 +255,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void forRangeDeclaration() {
+  void forRangeDeclaration() {
     setRootRule(CxxGrammarImpl.forRangeDeclaration);
 
     mockRule(CxxGrammarImpl.forRangeDeclSpecifierSeq);
@@ -276,7 +276,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void forRangeInitializer() {
+  void forRangeInitializer() {
     setRootRule(CxxGrammarImpl.forRangeInitializer);
 
     mockRule(CxxGrammarImpl.expression);
@@ -288,7 +288,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void jumpStatement() {
+  void jumpStatement() {
     setRootRule(CxxGrammarImpl.jumpStatement);
 
     mockRule(CxxGrammarImpl.expression);
@@ -305,7 +305,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void jumpStatement_reallife() {
+  void jumpStatement_reallife() {
     setRootRule(CxxGrammarImpl.jumpStatement);
 
     assertThatParser()
@@ -313,7 +313,7 @@ public class StatementTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void coroutineReturnStatement() {
+  void coroutineReturnStatement() {
     setRootRule(CxxGrammarImpl.jumpStatement);
     mockRule(CxxGrammarImpl.exprOrBracedInitList);
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/TemplatesTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/TemplatesTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class TemplatesTest extends ParserBaseTestHelper {
 
   @Test
-  public void templateDeclaration() {
+  void templateDeclaration() {
     setRootRule(CxxGrammarImpl.templateDeclaration);
 
     mockRule(CxxGrammarImpl.templateHead);
@@ -37,7 +37,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void templateDeclaration_reallife() {
+  void templateDeclaration_reallife() {
     setRootRule(CxxGrammarImpl.templateDeclaration);
 
     assertThatParser()
@@ -55,7 +55,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void templateHead() {
+  void templateHead() {
     setRootRule(CxxGrammarImpl.templateHead);
 
     mockRule(CxxGrammarImpl.templateParameterList);
@@ -68,7 +68,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void templateHead_reallife() {
+  void templateHead_reallife() {
     setRootRule(CxxGrammarImpl.templateHead);
 
     assertThatParser()
@@ -79,7 +79,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void templateParameterList() {
+  void templateParameterList() {
     setRootRule(CxxGrammarImpl.templateParameterList);
 
     mockRule(CxxGrammarImpl.templateParameter);
@@ -90,7 +90,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void templateParameter() {
+  void templateParameter() {
     setRootRule(CxxGrammarImpl.templateParameter);
 
     mockRule(CxxGrammarImpl.typeParameter);
@@ -102,7 +102,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void templateParameter_reallife() {
+  void templateParameter_reallife() {
     setRootRule(CxxGrammarImpl.templateParameter);
 
     // type-parameter: type-parameter-key ...opt identifieropt
@@ -139,7 +139,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void requiresClause() {
+  void requiresClause() {
     setRootRule(CxxGrammarImpl.requiresClause);
 
     mockRule(CxxGrammarImpl.constraintLogicalOrExpression);
@@ -148,7 +148,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void constraintLogicalOrExpression() {
+  void constraintLogicalOrExpression() {
     setRootRule(CxxGrammarImpl.constraintLogicalOrExpression);
 
     mockRule(CxxGrammarImpl.constraintLogicalAndExpression);
@@ -159,7 +159,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void constraintLogicalAndExpression() {
+  void constraintLogicalAndExpression() {
     setRootRule(CxxGrammarImpl.constraintLogicalAndExpression);
 
     mockRule(CxxGrammarImpl.primaryExpression);
@@ -170,7 +170,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void typeParameter() {
+  void typeParameter() {
     setRootRule(CxxGrammarImpl.typeParameter);
 
     mockRule(CxxGrammarImpl.typeParameterKey);
@@ -199,7 +199,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void simpleTemplateId_reallife() {
+  void simpleTemplateId_reallife() {
     setRootRule(CxxGrammarImpl.simpleTemplateId);
 
     assertThatParser()
@@ -218,7 +218,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void typeConstraint() {
+  void typeConstraint() {
     setRootRule(CxxGrammarImpl.typeConstraint);
 
     mockRule(CxxGrammarImpl.nestedNameSpecifier);
@@ -235,7 +235,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void templateId() {
+  void templateId() {
     setRootRule(CxxGrammarImpl.templateId);
 
     mockRule(CxxGrammarImpl.simpleTemplateId);
@@ -252,7 +252,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void templateId_reallife() {
+  void templateId_reallife() {
     setRootRule(CxxGrammarImpl.templateId);
 
     assertThatParser()
@@ -261,7 +261,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void templateArgumentList() {
+  void templateArgumentList() {
     setRootRule(CxxGrammarImpl.templateArgumentList);
 
     mockRule(CxxGrammarImpl.templateArgument);
@@ -274,7 +274,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void conceptDefinition() {
+  void conceptDefinition() {
     setRootRule(CxxGrammarImpl.conceptDefinition);
 
     mockRule(CxxGrammarImpl.conceptName);
@@ -284,7 +284,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void typenameSpecifier() {
+  void typenameSpecifier() {
     setRootRule(CxxGrammarImpl.typenameSpecifier);
 
     mockRule(CxxGrammarImpl.nestedNameSpecifier);
@@ -298,7 +298,7 @@ public class TemplatesTest extends ParserBaseTestHelper {
   }
 
   @Test
-  public void deductionGuide() {
+  void deductionGuide() {
     setRootRule(CxxGrammarImpl.deductionGuide);
 
     mockRule(CxxGrammarImpl.explicitSpecifier);

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppGrammarImplTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppGrammarImplTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sslr.grammar.GrammarRuleKey;
 import static org.sonar.cxx.sslr.tests.Assertions.assertThat;
 
-public class CppGrammarImplTest {
+class CppGrammarImplTest {
 
   private final Parser<Grammar> p = Parser.builder(CppGrammarImpl.create())
     .withLexer(CppLexer.create())
@@ -34,7 +34,7 @@ public class CppGrammarImplTest {
   private final Grammar g = p.getGrammar();
 
   @Test
-  public void preprocessorLine() {
+  void preprocessorLine() {
     mockRule(CppGrammarImpl.defineLine);
     mockRule(CppGrammarImpl.includeLine);
     mockRule(CppGrammarImpl.ifdefLine);
@@ -63,7 +63,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void preprocessorLine_reallife() {
+  void preprocessorLine_reallife() {
     assertThat(p).matches("#include      <ace/config-all.h>");
     assertThat(p).matches("#endif  // LLVM_DEBUGINFO_DWARFDEBUGRANGELIST_H");
     assertThat(p).matches(
@@ -74,7 +74,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void defineLine_reallife() {
+  void defineLine_reallife() {
     p.setRootRule(g.rule(CppGrammarImpl.defineLine));
 
     assertThat(p).matches("#define ALGOSTUFF_HPPEOF");
@@ -87,13 +87,13 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void define_containing_argumentList() {
+  void define_containing_argumentList() {
     AstNode define = p.parse("#define lala(a, b) a b");
     org.assertj.core.api.Assertions.assertThat(define.getDescendants(CppGrammarImpl.parameterList)).isNotNull();
   }
 
   @Test
-  public void functionlikeMacroDefinition() {
+  void functionlikeMacroDefinition() {
     p.setRootRule(g.rule(CppGrammarImpl.functionlikeMacroDefinition));
 
     mockRule(CppGrammarImpl.replacementList);
@@ -109,7 +109,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void functionlikeMacroDefinition_reallife() {
+  void functionlikeMacroDefinition_reallife() {
     p.setRootRule(g.rule(CppGrammarImpl.functionlikeMacroDefinition));
 
     assertThat(p).matches("#define foo() bar");
@@ -119,7 +119,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void objectlikeMacroDefinition() {
+  void objectlikeMacroDefinition() {
     p.setRootRule(g.rule(CppGrammarImpl.objectlikeMacroDefinition));
 
     mockRule(CppGrammarImpl.replacementList);
@@ -129,7 +129,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void objectlikeMacroDefinition_reallife() {
+  void objectlikeMacroDefinition_reallife() {
     p.setRootRule(g.rule(CppGrammarImpl.objectlikeMacroDefinition));
 
     assertThat(p).matches("#define foo");
@@ -139,7 +139,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void replacementList() {
+  void replacementList() {
     p.setRootRule(g.rule(CppGrammarImpl.replacementList));
 
     assertThat(p).matches("");
@@ -153,7 +153,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void argumentList() {
+  void argumentList() {
     p.setRootRule(g.rule(CppGrammarImpl.argumentList));
 
     assertThat(p).matches("foo");
@@ -164,7 +164,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void argument() {
+  void argument() {
     p.setRootRule(g.rule(CppGrammarImpl.argument));
 
     assertThat(p).matches("a");
@@ -173,7 +173,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void somethingContainingParantheses() {
+  void somethingContainingParantheses() {
     p.setRootRule(g.rule(CppGrammarImpl.somethingContainingParantheses));
 
     assertThat(p).matches("call()");
@@ -181,14 +181,14 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void somethingWithoutParantheses() {
+  void somethingWithoutParantheses() {
     p.setRootRule(g.rule(CppGrammarImpl.somethingWithoutParantheses));
 
     assertThat(p).matches("abc");
   }
 
   @Test
-  public void ppToken() {
+  void ppToken() {
     p.setRootRule(g.rule(CppGrammarImpl.ppToken));
 
     assertThat(p).matches("foo");
@@ -198,7 +198,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void includeLine() {
+  void includeLine() {
     p.setRootRule(g.rule(CppGrammarImpl.includeLine));
 
     mockRule(CppGrammarImpl.ppToken);
@@ -210,7 +210,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void importLine_reallife() {
+  void importLine_reallife() {
     p.setRootRule(g.rule(CppGrammarImpl.ppImport));
 
     assertThat(p).matches("import foo;");
@@ -223,7 +223,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void moduleLine_reallife() {
+  void moduleLine_reallife() {
     p.setRootRule(g.rule(CppGrammarImpl.ppModule));
 
     assertThat(p).matches("module;");
@@ -233,7 +233,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void expandedIncludeBody() {
+  void expandedIncludeBody() {
     p.setRootRule(g.rule(CppGrammarImpl.expandedIncludeBody));
 
     mockRule(CppGrammarImpl.ppToken);
@@ -243,7 +243,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void includeLine_reallife() {
+  void includeLine_reallife() {
     p.setRootRule(g.rule(CppGrammarImpl.includeLine));
 
     assertThat(p).matches("#include <file>");
@@ -263,7 +263,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void ifdefLine() {
+  void ifdefLine() {
     p.setRootRule(g.rule(CppGrammarImpl.ifdefLine));
 
     assertThat(p).matches("#ifdef foo");
@@ -273,7 +273,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void elseLine() {
+  void elseLine() {
     p.setRootRule(g.rule(CppGrammarImpl.elseLine));
 
     assertThat(p).matches("#else");
@@ -281,7 +281,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void endifLine() {
+  void endifLine() {
     p.setRootRule(g.rule(CppGrammarImpl.endifLine));
 
     assertThat(p).matches("#endif");
@@ -289,21 +289,21 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void undefLine() {
+  void undefLine() {
     p.setRootRule(g.rule(CppGrammarImpl.undefLine));
 
     assertThat(p).matches("#undef foo");
   }
 
   @Test
-  public void lineLine() {
+  void lineLine() {
     p.setRootRule(g.rule(CppGrammarImpl.lineLine));
 
     assertThat(p).matches("#line foo bar");
   }
 
   @Test
-  public void errorLine() {
+  void errorLine() {
     p.setRootRule(g.rule(CppGrammarImpl.errorLine));
 
     assertThat(p).matches("#error foo");
@@ -311,21 +311,21 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void pragmaLine() {
+  void pragmaLine() {
     p.setRootRule(g.rule(CppGrammarImpl.pragmaLine));
 
     assertThat(p).matches("#pragma foo");
   }
 
   @Test
-  public void warningLine() {
+  void warningLine() {
     p.setRootRule(g.rule(CppGrammarImpl.warningLine));
 
     assertThat(p).matches("#warning foo");
   }
 
   @Test
-  public void miscLine() {
+  void miscLine() {
     p.setRootRule(g.rule(CppGrammarImpl.miscLine));
 
     assertThat(p).matches("#");
@@ -334,7 +334,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void ifLine() {
+  void ifLine() {
     p.setRootRule(g.rule(CppGrammarImpl.ifLine));
 
     mockRule(CppGrammarImpl.constantExpression);
@@ -343,7 +343,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void elifLine() {
+  void elifLine() {
     p.setRootRule(g.rule(CppGrammarImpl.elifLine));
 
     mockRule(CppGrammarImpl.constantExpression);
@@ -352,7 +352,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void ifLine_reallive() {
+  void ifLine_reallive() {
     p.setRootRule(g.rule(CppGrammarImpl.ifLine));
 
     assertThat(p).matches(
@@ -370,7 +370,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void constantExpression() {
+  void constantExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.constantExpression));
 
     mockRule(CppGrammarImpl.conditionalExpression);
@@ -379,7 +379,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void constantExpression_reallive() {
+  void constantExpression_reallive() {
     p.setRootRule(g.rule(CppGrammarImpl.constantExpression));
 
     assertThat(p).matches("(1 || 0) && (0 && 1)");
@@ -391,7 +391,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void conditionalExpression() {
+  void conditionalExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.conditionalExpression));
 
     mockRule(CppGrammarImpl.logicalOrExpression);
@@ -403,7 +403,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void logicalOrExpression() {
+  void logicalOrExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.logicalOrExpression));
 
     mockRule(CppGrammarImpl.logicalAndExpression);
@@ -413,7 +413,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void logicalAndExpression() {
+  void logicalAndExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.logicalAndExpression));
 
     mockRule(CppGrammarImpl.inclusiveOrExpression);
@@ -423,14 +423,14 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void logicalAndExpression_reallive() {
+  void logicalAndExpression_reallive() {
     p.setRootRule(g.rule(CppGrammarImpl.logicalAndExpression));
 
     assertThat(p).matches("A() && B()");
   }
 
   @Test
-  public void inclusiveOrExpression() {
+  void inclusiveOrExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.inclusiveOrExpression));
 
     mockRule(CppGrammarImpl.exclusiveOrExpression);
@@ -440,7 +440,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void exclusiveOrExpression() {
+  void exclusiveOrExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.exclusiveOrExpression));
 
     mockRule(CppGrammarImpl.andExpression);
@@ -450,7 +450,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void andExpression() {
+  void andExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.andExpression));
 
     mockRule(CppGrammarImpl.equalityExpression);
@@ -460,7 +460,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void equalityExpression() {
+  void equalityExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.equalityExpression));
 
     mockRule(CppGrammarImpl.relationalExpression);
@@ -471,7 +471,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void relationalExpression() {
+  void relationalExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.relationalExpression));
 
     mockRule(CppGrammarImpl.shiftExpression);
@@ -484,7 +484,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void shiftExpression() {
+  void shiftExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.shiftExpression));
 
     mockRule(CppGrammarImpl.additiveExpression);
@@ -495,7 +495,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void additiveExpression() {
+  void additiveExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.additiveExpression));
 
     mockRule(CppGrammarImpl.multiplicativeExpression);
@@ -506,7 +506,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void multiplicativeExpression() {
+  void multiplicativeExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.multiplicativeExpression));
 
     mockRule(CppGrammarImpl.unaryExpression);
@@ -518,7 +518,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void unaryExpression() {
+  void unaryExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.unaryExpression));
 
     mockRule(CppGrammarImpl.multiplicativeExpression);
@@ -530,7 +530,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void primaryExpression() {
+  void primaryExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.primaryExpression));
 
     mockRule(CppGrammarImpl.literal);
@@ -546,14 +546,14 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void primaryExpression_reallive() {
+  void primaryExpression_reallive() {
     p.setRootRule(g.rule(CppGrammarImpl.primaryExpression));
 
     assertThat(p).matches("(C(A() && B()))");
   }
 
   @Test
-  public void expression() {
+  void expression() {
     p.setRootRule(g.rule(CppGrammarImpl.expression));
 
     mockRule(CppGrammarImpl.conditionalExpression);
@@ -563,14 +563,14 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void expression_reallive() {
+  void expression_reallive() {
     p.setRootRule(g.rule(CppGrammarImpl.expression));
 
     assertThat(p).matches("C(A() && B())");
   }
 
   @Test
-  public void definedExpression() {
+  void definedExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.definedExpression));
 
     assertThat(p).matches("defined LALA");
@@ -582,7 +582,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void functionlikeMacro() {
+  void functionlikeMacro() {
     p.setRootRule(g.rule(CppGrammarImpl.functionlikeMacro));
 
     mockRule(CppGrammarImpl.argumentList);
@@ -591,7 +591,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void hasIncludeExpression() {
+  void hasIncludeExpression() {
     p.setRootRule(g.rule(CppGrammarImpl.hasIncludeExpression));
 
     mockRule(CppGrammarImpl.includeBodyBracketed);
@@ -602,7 +602,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void hasIncludeExpression_reallife() {
+  void hasIncludeExpression_reallife() {
     p.setRootRule(g.rule(CppGrammarImpl.hasIncludeExpression));
 
     assertThat(p).matches("__has_include( <optional> )");
@@ -610,7 +610,7 @@ public class CppGrammarImplTest {
   }
 
   @Test
-  public void functionlikeMacro_reallife() {
+  void functionlikeMacro_reallife() {
     p.setRootRule(g.rule(CppGrammarImpl.functionlikeMacro));
 
     assertThat(p).matches("__has_feature(cxx_rvalue)");

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppKeywordTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppKeywordTest.java
@@ -22,10 +22,10 @@ package org.sonar.cxx.preprocessor;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
-public class CppKeywordTest {
+class CppKeywordTest {
 
   @Test
-  public void test() {
+  void test() {
     var softly = new SoftAssertions();
     softly.assertThat(CppKeyword.values()).hasSize(14);
     softly.assertThat(CppKeyword.keywordValues()).hasSize(CppKeyword.values().length);

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppLexerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppLexerTest.java
@@ -27,12 +27,12 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class CppLexerTest {
+class CppLexerTest {
 
   private final static Lexer LEXER = CppLexer.create();
 
   @Test
-  public void cpp_keywords() {
+  void cpp_keywords() {
     assertThat(hasToken("#define", CppKeyword.DEFINE)
       .matches(LEXER.lex("#define"))).isTrue();
     assertThat(hasToken("#define", CppKeyword.DEFINE)
@@ -42,7 +42,7 @@ public class CppLexerTest {
   }
 
   @Test
-  public void cpp_keywords_with_whitespaces() {
+  void cpp_keywords_with_whitespaces() {
     assertThat(hasToken("#define", CppKeyword.DEFINE)
       .matches(LEXER.lex("#  define"))).isTrue();
     assertThat(hasToken("#include", CppKeyword.INCLUDE)
@@ -50,7 +50,7 @@ public class CppLexerTest {
   }
 
   @Test
-  public void cpp_keywords_indented() {
+  void cpp_keywords_indented() {
     assertThat(hasToken("#define", CppKeyword.DEFINE)
       .matches(LEXER.lex(" #define"))).isTrue();
     assertThat(hasToken("#define", CppKeyword.DEFINE)
@@ -58,13 +58,13 @@ public class CppLexerTest {
   }
 
   @Test
-  public void cpp_identifiers() {
+  void cpp_identifiers() {
     assertThat(hasToken("lala", IDENTIFIER)
       .matches(LEXER.lex("lala"))).isTrue();
   }
 
   @Test
-  public void cpp_operators() {
+  void cpp_operators() {
     assertThat(hasToken("#", CppPunctuator.HASH)
       .matches(LEXER.lex("#"))).isTrue();
     assertThat(hasToken("##", CppPunctuator.HASHHASH)
@@ -72,7 +72,7 @@ public class CppLexerTest {
   }
 
   @Test
-  public void hashhash_followed_by_word() {
+  void hashhash_followed_by_word() {
     List<Token> tokens = LEXER.lex("##a");
     assertThat(hasToken("##", CppPunctuator.HASHHASH)
       .matches(tokens)).isTrue();
@@ -81,7 +81,7 @@ public class CppLexerTest {
   }
 
   @Test
-  public void hash_followed_by_word() {
+  void hash_followed_by_word() {
     List<Token> tokens = LEXER.lex("#a");
     assertThat(hasToken("#", CppPunctuator.HASH)
       .matches(tokens)).isTrue();

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppPunctuatorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/CppPunctuatorTest.java
@@ -25,10 +25,10 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 
-public class CppPunctuatorTest {
+class CppPunctuatorTest {
 
   @Test
-  public void test() {
+  void test() {
     assertThat(CppPunctuator.values()).hasSize(71);
 
     AstNode astNode = mock(AstNode.class);

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/ExpressionEvaluatorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/ExpressionEvaluatorTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import org.sonar.cxx.squidbridge.SquidAstVisitorContext;
 
-public class ExpressionEvaluatorTest {
+class ExpressionEvaluatorTest {
 
   static boolean eval(String constExpr, CxxPreprocessor pp) {
     return ExpressionEvaluator.eval(pp, constExpr);
@@ -42,13 +42,13 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void bools() {
+  void bools() {
     assertThat(eval("true")).isTrue();
     assertThat(eval("false")).isFalse();
   }
 
   @Test
-  public void numbers() {
+  void numbers() {
     assertThat(eval("1")).isTrue();
     assertThat(eval("0xAA")).isTrue();
     assertThat(eval("0XAA")).isTrue();
@@ -71,7 +71,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void characters() {
+  void characters() {
     assertThat(eval("'1'")).isTrue();
     assertThat(eval("'a'")).isTrue();
 
@@ -79,7 +79,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void conditional_expression() {
+  void conditional_expression() {
     assertThat(eval("1 ? 1 : 0")).isTrue();
     assertThat(eval("0 ? 0 : 1")).isTrue();
 
@@ -91,7 +91,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void logical_or() {
+  void logical_or() {
     assertThat(eval("1 || 0")).isTrue();
     assertThat(eval("0 || 1")).isTrue();
     assertThat(eval("1 || 1")).isTrue();
@@ -102,7 +102,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void logical_and() {
+  void logical_and() {
     assertThat(eval("1 && 1")).isTrue();
     assertThat(eval("1 && 1 && 1")).isTrue();
 
@@ -113,7 +113,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void inclusive_or() {
+  void inclusive_or() {
     assertThat(eval("1 | 0")).isTrue();
     assertThat(eval("0 | 1")).isTrue();
     assertThat(eval("1 | 1")).isTrue();
@@ -123,7 +123,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void exclusive_or() {
+  void exclusive_or() {
     assertThat(eval("1 ^ 0")).isTrue();
     assertThat(eval("0 ^ 1")).isTrue();
     assertThat(eval("0 ^ 1 ^ 0")).isTrue();
@@ -133,7 +133,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void and_expr() {
+  void and_expr() {
     assertThat(eval("1 & 1")).isTrue();
     assertThat(eval("2 & 2 & 2")).isTrue();
 
@@ -145,7 +145,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void equality_expr() {
+  void equality_expr() {
     assertThat(eval("1 == 1")).isTrue();
     assertThat(eval("1 == true")).isTrue();
     assertThat(eval("true == true")).isTrue();
@@ -166,7 +166,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void relational_expr() {
+  void relational_expr() {
     assertThat(eval("0 < 1")).isTrue();
     assertThat(eval("0 <= 1")).isTrue();
     assertThat(eval("1 > 0")).isTrue();
@@ -189,7 +189,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void shift_expr() {
+  void shift_expr() {
     assertThat(eval("1 << 2")).isTrue();
     assertThat(eval("1 >> 0")).isTrue();
 
@@ -199,7 +199,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void additive_expr() {
+  void additive_expr() {
     assertThat(eval("1 + 1")).isTrue();
     assertThat(eval("2 - 1")).isTrue();
     assertThat(eval("3 - 3 + 2")).isTrue();
@@ -210,7 +210,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void multiplicative_expr() {
+  void multiplicative_expr() {
     assertThat(eval("1 * 2")).isTrue();
     assertThat(eval("1 / 1")).isTrue();
     assertThat(eval("1 % 2")).isTrue();
@@ -222,7 +222,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void primary_expr() {
+  void primary_expr() {
     assertThat(eval("(1)")).isTrue();
 
     assertThat(eval("(0)")).isFalse();
@@ -231,7 +231,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void unary_expression() {
+  void unary_expression() {
     assertThat(eval("+1")).isTrue();
     assertThat(eval("-1")).isTrue();
     assertThat(eval("!0")).isTrue();
@@ -244,14 +244,14 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void identifier_defined() {
+  void identifier_defined() {
     CxxPreprocessor pp = mock(CxxPreprocessor.class);
     when(pp.valueOf(anyString())).thenReturn("1");
     assertThat(eval("LALA", pp)).isTrue();
   }
 
   @Test
-  public void self_referential_identifier0() {
+  void self_referential_identifier0() {
     CxxPreprocessor pp = mock(CxxPreprocessor.class);
     when(pp.valueOf("A")).thenReturn("A");
 
@@ -263,7 +263,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void self_referential_identifier1() {
+  void self_referential_identifier1() {
     CxxPreprocessor pp = mock(CxxPreprocessor.class);
     when(pp.valueOf("A")).thenReturn("B");
     when(pp.valueOf("B")).thenReturn("A");
@@ -272,7 +272,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void self_referential_identifier2() {
+  void self_referential_identifier2() {
     CxxPreprocessor pp = mock(CxxPreprocessor.class);
     when(pp.valueOf("C")).thenReturn("B");
     when(pp.valueOf("B")).thenReturn("C");
@@ -282,7 +282,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void self_referential_identifier3() {
+  void self_referential_identifier3() {
     CxxPreprocessor pp = mock(CxxPreprocessor.class);
     when(pp.valueOf("C")).thenReturn("B");
     when(pp.valueOf("B")).thenReturn("C");
@@ -294,7 +294,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void self_referential_identifier4() {
+  void self_referential_identifier4() {
     // https://gcc.gnu.org/onlinedocs/gcc-3.0.1/cpp_3.html#SEC31
     CxxPreprocessor pp = mock(CxxPreprocessor.class);
     when(pp.valueOf("x")).thenReturn("(4 + y)");
@@ -307,33 +307,33 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void identifier_undefined() {
+  void identifier_undefined() {
     assertThat(eval("LALA")).isFalse();
   }
 
   @Test
-  public void functionlike_macro_defined_true() {
+  void functionlike_macro_defined_true() {
     CxxPreprocessor pp = mock(CxxPreprocessor.class);
     when(pp.expandFunctionLikeMacro(anyString(), anyList())).thenReturn("1");
     assertThat(eval("has_feature(URG)", pp)).isTrue();
   }
 
   @Test
-  public void functionlike_macro_defined_false() {
+  void functionlike_macro_defined_false() {
     CxxPreprocessor pp = mock(CxxPreprocessor.class);
     when(pp.valueOf(anyString())).thenReturn("0");
     assertThat(eval("has_feature(URG)", pp)).isFalse();
   }
 
   @Test
-  public void functionlike_macro_undefined() {
+  void functionlike_macro_undefined() {
     CxxPreprocessor pp = mock(CxxPreprocessor.class);
     when(pp.valueOf(anyString())).thenReturn(null);
     assertThat(eval("has_feature(URG)", pp)).isFalse();
   }
 
   @Test
-  public void defined_true_without_parantheses() {
+  void defined_true_without_parantheses() {
     CxxPreprocessor pp = mock(CxxPreprocessor.class);
     var macro = "LALA";
     when(pp.valueOf(macro)).thenReturn("1");
@@ -341,12 +341,12 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void defined_false_without_parantheses() {
+  void defined_false_without_parantheses() {
     assertThat(eval("defined LALA")).isFalse();
   }
 
   @Test
-  public void defined_true_with_parantheses() {
+  void defined_true_with_parantheses() {
     CxxPreprocessor pp = mock(CxxPreprocessor.class);
     var macro = "LALA";
     when(pp.valueOf(macro)).thenReturn("1");
@@ -355,13 +355,13 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void defined_false_with_parantheses() {
+  void defined_false_with_parantheses() {
     assertThat(eval("defined (LALA)")).isFalse();
     assertThat(eval("defined(LALA)")).isFalse();
   }
 
   @Test
-  public void decode_numbers() {
+  void decode_numbers() {
     assertThat(ExpressionEvaluator.decode("1")).isEqualTo(new BigInteger("1", 10));
     assertThat(ExpressionEvaluator.decode("067")).isEqualTo(new BigInteger("67", 8));
     assertThat(ExpressionEvaluator.decode("0b11")).isEqualTo(new BigInteger("11", 2));
@@ -387,7 +387,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void throw_on_invalid_expressions() {
+  void throw_on_invalid_expressions() {
     EvaluationException thrown = catchThrowableOfType(() -> {
       eval("\"\"");
     }, EvaluationException.class);
@@ -395,7 +395,7 @@ public class ExpressionEvaluatorTest {
   }
 
   @Test
-  public void std_macro_evaluated_as_expected() {
+  void std_macro_evaluated_as_expected() {
     var file = new File("dummy.cpp");
     SquidAstVisitorContext<Grammar> context = mock(SquidAstVisitorContext.class);
     when(context.getFile()).thenReturn(file);

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/IncludeLexerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/IncludeLexerTest.java
@@ -28,12 +28,12 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.sonar.cxx.parser.CxxTokenType;
 
-public class IncludeLexerTest {
+class IncludeLexerTest {
 
   private final static Lexer LEXER = IncludeLexer.create();
 
   @Test
-  public void proper_preprocessor_directives_are_created() {
+  void proper_preprocessor_directives_are_created() {
     assertThat(hasToken("#include <iostream>", CxxTokenType.PREPROCESSOR)
       .matches(LEXER.lex("#include <iostream>"))).isTrue();
     assertThat(hasToken("#define lala", CxxTokenType.PREPROCESSOR)
@@ -43,7 +43,7 @@ public class IncludeLexerTest {
   }
 
   @Test
-  public void continued_lines_are_handled_correctly() {
+  void continued_lines_are_handled_correctly() {
     List<Token> tokens = LEXER.lex("#define\\\nname");
     assertThat(hasToken("#define name", CxxTokenType.PREPROCESSOR)
       .matches(tokens)).isTrue();
@@ -51,7 +51,7 @@ public class IncludeLexerTest {
   }
 
   @Test
-  public void multiline_comment_with_Include_is_swallowed() {
+  void multiline_comment_with_Include_is_swallowed() {
     List<Token> tokens = LEXER.lex("/* This is a multiline comment\n   #include should be swallowed\n */");
     assertThat(tokens).hasSize(1);
     assertThat(hasToken("EOF", EOF)
@@ -59,7 +59,7 @@ public class IncludeLexerTest {
   }
 
   @Test
-  public void singleline_comment_with_Include_is_swallowed() {
+  void singleline_comment_with_Include_is_swallowed() {
     List<Token> tokens = LEXER.lex("// #include should be swallowed\n");
     assertThat(tokens).hasSize(1);
     assertThat(hasToken("EOF", EOF)
@@ -67,7 +67,7 @@ public class IncludeLexerTest {
   }
 
   @Test
-  public void all_but_preprocessor_stuff_is_swallowed() {
+  void all_but_preprocessor_stuff_is_swallowed() {
     // all the other stuff should be consumed by the lexer without
     // generating any tokens
     List<Token> tokens = LEXER.lex("void foo();");

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/MapChainTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/MapChainTest.java
@@ -22,7 +22,7 @@ package org.sonar.cxx.preprocessor;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class MapChainTest {
+class MapChainTest {
 
   private final MapChain<String, String> mc;
 
@@ -31,39 +31,39 @@ public class MapChainTest {
   }
 
   @Test
-  public void getMapping() {
+  void getMapping() {
     mc.put("k", "v");
     assertThat(mc.get("k")).isEqualTo("v");
   }
 
   @Test
-  public void removeMapping() {
+  void removeMapping() {
     mc.put("k", "v");
     mc.remove("k");
     assertThat(mc.get("k")).isNull();
   }
 
   @Test
-  public void noValueMapping() {
+  void noValueMapping() {
     assertThat(mc.get("k")).isNull();
   }
 
   @Test
-  public void clearMapping() {
+  void clearMapping() {
     mc.put("k", "v");
     mc.clear();
     assertThat(mc.get("k")).isNull();
   }
 
   @Test
-  public void disable() {
+  void disable() {
     mc.put("k", "v");
     mc.disable("k");
     assertThat(mc.get("k")).isNull();
   }
 
   @Test
-  public void enable() {
+  void enable() {
     mc.put("k", "v");
     mc.disable("k");
     mc.enable("k");

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/SourceCodeProviderTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/SourceCodeProviderTest.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class SourceCodeProviderTest {
+class SourceCodeProviderTest {
 
   private final File expected1 = new File(new File("src/test/resources/codeprovider/source.hh").getAbsolutePath());
   private final File expected2 = new File(new File("src/test/resources/codeprovider/source").getAbsolutePath());
@@ -36,7 +36,7 @@ public class SourceCodeProviderTest {
   // ////////////////////////////////////////////////////////////////////////////
   // Behavior in the absolute path case
   @Test
-  public void getting_file_with_abspath() {
+  void getting_file_with_abspath() {
     // lookup with absolute paths should ignore the value of current
     // working directory and should work the same in the quoted and
     // unquoted case
@@ -59,7 +59,7 @@ public class SourceCodeProviderTest {
   // -------------------------------------------
   // rel. path | 3        | 4        |
   @Test
-  public void getting_file_relpath_case1() {
+  void getting_file_relpath_case1() {
     var codeProvider = new SourceCodeProvider(new File("dummy"));
 
     var includeRoot = Paths.get("src/test/resources/codeprovider").toAbsolutePath().toString();
@@ -72,7 +72,7 @@ public class SourceCodeProviderTest {
   }
 
   @Test
-  public void getting_file_relpath_case1_without_extension() {
+  void getting_file_relpath_case1_without_extension() {
     var codeProvider = new SourceCodeProvider(new File("dummy"));
 
     var includeRoot = Paths.get("src/test/resources/codeprovider").toAbsolutePath().toString();
@@ -85,7 +85,7 @@ public class SourceCodeProviderTest {
   }
 
   @Test
-  public void getting_file_relpath_case2() {
+  void getting_file_relpath_case2() {
     var codeProvider = new SourceCodeProvider(new File("dummy"));
 
     var includeRoot = Paths.get("resources/codeprovider").toString();
@@ -98,7 +98,7 @@ public class SourceCodeProviderTest {
   }
 
   @Test
-  public void getting_file_relpath_case2_without_extension() {
+  void getting_file_relpath_case2_without_extension() {
     var codeProvider = new SourceCodeProvider(new File("dummy"));
 
     var includeRoot = Paths.get("resources/codeprovider").toString();
@@ -111,7 +111,7 @@ public class SourceCodeProviderTest {
   }
 
   @Test
-  public void getting_file_relpath_case3() {
+  void getting_file_relpath_case3() {
     var codeProvider = new SourceCodeProvider(new File("dummy"));
 
     var includeRoot = Paths.get("src/test/resources").toAbsolutePath().toString();
@@ -124,7 +124,7 @@ public class SourceCodeProviderTest {
   }
 
   @Test
-  public void getting_file_relpath_case3_without_extension() {
+  void getting_file_relpath_case3_without_extension() {
     var codeProvider = new SourceCodeProvider(new File("dummy"));
 
     var includeRoot = Paths.get("src/test/resources").toAbsolutePath().toString();
@@ -137,7 +137,7 @@ public class SourceCodeProviderTest {
   }
 
   @Test
-  public void getting_file_relpath_case4() {
+  void getting_file_relpath_case4() {
     var codeProvider = new SourceCodeProvider(new File("dummy"));
 
     var includeRoot = Paths.get("resources").toString();
@@ -150,7 +150,7 @@ public class SourceCodeProviderTest {
   }
 
   @Test
-  public void getting_file_relpath_case4_without_extension() {
+  void getting_file_relpath_case4_without_extension() {
     var codeProvider = new SourceCodeProvider(new File("dummy"));
 
     var includeRoot = Paths.get("resources").toString();
@@ -166,7 +166,7 @@ public class SourceCodeProviderTest {
   // Special behavior in the quoted case
   // Lookup in the current directory. Has to fail for the angle case
   @Test
-  public void getting_file_with_filename_and_cwd() {
+  void getting_file_with_filename_and_cwd() {
     var codeProvider = new SourceCodeProvider(new File("src/test/resources/codeprovider/dummy.cpp"));
 
     var path = "source.hh";
@@ -175,7 +175,7 @@ public class SourceCodeProviderTest {
   }
 
   @Test
-  public void getting_file_with_relpath_and_cwd() {
+  void getting_file_with_relpath_and_cwd() {
     var codeProvider = new SourceCodeProvider(new File("src/test/resources/dummy.cpp"));
 
     var path = "codeprovider/source.hh";
@@ -184,7 +184,7 @@ public class SourceCodeProviderTest {
   }
 
   @Test
-  public void getting_file_with_relpath_containing_backsteps_and_cwd() {
+  void getting_file_with_relpath_containing_backsteps_and_cwd() {
     var codeProvider = new SourceCodeProvider(
       new File("src/test/resources/codeprovider/folder/dummy.cpp"));
 
@@ -194,33 +194,33 @@ public class SourceCodeProviderTest {
   }
 
   @Test
-  public void getting_source_code1() throws IOException {
+  void getting_source_code1() throws IOException {
     var codeProvider = new SourceCodeProvider(new File("dummy"));
     assertThat(codeProvider.getSourceCode(expected1, Charset.defaultCharset())).isEqualTo("source code");
   }
 
   @Test
-  public void getting_source_code2() throws IOException {
+  void getting_source_code2() throws IOException {
     var codeProvider = new SourceCodeProvider(new File("dummy"));
     assertThat(codeProvider.getSourceCode(expected2, Charset.defaultCharset())).isEqualTo("source code");
   }
 
   @Test
-  public void getting_source_code_utf_8() throws IOException {
+  void getting_source_code_utf_8() throws IOException {
     var codeProvider = new SourceCodeProvider(new File("dummy"));
     assertThat(codeProvider.getSourceCode(new File(root, "./utf-8.hh"),
                                           Charset.defaultCharset())).isEqualTo("UTF-8");
   }
 
   @Test
-  public void getting_source_code_utf_8_bom() throws IOException {
+  void getting_source_code_utf_8_bom() throws IOException {
     var codeProvider = new SourceCodeProvider(new File("dummy"));
     assertThat(codeProvider.getSourceCode(new File(root, "./utf-8-bom.hh"),
                                           Charset.defaultCharset())).isEqualTo("UTF-8-BOM");
   }
 
   @Test
-  public void getting_source_code_utf_16_le_bom() throws IOException {
+  void getting_source_code_utf_16_le_bom() throws IOException {
     var codeProvider = new SourceCodeProvider(new File("dummy"));
     assertThat(
       codeProvider.getSourceCode(new File(root, "./utf-16le-bom.hh"),

--- a/cxx-squid/src/test/java/org/sonar/cxx/utils/CxxReportIssueTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/utils/CxxReportIssueTest.java
@@ -23,14 +23,14 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class CxxReportIssueTest {
+class CxxReportIssueTest {
 
   @Test
-  public void reportLocationEquality() {
+  void reportLocationEquality() {
     var location0 = new CxxReportLocation("path0.cpp", "1", null, "Boolean value assigned to pointer.");
     var location1 = new CxxReportLocation("path0.cpp", "1", null, "Boolean value assigned to pointer.");
     assertThat(location1).isEqualTo(location0);
-    assertThat(location1.hashCode()).isEqualTo(location0.hashCode());
+    assertThat(location1).hasSameHashCodeAs(location0);
 
     var location2 = new CxxReportLocation("path2.cpp", "1", null, "Exception thrown in destructor.");
     assertThat(location0).isNotEqualTo(location2);
@@ -41,7 +41,7 @@ public class CxxReportIssueTest {
   }
 
   @Test
-  public void reportIssueEquality() {
+  void reportIssueEquality() {
     var issue0 = new CxxReportIssue("nullPointer", "path0.cpp", "1", null, "Null pointer dereference: ptr");
     issue0.addLocation("path0.cpp", "1", null, "Assignment &apos;ptr=nullptr&apos;, assigned value is 0");
 
@@ -49,7 +49,7 @@ public class CxxReportIssueTest {
     var issue2 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", null, "Exception thrown in destructor.");
 
     assertThat(issue2).isEqualTo(issue1);
-    assertThat(issue2.hashCode()).isEqualTo(issue1.hashCode());
+    assertThat(issue2).hasSameHashCodeAs(issue1);
 
     assertThat(issue1).isNotEqualTo(issue0);
     assertThat(issue1.hashCode()).isNotEqualTo(issue0.hashCode());
@@ -59,7 +59,7 @@ public class CxxReportIssueTest {
   }
 
   @Test
-  public void reportIssueEqualityConsideringFlow() {
+  void reportIssueEqualityConsideringFlow() {
     var issue0 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", null, "Exception thrown in destructor.");
     issue0.addFlowElement("path0.cpp", "1", null, "a");
     issue0.addFlowElement("path1.cpp", "1", null, "b");
@@ -77,7 +77,7 @@ public class CxxReportIssueTest {
     var issue3 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", null, "Exception thrown in destructor.");
 
     assertThat(issue1).isEqualTo(issue0);
-    assertThat(issue1.hashCode()).isEqualTo(issue0.hashCode());
+    assertThat(issue1).hasSameHashCodeAs(issue0);
 
     assertThat(issue2).isNotEqualTo(issue0);
     assertThat(issue2.hashCode()).isNotEqualTo(issue0.hashCode());
@@ -90,7 +90,7 @@ public class CxxReportIssueTest {
   }
 
   @Test
-  public void reportIssueFlowOrder() {
+  void reportIssueFlowOrder() {
     var issue0 = new CxxReportIssue("exceptThrowInDestructor", "path2.cpp", "1", null, "Exception thrown in destructor.");
     issue0.addFlowElement("path0.cpp", "1", null, "a");
     issue0.addFlowElement("path1.cpp", "2", null, "b");

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxCognitiveComplexityVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxCognitiveComplexityVisitorTest.java
@@ -28,125 +28,125 @@ import org.sonar.cxx.CxxFileTesterHelper;
 import org.sonar.cxx.api.CxxMetric;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 
-public class CxxCognitiveComplexityVisitorTest {
+class CxxCognitiveComplexityVisitorTest {
 
   @Test
-  public void if_statement() throws UnsupportedEncodingException, IOException {
+  void if_statement() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/if.cc")).isEqualTo(1);
   }
 
   @Test
-  public void if_else() throws UnsupportedEncodingException, IOException {
+  void if_else() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/if_else.cc")).isEqualTo(2);
   }
 
   @Test
-  public void if_else_if() throws UnsupportedEncodingException, IOException {
+  void if_else_if() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/if_else_if.cc")).isEqualTo(2);
   }
 
   @Test
-  public void if_else_if_else() throws UnsupportedEncodingException, IOException {
+  void if_else_if_else() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/if_else_if_else.cc")).isEqualTo(3);
   }
 
   @Test
-  public void ternary() throws UnsupportedEncodingException, IOException {
+  void ternary() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/ternary.cc")).isEqualTo(1);
   }
 
   @Test
-  public void nesting() throws UnsupportedEncodingException, IOException {
+  void nesting() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/nesting.cc")).isEqualTo(20);
   }
 
   @Test
-  public void switch_statement() throws UnsupportedEncodingException, IOException {
+  void switch_statement() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/switch.cc")).isEqualTo(1);
   }
 
   @Test
-  public void for_statement() throws UnsupportedEncodingException, IOException {
+  void for_statement() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/for.cc")).isEqualTo(1);
   }
 
   @Test
-  public void while_statement() throws UnsupportedEncodingException, IOException {
+  void while_statement() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/while.cc")).isEqualTo(1);
   }
 
   @Test
-  public void do_while() throws UnsupportedEncodingException, IOException {
+  void do_while() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/do_while.cc")).isEqualTo(1);
   }
 
   @Test
-  public void catch_statement() throws UnsupportedEncodingException, IOException {
+  void catch_statement() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/catch.cc")).isEqualTo(1);
   }
 
   @Test
-  public void multiple_catch() throws UnsupportedEncodingException, IOException {
+  void multiple_catch() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/multiple_catch.cc")).isEqualTo(3);
   }
 
   @Test
-  public void goto_statement() throws UnsupportedEncodingException, IOException {
+  void goto_statement() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/goto.cc")).isEqualTo(1);
   }
 
   @Test
-  public void binary_logical() throws UnsupportedEncodingException, IOException {
+  void binary_logical() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/binary_logical.cc")).isEqualTo(2);
   }
 
   @Test
-  public void binary_logical_mixed() throws UnsupportedEncodingException, IOException {
+  void binary_logical_mixed() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/binary_logical_mixed.cc")).isEqualTo(4);
   }
 
   @Test
-  public void binary_logical_mixed_alternative() throws UnsupportedEncodingException, IOException {
+  void binary_logical_mixed_alternative() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/binary_logical_mixed_alternative.cc")).isEqualTo(4);
   }
 
   @Test
-  public void binary_logical_not() throws UnsupportedEncodingException, IOException {
+  void binary_logical_not() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/binary_logical_not.cc")).isEqualTo(3);
   }
 
   @Test
-  public void lambda() throws UnsupportedEncodingException, IOException {
+  void lambda() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/lambda.cc")).isEqualTo(2);
   }
 
   @Test
-  public void sum_of_primes() throws UnsupportedEncodingException, IOException {
+  void sum_of_primes() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/sum_of_primes.cc")).isEqualTo(7);
   }
 
   @Test
-  public void get_words() throws UnsupportedEncodingException, IOException {
+  void get_words() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/get_words.cc")).isEqualTo(1);
   }
 
   @Test
-  public void overridden_symbol_from() throws UnsupportedEncodingException, IOException {
+  void overridden_symbol_from() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/overridden_symbol_from.cc")).isEqualTo(19);
   }
 
   @Test
-  public void add_version() throws UnsupportedEncodingException, IOException {
+  void add_version() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/add_version.cc")).isEqualTo(35);
   }
 
   @Test
-  public void add_version_macro() throws UnsupportedEncodingException, IOException {
+  void add_version_macro() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/add_version_macro.cc")).isEqualTo(1);
   }
 
   @Test
-  public void to_regexp() throws UnsupportedEncodingException, IOException {
+  void to_regexp() throws UnsupportedEncodingException, IOException {
     assertThat(testFile("src/test/resources/visitors/to_regexp.cc")).isEqualTo(20);
   }
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxCpdVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxCpdVisitorTest.java
@@ -31,7 +31,7 @@ import org.sonar.cxx.api.CxxMetric;
 import org.sonar.cxx.config.CxxSquidConfiguration;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 
-public class CxxCpdVisitorTest {
+class CxxCpdVisitorTest {
 
   private SourceFile sourceFile;
 
@@ -48,7 +48,7 @@ public class CxxCpdVisitorTest {
   }
 
   @Test
-  public void testCpdTokens() throws Exception {
+  void testCpdTokens() throws Exception {
     List<CxxCpdVisitor.CpdToken> data = (List<CxxCpdVisitor.CpdToken>) sourceFile.getData(CxxMetric.CPD_TOKENS_DATA);
     assertThat(data).hasSize(391);
   }

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxFileLinesVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxFileLinesVisitorTest.java
@@ -35,7 +35,7 @@ import org.sonar.cxx.CxxFileTesterHelper;
 import org.sonar.cxx.api.CxxMetric;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 
-public class CxxFileLinesVisitorTest {
+class CxxFileLinesVisitorTest {
 
   private SourceFile sourceFile;
 
@@ -46,7 +46,7 @@ public class CxxFileLinesVisitorTest {
   }
 
   @Test
-  public void testLinesOfCode() throws UnsupportedEncodingException, IOException {
+  void testLinesOfCode() throws UnsupportedEncodingException, IOException {
     Set<Integer> testLines = Stream.of(
       8, 10, 14, 16, 17, 21, 22, 23, 26, 31, 34, 35, 42, 44, 45, 49, 51, 53, 55, 56,
       58, 59, 63, 65, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 79, 82, 84, 86, 87, 89,
@@ -59,7 +59,7 @@ public class CxxFileLinesVisitorTest {
   }
 
   @Test
-  public void testExecutableLinesOfCode() throws UnsupportedEncodingException, IOException {
+  void testExecutableLinesOfCode() throws UnsupportedEncodingException, IOException {
     List<Integer> executableLines = (List<Integer>) sourceFile.getData(CxxMetric.EXECUTABLE_LINES_DATA);
     assertThat(executableLines).containsExactlyInAnyOrder(
       10, 26, 34, 35, 56, 59, 69, 70, 72, 73,

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxFunctionComplexityVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxFunctionComplexityVisitorTest.java
@@ -28,10 +28,10 @@ import org.sonar.cxx.api.CxxMetric;
 import org.sonar.cxx.config.CxxSquidConfiguration;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 
-public class CxxFunctionComplexityVisitorTest {
+class CxxFunctionComplexityVisitorTest {
 
   @Test
-  public void testPublishMeasuresForFile() throws IOException {
+  void testPublishMeasuresForFile() throws IOException {
 
     CxxSquidConfiguration squidConfig = new CxxSquidConfiguration();
     squidConfig.add(CxxSquidConfiguration.SONAR_PROJECT_PROPERTIES, CxxSquidConfiguration.FUNCTION_COMPLEXITY_THRESHOLD,
@@ -47,7 +47,7 @@ public class CxxFunctionComplexityVisitorTest {
   }
 
   @Test
-  public void testPublishMeasuresForEmptyFile() throws IOException {
+  void testPublishMeasuresForEmptyFile() throws IOException {
 
     var tester = CxxFileTesterHelper.create("src/test/resources/metrics/EmptyFile.cc", ".", "");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile());

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxFunctionSizeVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxFunctionSizeVisitorTest.java
@@ -28,10 +28,10 @@ import org.sonar.cxx.api.CxxMetric;
 import org.sonar.cxx.config.CxxSquidConfiguration;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 
-public class CxxFunctionSizeVisitorTest {
+class CxxFunctionSizeVisitorTest {
 
   @Test
-  public void testPublishMeasuresForFile() throws IOException {
+  void testPublishMeasuresForFile() throws IOException {
 
     CxxSquidConfiguration squidConfig = new CxxSquidConfiguration();
     squidConfig.add(CxxSquidConfiguration.SONAR_PROJECT_PROPERTIES, CxxSquidConfiguration.FUNCTION_SIZE_THRESHOLD,
@@ -48,7 +48,7 @@ public class CxxFunctionSizeVisitorTest {
   }
 
   @Test
-  public void testPublishMeasuresForEmptyFile() throws IOException {
+  void testPublishMeasuresForEmptyFile() throws IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/metrics/EmptyFile.cc", ".", "");
     SourceFile file = CxxAstScanner.scanSingleInputFile(tester.asInputFile());
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
@@ -27,13 +27,13 @@ import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.cxx.CxxAstScanner;
 import org.sonar.cxx.CxxFileTesterHelper;
 
-public class CxxParseErrorLoggerVisitorTest {
+class CxxParseErrorLoggerVisitorTest {
 
   @RegisterExtension
   public LogTesterJUnit5 logTester = new LogTesterJUnit5();
 
   @Test
-  public void handleParseErrorTest() throws Exception {
+  void handleParseErrorTest() throws Exception {
     logTester.setLevel(LoggerLevel.DEBUG);
     var tester = CxxFileTesterHelper.create("src/test/resources/visitors/syntaxerror.cc", ".", "");
     CxxAstScanner.scanSingleInputFile(tester.asInputFile());

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxPublicApiVisitorTest.java
@@ -38,7 +38,7 @@ import org.sonar.cxx.api.CxxMetric;
 import org.sonar.cxx.config.CxxSquidConfiguration;
 import org.sonar.cxx.squidbridge.api.SourceFile;
 
-public class CxxPublicApiVisitorTest {
+class CxxPublicApiVisitorTest {
 
   private static final org.sonar.api.utils.log.Logger LOG = Loggers.get(CxxPublicApiVisitorTest.class);
 
@@ -51,7 +51,7 @@ public class CxxPublicApiVisitorTest {
   }
 
   @Test
-  public void test_no_matching_suffix() throws IOException {
+  void test_no_matching_suffix() throws IOException {
     var tester = CxxFileTesterHelper.create("src/test/resources/metrics/doxygen_example.h", ".",
                                         "");
     var squidConfig = new CxxSquidConfiguration();
@@ -65,48 +65,48 @@ public class CxxPublicApiVisitorTest {
   }
 
   @Test
-  public void doxygen_example() throws IOException {
+  void doxygen_example() throws IOException {
     assertThat(verifyPublicApiOfFile("src/test/resources/metrics/doxygen_example.h")).isEqualTo(tuple(13, 0));
   }
 
   @Test
-  public void to_delete() throws IOException {
+  void to_delete() throws IOException {
     assertThat(verifyPublicApiOfFile("src/test/resources/metrics/public_api.h")).isEqualTo(tuple(47, 0));
 
   }
 
   @Test
-  public void no_doc() throws IOException {
+  void no_doc() throws IOException {
     assertThat(verifyPublicApiOfFile("src/test/resources/metrics/no_doc.h")).isEqualTo(tuple(22, 22));
   }
 
   @Test
-  public void template() throws IOException {
+  void template() throws IOException {
     assertThat(verifyPublicApiOfFile("src/test/resources/metrics/template.h")).isEqualTo(tuple(15, 4));
   }
 
   @Test
-  public void alias_function_template() throws IOException {
+  void alias_function_template() throws IOException {
     assertThat(verifyPublicApiOfFile("src/test/resources/metrics/alias_in_template_func.h")).isEqualTo(tuple(4, 3));
   }
 
   @Test
-  public void unnamed_class() throws IOException {
+  void unnamed_class() throws IOException {
     assertThat(verifyPublicApiOfFile("src/test/resources/metrics/unnamed_class.h")).isEqualTo(tuple(3, 1));
   }
 
   @Test
-  public void unnamed_enum() throws IOException {
+  void unnamed_enum() throws IOException {
     assertThat(verifyPublicApiOfFile("src/test/resources/metrics/unnamed_enum.h")).isEqualTo(tuple(8, 0));
   }
 
   @Test
-  public void multiline() throws IOException {
+  void multiline() throws IOException {
     assertThat(verifyPublicApiOfFile("src/test/resources/metrics/multiline.h")).isEqualTo(tuple(9, 0));
   }
 
   @Test
-  public void public_api() throws UnsupportedEncodingException, IOException {
+  void public_api() throws UnsupportedEncodingException, IOException {
     var fileNme = "src/test/resources/metrics/public_api.h";
     var visitor = new TestPublicApiVisitor(fileNme, true);
 

--- a/cxx-sslr/pom.xml
+++ b/cxx-sslr/pom.xml
@@ -16,8 +16,6 @@
 
   <properties>
     <license.years>2022</license.years>
-    <!-- in addition, a dependency must be set in 'integration-tests/pom.xml' to aggregate the results -->
-    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <licenses>

--- a/cxx-sslr/sslr-core/pom.xml
+++ b/cxx-sslr/sslr-core/pom.xml
@@ -11,6 +11,11 @@
   <artifactId>sslr-core</artifactId>
   <name>Cxx :: Language Recognizer :: Core</name>
 
+  <properties>
+    <!-- in addition, a dependency must be set in 'integration-tests/pom.xml' to aggregate the results -->
+    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/api/AstNodeTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/api/AstNodeTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AstNodeTest {
+class AstNodeTest {
 
   /**
    * <pre>
@@ -42,7 +42,7 @@ public class AstNodeTest {
    * </pre>
    */
   @Test
-  public void test() {
+  void test() {
     var a = mock(AstNodeType.class);
     var b = mock(AstNodeType.class);
     var c = mock(AstNodeType.class);
@@ -140,7 +140,7 @@ public class AstNodeTest {
    * </pre>
    */
   @Test
-  public void test_getLastToken() {
+  void test_getLastToken() {
     var token = mock(Token.class);
     var a = mock(AstNodeType.class);
     var rootNode = new AstNode(a, "root", token);
@@ -160,7 +160,7 @@ public class AstNodeTest {
   }
 
   @Test
-  public void test_getTokens() {
+  void test_getTokens() {
     var token = mock(Token.class);
     var a = mock(AstNodeType.class);
     var rootNode = new AstNode(a, "root", token);
@@ -178,16 +178,16 @@ public class AstNodeTest {
   }
 
   @Test
-  public void test_toString() {
+  void test_toString() {
     var token = mock(Token.class);
     when(token.getValue()).thenReturn("foo");
     when(token.getLine()).thenReturn(42);
     when(token.getColumn()).thenReturn(24);
     var node = new AstNode(mock(AstNodeType.class), "node_name", token);
-    assertThat(node.toString()).isEqualTo("node_name tokenValue='foo' tokenLine=42 tokenColumn=24");
+    assertThat(node).hasToString("node_name tokenValue='foo' tokenLine=42 tokenColumn=24");
 
     node = new AstNode(mock(AstNodeType.class), "node_name", null);
-    assertThat(node.toString()).isEqualTo("node_name");
+    assertThat(node).hasToString("node_name");
   }
 
 }

--- a/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/api/GrammarTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/api/GrammarTest.java
@@ -32,22 +32,22 @@ import org.sonar.cxx.sslr.grammar.GrammarRuleKey;
 import org.sonar.cxx.sslr.internal.grammar.MutableParsingRule;
 import org.sonar.cxx.sslr.parser.LexerlessGrammar;
 
-public class GrammarTest {
+class GrammarTest {
 
   @Test
-  public void testGetRuleFields() {
+  void testGetRuleFields() {
     var ruleFields = Grammar.getRuleFields(MyGrammar.class);
-    assertThat(ruleFields.size()).isEqualTo(1);
+    assertThat(ruleFields).hasSize(1);
   }
 
   @Test
-  public void testGetAllRuleFields() {
+  void testGetAllRuleFields() {
     var ruleFields = Grammar.getAllRuleFields(MyGrammar.class);
-    assertThat(ruleFields.size()).isEqualTo(5);
+    assertThat(ruleFields).hasSize(5);
   }
 
   @Test
-  public void method_rule_should_throw_exception_by_default() {
+  void method_rule_should_throw_exception_by_default() {
     var thrown = catchThrowableOfType(
       () -> new MyGrammar().rule(mock(GrammarRuleKey.class)),
       UnsupportedOperationException.class);
@@ -55,7 +55,7 @@ public class GrammarTest {
   }
 
   @Test
-  public void should_automatically_instanciate_lexerful_rules() throws IllegalAccessException {
+  void should_automatically_instanciate_lexerful_rules() throws IllegalAccessException {
     var ruleFields = Grammar.getAllRuleFields(MyGrammar.class);
     Grammar grammar = new MyGrammar();
     for (var ruleField : ruleFields) {
@@ -66,7 +66,7 @@ public class GrammarTest {
   }
 
   @Test
-  public void should_automatically_instanciate_lexerless_rules() throws IllegalAccessException {
+  void should_automatically_instanciate_lexerless_rules() throws IllegalAccessException {
     var ruleFields = Grammar.getAllRuleFields(MyLexerlessGrammar.class);
     LexerlessGrammar grammar = new MyLexerlessGrammar();
     for (var ruleField : ruleFields) {
@@ -77,7 +77,7 @@ public class GrammarTest {
   }
 
   @Test
-  public void should_throw_exception() {
+  void should_throw_exception() {
     var thrown = catchThrowableOfType(IllegalGrammar::new, GrammarException.class);
     assertThat(thrown).hasMessageStartingWith("Unable to instanciate the rule 'rootRule': ");
   }

--- a/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/api/typed/ActionParserTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/api/typed/ActionParserTest.java
@@ -40,10 +40,10 @@ import org.sonar.cxx.sslr.grammar.LexerlessGrammarBuilder;
 import org.sonar.cxx.sslr.internal.vm.PatternExpression;
 import org.sonar.cxx.sslr.internal.vm.TriviaExpression;
 
-public class ActionParserTest {
+class ActionParserTest {
 
   @Test
-  public void not_matching() throws Exception {
+  void not_matching() throws Exception {
     var thrown = catchThrowableOfType(
       () -> parse(MyGrammarKeys.NUMERIC, "x"),
       RecognitionException.class);
@@ -51,43 +51,43 @@ public class ActionParserTest {
   }
 
   @Test
-  public void basic() throws Exception {
-    assertThat(parse(MyGrammarKeys.NUMERIC, "42", Numeric.class).toString()).isEqualTo("42");
+  void basic() throws Exception {
+    assertThat(parse(MyGrammarKeys.NUMERIC, "42", Numeric.class)).hasToString("42");
   }
 
   @Test
-  public void firstOf() throws Exception {
-    assertThat(parse(MyGrammarKeys.OPERATOR, "+", Operator.class).toString()).isEqualTo("+");
-    assertThat(parse(MyGrammarKeys.OPERATOR, "-", Operator.class).toString()).isEqualTo("-");
+  void firstOf() throws Exception {
+    assertThat(parse(MyGrammarKeys.OPERATOR, "+", Operator.class)).hasToString("+");
+    assertThat(parse(MyGrammarKeys.OPERATOR, "-", Operator.class)).hasToString("-");
     assertNotParse(MyGrammarKeys.OPERATOR, "x");
   }
 
   @Test
-  public void optional() throws Exception {
-    assertThat(parse(MyGrammarKeys.UNARY_EXP, "42", UnaryExp.class).toString()).isEqualTo("42");
-    assertThat(parse(MyGrammarKeys.UNARY_EXP, "+42", UnaryExp.class).toString()).isEqualTo("+ 42");
+  void optional() throws Exception {
+    assertThat(parse(MyGrammarKeys.UNARY_EXP, "42", UnaryExp.class)).hasToString("42");
+    assertThat(parse(MyGrammarKeys.UNARY_EXP, "+42", UnaryExp.class)).hasToString("+ 42");
   }
 
   @Test
-  public void oneOrMore() throws Exception {
-    assertThat(parse(MyGrammarKeys.NUMERIC_LIST, "42 7", NumericList.class).toString()).isEqualTo("[42, 7]");
+  void oneOrMore() throws Exception {
+    assertThat(parse(MyGrammarKeys.NUMERIC_LIST, "42 7", NumericList.class)).hasToString("[42, 7]");
     assertNotParse(MyGrammarKeys.NUMERIC_LIST, "");
   }
 
   @Test
-  public void zeroOrMore() throws Exception {
-    assertThat(parse(MyGrammarKeys.POTENTIALLY_EMPTY_NUMERIC_LIST, "42 7", NumericList.class).toString()).isEqualTo(
+  void zeroOrMore() throws Exception {
+    assertThat(parse(MyGrammarKeys.POTENTIALLY_EMPTY_NUMERIC_LIST, "42 7", NumericList.class)).hasToString(
       "[42, 7]");
-    assertThat(parse(MyGrammarKeys.POTENTIALLY_EMPTY_NUMERIC_LIST, "", NumericList.class).toString()).isEqualTo("[]");
+    assertThat(parse(MyGrammarKeys.POTENTIALLY_EMPTY_NUMERIC_LIST, "", NumericList.class)).hasToString("[]");
   }
 
   @Test
-  public void skipped_astnode() throws Exception {
-    assertThat(parse(MyGrammarKeys.NUMERIC_WITH_EOF, "42", Numeric.class).toString()).isEqualTo("42");
+  void skipped_astnode() throws Exception {
+    assertThat(parse(MyGrammarKeys.NUMERIC_WITH_EOF, "42", Numeric.class)).hasToString("42");
   }
 
   @Test
-  public void undefined_token_type() throws Exception {
+  void undefined_token_type() throws Exception {
     var numeric = parse(MyGrammarKeys.NUMERIC, "42", Numeric.class);
     var type = numeric.getFirstChild().getToken().getType();
     assertThat(type.hasToBeSkippedFromAst(null)).isFalse();
@@ -96,7 +96,7 @@ public class ActionParserTest {
   }
 
   @Test
-  public void comment() throws Exception {
+  void comment() throws Exception {
     var numeric = parse(MyGrammarKeys.NUMERIC, "/* myComment */42", Numeric.class);
     var trivia = numeric.getFirstChild().getToken().getTrivia().get(0);
     assertThat(trivia.isComment()).isTrue();
@@ -104,31 +104,31 @@ public class ActionParserTest {
   }
 
   @Test
-  public void skipped_text() throws Exception {
-    assertThat(parse(MyGrammarKeys.NUMERIC, "  42", Numeric.class).toString()).isEqualTo("42");
+  void skipped_text() throws Exception {
+    assertThat(parse(MyGrammarKeys.NUMERIC, "  42", Numeric.class)).hasToString("42");
   }
 
   @Test
-  public void unknown_trivia() throws Exception {
+  void unknown_trivia() throws Exception {
     var thrown = catchThrowableOfType(() -> parse(MyGrammarKeys.NUMERIC, "#preprocessor 42",
                                               Numeric.class), IllegalStateException.class);
     assertThat(thrown).hasMessage("Unexpected trivia kind: PREPROCESSOR");
   }
 
   @Test
-  public void rootRule() throws Exception {
+  void rootRule() throws Exception {
     assertThat(parser(MyGrammarKeys.OPERATOR).rootRule()).isEqualTo(MyGrammarKeys.OPERATOR);
   }
 
   @Test
-  public void parse_file() throws Exception {
+  void parse_file() throws Exception {
     var parser = parser(MyGrammarKeys.UNARY_EXP);
     var node = parser.parse(new File("src/test/resources/typed/42.txt"));
     assertThat(node).isInstanceOf(UnaryExp.class);
   }
 
   @Test
-  public void unknown_file() throws Exception {
+  void unknown_file() throws Exception {
     var parser = parser(MyGrammarKeys.NUMERIC);
     try {
       parser.parse(new File("unknown"));
@@ -139,9 +139,9 @@ public class ActionParserTest {
   }
 
   @Test
-  public void more_than_one_call_to_the_same_action_method() throws Exception {
-    assertThat(parse(MyGrammarKeys.NUMERIC, "42", Numeric.class).toString()).isEqualTo("42");
-    assertThat(parse(MyGrammarKeys.NUMERIC2, "42", Numeric.class).toString()).isEqualTo("42");
+  void more_than_one_call_to_the_same_action_method() throws Exception {
+    assertThat(parse(MyGrammarKeys.NUMERIC, "42", Numeric.class)).hasToString("42");
+    assertThat(parse(MyGrammarKeys.NUMERIC2, "42", Numeric.class)).hasToString("42");
   }
 
   @SuppressWarnings("unchecked")

--- a/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/api/typed/InputTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/api/typed/InputTest.java
@@ -27,22 +27,22 @@ import java.io.File;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class InputTest {
+class InputTest {
 
   @Test
-  public void input() {
+  void input() {
     var input = new char[0];
     assertThat(new Input(input).input()).isSameAs(input);
   }
 
   @Test
-  public void uri() {
+  void uri() {
     var uri = new File("tests://something").toURI();
     assertThat(new Input("".toCharArray(), uri).uri()).isSameAs(uri);
   }
 
   @Test
-  public void substring() {
+  void substring() {
     var input = new Input("abc".toCharArray());
     assertThat(input.substring(0, 3)).isEqualTo("abc");
     assertThat(input.substring(0, 2)).isEqualTo("ab");
@@ -54,7 +54,7 @@ public class InputTest {
   }
 
   @Test
-  public void lineAndColumnAt() {
+  void lineAndColumnAt() {
     assertLineAndColumn(
       "", 0,
       1, 1);

--- a/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/api/typed/OptionalTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/api/typed/OptionalTest.java
@@ -26,13 +26,13 @@ package com.sonar.cxx.sslr.api.typed;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class OptionalTest {
+class OptionalTest {
 
   private final Optional<String> present = Optional.of("foo");
   private final Optional<String> absent = Optional.absent();
 
   @Test
-  public void present() {
+  void present() {
     assertThat(present.isPresent()).isTrue();
 
     assertThat(present.orNull()).isSameAs("foo");
@@ -41,7 +41,7 @@ public class OptionalTest {
 
     assertThat(present.get()).isSameAs("foo");
 
-    assertThat(present.toString()).isEqualTo("Optional.of(foo)");
+    assertThat(present).hasToString("Optional.of(foo)");
 
     assertThat(present.equals(present)).isTrue();
     assertThat(present.equals(Optional.of("foo"))).isTrue();
@@ -52,14 +52,14 @@ public class OptionalTest {
   }
 
   @Test
-  public void absent() {
+  void absent() {
     assertThat(absent.isPresent()).isFalse();
 
     assertThat(absent.orNull()).isNull();
 
     assertThat(absent.or("bar")).isSameAs("bar");
 
-    assertThat(absent.toString()).isEqualTo("Optional.absent()");
+    assertThat(absent).hasToString("Optional.absent()");
 
     assertThat(absent.equals(present)).isFalse();
     assertThat(absent.equals(absent)).isTrue();
@@ -71,13 +71,13 @@ public class OptionalTest {
   }
 
   @Test
-  public void present_or_null() {
+  void present_or_null() {
     var thrown = catchThrowableOfType(() -> present.or(null), NullPointerException.class);
     assertThat(thrown).hasMessage("use orNull() instead of or(null)");
   }
 
   @Test
-  public void absent_or_null() {
+  void absent_or_null() {
     var thrown = catchThrowableOfType(() -> absent.or(null), NullPointerException.class);
     assertThat(thrown).hasMessage("use orNull() instead of or(null)");
   }

--- a/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/impl/ast/AlwaysSkipFromAstTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/impl/ast/AlwaysSkipFromAstTest.java
@@ -28,10 +28,10 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 
-public class AlwaysSkipFromAstTest {
+class AlwaysSkipFromAstTest {
 
   @Test
-  public void test() {
+  void test() {
     var astNode = mock(AstNode.class);
     assertThat(AlwaysSkipFromAst.INSTANCE.hasToBeSkippedFromAst(astNode)).isTrue();
   }

--- a/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/impl/ast/NeverSkipFromAstTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/impl/ast/NeverSkipFromAstTest.java
@@ -28,10 +28,10 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 
-public class NeverSkipFromAstTest {
+class NeverSkipFromAstTest {
 
   @Test
-  public void test() {
+  void test() {
     var astNode = mock(AstNode.class);
     assertThat(NeverSkipFromAst.INSTANCE.hasToBeSkippedFromAst(astNode)).isFalse();
   }

--- a/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/impl/ast/SkipFromAstIfOnlyOneChildTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/impl/ast/SkipFromAstIfOnlyOneChildTest.java
@@ -29,10 +29,10 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class SkipFromAstIfOnlyOneChildTest {
+class SkipFromAstIfOnlyOneChildTest {
 
   @Test
-  public void testHasToBeSkippedFromAst() {
+  void testHasToBeSkippedFromAst() {
     var astNode = mock(AstNode.class);
 
     when(astNode.getNumberOfChildren()).thenReturn(1);

--- a/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/impl/matcher/GrammarFunctionsTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/impl/matcher/GrammarFunctionsTest.java
@@ -44,10 +44,10 @@ import org.sonar.cxx.sslr.internal.vm.lexerful.TokenTypesExpression;
 import org.sonar.cxx.sslr.internal.vm.lexerful.TokenValueExpression;
 import org.sonar.cxx.sslr.internal.vm.lexerful.TokensBridgeExpression;
 
-public class GrammarFunctionsTest {
+class GrammarFunctionsTest {
 
   @Test
-  public void test() {
+  void test() {
     var e1 = mock(ParsingExpression.class);
     var e2 = mock(ParsingExpression.class);
 
@@ -87,43 +87,43 @@ public class GrammarFunctionsTest {
     assertThat(GrammarFunctions.Advanced.isOneOfThem(mock(TokenType.class), mock(TokenType.class))).isInstanceOf(
       TokenTypesExpression.class);
 
-    assertThat(GrammarFunctions.Advanced.adjacent(e1).toString()).isEqualTo("Sequence[Adjacent, " + e1 + "]");
+    assertThat(GrammarFunctions.Advanced.adjacent(e1)).hasToString("Sequence[Adjacent, " + e1 + "]");
 
-    assertThat(GrammarFunctions.Advanced.anyTokenButNot(e1).toString()).isEqualTo("Sequence[NextNot[" + e1
+    assertThat(GrammarFunctions.Advanced.anyTokenButNot(e1)).hasToString("Sequence[NextNot[" + e1
                                                                                     + "], AnyToken]");
 
-    assertThat(GrammarFunctions.Advanced.till(e1).toString()).isEqualTo("Sequence[ZeroOrMore[Sequence[NextNot[" + e1
+    assertThat(GrammarFunctions.Advanced.till(e1)).hasToString("Sequence[ZeroOrMore[Sequence[NextNot[" + e1
                                                                           + "], AnyToken]], " + e1 + "]");
 
-    assertThat(GrammarFunctions.Advanced.exclusiveTill(e1).toString()).isEqualTo("ZeroOrMore[Sequence[NextNot[" + e1
+    assertThat(GrammarFunctions.Advanced.exclusiveTill(e1)).hasToString("ZeroOrMore[Sequence[NextNot[" + e1
                                                                                    + "], AnyToken]]");
-    assertThat(GrammarFunctions.Advanced.exclusiveTill(e1, e2).toString()).isEqualTo(
+    assertThat(GrammarFunctions.Advanced.exclusiveTill(e1, e2)).hasToString(
       "ZeroOrMore[Sequence[NextNot[FirstOf[" + e1 + ", " + e2 + "]], AnyToken]]");
   }
 
   @Test
-  public void firstOf_requires_at_least_one_argument() {
+  void firstOf_requires_at_least_one_argument() {
     var thrown = catchThrowableOfType(GrammarFunctions.Standard::firstOf,
                                   IllegalArgumentException.class);
     assertThat(thrown).hasMessage("You must define at least one matcher.");
   }
 
   @Test
-  public void and_requires_at_least_one_argument() {
+  void and_requires_at_least_one_argument() {
     var thrown = catchThrowableOfType(GrammarFunctions.Standard::and,
                                   IllegalArgumentException.class);
     assertThat(thrown).hasMessage("You must define at least one matcher.");
   }
 
   @Test
-  public void isOneOfThem_requires_at_least_one_argument() {
+  void isOneOfThem_requires_at_least_one_argument() {
     var thrown = catchThrowableOfType(GrammarFunctions.Advanced::isOneOfThem,
                                   IllegalArgumentException.class);
     assertThat(thrown).hasMessage("You must define at least one matcher.");
   }
 
   @Test
-  public void test_incorrect_type_of_parsing_expression() {
+  void test_incorrect_type_of_parsing_expression() {
     var thrown = catchThrowableOfType(() -> GrammarFunctions.Standard.and(new Object()),
                                   IllegalArgumentException.class);
     assertThat(thrown).hasMessageStartingWith(
@@ -131,7 +131,7 @@ public class GrammarFunctionsTest {
   }
 
   @Test
-  public void private_constructors() throws Exception {
+  void private_constructors() throws Exception {
     assertThat(hasPrivateConstructor(GrammarFunctions.class)).isTrue();
     assertThat(hasPrivateConstructor(GrammarFunctions.Standard.class)).isTrue();
     assertThat(hasPrivateConstructor(GrammarFunctions.Predicate.class)).isTrue();

--- a/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/impl/typed/DelayedRuleInvocationExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/impl/typed/DelayedRuleInvocationExpressionTest.java
@@ -36,10 +36,10 @@ import org.sonar.cxx.sslr.internal.grammar.MutableParsingRule;
 import org.sonar.cxx.sslr.internal.vm.CompilationHandler;
 import org.sonar.cxx.sslr.internal.vm.ParsingExpression;
 
-public class DelayedRuleInvocationExpressionTest {
+class DelayedRuleInvocationExpressionTest {
 
   @Test
-  public void should_compile_rule_keys() {
+  void should_compile_rule_keys() {
     var b = spy(LexerlessGrammarBuilder.create());
     var ruleKey = mock(GrammarRuleKey.class);
 
@@ -57,7 +57,7 @@ public class DelayedRuleInvocationExpressionTest {
   }
 
   @Test
-  public void should_compile_methods() throws Exception {
+  void should_compile_methods() throws Exception {
     var b = spy(LexerlessGrammarBuilder.create());
     var ruleKey = mock(GrammarRuleKey.class);
     var method = DelayedRuleInvocationExpressionTest.class.getDeclaredMethod("FOO");
@@ -79,7 +79,7 @@ public class DelayedRuleInvocationExpressionTest {
   }
 
   @Test
-  public void should_fail_when_method_is_not_mapped() throws Exception {
+  void should_fail_when_method_is_not_mapped() throws Exception {
     var thrown = catchThrowableOfType(() -> {
       var method = DelayedRuleInvocationExpressionTest.class
         .getDeclaredMethod("FOO");
@@ -92,15 +92,15 @@ public class DelayedRuleInvocationExpressionTest {
   }
 
   @Test
-  public void test_toString() throws Exception {
+  void test_toString() throws Exception {
     var ruleKey = mock(GrammarRuleKey.class);
     when(ruleKey.toString()).thenReturn("foo");
-    assertThat(new DelayedRuleInvocationExpression(mock(LexerlessGrammarBuilder.class), ruleKey).toString()).isEqualTo(
+    assertThat(new DelayedRuleInvocationExpression(mock(LexerlessGrammarBuilder.class), ruleKey)).hasToString(
       "foo");
 
     var method = DelayedRuleInvocationExpressionTest.class.getDeclaredMethod("FOO");
     assertThat(new DelayedRuleInvocationExpression(mock(LexerlessGrammarBuilder.class), mock(
-                                                   GrammarBuilderInterceptor.class), method).toString()).isEqualTo(
+                                                   GrammarBuilderInterceptor.class), method)).hasToString(
       "FOO()");
   }
 

--- a/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/impl/typed/InterceptorTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/com/sonar/cxx/sslr/impl/typed/InterceptorTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 
-public class InterceptorTest {
+class InterceptorTest {
 
   public static class Target extends BaseTarget {
 
@@ -94,39 +94,39 @@ public class InterceptorTest {
   );
 
   @Test
-  public void should_invoke_constructor() {
+  void should_invoke_constructor() {
     assertThat(interceptedTarget.p).isEqualTo("arg");
   }
 
   @Test
-  public void should_intercept() {
+  void should_intercept() {
     assertThat(interceptedTarget.m()).isEqualTo("m()");
-    assertThat(interceptedMethods.size()).isEqualTo(1);
+    assertThat(interceptedMethods).hasSize(1);
 
     intercept = true;
     assertThat(interceptedTarget.m()).isNull();
-    assertThat(interceptedMethods.size()).isEqualTo(2);
+    assertThat(interceptedMethods).hasSize(2);
   }
 
   @Test
-  public void should_intercept_overloaded_methods() {
+  void should_intercept_overloaded_methods() {
     assertThat(interceptedTarget.overloaded()).isEqualTo("overloaded()");
-    assertThat(interceptedMethods.size()).isEqualTo(1);
+    assertThat(interceptedMethods).hasSize(1);
 
     assertThat(interceptedTarget.overloaded("arg")).isEqualTo("overloaded(arg)");
-    assertThat(interceptedMethods.size()).isEqualTo(2);
+    assertThat(interceptedMethods).hasSize(2);
   }
 
   @Test
-  public void should_intercept_overridden_methods() {
+  void should_intercept_overridden_methods() {
     assertThat(interceptedTarget.overridden()).isEqualTo("Target.overridden()");
-    assertThat(interceptedMethods.size()).isEqualTo(1);
+    assertThat(interceptedMethods).hasSize(1);
   }
 
   @Test
-  public void should_intercept_base_methods() {
+  void should_intercept_base_methods() {
     assertThat(interceptedTarget.base()).isEqualTo("base()");
-    assertThat(interceptedMethods.size()).isEqualTo(1);
+    assertThat(interceptedMethods).hasSize(1);
   }
 
   /**
@@ -135,7 +135,7 @@ public class InterceptorTest {
    * because SonarTSQL uses private helper methods.
    */
   @Test
-  public void can_not_intercept_non_public_methods() {
+  void can_not_intercept_non_public_methods() {
     assertThat(interceptedTarget.privateMethod()).isEqualTo("privateMethod()");
     assertThat(interceptedTarget.packageLocalMethod()).isEqualTo("packageLocalMethod()");
     assertThat(interceptedMethods).isEmpty();
@@ -148,7 +148,7 @@ public class InterceptorTest {
   }
 
   @Test
-  public void requires_class_to_be_public() {
+  void requires_class_to_be_public() {
     var thrown = catchThrowableOfType(() -> Interceptor.create(NonPublicClass.class, new Class<?>[]{},
                                                            new Object[]{}, methodInterceptor),
                                   IllegalAccessError.class);
@@ -165,7 +165,7 @@ public class InterceptorTest {
    * @see #can_not_intercept_non_public_methods()
    */
   @Test
-  public void requires_final_methods_to_be_non_public() {
+  void requires_final_methods_to_be_non_public() {
     var thrown = catchThrowableOfType(() -> Interceptor.create(PublicFinalMethod.class, new Class[]{},
                                                            new Object[]{},
                                                            methodInterceptor),
@@ -184,7 +184,7 @@ public class InterceptorTest {
   }
 
   @Test
-  public void requires_non_primitive_return_types() {
+  void requires_non_primitive_return_types() {
     var thrown = catchThrowableOfType(() -> Interceptor.create(PrimitiveReturnType.class,
                                                            new Class[]{}, new Object[]{},
                                                            methodInterceptor),
@@ -200,7 +200,7 @@ public class InterceptorTest {
   }
 
   @Test
-  public void should_use_ClassLoader_of_intercepted_class() throws Exception {
+  void should_use_ClassLoader_of_intercepted_class() throws Exception {
     var cv = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
     cv.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "Target", null, "java/lang/Object", null);
     var mv = cv.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
@@ -225,7 +225,7 @@ public class InterceptorTest {
 
     var interceptedTarget = Interceptor.create(cls, new Class[]{}, new Object[]{}, methodInterceptor);
     assertThat(interceptedTarget.getClass().getMethod("m").invoke(interceptedTarget)).isEqualTo("m()");
-    assertThat(interceptedMethods.size()).isEqualTo(1);
+    assertThat(interceptedMethods).hasSize(1);
   }
 
 }

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/channel/ChannelDispatcherTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/channel/ChannelDispatcherTest.java
@@ -26,19 +26,19 @@ package org.sonar.cxx.sslr.channel;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class ChannelDispatcherTest {
+class ChannelDispatcherTest {
 
   @Test
-  public void shouldRemoveSpacesFromString() {
+  void shouldRemoveSpacesFromString() {
     var dispatcher = ChannelDispatcher.builder().addChannel(new SpaceDeletionChannel())
       .build();
     var output = new StringBuilder();
     dispatcher.consume(new CodeReader("two words"), output);
-    assertThat(output.toString()).isEqualTo("twowords");
+    assertThat(output).hasToString("twowords");
   }
 
   @Test
-  public void shouldAddChannels() {
+  void shouldAddChannels() {
     var dispatcher = ChannelDispatcher.builder().addChannels(new SpaceDeletionChannel(),
                                                          new FakeChannel()).build();
     assertThat(dispatcher.getChannels().length).isEqualTo(2);
@@ -47,7 +47,7 @@ public class ChannelDispatcherTest {
   }
 
   @Test
-  public void shouldThrowExceptionWhenNoChannelToConsumeNextCharacter() {
+  void shouldThrowExceptionWhenNoChannelToConsumeNextCharacter() {
     var thrown = catchThrowableOfType(() -> {
       var dispatcher = ChannelDispatcher.builder()
         .failIfNoChannelToConsumeOneCharacter()

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/channel/CodeBufferTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/channel/CodeBufferTest.java
@@ -29,12 +29,12 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-public class CodeBufferTest {
+class CodeBufferTest {
 
   private final CodeReaderConfiguration defaulConfiguration = new CodeReaderConfiguration();
 
   @Test
-  public void testPop() {
+  void testPop() {
     var code = new CodeBuffer("pa", defaulConfiguration);
     assertThat((char) code.pop()).isEqualTo('p');
     assertThat((char) code.pop()).isEqualTo('a');
@@ -42,7 +42,7 @@ public class CodeBufferTest {
   }
 
   @Test
-  public void testPeek() {
+  void testPeek() {
     var code = new CodeBuffer("pa", defaulConfiguration);
     assertThat((char) code.peek()).isEqualTo('p');
     assertThat((char) code.peek()).isEqualTo('p');
@@ -53,7 +53,7 @@ public class CodeBufferTest {
   }
 
   @Test
-  public void testLastCharacter() {
+  void testLastCharacter() {
     var reader = new CodeBuffer("bar", defaulConfiguration);
     assertThat(reader.lastChar()).isEqualTo(-1);
     reader.pop();
@@ -61,9 +61,9 @@ public class CodeBufferTest {
   }
 
   @Test
-  public void testGetColumnAndLinePosition() {
+  void testGetColumnAndLinePosition() {
     var reader = new CodeBuffer("pa\nc\r\ns\r\n\r\n", defaulConfiguration);
-    assertThat(reader.getColumnPosition()).isEqualTo(0);
+    assertThat(reader.getColumnPosition()).isZero();
     assertThat(reader.getLinePosition()).isEqualTo(1);
     reader.pop(); // p
     reader.pop(); // a
@@ -74,64 +74,64 @@ public class CodeBufferTest {
     assertThat(reader.getColumnPosition()).isEqualTo(2);
     assertThat(reader.getLinePosition()).isEqualTo(1);
     reader.pop(); // \n
-    assertThat(reader.getColumnPosition()).isEqualTo(0);
+    assertThat(reader.getColumnPosition()).isZero();
     assertThat(reader.getLinePosition()).isEqualTo(2);
     reader.pop(); // c
     assertThat(reader.getColumnPosition()).isEqualTo(1);
     assertThat(reader.getLinePosition()).isEqualTo(2);
     reader.pop(); // \r
     reader.pop(); // \n
-    assertThat(reader.getColumnPosition()).isEqualTo(0);
+    assertThat(reader.getColumnPosition()).isZero();
     assertThat(reader.getLinePosition()).isEqualTo(3);
     assertThat((char) reader.pop()).isEqualTo('s');
     reader.pop(); // \r
     assertThat(reader.getColumnPosition()).isEqualTo(2);
     assertThat(reader.getLinePosition()).isEqualTo(3);
     reader.pop(); // \n
-    assertThat(reader.getColumnPosition()).isEqualTo(0);
+    assertThat(reader.getColumnPosition()).isZero();
     assertThat(reader.getLinePosition()).isEqualTo(4);
     reader.pop(); // \r
     reader.pop(); // \n
-    assertThat(reader.getColumnPosition()).isEqualTo(0);
+    assertThat(reader.getColumnPosition()).isZero();
     assertThat(reader.getLinePosition()).isEqualTo(5);
   }
 
   @Test
-  public void testStartAndStopRecording() {
+  void testStartAndStopRecording() {
     var reader = new CodeBuffer("123456", defaulConfiguration);
     reader.pop();
-    assertThat(reader.stopRecording().toString()).isEqualTo("");
+    assertThat(reader.stopRecording()).hasToString("");
 
     reader.startRecording();
     reader.pop();
     reader.pop();
     reader.peek();
-    assertThat(reader.stopRecording().toString()).isEqualTo("23");
-    assertThat(reader.stopRecording().toString()).isEqualTo("");
+    assertThat(reader.stopRecording()).hasToString("23");
+    assertThat(reader.stopRecording()).hasToString("");
   }
 
   @Test
-  public void testCharAt() {
+  void testCharAt() {
     var reader = new CodeBuffer("123456", defaulConfiguration);
     assertThat(reader.charAt(0)).isEqualTo('1');
     assertThat(reader.charAt(5)).isEqualTo('6');
   }
 
   @Test
-  public void testCharAtIndexOutOfBoundsException() {
+  void testCharAtIndexOutOfBoundsException() {
     var reader = new CodeBuffer("12345", defaulConfiguration);
     assertThat(reader.charAt(5)).isEqualTo((char) -1);
   }
 
   @Test
-  public void testReadWithSpecificTabWidth() {
+  void testReadWithSpecificTabWidth() {
     var configuration = new CodeReaderConfiguration();
     configuration.setTabWidth(4);
     var reader = new CodeBuffer("pa\n\tc", configuration);
     assertThat(reader.charAt(2)).isEqualTo('\n');
     assertThat(reader.charAt(3)).isEqualTo('\t');
     assertThat(reader.charAt(4)).isEqualTo('c');
-    assertThat(reader.getColumnPosition()).isEqualTo(0);
+    assertThat(reader.getColumnPosition()).isZero();
     assertThat(reader.getLinePosition()).isEqualTo(1);
     reader.pop(); // p
     reader.pop(); // a
@@ -142,7 +142,7 @@ public class CodeBufferTest {
     assertThat(reader.getColumnPosition()).isEqualTo(2);
     assertThat(reader.getLinePosition()).isEqualTo(1);
     reader.pop(); // \n
-    assertThat(reader.getColumnPosition()).isEqualTo(0);
+    assertThat(reader.getColumnPosition()).isZero();
     assertThat(reader.getLinePosition()).isEqualTo(2);
     reader.pop(); // \t
     assertThat(reader.getColumnPosition()).isEqualTo(4);
@@ -153,7 +153,7 @@ public class CodeBufferTest {
   }
 
   @Test
-  public void testCodeReaderFilter() throws Exception {
+  void testCodeReaderFilter() throws Exception {
     var configuration = new CodeReaderConfiguration();
     configuration.setCodeReaderFilters(new ReplaceNumbersFilter());
     var code = new CodeBuffer("abcd12efgh34", configuration);
@@ -182,13 +182,13 @@ public class CodeBufferTest {
   }
 
   @Test
-  public void theLengthShouldBeTheSameThanTheStringLength() {
+  void theLengthShouldBeTheSameThanTheStringLength() {
     var myCode = "myCode";
     assertThat(new CodeBuffer(myCode, new CodeReaderConfiguration()).length()).isEqualTo(6);
   }
 
   @Test
-  public void theLengthShouldDecreaseEachTimeTheInputStreamIsConsumed() {
+  void theLengthShouldDecreaseEachTimeTheInputStreamIsConsumed() {
     var myCode = "myCode";
     var codeBuffer = new CodeBuffer(myCode, new CodeReaderConfiguration());
     codeBuffer.pop();
@@ -197,7 +197,7 @@ public class CodeBufferTest {
   }
 
   @Test
-  public void testSeveralCodeReaderFilter() throws Exception {
+  void testSeveralCodeReaderFilter() throws Exception {
     var configuration = new CodeReaderConfiguration();
     configuration.setCodeReaderFilters(new ReplaceNumbersFilter(), new ReplaceCharFilter());
     var code = new CodeBuffer("abcd12efgh34", configuration);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/channel/CodeReaderTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/channel/CodeReaderTest.java
@@ -28,22 +28,22 @@ import java.util.regex.Pattern;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class CodeReaderTest {
+class CodeReaderTest {
 
   @Test
-  public void testPopWithAppendable() {
+  void testPopWithAppendable() {
     var reader = new CodeReader("package org.sonar;");
 
     var sw = new StringBuilder();
     reader.pop(sw);
-    assertThat(sw.toString()).isEqualTo("p");
+    assertThat(sw).hasToString("p");
     reader.pop(sw);
-    assertThat(sw.toString()).isEqualTo("pa");
+    assertThat(sw).hasToString("pa");
 
   }
 
   @Test
-  public void testPeekACharArray() {
+  void testPeekACharArray() {
     var reader = new CodeReader(new StringReader("bar"));
     var chars = reader.peek(2);
     assertThat(chars.length).isEqualTo(2);
@@ -52,31 +52,31 @@ public class CodeReaderTest {
   }
 
   @Test
-  public void testPeekTo() {
+  void testPeekTo() {
     var reader = new CodeReader(new StringReader("package org.sonar;"));
     var result = new StringBuilder();
     reader.peekTo((int endFlag) -> 'r' == (char) endFlag, result);
-    assertThat(result.toString()).isEqualTo("package o");
+    assertThat(result).hasToString("package o");
     assertThat(reader.peek()).isEqualTo((int) 'p'); // never called pop()
   }
 
   @Test
-  public void peekTo_should_stop_at_end_of_input() {
+  void peekTo_should_stop_at_end_of_input() {
     var reader = new CodeReader("foo");
     var result = new StringBuilder();
     reader.peekTo(i -> false, result);
-    assertThat(result.toString()).isEqualTo("foo");
+    assertThat(result).hasToString("foo");
   }
 
   @Test
-  public void testPopToWithRegex() {
+  void testPopToWithRegex() {
     var reader = new CodeReader(new StringReader("123ABC"));
     var token = new StringBuilder();
     assertThat(reader.popTo(Pattern.compile("\\d+").matcher(new String()), token)).isEqualTo(3);
-    assertThat(token.toString()).isEqualTo("123");
+    assertThat(token).hasToString("123");
     assertThat(reader.popTo(Pattern.compile("\\d+").matcher(new String()), token)).isEqualTo(-1);
     assertThat(reader.popTo(Pattern.compile("\\w+").matcher(new String()), token)).isEqualTo(3);
-    assertThat(token.toString()).isEqualTo("123ABC");
+    assertThat(token).hasToString("123ABC");
     assertThat(reader.popTo(Pattern.compile("\\w+").matcher(new String()), token)).isEqualTo(-1);
 
     // Should reset matcher with empty string:
@@ -91,7 +91,7 @@ public class CodeReaderTest {
   }
 
   @Test
-  public void testStackOverflowError() {
+  void testStackOverflowError() {
     var sb = new StringBuilder();
     sb.append("\n");
     for (int i = 0; i < 10000; i++) {
@@ -111,13 +111,13 @@ public class CodeReaderTest {
   }
 
   @Test
-  public void testPopToWithRegexAndFollowingMatcher() {
+  void testPopToWithRegexAndFollowingMatcher() {
     var digitMatcher = Pattern.compile("\\d+").matcher(new String());
     var alphabeticMatcher = Pattern.compile("[a-zA-Z]").matcher(new String());
     var token = new StringBuilder();
     assertThat(new CodeReader(new StringReader("123 ABC")).popTo(digitMatcher, alphabeticMatcher, token)).isEqualTo(-1);
-    assertThat(token.toString()).isEqualTo("");
+    assertThat(token).hasToString("");
     assertThat(new CodeReader(new StringReader("123ABC")).popTo(digitMatcher, alphabeticMatcher, token)).isEqualTo(3);
-    assertThat(token.toString()).isEqualTo("123");
+    assertThat(token).hasToString("123");
   }
 }

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/channel/RegexChannelTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/channel/RegexChannelTest.java
@@ -26,19 +26,19 @@ package org.sonar.cxx.sslr.channel;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class RegexChannelTest {
+class RegexChannelTest {
 
   @Test
-  public void shouldMatch() {
+  void shouldMatch() {
     var dispatcher = ChannelDispatcher.builder().addChannel(new MyWordChannel())
       .addChannel(new BlackholeChannel()).build();
     var output = new StringBuilder();
     dispatcher.consume(new CodeReader("my word"), output);
-    assertThat(output.toString()).isEqualTo("<w>my</w> <w>word</w>");
+    assertThat(output).hasToString("<w>my</w> <w>word</w>");
   }
 
   @Test
-  public void shouldMatchTokenLongerThanBuffer() {
+  void shouldMatchTokenLongerThanBuffer() {
     var dispatcher = ChannelDispatcher.builder().addChannel(new MyLiteralChannel()).build();
     var output = new StringBuilder();
 
@@ -49,7 +49,7 @@ public class RegexChannelTest {
 
     assertThat(veryLongLiteral.length()).isEqualTo(100000);
     dispatcher.consume(new CodeReader("\">" + veryLongLiteral + "<\"", codeReaderConfiguration), output);
-    assertThat(output.toString()).isEqualTo("<literal>\">" + veryLongLiteral + "<\"</literal>");
+    assertThat(output).hasToString("<literal>\">" + veryLongLiteral + "<\"</literal>");
   }
 
   private static class MyLiteralChannel extends RegexChannel<StringBuilder> {

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/grammar/LexerfulGrammarBuilderTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/grammar/LexerfulGrammarBuilderTest.java
@@ -47,10 +47,10 @@ import org.sonar.cxx.sslr.internal.vm.lexerful.TokenTypesExpression;
 import org.sonar.cxx.sslr.internal.vm.lexerful.TokenValueExpression;
 import org.sonar.cxx.sslr.internal.vm.lexerful.TokensBridgeExpression;
 
-public class LexerfulGrammarBuilderTest {
+class LexerfulGrammarBuilderTest {
 
   @Test
-  public void should_create_expressions() {
+  void should_create_expressions() {
     var b = LexerfulGrammarBuilder.create();
 
     var e1 = mock(ParsingExpression.class);
@@ -88,15 +88,15 @@ public class LexerfulGrammarBuilderTest {
     assertThat(b.isOneOfThem(mock(TokenType.class), mock(TokenType.class))).isInstanceOf(TokenTypesExpression.class);
     assertThat(b.bridge(mock(TokenType.class), mock(TokenType.class))).isInstanceOf(TokensBridgeExpression.class);
 
-    assertThat(b.adjacent(e1).toString()).isEqualTo("Sequence[Adjacent, " + e1 + "]");
+    assertThat(b.adjacent(e1)).hasToString("Sequence[Adjacent, " + e1 + "]");
 
-    assertThat(b.anyTokenButNot(e1).toString()).isEqualTo("Sequence[NextNot[" + e1 + "], AnyToken]");
+    assertThat(b.anyTokenButNot(e1)).hasToString("Sequence[NextNot[" + e1 + "], AnyToken]");
 
-    assertThat(b.till(e1).toString()).isEqualTo("Sequence[ZeroOrMore[Sequence[NextNot[" + e1 + "], AnyToken]], " + e1
+    assertThat(b.till(e1)).hasToString("Sequence[ZeroOrMore[Sequence[NextNot[" + e1 + "], AnyToken]], " + e1
                                                   + "]");
 
-    assertThat(b.exclusiveTill(e1).toString()).isEqualTo("ZeroOrMore[Sequence[NextNot[" + e1 + "], AnyToken]]");
-    assertThat(b.exclusiveTill(e1, e2).toString()).isEqualTo("ZeroOrMore[Sequence[NextNot[FirstOf[" + e1 + ", " + e2
+    assertThat(b.exclusiveTill(e1)).hasToString("ZeroOrMore[Sequence[NextNot[" + e1 + "], AnyToken]]");
+    assertThat(b.exclusiveTill(e1, e2)).hasToString("ZeroOrMore[Sequence[NextNot[FirstOf[" + e1 + ", " + e2
                                                                + "]], AnyToken]]");
 
     assertThat(b.everything()).as("singleton").isSameAs(AnyTokenExpression.INSTANCE);
@@ -105,7 +105,7 @@ public class LexerfulGrammarBuilderTest {
   }
 
   @Test
-  public void should_set_root_rule() {
+  void should_set_root_rule() {
     var b = LexerfulGrammarBuilder.create();
     var ruleKey = mock(GrammarRuleKey.class);
     b.rule(ruleKey).is(b.nothing());
@@ -115,7 +115,7 @@ public class LexerfulGrammarBuilderTest {
   }
 
   @Test
-  public void should_build_with_memoization() {
+  void should_build_with_memoization() {
     var b = LexerfulGrammarBuilder.create();
     var ruleKey = mock(GrammarRuleKey.class);
     b.rule(ruleKey).is("foo");
@@ -124,7 +124,7 @@ public class LexerfulGrammarBuilderTest {
   }
 
   @Test
-  public void test_undefined_root_rule() {
+  void test_undefined_root_rule() {
     var b = LexerfulGrammarBuilder.create();
     var ruleKey = mock(GrammarRuleKey.class);
     b.setRootRule(ruleKey);
@@ -133,7 +133,7 @@ public class LexerfulGrammarBuilderTest {
   }
 
   @Test
-  public void test_undefined_rule() {
+  void test_undefined_rule() {
     var b = LexerfulGrammarBuilder.create();
     var ruleKey = mock(GrammarRuleKey.class);
     b.rule(ruleKey);
@@ -142,7 +142,7 @@ public class LexerfulGrammarBuilderTest {
   }
 
   @Test
-  public void test_used_undefined_rule() {
+  void test_used_undefined_rule() {
     var b = LexerfulGrammarBuilder.create();
     var ruleKey1 = mock(GrammarRuleKey.class);
     var ruleKey2 = mock(GrammarRuleKey.class);
@@ -152,7 +152,7 @@ public class LexerfulGrammarBuilderTest {
   }
 
   @Test
-  public void test_incorrect_type_of_parsing_expression() {
+  void test_incorrect_type_of_parsing_expression() {
     var thrown = catchThrowableOfType(
       () -> LexerfulGrammarBuilder.create().convertToExpression(new Object()),
       IllegalArgumentException.class);
@@ -160,7 +160,7 @@ public class LexerfulGrammarBuilderTest {
   }
 
   @Test
-  public void test_null_parsing_expression() {
+  void test_null_parsing_expression() {
     var thrown = catchThrowableOfType(
       () -> LexerfulGrammarBuilder.create().convertToExpression(null),
       NullPointerException.class);
@@ -168,7 +168,7 @@ public class LexerfulGrammarBuilderTest {
   }
 
   @Test
-  public void should_fail_to_redefine() {
+  void should_fail_to_redefine() {
     var b = LexerfulGrammarBuilder.create();
     var ruleKey = mock(GrammarRuleKey.class);
     b.rule(ruleKey).is("foo");
@@ -179,7 +179,7 @@ public class LexerfulGrammarBuilderTest {
   }
 
   @Test
-  public void should_fail_to_redefine2() {
+  void should_fail_to_redefine2() {
     var b = LexerfulGrammarBuilder.create();
     var ruleKey = mock(GrammarRuleKey.class);
     b.rule(ruleKey).is("foo", "bar");

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/grammar/LexerlessGrammarBuilderTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/grammar/LexerlessGrammarBuilderTest.java
@@ -47,10 +47,10 @@ import org.sonar.cxx.sslr.internal.vm.TokenExpression;
 import org.sonar.cxx.sslr.internal.vm.TriviaExpression;
 import org.sonar.cxx.sslr.internal.vm.ZeroOrMoreExpression;
 
-public class LexerlessGrammarBuilderTest {
+class LexerlessGrammarBuilderTest {
 
   @Test
-  public void should_create_expressions() {
+  void should_create_expressions() {
     var b = LexerlessGrammarBuilder.create();
     var e1 = mock(ParsingExpression.class);
     var e2 = mock(ParsingExpression.class);
@@ -93,7 +93,7 @@ public class LexerlessGrammarBuilderTest {
   }
 
   @Test
-  public void test_token() {
+  void test_token() {
     var tokenType = mock(TokenType.class);
     var e = mock(ParsingExpression.class);
     var result = LexerlessGrammarBuilder.create().token(tokenType, e);
@@ -102,7 +102,7 @@ public class LexerlessGrammarBuilderTest {
   }
 
   @Test
-  public void test_commentTrivia() {
+  void test_commentTrivia() {
     var e = mock(ParsingExpression.class);
     var result = LexerlessGrammarBuilder.create().commentTrivia(e);
     assertThat(result).isInstanceOf(TriviaExpression.class);
@@ -110,7 +110,7 @@ public class LexerlessGrammarBuilderTest {
   }
 
   @Test
-  public void test_skippedTrivia() {
+  void test_skippedTrivia() {
     var e = mock(ParsingExpression.class);
     var result = LexerlessGrammarBuilder.create().skippedTrivia(e);
     assertThat(result).isInstanceOf(TriviaExpression.class);
@@ -118,7 +118,7 @@ public class LexerlessGrammarBuilderTest {
   }
 
   @Test
-  public void should_set_root_rule() {
+  void should_set_root_rule() {
     var b = LexerlessGrammarBuilder.create();
     var ruleKey = mock(GrammarRuleKey.class);
     b.rule(ruleKey).is(b.nothing());
@@ -128,7 +128,7 @@ public class LexerlessGrammarBuilderTest {
   }
 
   @Test
-  public void test_undefined_root_rule() {
+  void test_undefined_root_rule() {
     var b = LexerlessGrammarBuilder.create();
     var ruleKey = mock(GrammarRuleKey.class);
     b.setRootRule(ruleKey);
@@ -137,7 +137,7 @@ public class LexerlessGrammarBuilderTest {
   }
 
   @Test
-  public void test_undefined_rule() {
+  void test_undefined_rule() {
     var b = LexerlessGrammarBuilder.create();
     var ruleKey = mock(GrammarRuleKey.class);
     b.rule(ruleKey);
@@ -146,7 +146,7 @@ public class LexerlessGrammarBuilderTest {
   }
 
   @Test
-  public void test_used_undefined_rule() {
+  void test_used_undefined_rule() {
     var b = LexerlessGrammarBuilder.create();
     var ruleKey1 = mock(GrammarRuleKey.class);
     var ruleKey2 = mock(GrammarRuleKey.class);
@@ -156,14 +156,14 @@ public class LexerlessGrammarBuilderTest {
   }
 
   @Test
-  public void test_wrong_regexp() {
+  void test_wrong_regexp() {
     var b = LexerlessGrammarBuilder.create();
     var thrown = catchThrowableOfType(() -> b.regexp("["), PatternSyntaxException.class);
     assertThat(thrown).isExactlyInstanceOf(PatternSyntaxException.class);
   }
 
   @Test
-  public void test_incorrect_type_of_parsing_expression() {
+  void test_incorrect_type_of_parsing_expression() {
     var thrown = catchThrowableOfType(
       () -> LexerlessGrammarBuilder.create().convertToExpression(new Object()),
       IllegalArgumentException.class);
@@ -171,7 +171,7 @@ public class LexerlessGrammarBuilderTest {
   }
 
   @Test
-  public void test_null_parsing_expression() {
+  void test_null_parsing_expression() {
     var thrown = catchThrowableOfType(
       () -> LexerlessGrammarBuilder.create().convertToExpression(null),
       NullPointerException.class);
@@ -179,7 +179,7 @@ public class LexerlessGrammarBuilderTest {
   }
 
   @Test
-  public void should_fail_to_redefine() {
+  void should_fail_to_redefine() {
     var b = LexerlessGrammarBuilder.create();
     var ruleKey = mock(GrammarRuleKey.class);
     b.rule(ruleKey).is("foo");
@@ -190,7 +190,7 @@ public class LexerlessGrammarBuilderTest {
   }
 
   @Test
-  public void should_fail_to_redefine2() {
+  void should_fail_to_redefine2() {
     var b = LexerlessGrammarBuilder.create();
     var ruleKey = mock(GrammarRuleKey.class);
     b.rule(ruleKey).is("foo", "bar");

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/grammar/RuleBuilderTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/grammar/RuleBuilderTest.java
@@ -34,14 +34,14 @@ import org.sonar.cxx.sslr.internal.vm.CompilableGrammarRule;
 import org.sonar.cxx.sslr.internal.vm.ParsingExpression;
 import org.sonar.cxx.sslr.internal.vm.SequenceExpression;
 
-public class RuleBuilderTest {
+class RuleBuilderTest {
 
   private final GrammarBuilder b = mock(GrammarBuilder.class);
   private final CompilableGrammarRule delegate = mock(CompilableGrammarRule.class);
   private final RuleBuilder ruleBuilder = new RuleBuilder(b, delegate);
 
   @Test
-  public void test_is() {
+  void test_is() {
     var e1 = mock(ParsingExpression.class);
     var e2 = mock(ParsingExpression.class);
     when(b.convertToExpression(e1)).thenReturn(e2);
@@ -50,7 +50,7 @@ public class RuleBuilderTest {
   }
 
   @Test
-  public void test_is2() {
+  void test_is2() {
     var e1 = mock(ParsingExpression.class);
     var e2 = mock(ParsingExpression.class);
     var e3 = mock(ParsingExpression.class);
@@ -60,7 +60,7 @@ public class RuleBuilderTest {
   }
 
   @Test
-  public void should_fail_to_redefine() {
+  void should_fail_to_redefine() {
     var e = mock(ParsingExpression.class);
     when(delegate.getExpression()).thenReturn(e);
     var ruleKey = mock(GrammarRuleKey.class);
@@ -72,7 +72,7 @@ public class RuleBuilderTest {
   }
 
   @Test
-  public void test_override() {
+  void test_override() {
     var e1 = mock(ParsingExpression.class);
     var e2 = mock(ParsingExpression.class);
     var e3 = mock(ParsingExpression.class);
@@ -86,7 +86,7 @@ public class RuleBuilderTest {
   }
 
   @Test
-  public void test_override2() {
+  void test_override2() {
     var e1 = mock(ParsingExpression.class);
     var e2 = mock(ParsingExpression.class);
     var e3 = mock(ParsingExpression.class);
@@ -99,13 +99,13 @@ public class RuleBuilderTest {
   }
 
   @Test
-  public void test_skip() {
+  void test_skip() {
     ruleBuilder.skip();
     verify(delegate).skip();
   }
 
   @Test
-  public void test_skipIfOneChild() {
+  void test_skipIfOneChild() {
     ruleBuilder.skipIfOneChild();
     verify(delegate).skipIfOneChild();
   }

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/ast/AstSelectFactoryTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/ast/AstSelectFactoryTest.java
@@ -34,16 +34,16 @@ import org.sonar.cxx.sslr.internal.ast.select.EmptyAstSelect;
 import org.sonar.cxx.sslr.internal.ast.select.ListAstSelect;
 import org.sonar.cxx.sslr.internal.ast.select.SingleAstSelect;
 
-public class AstSelectFactoryTest {
+class AstSelectFactoryTest {
 
   @Test
-  public void test_select() {
+  void test_select() {
     assertThat((Object) AstSelectFactory.select(null)).isInstanceOf(EmptyAstSelect.class);
     assertThat((Object) AstSelectFactory.select(mock(AstNode.class))).isInstanceOf(SingleAstSelect.class);
   }
 
   @Test
-  public void test_create() {
+  void test_create() {
     var node1 = mock(AstNode.class);
     var node2 = mock(AstNode.class);
     assertThat((Object) AstSelectFactory.create(Collections.emptyList())).isSameAs(AstSelectFactory.empty());
@@ -52,7 +52,7 @@ public class AstSelectFactoryTest {
   }
 
   @Test
-  public void test_empty() {
+  void test_empty() {
     assertThat((Object) AstSelectFactory.empty()).isInstanceOf(EmptyAstSelect.class);
     assertThat((Object) AstSelectFactory.empty()).isSameAs(AstSelectFactory.empty());
   }

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/ast/EmptyAstSelectTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/ast/EmptyAstSelectTest.java
@@ -32,63 +32,63 @@ import static org.mockito.Mockito.mock;
 import org.sonar.cxx.sslr.ast.AstSelect;
 import org.sonar.cxx.sslr.internal.ast.select.EmptyAstSelect;
 
-public class EmptyAstSelectTest {
+class EmptyAstSelectTest {
 
   private final AstSelect select = new EmptyAstSelect();
 
   @Test
-  public void test_children() {
+  void test_children() {
     assertThat((Object) select.children()).isSameAs(select);
     assertThat((Object) select.children(mock(AstNodeType.class))).isSameAs(select);
     assertThat((Object) select.children(mock(AstNodeType.class), mock(AstNodeType.class))).isSameAs(select);
   }
 
   @Test
-  public void test_nextSibling() {
+  void test_nextSibling() {
     assertThat((Object) select.nextSibling()).isSameAs(select);
   }
 
   @Test
-  public void test_previousSibling() {
+  void test_previousSibling() {
     assertThat((Object) select.previousSibling()).isSameAs(select);
   }
 
   @Test
-  public void test_parent() {
+  void test_parent() {
     assertThat((Object) select.parent()).isSameAs(select);
   }
 
   @Test
-  public void test_firstAncestor() {
+  void test_firstAncestor() {
     assertThat((Object) select.firstAncestor(mock(AstNodeType.class))).isSameAs(select);
     assertThat((Object) select.firstAncestor(mock(AstNodeType.class), mock(AstNodeType.class))).isSameAs(select);
   }
 
   @Test
-  public void test_descendants() {
+  void test_descendants() {
     assertThat((Object) select.descendants(mock(AstNodeType.class))).isSameAs(select);
     assertThat((Object) select.descendants(mock(AstNodeType.class), mock(AstNodeType.class))).isSameAs(select);
   }
 
   @Test
-  public void test_isEmpty() {
-    assertThat(select.isEmpty()).isTrue();
+  void test_isEmpty() {
+    assertThat(select).isEmpty();
   }
 
   @Test
-  public void test_isNotEmpty() {
+  void test_isNotEmpty() {
     assertThat(select.isNotEmpty()).isFalse();
   }
 
   @Test
-  public void test_filter() {
+  void test_filter() {
     assertThat((Object) select.filter(mock(AstNodeType.class))).isSameAs(select);
     assertThat((Object) select.filter(mock(AstNodeType.class), mock(AstNodeType.class))).isSameAs(select);
     assertThat((Object) select.filter(mock(Predicate.class))).isSameAs(select);
   }
 
   @Test
-  public void test_get_non_existing() {
+  void test_get_non_existing() {
     var thrown = catchThrowableOfType(
       () -> select.get(0),
       IndexOutOfBoundsException.class);
@@ -96,12 +96,12 @@ public class EmptyAstSelectTest {
   }
 
   @Test
-  public void test_size() {
-    assertThat(select.size()).isEqualTo(0);
+  void test_size() {
+    assertThat(select).isEmpty();
   }
 
   @Test
-  public void test_iterator() {
+  void test_iterator() {
     assertThat((Object) select.iterator()).isSameAs(Collections.emptyIterator());
   }
 

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/ast/ListAstSelectTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/ast/ListAstSelectTest.java
@@ -37,7 +37,7 @@ import org.sonar.cxx.sslr.internal.ast.select.AstSelectFactory;
 import org.sonar.cxx.sslr.internal.ast.select.ListAstSelect;
 import org.sonar.cxx.sslr.internal.ast.select.SingleAstSelect;
 
-public class ListAstSelectTest {
+class ListAstSelectTest {
 
   private AstNode node1, node2;
   private ListAstSelect select;
@@ -50,7 +50,7 @@ public class ListAstSelectTest {
   }
 
   @Test
-  public void test_children_when_no_children() {
+  void test_children_when_no_children() {
     assertThat((Object) select.children()).isSameAs(AstSelectFactory.empty());
     assertThat((Object) select.children(mock(AstNodeType.class))).isSameAs(AstSelectFactory.empty());
     assertThat((Object) select.children(mock(AstNodeType.class), mock(AstNodeType.class))).isSameAs(AstSelectFactory
@@ -58,7 +58,7 @@ public class ListAstSelectTest {
   }
 
   @Test
-  public void test_children_when_one_child() {
+  void test_children_when_one_child() {
     var type1 = mock(AstNodeType.class);
     var type2 = mock(AstNodeType.class);
     var child = mock(AstNode.class);
@@ -89,7 +89,7 @@ public class ListAstSelectTest {
   }
 
   @Test
-  public void test_chilren_when_more_than_one_child() {
+  void test_chilren_when_more_than_one_child() {
     var type1 = mock(AstNodeType.class);
     var type2 = mock(AstNodeType.class);
     var child1 = mock(AstNode.class);
@@ -129,7 +129,7 @@ public class ListAstSelectTest {
   }
 
   @Test
-  public void test_nextSibling() {
+  void test_nextSibling() {
     assertThat((Object) select.nextSibling()).isSameAs(AstSelectFactory.empty());
 
     var sibling1 = mock(AstNode.class);
@@ -144,7 +144,7 @@ public class ListAstSelectTest {
   }
 
   @Test
-  public void test_previousSibling() {
+  void test_previousSibling() {
     assertThat((Object) select.previousSibling()).isSameAs(AstSelectFactory.empty());
 
     var sibling1 = mock(AstNode.class);
@@ -159,7 +159,7 @@ public class ListAstSelectTest {
   }
 
   @Test
-  public void test_parent() {
+  void test_parent() {
     assertThat((Object) select.parent()).isSameAs(AstSelectFactory.empty());
 
     var parent1 = mock(AstNode.class);
@@ -174,7 +174,7 @@ public class ListAstSelectTest {
   }
 
   @Test
-  public void test_firstAncestor_by_type() {
+  void test_firstAncestor_by_type() {
     var type = mock(AstNodeType.class);
     assertThat((Object) select.firstAncestor(type)).isSameAs(AstSelectFactory.empty());
 
@@ -194,7 +194,7 @@ public class ListAstSelectTest {
   }
 
   @Test
-  public void test_firstAncestor_by_types() {
+  void test_firstAncestor_by_types() {
     var type1 = mock(AstNodeType.class);
     var type2 = mock(AstNodeType.class);
     assertThat((Object) select.firstAncestor(type1, type2)).isSameAs(AstSelectFactory.empty());
@@ -215,24 +215,24 @@ public class ListAstSelectTest {
   }
 
   @Test
-  public void test_descendants() {
+  void test_descendants() {
     assertThat((Object) select.descendants(mock(AstNodeType.class))).isSameAs(AstSelectFactory.empty());
     assertThat((Object) select.descendants(mock(AstNodeType.class), mock(AstNodeType.class))).isSameAs(AstSelectFactory
       .empty());
   }
 
   @Test
-  public void test_isEmpty() {
+  void test_isEmpty() {
     assertThat(select.isEmpty()).isFalse();
   }
 
   @Test
-  public void test_isNotEmpty() {
+  void test_isNotEmpty() {
     assertThat(select.isNotEmpty()).isTrue();
   }
 
   @Test
-  public void test_filter_by_type() {
+  void test_filter_by_type() {
     var type = mock(AstNodeType.class);
     assertThat((Object) select.filter(type)).isSameAs(AstSelectFactory.empty());
 
@@ -246,7 +246,7 @@ public class ListAstSelectTest {
   }
 
   @Test
-  public void test_filter_by_types() {
+  void test_filter_by_types() {
     var type1 = mock(AstNodeType.class);
     var type2 = mock(AstNodeType.class);
     assertThat((Object) select.filter(type1, type2)).isSameAs(AstSelectFactory.empty());
@@ -261,7 +261,7 @@ public class ListAstSelectTest {
   }
 
   @Test
-  public void test_filter() {
+  void test_filter() {
     Predicate<AstNode> predicate = mock(Predicate.class);
     assertThat((Object) select.filter(predicate)).isSameAs(AstSelectFactory.empty());
 
@@ -275,13 +275,13 @@ public class ListAstSelectTest {
   }
 
   @Test
-  public void test_get() {
+  void test_get() {
     assertThat(select.get(0)).isSameAs(node1);
     assertThat(select.get(1)).isSameAs(node2);
   }
 
   @Test
-  public void test_get_non_existing() {
+  void test_get_non_existing() {
     var thrown = catchThrowableOfType(
       () -> select.get(2),
       IndexOutOfBoundsException.class);
@@ -289,12 +289,12 @@ public class ListAstSelectTest {
   }
 
   @Test
-  public void test_size() {
-    assertThat(select.size()).isEqualTo(2);
+  void test_size() {
+    assertThat(select).hasSize(2);
   }
 
   @Test
-  public void test_iterator() {
+  void test_iterator() {
     assertThat(select.iterator()).toIterable().containsOnly(node1, node2);
   }
 

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/ast/SingleAstSelectTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/ast/SingleAstSelectTest.java
@@ -37,7 +37,7 @@ import org.sonar.cxx.sslr.internal.ast.select.AstSelectFactory;
 import org.sonar.cxx.sslr.internal.ast.select.ListAstSelect;
 import org.sonar.cxx.sslr.internal.ast.select.SingleAstSelect;
 
-public class SingleAstSelectTest {
+class SingleAstSelectTest {
 
   private AstNode node;
   private SingleAstSelect select;
@@ -49,7 +49,7 @@ public class SingleAstSelectTest {
   }
 
   @Test
-  public void test_children_when_no_children() {
+  void test_children_when_no_children() {
     assertThat((Object) select.children()).isSameAs(AstSelectFactory.empty());
     assertThat((Object) select.children(mock(AstNodeType.class))).isSameAs(AstSelectFactory.empty());
     assertThat((Object) select.children(mock(AstNodeType.class), mock(AstNodeType.class))).isSameAs(AstSelectFactory
@@ -57,7 +57,7 @@ public class SingleAstSelectTest {
   }
 
   @Test
-  public void test_children_when_one_child() {
+  void test_children_when_one_child() {
     var type1 = mock(AstNodeType.class);
     var type2 = mock(AstNodeType.class);
     var child = mock(AstNode.class);
@@ -88,7 +88,7 @@ public class SingleAstSelectTest {
   }
 
   @Test
-  public void test_chilren_when_more_than_one_child() {
+  void test_chilren_when_more_than_one_child() {
     var type1 = mock(AstNodeType.class);
     var type2 = mock(AstNodeType.class);
     var child1 = mock(AstNode.class);
@@ -128,7 +128,7 @@ public class SingleAstSelectTest {
   }
 
   @Test
-  public void test_nextSibling() {
+  void test_nextSibling() {
     assertThat((Object) select.nextSibling()).isSameAs(AstSelectFactory.empty());
 
     var sibling = mock(AstNode.class);
@@ -138,7 +138,7 @@ public class SingleAstSelectTest {
   }
 
   @Test
-  public void test_previousSibling() {
+  void test_previousSibling() {
     assertThat((Object) select.previousSibling()).isSameAs(AstSelectFactory.empty());
 
     var sibling = mock(AstNode.class);
@@ -148,7 +148,7 @@ public class SingleAstSelectTest {
   }
 
   @Test
-  public void test_parent() {
+  void test_parent() {
     assertThat((Object) select.parent()).isSameAs(AstSelectFactory.empty());
 
     var parent = mock(AstNode.class);
@@ -158,7 +158,7 @@ public class SingleAstSelectTest {
   }
 
   @Test
-  public void test_firstAncestor_by_type() {
+  void test_firstAncestor_by_type() {
     var type = mock(AstNodeType.class);
     assertThat((Object) select.firstAncestor(type)).isSameAs(AstSelectFactory.empty());
 
@@ -172,7 +172,7 @@ public class SingleAstSelectTest {
   }
 
   @Test
-  public void test_firstAncestor_by_types() {
+  void test_firstAncestor_by_types() {
     var type1 = mock(AstNodeType.class);
     var type2 = mock(AstNodeType.class);
     assertThat((Object) select.firstAncestor(type1, type2)).isSameAs(AstSelectFactory.empty());
@@ -187,24 +187,24 @@ public class SingleAstSelectTest {
   }
 
   @Test
-  public void test_descendants() {
+  void test_descendants() {
     assertThat((Object) select.descendants(mock(AstNodeType.class))).isSameAs(AstSelectFactory.empty());
     assertThat((Object) select.descendants(mock(AstNodeType.class), mock(AstNodeType.class))).isSameAs(AstSelectFactory
       .empty());
   }
 
   @Test
-  public void test_isEmpty() {
+  void test_isEmpty() {
     assertThat(select.isEmpty()).isFalse();
   }
 
   @Test
-  public void test_isNotEmpty() {
+  void test_isNotEmpty() {
     assertThat(select.isNotEmpty()).isTrue();
   }
 
   @Test
-  public void test_filter_by_type() {
+  void test_filter_by_type() {
     var type = mock(AstNodeType.class);
     assertThat((Object) select.filter(type)).isSameAs(AstSelectFactory.empty());
 
@@ -213,7 +213,7 @@ public class SingleAstSelectTest {
   }
 
   @Test
-  public void test_filter_by_types() {
+  void test_filter_by_types() {
     var type1 = mock(AstNodeType.class);
     var type2 = mock(AstNodeType.class);
     assertThat((Object) select.filter(type1, type2)).isSameAs(AstSelectFactory.empty());
@@ -223,7 +223,7 @@ public class SingleAstSelectTest {
   }
 
   @Test
-  public void test_filter() {
+  void test_filter() {
     Predicate<AstNode> predicate = mock(Predicate.class);
     assertThat((Object) select.filter(predicate)).isSameAs(AstSelectFactory.empty());
 
@@ -232,12 +232,12 @@ public class SingleAstSelectTest {
   }
 
   @Test
-  public void test_get0() {
+  void test_get0() {
     assertThat(select.get(0)).isSameAs(node);
   }
 
   @Test
-  public void test_get_non_existing() {
+  void test_get_non_existing() {
     IndexOutOfBoundsException thrown = catchThrowableOfType(
       () -> select.get(1),
       IndexOutOfBoundsException.class);
@@ -245,12 +245,12 @@ public class SingleAstSelectTest {
   }
 
   @Test
-  public void test_size() {
-    assertThat(select.size()).isEqualTo(1);
+  void test_size() {
+    assertThat(select).hasSize(1);
   }
 
   @Test
-  public void test_iterator() {
+  void test_iterator() {
     assertThat(select.iterator()).toIterable().containsOnly(node);
   }
 

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/grammar/MutableGrammarTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/grammar/MutableGrammarTest.java
@@ -30,10 +30,10 @@ import static org.mockito.Mockito.mock;
 import org.sonar.cxx.sslr.grammar.GrammarRuleKey;
 import org.sonar.cxx.sslr.internal.vm.CompilableGrammarRule;
 
-public class MutableGrammarTest {
+class MutableGrammarTest {
 
   @Test
-  public void test() {
+  void test() {
     var ruleKey = mock(GrammarRuleKey.class);
     var rule = mock(CompilableGrammarRule.class);
     var rootRuleKey = mock(GrammarRuleKey.class);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/grammar/MutableParsingRuleTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/grammar/MutableParsingRuleTest.java
@@ -33,10 +33,10 @@ import org.sonar.cxx.sslr.grammar.GrammarRuleKey;
 import org.sonar.cxx.sslr.internal.vm.ParsingExpression;
 import org.sonar.cxx.sslr.internal.vm.SequenceExpression;
 
-public class MutableParsingRuleTest {
+class MutableParsingRuleTest {
 
   @Test
-  public void should_not_allow_redefinition() {
+  void should_not_allow_redefinition() {
     var ruleKey = mock(GrammarRuleKey.class);
     var rule = new MutableParsingRule(ruleKey);
     rule.is(mock(ParsingExpression.class));
@@ -47,7 +47,7 @@ public class MutableParsingRuleTest {
   }
 
   @Test
-  public void should_override() {
+  void should_override() {
     var ruleKey = mock(GrammarRuleKey.class);
     var rule = new MutableParsingRule(ruleKey);
     var e1 = mock(ParsingExpression.class);
@@ -60,7 +60,7 @@ public class MutableParsingRuleTest {
   }
 
   @Test
-  public void should_not_skip_from_AST() {
+  void should_not_skip_from_AST() {
     var ruleKey = mock(GrammarRuleKey.class);
     var rule = new MutableParsingRule(ruleKey);
     var astNode = mock(AstNode.class);
@@ -68,7 +68,7 @@ public class MutableParsingRuleTest {
   }
 
   @Test
-  public void should_skip_from_AST() {
+  void should_skip_from_AST() {
     var ruleKey = mock(GrammarRuleKey.class);
     var rule = new MutableParsingRule(ruleKey);
     rule.skip();
@@ -77,7 +77,7 @@ public class MutableParsingRuleTest {
   }
 
   @Test
-  public void should_skip_from_AST_if_one_child() {
+  void should_skip_from_AST_if_one_child() {
     var ruleKey = mock(GrammarRuleKey.class);
     var rule = new MutableParsingRule(ruleKey);
     rule.skipIfOneChild();
@@ -87,7 +87,7 @@ public class MutableParsingRuleTest {
   }
 
   @Test
-  public void should_return_real_AstNodeType() {
+  void should_return_real_AstNodeType() {
     var ruleKey = mock(GrammarRuleKey.class);
     var rule = new MutableParsingRule(ruleKey);
     assertThat(rule.getRealAstNodeType()).isSameAs(ruleKey);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/matchers/AstCreatorTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/matchers/AstCreatorTest.java
@@ -39,10 +39,10 @@ import org.sonar.cxx.sslr.internal.grammar.MutableParsingRule;
 import org.sonar.cxx.sslr.internal.vm.TokenExpression;
 import org.sonar.cxx.sslr.parser.ParsingResult;
 
-public class AstCreatorTest {
+class AstCreatorTest {
 
   @Test
-  public void should_create_tokens_and_trivias() {
+  void should_create_tokens_and_trivias() {
     var input = "foo bar".toCharArray();
 
     var tokenMatcher = mockTokenMatcher(GenericTokenType.IDENTIFIER);
@@ -63,7 +63,7 @@ public class AstCreatorTest {
 
     assertThat(astNode.getType()).isSameAs(realAstNodeType);
     assertThat(astNode.getName()).isEqualTo("rule");
-    assertThat(astNode.getFromIndex()).isEqualTo(0);
+    assertThat(astNode.getFromIndex()).isZero();
     assertThat(astNode.getToIndex()).isEqualTo(7);
     assertThat(astNode.hasChildren()).isTrue();
 
@@ -82,12 +82,12 @@ public class AstCreatorTest {
     assertThat(triviaToken.getValue()).isEqualTo("foo ");
     assertThat(triviaToken.getOriginalValue()).isEqualTo("foo ");
     assertThat(triviaToken.getLine()).isEqualTo(1);
-    assertThat(triviaToken.getColumn()).isEqualTo(0);
+    assertThat(triviaToken.getColumn()).isZero();
     assertThat(triviaToken.getType()).isEqualTo(GenericTokenType.COMMENT);
   }
 
   @Test
-  public void should_create_tokens_without_TokenMatcher() {
+  void should_create_tokens_without_TokenMatcher() {
     var input = "foobar".toCharArray();
 
     var firstTerminal = new ParseNode(0, 3, Collections.<ParseNode>emptyList(), null);
@@ -105,7 +105,7 @@ public class AstCreatorTest {
 
     assertThat(astNode.getType()).isSameAs(realAstNodeType);
     assertThat(astNode.getName()).isEqualTo("rule");
-    assertThat(astNode.getFromIndex()).isEqualTo(0);
+    assertThat(astNode.getFromIndex()).isZero();
     assertThat(astNode.getToIndex()).isEqualTo(6);
     assertThat(astNode.hasChildren()).isTrue();
 
@@ -115,7 +115,7 @@ public class AstCreatorTest {
     assertThat(token.getValue()).isEqualTo("foo");
     assertThat(token.getOriginalValue()).isEqualTo("foo");
     assertThat(token.getLine()).isEqualTo(1);
-    assertThat(token.getColumn()).isEqualTo(0);
+    assertThat(token.getColumn()).isZero();
     assertThat(token.getType()).isSameAs(AstCreator.UNDEFINED_TOKEN_TYPE);
     assertThat(token.getType().getName()).isEqualTo("TOKEN");
 
@@ -128,7 +128,7 @@ public class AstCreatorTest {
   }
 
   @Test
-  public void should_skip_nodes() {
+  void should_skip_nodes() {
     var input = "foo".toCharArray();
 
     var ruleMatcher1 = mockRuleMatcher("rule1");
@@ -148,7 +148,7 @@ public class AstCreatorTest {
 
     assertThat(astNode.getType()).isSameAs(realAstNodeType);
     assertThat(astNode.getName()).isEqualTo("rule2");
-    assertThat(astNode.getFromIndex()).isEqualTo(0);
+    assertThat(astNode.getFromIndex()).isZero();
     assertThat(astNode.getToIndex()).isEqualTo(3);
     assertThat(astNode.hasChildren()).isFalse();
     assertThat(astNode.getToken()).isNull();

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/matchers/ExpressionGrammarTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/matchers/ExpressionGrammarTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sslr.parser.ParseErrorFormatter;
 import org.sonar.cxx.sslr.parser.ParseRunner;
 
-public class ExpressionGrammarTest {
+class ExpressionGrammarTest {
 
   private ExpressionGrammar grammar;
 
@@ -40,7 +40,7 @@ public class ExpressionGrammarTest {
   }
 
   @Test
-  public void match() {
+  void match() {
     var inputString = "20 * ( 2 + 2 ) - var";
     var input = inputString.toCharArray();
     var parseRunner = new ParseRunner(grammar.root);
@@ -52,7 +52,7 @@ public class ExpressionGrammarTest {
   }
 
   @Test
-  public void mismatch() {
+  void mismatch() {
     var inputString = "term +";
     var input = inputString.toCharArray();
     var parseRunner = new ParseRunner(grammar.root);
@@ -64,7 +64,7 @@ public class ExpressionGrammarTest {
   }
 
   @Test
-  public void prefix_match() {
+  void prefix_match() {
     var inputString = "term +";
     var input = inputString.toCharArray();
     var parseRunner = new ParseRunner(grammar.expression);
@@ -73,7 +73,7 @@ public class ExpressionGrammarTest {
   }
 
   @Test
-  public void should_mock() {
+  void should_mock() {
     var inputString = "term plus term";
     var input = inputString.toCharArray();
     grammar.term.mock();
@@ -87,7 +87,7 @@ public class ExpressionGrammarTest {
   }
 
   @Test
-  public void should_create_ast() throws Exception {
+  void should_create_ast() throws Exception {
     var inputString = "20 * 2 + 2 - var";
     var grammar = new ExpressionGrammar();
     var input = inputString.toCharArray();
@@ -102,7 +102,7 @@ public class ExpressionGrammarTest {
 
     var firstToken = astNode.getToken();
     assertThat(firstToken.getLine()).isEqualTo(1);
-    assertThat(firstToken.getColumn()).isEqualTo(0);
+    assertThat(firstToken.getColumn()).isZero();
     assertThat(firstToken.getValue()).isEqualTo("20");
     assertThat(firstToken.getOriginalValue()).isEqualTo("20");
 

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/matchers/ImmutableInputBufferTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/matchers/ImmutableInputBufferTest.java
@@ -27,10 +27,10 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sslr.internal.matchers.InputBuffer.Position;
 
-public class ImmutableInputBufferTest {
+class ImmutableInputBufferTest {
 
   @Test
-  public void test() {
+  void test() {
     InputBuffer inputBuffer = new ImmutableInputBuffer("foo\r\nbar\nbaz\rqux\r".toCharArray());
 
     assertThat(inputBuffer.getLineCount()).isEqualTo(5);
@@ -53,7 +53,7 @@ public class ImmutableInputBufferTest {
   }
 
   @Test
-  public void test_single_line() {
+  void test_single_line() {
     InputBuffer inputBuffer = new ImmutableInputBuffer("foo".toCharArray());
 
     assertThat(inputBuffer.getLineCount()).isEqualTo(1);
@@ -67,7 +67,7 @@ public class ImmutableInputBufferTest {
   }
 
   @Test
-  public void test_empty() {
+  void test_empty() {
     InputBuffer inputBuffer = new ImmutableInputBuffer("".toCharArray());
 
     assertThat(inputBuffer.getLineCount()).isEqualTo(1);
@@ -79,7 +79,7 @@ public class ImmutableInputBufferTest {
   }
 
   @Test
-  public void test_empty_lines_with_LF() {
+  void test_empty_lines_with_LF() {
     InputBuffer inputBuffer = new ImmutableInputBuffer("\n\n".toCharArray());
 
     assertThat(inputBuffer.getLineCount()).isEqualTo(3);
@@ -94,7 +94,7 @@ public class ImmutableInputBufferTest {
   }
 
   @Test
-  public void test_empty_lines_with_CR() {
+  void test_empty_lines_with_CR() {
     InputBuffer inputBuffer = new ImmutableInputBuffer("\r\r".toCharArray());
 
     assertThat(inputBuffer.getLineCount()).isEqualTo(3);
@@ -109,7 +109,7 @@ public class ImmutableInputBufferTest {
   }
 
   @Test
-  public void test_empty_lines_with_CRLF() {
+  void test_empty_lines_with_CRLF() {
     InputBuffer inputBuffer = new ImmutableInputBuffer("\r\n\r\n".toCharArray());
 
     assertThat(inputBuffer.getLineCount()).isEqualTo(3);
@@ -126,11 +126,11 @@ public class ImmutableInputBufferTest {
   }
 
   @Test
-  public void test_equality_and_hash_code_of_positions() {
+  void test_equality_and_hash_code_of_positions() {
     var position = new Position(0, 0);
     assertThat(position).isEqualTo(position);
     assertThat(position).isEqualTo(new Position(0, 0));
-    assertThat(position.hashCode()).isEqualTo(new Position(0, 0).hashCode());
+    assertThat(position).hasSameHashCodeAs(new Position(0, 0));
     assertThat(position).isNotEqualTo(new Position(0, 1));
     assertThat(position).isNotEqualTo(new Position(1, 1));
     assertThat(position).isNotEqualTo(new Object());

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/matchers/TextUtilsTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/matchers/TextUtilsTest.java
@@ -27,10 +27,10 @@ import java.lang.reflect.Constructor;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class TextUtilsTest {
+class TextUtilsTest {
 
   @Test
-  public void should_escape() {
+  void should_escape() {
     assertThat(TextUtils.escape('\r')).isEqualTo("\\r");
     assertThat(TextUtils.escape('\n')).isEqualTo("\\n");
     assertThat(TextUtils.escape('\f')).isEqualTo("\\f");
@@ -40,13 +40,13 @@ public class TextUtilsTest {
   }
 
   @Test
-  public void should_trim_trailing_line_separator() {
+  void should_trim_trailing_line_separator() {
     assertThat(TextUtils.trimTrailingLineSeparatorFrom("\r\n")).isEqualTo("");
     assertThat(TextUtils.trimTrailingLineSeparatorFrom("\r\nfoo\r\n")).isEqualTo("\r\nfoo");
   }
 
   @Test
-  public void private_constructor() throws Exception {
+  void private_constructor() throws Exception {
     Constructor constructor = TextUtils.class.getDeclaredConstructor();
     assertThat(constructor.isAccessible()).isFalse();
     constructor.setAccessible(true);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/EndOfInputExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/EndOfInputExpressionTest.java
@@ -30,19 +30,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class EndOfInputExpressionTest {
+class EndOfInputExpressionTest {
 
   private final EndOfInputExpression expression = EndOfInputExpression.INSTANCE;
   private final Machine machine = mock(Machine.class);
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     assertThat(expression.compile(new CompilationHandler())).containsOnly(expression);
-    assertThat(expression.toString()).isEqualTo("EndOfInput");
+    assertThat(expression).hasToString("EndOfInput");
   }
 
   @Test
-  public void should_stop() {
+  void should_stop() {
     when(machine.length()).thenReturn(0);
     expression.execute(machine);
     var inOrder = Mockito.inOrder(machine);
@@ -52,7 +52,7 @@ public class EndOfInputExpressionTest {
   }
 
   @Test
-  public void should_backtrack() {
+  void should_backtrack() {
     when(machine.length()).thenReturn(1);
     expression.execute(machine);
     var inOrder = Mockito.inOrder(machine);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/ErrorLocatingHandlerTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/ErrorLocatingHandlerTest.java
@@ -28,12 +28,12 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ErrorLocatingHandlerTest {
+class ErrorLocatingHandlerTest {
 
   private final ErrorLocatingHandler errorLocatingHandler = new ErrorLocatingHandler();
 
   @Test
-  public void should_find_location_of_error() {
+  void should_find_location_of_error() {
     var machine = mock(Machine.class);
     when(machine.getIndex()).thenReturn(1);
     errorLocatingHandler.onBacktrack(machine);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/FirstOfExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/FirstOfExpressionTest.java
@@ -26,15 +26,15 @@ package org.sonar.cxx.sslr.internal.vm;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class FirstOfExpressionTest {
+class FirstOfExpressionTest {
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     var expression = new FirstOfExpression(
       new SubExpression(1, 2, 3),
       new SubExpression(4, 5),
       new SubExpression(6));
-    assertThat(expression.toString()).isEqualTo("FirstOf[SubExpression, SubExpression, SubExpression]");
+    assertThat(expression).hasToString("FirstOf[SubExpression, SubExpression, SubExpression]");
     var instructions = expression.compile(new CompilationHandler());
     assertThat(instructions).isEqualTo(new Instruction[]{
       Instruction.choice(5),

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/InstructionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/InstructionTest.java
@@ -46,15 +46,15 @@ import org.sonar.cxx.sslr.internal.vm.Instruction.JumpInstruction;
 import org.sonar.cxx.sslr.internal.vm.Instruction.PredicateChoiceInstruction;
 import org.sonar.cxx.sslr.internal.vm.Instruction.RetInstruction;
 
-public class InstructionTest {
+class InstructionTest {
 
   private final Machine machine = mock(Machine.class);
 
   @Test
-  public void jump() {
+  void jump() {
     var instruction = Instruction.jump(42);
     assertThat(instruction).isInstanceOf(JumpInstruction.class);
-    assertThat(instruction.toString()).isEqualTo("Jump 42");
+    assertThat(instruction).hasToString("Jump 42");
     assertThat(instruction.equals(Instruction.jump(42))).isTrue();
     assertThat(instruction.equals(Instruction.jump(13))).isFalse();
     assertThat(instruction.equals(new Object())).isFalse();
@@ -67,11 +67,11 @@ public class InstructionTest {
   }
 
   @Test
-  public void call() {
+  void call() {
     var matcher = mock(Matcher.class);
     var instruction = Instruction.call(42, matcher);
     assertThat(instruction).isInstanceOf(CallInstruction.class);
-    assertThat(instruction.toString()).isEqualTo("Call 42");
+    assertThat(instruction).hasToString("Call 42");
     assertThat(instruction.equals(Instruction.call(42, matcher))).isTrue();
     assertThat(instruction.equals(Instruction.call(42, mock(Matcher.class)))).isFalse();
     assertThat(instruction.equals(Instruction.call(13, matcher))).isFalse();
@@ -85,10 +85,10 @@ public class InstructionTest {
   }
 
   @Test
-  public void choice() {
+  void choice() {
     var instruction = Instruction.choice(42);
     assertThat(instruction).isInstanceOf(ChoiceInstruction.class);
-    assertThat(instruction.toString()).isEqualTo("Choice 42");
+    assertThat(instruction).hasToString("Choice 42");
     assertThat(instruction.equals(Instruction.choice(42))).isTrue();
     assertThat(instruction.equals(Instruction.choice(13))).isFalse();
     assertThat(instruction.equals(new Object())).isFalse();
@@ -102,10 +102,10 @@ public class InstructionTest {
   }
 
   @Test
-  public void predicateChoice() {
+  void predicateChoice() {
     var instruction = Instruction.predicateChoice(42);
     assertThat(instruction).isInstanceOf(PredicateChoiceInstruction.class);
-    assertThat(instruction.toString()).isEqualTo("PredicateChoice 42");
+    assertThat(instruction).hasToString("PredicateChoice 42");
     assertThat(instruction.equals(Instruction.predicateChoice(42))).isTrue();
     assertThat(instruction.equals(Instruction.predicateChoice(13))).isFalse();
     assertThat(instruction.equals(new Object())).isFalse();
@@ -120,10 +120,10 @@ public class InstructionTest {
   }
 
   @Test
-  public void commit() {
+  void commit() {
     var instruction = Instruction.commit(42);
     assertThat(instruction).isInstanceOf(CommitInstruction.class);
-    assertThat(instruction.toString()).isEqualTo("Commit " + 42);
+    assertThat(instruction).hasToString("Commit " + 42);
     assertThat(instruction.equals(Instruction.commit(42))).isTrue();
     assertThat(instruction.equals(Instruction.commit(13))).isFalse();
     assertThat(instruction.equals(new Object())).isFalse();
@@ -140,10 +140,10 @@ public class InstructionTest {
   }
 
   @Test
-  public void commitVerify() {
+  void commitVerify() {
     var instruction = Instruction.commitVerify(42);
     assertThat(instruction).isInstanceOf(CommitVerifyInstruction.class);
-    assertThat(instruction.toString()).isEqualTo("CommitVerify " + 42);
+    assertThat(instruction).hasToString("CommitVerify " + 42);
     assertThat(instruction.equals(Instruction.commitVerify(42))).isTrue();
     assertThat(instruction.equals(Instruction.commitVerify(13))).isFalse();
     assertThat(instruction.equals(new Object())).isFalse();
@@ -162,7 +162,7 @@ public class InstructionTest {
   }
 
   @Test
-  public void commitVerify_should_throw_exception() {
+  void commitVerify_should_throw_exception() {
     var instruction = Instruction.commitVerify(42);
     var stack = new MachineStack().getOrCreateChild();
     stack.setIndex(13);
@@ -175,10 +175,10 @@ public class InstructionTest {
   }
 
   @Test
-  public void ret() {
+  void ret() {
     var instruction = Instruction.ret();
     assertThat(instruction).isInstanceOf(RetInstruction.class);
-    assertThat(instruction.toString()).isEqualTo("Ret");
+    assertThat(instruction).hasToString("Ret");
     assertThat(instruction).as("singleton").isSameAs(Instruction.ret());
 
     var stack = mock(MachineStack.class);
@@ -196,10 +196,10 @@ public class InstructionTest {
   }
 
   @Test
-  public void backtrack() {
+  void backtrack() {
     var instruction = Instruction.backtrack();
     assertThat(instruction).isInstanceOf(BacktrackInstruction.class);
-    assertThat(instruction.toString()).isEqualTo("Backtrack");
+    assertThat(instruction).hasToString("Backtrack");
     assertThat(instruction).as("singleton").isSameAs(Instruction.backtrack());
 
     instruction.execute(machine);
@@ -209,10 +209,10 @@ public class InstructionTest {
   }
 
   @Test
-  public void end() {
+  void end() {
     var instruction = Instruction.end();
     assertThat(instruction).isInstanceOf(EndInstruction.class);
-    assertThat(instruction.toString()).isEqualTo("End");
+    assertThat(instruction).hasToString("End");
     assertThat(instruction).as("singleton").isSameAs(Instruction.end());
 
     instruction.execute(machine);
@@ -222,10 +222,10 @@ public class InstructionTest {
   }
 
   @Test
-  public void failTwice() {
+  void failTwice() {
     var instruction = Instruction.failTwice();
     assertThat(instruction).isInstanceOf(FailTwiceInstruction.class);
-    assertThat(instruction.toString()).isEqualTo("FailTwice");
+    assertThat(instruction).hasToString("FailTwice");
     assertThat(instruction).as("singleton").isSameAs(Instruction.failTwice());
 
     var stack = mock(MachineStack.class);
@@ -241,10 +241,10 @@ public class InstructionTest {
   }
 
   @Test
-  public void backCommit() {
+  void backCommit() {
     var instruction = Instruction.backCommit(42);
     assertThat(instruction).isInstanceOf(BackCommitInstruction.class);
-    assertThat(instruction.toString()).isEqualTo("BackCommit 42");
+    assertThat(instruction).hasToString("BackCommit 42");
     assertThat(instruction.equals(Instruction.backCommit(42))).isTrue();
     assertThat(instruction.equals(Instruction.backCommit(13))).isFalse();
     assertThat(instruction.equals(new Object())).isFalse();
@@ -265,10 +265,10 @@ public class InstructionTest {
   }
 
   @Test
-  public void ignoreErrors() {
+  void ignoreErrors() {
     var instruction = Instruction.ignoreErrors();
     assertThat(instruction).isInstanceOf(IgnoreErrorsInstruction.class);
-    assertThat(instruction.toString()).isEqualTo("IgnoreErrors");
+    assertThat(instruction).hasToString("IgnoreErrors");
     assertThat(instruction).as("singleton").isSameAs(Instruction.ignoreErrors());
 
     instruction.execute(machine);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/MachineIntegrationTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/MachineIntegrationTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Timeout;
 import org.sonar.cxx.sslr.grammar.GrammarException;
 
 // TODO this test should also check state of machine after execution
-public class MachineIntegrationTest {
+class MachineIntegrationTest {
 
   @Test
   @Timeout(5000)

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/MachineTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/MachineTest.java
@@ -30,10 +30,10 @@ import static org.mockito.Mockito.when;
 import org.sonar.cxx.sslr.grammar.GrammarException;
 import org.sonar.cxx.sslr.internal.matchers.Matcher;
 
-public class MachineTest {
+class MachineTest {
 
   @Test
-  public void subSequence_not_supported() {
+  void subSequence_not_supported() {
     var machine = new Machine("", new Instruction[0]);
     var thrown = catchThrowableOfType(
       () -> machine.subSequence(0, 0),
@@ -42,17 +42,17 @@ public class MachineTest {
   }
 
   @Test
-  public void test_initial_state() {
+  void test_initial_state() {
     var machine = new Machine("", new Instruction[2]);
-    assertThat(machine.getAddress()).isEqualTo(0);
-    assertThat(machine.getIndex()).isEqualTo(0);
+    assertThat(machine.getAddress()).isZero();
+    assertThat(machine.getIndex()).isZero();
     assertThat(machine.peek().isEmpty()).isTrue();
   }
 
   @Test
-  public void should_jump() {
+  void should_jump() {
     var machine = new Machine("", new Instruction[2]);
-    assertThat(machine.getAddress()).isEqualTo(0);
+    assertThat(machine.getAddress()).isZero();
     machine.jump(42);
     assertThat(machine.getAddress()).isEqualTo(42);
     machine.jump(13);
@@ -60,9 +60,9 @@ public class MachineTest {
   }
 
   @Test
-  public void should_advanceIndex() {
+  void should_advanceIndex() {
     var machine = new Machine("foo bar", new Instruction[2]);
-    assertThat(machine.getIndex()).isEqualTo(0);
+    assertThat(machine.getIndex()).isZero();
     assertThat(machine.length()).isEqualTo(7);
     assertThat(machine.charAt(0)).isEqualTo('f');
     assertThat(machine.charAt(1)).isEqualTo('o');
@@ -79,7 +79,7 @@ public class MachineTest {
   }
 
   @Test
-  public void should_pushReturn() {
+  void should_pushReturn() {
     var machine = new Machine("foo", new Instruction[3]);
     var matcher = mock(Matcher.class);
     machine.advanceIndex(1);
@@ -95,7 +95,7 @@ public class MachineTest {
   }
 
   @Test
-  public void should_detect_left_recursion() {
+  void should_detect_left_recursion() {
     var machine = new Machine("foo", new Instruction[2]);
     var matcher = mock(Matcher.class);
 
@@ -118,7 +118,7 @@ public class MachineTest {
   }
 
   @Test
-  public void should_pushBacktrack() {
+  void should_pushBacktrack() {
     var machine = new Machine("foo", new Instruction[2]);
     machine.advanceIndex(1);
     machine.jump(42);
@@ -132,7 +132,7 @@ public class MachineTest {
   }
 
   @Test
-  public void should_pop() {
+  void should_pop() {
     var machine = new Machine("", new Instruction[2]);
     var previousStack = machine.peek();
     machine.pushBacktrack(13);
@@ -142,7 +142,7 @@ public class MachineTest {
   }
 
   @Test
-  public void should_fail() {
+  void should_fail() {
     var machine = new Machine("", new Instruction[3]);
     var matcher = mock(Matcher.class);
     machine.pushReturn(13, matcher, 0);
@@ -153,7 +153,7 @@ public class MachineTest {
   }
 
   @Test
-  public void should_backtrack() {
+  void should_backtrack() {
     var machine = new Machine("", new Instruction[4]);
     var matcher = mock(Matcher.class);
     var previousStack = machine.peek();
@@ -166,7 +166,7 @@ public class MachineTest {
   }
 
   @Test
-  public void should_createLeafNode() {
+  void should_createLeafNode() {
     var machine = new Machine("", new Instruction[2]);
     var matcher = mock(Matcher.class);
     machine.advanceIndex(42);
@@ -179,7 +179,7 @@ public class MachineTest {
   }
 
   @Test
-  public void should_createNode() {
+  void should_createNode() {
     var machine = new Machine(" ", new Instruction[2]);
     var matcher = mock(Matcher.class);
     machine.advanceIndex(1);
@@ -197,7 +197,7 @@ public class MachineTest {
   }
 
   @Test
-  public void should_use_memo() {
+  void should_use_memo() {
     var machine = new Machine("foo", new Instruction[3]);
     var matcher = mock(MemoParsingExpression.class);
     when(matcher.shouldMemoize()).thenReturn(true);
@@ -214,7 +214,7 @@ public class MachineTest {
   }
 
   @Test
-  public void should_not_memorize() {
+  void should_not_memorize() {
     var machine = new Machine("foo", new Instruction[3]);
     var matcher = mock(MemoParsingExpression.class);
     when(matcher.shouldMemoize()).thenReturn(false);
@@ -225,12 +225,12 @@ public class MachineTest {
     machine.backtrack();
     machine.pushReturn(2, matcher, 1);
     assertThat(machine.getAddress()).isEqualTo(1);
-    assertThat(machine.getIndex()).isEqualTo(0);
+    assertThat(machine.getIndex()).isZero();
     assertThat(machine.peek().subNodes()).isEmpty();
   }
 
   @Test
-  public void should_not_use_memo() {
+  void should_not_use_memo() {
     var machine = new Machine("foo", new Instruction[3]);
     var matcher = mock(MemoParsingExpression.class);
     when(matcher.shouldMemoize()).thenReturn(true);
@@ -242,7 +242,7 @@ public class MachineTest {
     var anotherMatcher = mock(Matcher.class);
     machine.pushReturn(2, anotherMatcher, 1);
     assertThat(machine.getAddress()).isEqualTo(1);
-    assertThat(machine.getIndex()).isEqualTo(0);
+    assertThat(machine.getIndex()).isZero();
     assertThat(machine.peek().subNodes()).isEmpty();
   }
 

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/NextExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/NextExpressionTest.java
@@ -26,12 +26,12 @@ package org.sonar.cxx.sslr.internal.vm;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class NextExpressionTest {
+class NextExpressionTest {
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     var expression = new NextExpression(new SubExpression(1, 2));
-    assertThat(expression.toString()).isEqualTo("Next[SubExpression]");
+    assertThat(expression).hasToString("Next[SubExpression]");
     var instructions = expression.compile(new CompilationHandler());
     assertThat(instructions).isEqualTo(new Instruction[]{
       Instruction.choice(4),

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/NextNotExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/NextNotExpressionTest.java
@@ -26,12 +26,12 @@ package org.sonar.cxx.sslr.internal.vm;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class NextNotExpressionTest {
+class NextNotExpressionTest {
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     var expression = new NextNotExpression(new SubExpression(1, 2));
-    assertThat(expression.toString()).isEqualTo("NextNot[SubExpression]");
+    assertThat(expression).hasToString("NextNot[SubExpression]");
     var instructions = expression.compile(new CompilationHandler());
     assertThat(instructions).isEqualTo(new Instruction[]{
       Instruction.predicateChoice(4),

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/NothingExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/NothingExpressionTest.java
@@ -29,19 +29,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class NothingExpressionTest {
+class NothingExpressionTest {
 
   private final NothingExpression expression = NothingExpression.INSTANCE;
   private final Machine machine = mock(Machine.class);
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     assertThat(expression.compile(new CompilationHandler())).containsOnly(expression);
-    assertThat(expression.toString()).isEqualTo("Nothing");
+    assertThat(expression).hasToString("Nothing");
   }
 
   @Test
-  public void should_backtrack() {
+  void should_backtrack() {
     expression.execute(machine);
     verify(machine).backtrack();
     verifyNoMoreInteractions(machine);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/OneOrMoreExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/OneOrMoreExpressionTest.java
@@ -26,12 +26,12 @@ package org.sonar.cxx.sslr.internal.vm;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class OneOrMoreExpressionTest {
+class OneOrMoreExpressionTest {
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     var expression = new OneOrMoreExpression(new SubExpression(1, 2));
-    assertThat(expression.toString()).isEqualTo("OneOrMore[SubExpression]");
+    assertThat(expression).hasToString("OneOrMore[SubExpression]");
     var instructions = expression.compile(new CompilationHandler());
     assertThat(instructions).isEqualTo(new Instruction[]{
       Instruction.choice(6),

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/OptionalExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/OptionalExpressionTest.java
@@ -26,12 +26,12 @@ package org.sonar.cxx.sslr.internal.vm;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class OptionalExpressionTest {
+class OptionalExpressionTest {
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     var expression = new OptionalExpression(new SubExpression(1, 2));
-    assertThat(expression.toString()).isEqualTo("Optional[SubExpression]");
+    assertThat(expression).hasToString("Optional[SubExpression]");
     var instructions = expression.compile(new CompilationHandler());
     assertThat(instructions).isEqualTo(new Instruction[]{
       Instruction.choice(4),

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/PatternExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/PatternExpressionTest.java
@@ -32,19 +32,19 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import org.sonar.cxx.sslr.grammar.GrammarException;
 
-public class PatternExpressionTest {
+class PatternExpressionTest {
 
   private final PatternExpression expression = new PatternExpression("foo|bar");
   private final Machine machine = mock(Machine.class);
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     assertThat(expression.compile(new CompilationHandler())).containsOnly(expression);
-    assertThat(expression.toString()).isEqualTo("Pattern foo|bar");
+    assertThat(expression).hasToString("Pattern foo|bar");
   }
 
   @Test
-  public void should_match() {
+  void should_match() {
     when(machine.length()).thenReturn(3);
     when(machine.charAt(0)).thenReturn('f');
     when(machine.charAt(1)).thenReturn('o');
@@ -69,7 +69,7 @@ public class PatternExpressionTest {
   }
 
   @Test
-  public void should_backtrack() {
+  void should_backtrack() {
     when(machine.length()).thenReturn(1);
     when(machine.charAt(0)).thenReturn('z');
     expression.execute(machine);
@@ -89,7 +89,7 @@ public class PatternExpressionTest {
   }
 
   @Test
-  public void should_catch_StackOverflowError() {
+  void should_catch_StackOverflowError() {
     when(machine.length()).thenReturn(1);
     when(machine.charAt(0)).thenThrow(StackOverflowError.class);
     var thrown = catchThrowableOfType(

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/RuleRefExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/RuleRefExpressionTest.java
@@ -28,21 +28,21 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import org.sonar.cxx.sslr.grammar.GrammarRuleKey;
 
-public class RuleRefExpressionTest {
+class RuleRefExpressionTest {
 
   private final GrammarRuleKey ruleKey = mock(GrammarRuleKey.class);
   private final RuleRefExpression expression = new RuleRefExpression(ruleKey);
   private final Machine machine = mock(Machine.class);
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     assertThat(expression.compile(new CompilationHandler())).containsOnly(expression);
     assertThat(expression.getRuleKey()).isSameAs(ruleKey);
-    assertThat(expression.toString()).isEqualTo("Ref " + ruleKey);
+    assertThat(expression).hasToString("Ref " + ruleKey);
   }
 
   @Test
-  public void can_not_be_executed() {
+  void can_not_be_executed() {
     var thrown = catchThrowableOfType(
       () -> expression.execute(machine),
       UnsupportedOperationException.class);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/SequenceExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/SequenceExpressionTest.java
@@ -26,14 +26,14 @@ package org.sonar.cxx.sslr.internal.vm;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class SequenceExpressionTest {
+class SequenceExpressionTest {
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     var expression = new SequenceExpression(
       new SubExpression(1, 2),
       new SubExpression(3));
-    assertThat(expression.toString()).isEqualTo("Sequence[SubExpression, SubExpression]");
+    assertThat(expression).hasToString("Sequence[SubExpression, SubExpression]");
     var instructions = expression.compile(new CompilationHandler());
     assertThat(instructions).isEqualTo(new Instruction[]{
       SubExpression.mockInstruction(1),

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/StringExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/StringExpressionTest.java
@@ -30,19 +30,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class StringExpressionTest {
+class StringExpressionTest {
 
   private final StringExpression expression = new StringExpression("foo");
   private final Machine machine = mock(Machine.class);
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     assertThat(expression.compile(new CompilationHandler())).containsOnly(expression);
-    assertThat(expression.toString()).isEqualTo("String foo");
+    assertThat(expression).hasToString("String foo");
   }
 
   @Test
-  public void should_match() {
+  void should_match() {
     when(machine.length()).thenReturn(3);
     when(machine.charAt(0)).thenReturn('f');
     when(machine.charAt(1)).thenReturn('o');
@@ -59,7 +59,7 @@ public class StringExpressionTest {
   }
 
   @Test
-  public void should_backtrack() {
+  void should_backtrack() {
     when(machine.length()).thenReturn(0);
     expression.execute(machine);
     var inOrder = Mockito.inOrder(machine);
@@ -69,7 +69,7 @@ public class StringExpressionTest {
   }
 
   @Test
-  public void should_backtrack2() {
+  void should_backtrack2() {
     when(machine.length()).thenReturn(3);
     when(machine.charAt(0)).thenReturn('b');
     expression.execute(machine);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/TokenExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/TokenExpressionTest.java
@@ -28,12 +28,12 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 
-public class TokenExpressionTest {
+class TokenExpressionTest {
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     var expression = new TokenExpression(GenericTokenType.IDENTIFIER, new SubExpression(1, 2));
-    assertThat(expression.toString()).isEqualTo("Token IDENTIFIER[SubExpression]");
+    assertThat(expression).hasToString("Token IDENTIFIER[SubExpression]");
     var instructions = expression.compile(new CompilationHandler());
     assertThat(instructions).isEqualTo(new Instruction[]{
       Instruction.call(2, expression),
@@ -46,7 +46,7 @@ public class TokenExpressionTest {
   }
 
   @Test
-  public void should_implement_Matcher() {
+  void should_implement_Matcher() {
     var expression = new TokenExpression(GenericTokenType.IDENTIFIER, mock(ParsingExpression.class));
     // Important for AstCreator
     assertThat(expression.getTokenType()).isSameAs(GenericTokenType.IDENTIFIER);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/TriviaExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/TriviaExpressionTest.java
@@ -28,12 +28,12 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 
-public class TriviaExpressionTest {
+class TriviaExpressionTest {
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     var expression = new TriviaExpression(TriviaKind.COMMENT, new SubExpression(1, 2));
-    assertThat(expression.toString()).isEqualTo("Trivia COMMENT[SubExpression]");
+    assertThat(expression).hasToString("Trivia COMMENT[SubExpression]");
     var instructions = expression.compile(new CompilationHandler());
     assertThat(instructions).isEqualTo(new Instruction[]{
       Instruction.call(2, expression),
@@ -46,7 +46,7 @@ public class TriviaExpressionTest {
   }
 
   @Test
-  public void should_implement_Matcher() {
+  void should_implement_Matcher() {
     var expression = new TriviaExpression(TriviaKind.COMMENT, mock(ParsingExpression.class));
     // Important for AstCreator
     assertThat(expression.getTriviaKind()).isSameAs(TriviaKind.COMMENT);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/ZeroOrMoreExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/ZeroOrMoreExpressionTest.java
@@ -26,10 +26,10 @@ package org.sonar.cxx.sslr.internal.vm;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class ZeroOrMoreExpressionTest {
+class ZeroOrMoreExpressionTest {
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     var expression = new ZeroOrMoreExpression(new SubExpression(1, 2));
     var instructions = expression.compile(new CompilationHandler());
     assertThat(instructions).isEqualTo(new Instruction[]{

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/AdjacentExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/AdjacentExpressionTest.java
@@ -33,19 +33,19 @@ import static org.mockito.Mockito.when;
 import org.sonar.cxx.sslr.internal.vm.CompilationHandler;
 import org.sonar.cxx.sslr.internal.vm.Machine;
 
-public class AdjacentExpressionTest {
+class AdjacentExpressionTest {
 
   private final AdjacentExpression expression = AdjacentExpression.INSTANCE;
   private final Machine machine = mock(Machine.class);
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     assertThat(expression.compile(new CompilationHandler())).containsOnly(expression);
-    assertThat(expression.toString()).isEqualTo("Adjacent");
+    assertThat(expression).hasToString("Adjacent");
   }
 
   @Test
-  public void should_match() {
+  void should_match() {
     var previousToken = mock(Token.class);
     when(previousToken.getValue()).thenReturn("foo");
     when(previousToken.getLine()).thenReturn(42);
@@ -66,7 +66,7 @@ public class AdjacentExpressionTest {
   }
 
   @Test
-  public void should_backtrack() {
+  void should_backtrack() {
     var previousToken = mock(Token.class);
     when(previousToken.getValue()).thenReturn("foo");
     when(previousToken.getLine()).thenReturn(42);
@@ -87,7 +87,7 @@ public class AdjacentExpressionTest {
   }
 
   @Test
-  public void should_backtrack2() {
+  void should_backtrack2() {
     var previousToken = mock(Token.class);
     when(previousToken.getValue()).thenReturn("foo");
     when(previousToken.getLine()).thenReturn(42);
@@ -108,7 +108,7 @@ public class AdjacentExpressionTest {
   }
 
   @Test
-  public void should_backtrack3() {
+  void should_backtrack3() {
     when(machine.getIndex()).thenReturn(0);
     expression.execute(machine);
     var inOrder = Mockito.inOrder(machine);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/AnyTokenExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/AnyTokenExpressionTest.java
@@ -33,19 +33,19 @@ import static org.mockito.Mockito.when;
 import org.sonar.cxx.sslr.internal.vm.CompilationHandler;
 import org.sonar.cxx.sslr.internal.vm.Machine;
 
-public class AnyTokenExpressionTest {
+class AnyTokenExpressionTest {
 
   private final AnyTokenExpression expression = AnyTokenExpression.INSTANCE;
   private final Machine machine = mock(Machine.class);
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     assertThat(expression.compile(new CompilationHandler())).containsOnly(expression);
-    assertThat(expression.toString()).isEqualTo("AnyToken");
+    assertThat(expression).hasToString("AnyToken");
   }
 
   @Test
-  public void should_match() {
+  void should_match() {
     var token = mock(Token.class);
     when(machine.length()).thenReturn(1);
     when(machine.tokenAt(0)).thenReturn(token);
@@ -58,7 +58,7 @@ public class AnyTokenExpressionTest {
   }
 
   @Test
-  public void should_backtrack() {
+  void should_backtrack() {
     when(machine.length()).thenReturn(0);
     expression.execute(machine);
     var inOrder = Mockito.inOrder(machine);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/LexerfulMachineIntegrationTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/LexerfulMachineIntegrationTest.java
@@ -34,19 +34,19 @@ import org.sonar.cxx.sslr.internal.vm.CompilationHandler;
 import org.sonar.cxx.sslr.internal.vm.Machine;
 import org.sonar.cxx.sslr.internal.vm.SequenceExpression;
 
-public class LexerfulMachineIntegrationTest {
+class LexerfulMachineIntegrationTest {
 
   private Token[] tokens;
 
   @Test
-  public void tokenType() {
+  void tokenType() {
     var instructions = new TokenTypeExpression(GenericTokenType.IDENTIFIER).compile(new CompilationHandler());
     assertThat(Machine.execute(instructions, token(GenericTokenType.IDENTIFIER))).isTrue();
     assertThat(Machine.execute(instructions, token(GenericTokenType.LITERAL))).isFalse();
   }
 
   @Test
-  public void tokenTypes() {
+  void tokenTypes() {
     var instructions = new TokenTypesExpression(GenericTokenType.IDENTIFIER, GenericTokenType.LITERAL)
       .compile(new CompilationHandler());
     tokens = new Token[]{token(GenericTokenType.IDENTIFIER)};
@@ -58,20 +58,20 @@ public class LexerfulMachineIntegrationTest {
   }
 
   @Test
-  public void tokenValue() {
+  void tokenValue() {
     var instructions = new TokenValueExpression("foo").compile(new CompilationHandler());
     assertThat(Machine.execute(instructions, token("foo"))).isTrue();
     assertThat(Machine.execute(instructions, token("bar"))).isFalse();
   }
 
   @Test
-  public void anyToken() {
+  void anyToken() {
     var instructions = AnyTokenExpression.INSTANCE.compile(new CompilationHandler());
     assertThat(Machine.execute(instructions, token("foo"))).isTrue();
   }
 
   @Test
-  public void tokensBridge() {
+  void tokensBridge() {
     var instructions = new TokensBridgeExpression(GenericTokenType.IDENTIFIER, GenericTokenType.LITERAL)
       .compile(new CompilationHandler());
     tokens = new Token[]{token(GenericTokenType.IDENTIFIER), token(GenericTokenType.LITERAL)};
@@ -88,14 +88,14 @@ public class LexerfulMachineIntegrationTest {
   }
 
   @Test
-  public void tokenTypeClass() {
+  void tokenTypeClass() {
     var instructions = new TokenTypeClassExpression(GenericTokenType.class).compile(new CompilationHandler());
     tokens = new Token[]{token(GenericTokenType.IDENTIFIER)};
     assertThat(Machine.execute(instructions, tokens)).isTrue();
   }
 
   @Test
-  public void adjacent() {
+  void adjacent() {
     var instructions = new SequenceExpression(
       new TokenValueExpression("foo"),
       AdjacentExpression.INSTANCE,

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/LexerfulParseErrorFormatterTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/LexerfulParseErrorFormatterTest.java
@@ -30,10 +30,10 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class LexerfulParseErrorFormatterTest {
+class LexerfulParseErrorFormatterTest {
 
   @Test
-  public void test() {
+  void test() {
     var tokens = Arrays.asList(
       token(2, 1, "foo\nbar\nbaz"),
       token(4, 6, "qux"),

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/TillNewLineExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/TillNewLineExpressionTest.java
@@ -36,19 +36,19 @@ import static org.mockito.Mockito.when;
 import org.sonar.cxx.sslr.internal.vm.CompilationHandler;
 import org.sonar.cxx.sslr.internal.vm.Machine;
 
-public class TillNewLineExpressionTest {
+class TillNewLineExpressionTest {
 
   private final TillNewLineExpression expression = TillNewLineExpression.INSTANCE;
   private final Machine machine = mock(Machine.class);
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     assertThat(expression.compile(new CompilationHandler())).containsOnly(expression);
-    assertThat(expression.toString()).isEqualTo("TillNewLine");
+    assertThat(expression).hasToString("TillNewLine");
   }
 
   @Test
-  public void should_match() {
+  void should_match() {
     var token1 = token(GenericTokenType.IDENTIFIER, 1);
     var token2 = token(GenericTokenType.IDENTIFIER, 1);
     var token3 = token(GenericTokenType.IDENTIFIER, 2);
@@ -68,7 +68,7 @@ public class TillNewLineExpressionTest {
   }
 
   @Test
-  public void should_match2() {
+  void should_match2() {
     var token0 = token(GenericTokenType.IDENTIFIER, 1);
     var token1 = token(GenericTokenType.IDENTIFIER, 1);
     var token2 = token(GenericTokenType.IDENTIFIER, 1);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/TokenTypeClassTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/TokenTypeClassTest.java
@@ -35,19 +35,19 @@ import static org.mockito.Mockito.when;
 import org.sonar.cxx.sslr.internal.vm.CompilationHandler;
 import org.sonar.cxx.sslr.internal.vm.Machine;
 
-public class TokenTypeClassTest {
+class TokenTypeClassTest {
 
   private final TokenTypeClassExpression expression = new TokenTypeClassExpression(GenericTokenType.class);
   private final Machine machine = mock(Machine.class);
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     assertThat(expression.compile(new CompilationHandler())).containsOnly(expression);
-    assertThat(expression.toString()).isEqualTo("TokenTypeClass " + GenericTokenType.class);
+    assertThat(expression).hasToString("TokenTypeClass " + GenericTokenType.class);
   }
 
   @Test
-  public void should_match() {
+  void should_match() {
     var token = mock(Token.class);
     when(token.getType()).thenReturn(GenericTokenType.IDENTIFIER);
     when(machine.length()).thenReturn(1);
@@ -62,7 +62,7 @@ public class TokenTypeClassTest {
   }
 
   @Test
-  public void should_backtrack() {
+  void should_backtrack() {
     when(machine.length()).thenReturn(0);
     expression.execute(machine);
     var inOrder = Mockito.inOrder(machine);
@@ -72,7 +72,7 @@ public class TokenTypeClassTest {
   }
 
   @Test
-  public void should_backtrack2() {
+  void should_backtrack2() {
     var token = mock(Token.class);
     when(token.getType()).thenReturn(mock(TokenType.class));
     when(machine.length()).thenReturn(1);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/TokenTypeExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/TokenTypeExpressionTest.java
@@ -34,20 +34,20 @@ import static org.mockito.Mockito.when;
 import org.sonar.cxx.sslr.internal.vm.CompilationHandler;
 import org.sonar.cxx.sslr.internal.vm.Machine;
 
-public class TokenTypeExpressionTest {
+class TokenTypeExpressionTest {
 
   private final TokenType type = mock(TokenType.class);
   private final TokenTypeExpression expression = new TokenTypeExpression(type);
   private final Machine machine = mock(Machine.class);
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     assertThat(expression.compile(new CompilationHandler())).containsOnly(expression);
-    assertThat(expression.toString()).isEqualTo("TokenType " + type);
+    assertThat(expression).hasToString("TokenType " + type);
   }
 
   @Test
-  public void should_match() {
+  void should_match() {
     var token = mock(Token.class);
     when(token.getType()).thenReturn(type);
     when(machine.length()).thenReturn(1);
@@ -62,7 +62,7 @@ public class TokenTypeExpressionTest {
   }
 
   @Test
-  public void should_backtrack() {
+  void should_backtrack() {
     when(machine.length()).thenReturn(0);
     expression.execute(machine);
     var inOrder = Mockito.inOrder(machine);
@@ -72,7 +72,7 @@ public class TokenTypeExpressionTest {
   }
 
   @Test
-  public void should_backtrack2() {
+  void should_backtrack2() {
     var token = mock(Token.class);
     when(token.getType()).thenReturn(mock(TokenType.class));
     when(machine.length()).thenReturn(1);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/TokenTypesExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/TokenTypesExpressionTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.when;
 import org.sonar.cxx.sslr.internal.vm.CompilationHandler;
 import org.sonar.cxx.sslr.internal.vm.Machine;
 
-public class TokenTypesExpressionTest {
+class TokenTypesExpressionTest {
 
   private final TokenType type1 = mock(TokenType.class);
   private final TokenType type2 = mock(TokenType.class);
@@ -42,13 +42,13 @@ public class TokenTypesExpressionTest {
   private final Machine machine = mock(Machine.class);
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     assertThat(expression.compile(new CompilationHandler())).containsOnly(expression);
     assertThat(expression.toString()).startsWith("TokenTypes [Mock for TokenType, ");
   }
 
   @Test
-  public void should_match() {
+  void should_match() {
     var token = mock(Token.class);
     when(token.getType()).thenReturn(type1);
     when(machine.length()).thenReturn(1);
@@ -63,7 +63,7 @@ public class TokenTypesExpressionTest {
   }
 
   @Test
-  public void should_backtrack() {
+  void should_backtrack() {
     when(machine.length()).thenReturn(0);
     expression.execute(machine);
     var inOrder = Mockito.inOrder(machine);
@@ -73,7 +73,7 @@ public class TokenTypesExpressionTest {
   }
 
   @Test
-  public void should_backtrack2() {
+  void should_backtrack2() {
     var token = mock(Token.class);
     when(token.getType()).thenReturn(mock(TokenType.class));
     when(machine.length()).thenReturn(1);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/TokenValueExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/TokenValueExpressionTest.java
@@ -33,19 +33,19 @@ import static org.mockito.Mockito.when;
 import org.sonar.cxx.sslr.internal.vm.CompilationHandler;
 import org.sonar.cxx.sslr.internal.vm.Machine;
 
-public class TokenValueExpressionTest {
+class TokenValueExpressionTest {
 
   private final TokenValueExpression expression = new TokenValueExpression("foo");
   private final Machine machine = mock(Machine.class);
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     assertThat(expression.compile(new CompilationHandler())).containsOnly(expression);
-    assertThat(expression.toString()).isEqualTo("TokenValue foo");
+    assertThat(expression).hasToString("TokenValue foo");
   }
 
   @Test
-  public void should_match() {
+  void should_match() {
     var token = mock(Token.class);
     when(token.getValue()).thenReturn("foo");
     when(machine.length()).thenReturn(1);
@@ -60,7 +60,7 @@ public class TokenValueExpressionTest {
   }
 
   @Test
-  public void should_backtrack() {
+  void should_backtrack() {
     when(machine.length()).thenReturn(0);
     expression.execute(machine);
     var inOrder = Mockito.inOrder(machine);
@@ -70,7 +70,7 @@ public class TokenValueExpressionTest {
   }
 
   @Test
-  public void should_backtrack2() {
+  void should_backtrack2() {
     var token = mock(Token.class);
     when(token.getValue()).thenReturn("bar");
     when(machine.length()).thenReturn(1);
@@ -84,7 +84,7 @@ public class TokenValueExpressionTest {
   }
 
   @Test
-  public void should_backtrack3() {
+  void should_backtrack3() {
     var token = mock(Token.class);
     when(token.getValue()).thenReturn("h31"/* same hash code as for "foo" */);
     when(machine.length()).thenReturn(1);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/TokensBridgeExpressionTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/internal/vm/lexerful/TokensBridgeExpressionTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
 import org.sonar.cxx.sslr.internal.vm.CompilationHandler;
 import org.sonar.cxx.sslr.internal.vm.Machine;
 
-public class TokensBridgeExpressionTest {
+class TokensBridgeExpressionTest {
 
   private final TokenType fromType = mock(TokenType.class);
   private final TokenType toType = mock(TokenType.class);
@@ -44,13 +44,13 @@ public class TokensBridgeExpressionTest {
   private final Machine machine = mock(Machine.class);
 
   @Test
-  public void should_compile() {
+  void should_compile() {
     assertThat(expression.compile(new CompilationHandler())).containsOnly(expression);
-    assertThat(expression.toString()).isEqualTo("Bridge[" + fromType + "," + toType + "]");
+    assertThat(expression).hasToString("Bridge[" + fromType + "," + toType + "]");
   }
 
   @Test
-  public void should_match() {
+  void should_match() {
     when(machine.length()).thenReturn(5);
     var token1 = token(fromType);
     var token2 = token(fromType);
@@ -77,7 +77,7 @@ public class TokensBridgeExpressionTest {
   }
 
   @Test
-  public void should_backtrack() {
+  void should_backtrack() {
     when(machine.length()).thenReturn(0);
     expression.execute(machine);
     var inOrder = Mockito.inOrder(machine);
@@ -87,7 +87,7 @@ public class TokensBridgeExpressionTest {
   }
 
   @Test
-  public void should_backtrack2() {
+  void should_backtrack2() {
     when(machine.length()).thenReturn(2);
     var token1 = token(anotherType);
     when(machine.tokenAt(0)).thenReturn(token1);
@@ -100,7 +100,7 @@ public class TokensBridgeExpressionTest {
   }
 
   @Test
-  public void should_backtrack3() {
+  void should_backtrack3() {
     when(machine.length()).thenReturn(2);
     var token1 = token(fromType);
     var token2 = token(fromType);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/parser/GrammarOperatorsTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/parser/GrammarOperatorsTest.java
@@ -44,10 +44,10 @@ import org.sonar.cxx.sslr.internal.vm.TokenExpression;
 import org.sonar.cxx.sslr.internal.vm.TriviaExpression;
 import org.sonar.cxx.sslr.internal.vm.ZeroOrMoreExpression;
 
-public class GrammarOperatorsTest {
+class GrammarOperatorsTest {
 
   @Test
-  public void test() {
+  void test() {
     var e1 = mock(ParsingExpression.class);
     var e2 = mock(ParsingExpression.class);
 
@@ -77,7 +77,7 @@ public class GrammarOperatorsTest {
   }
 
   @Test
-  public void test_token() {
+  void test_token() {
     var tokenType = mock(TokenType.class);
     var e = mock(ParsingExpression.class);
     var result = GrammarOperators.token(tokenType, e);
@@ -86,7 +86,7 @@ public class GrammarOperatorsTest {
   }
 
   @Test
-  public void test_commentTrivia() {
+  void test_commentTrivia() {
     var e = mock(ParsingExpression.class);
     var result = GrammarOperators.commentTrivia(e);
     assertThat(result).isInstanceOf(TriviaExpression.class);
@@ -94,7 +94,7 @@ public class GrammarOperatorsTest {
   }
 
   @Test
-  public void test_skippedTrivia() {
+  void test_skippedTrivia() {
     var e = mock(ParsingExpression.class);
     var result = GrammarOperators.skippedTrivia(e);
     assertThat(result).isInstanceOf(TriviaExpression.class);
@@ -102,7 +102,7 @@ public class GrammarOperatorsTest {
   }
 
   @Test
-  public void illegal_argument() {
+  void illegal_argument() {
     var thrown = catchThrowableOfType(
       () -> GrammarOperators.sequence(new Object()),
       IllegalArgumentException.class);
@@ -110,7 +110,7 @@ public class GrammarOperatorsTest {
   }
 
   @Test
-  public void private_constructor() throws Exception {
+  void private_constructor() throws Exception {
     Constructor constructor = GrammarOperators.class.getDeclaredConstructor();
     assertThat(constructor.isAccessible()).isFalse();
     constructor.setAccessible(true);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/parser/LexerlessGrammarTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/parser/LexerlessGrammarTest.java
@@ -30,17 +30,17 @@ import static org.mockito.Mockito.mock;
 import org.sonar.cxx.sslr.grammar.GrammarException;
 import org.sonar.cxx.sslr.internal.grammar.MutableParsingRule;
 
-public class LexerlessGrammarTest {
+class LexerlessGrammarTest {
 
   @Test
-  public void should_instanciate_rule_fields() {
+  void should_instanciate_rule_fields() {
     var grammar = new TestGrammar();
     assertThat(grammar.getRootRule()).isInstanceOf(MutableParsingRule.class);
     assertThat(((MutableParsingRule) grammar.getRootRule()).getName()).isEqualTo("rootRule");
   }
 
   @Test
-  public void should_throw_exception() {
+  void should_throw_exception() {
     var thrown = catchThrowableOfType(IllegalGrammar::new, GrammarException.class);
     assertThat(thrown).hasMessageStartingWith("Unable to instanciate the rule 'rootRule': ");
   }

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/parser/ParseErrorFormatterTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/parser/ParseErrorFormatterTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sslr.internal.matchers.ImmutableInputBuffer;
 import org.sonar.cxx.sslr.internal.matchers.InputBuffer;
 
-public class ParseErrorFormatterTest {
+class ParseErrorFormatterTest {
 
   private ParseErrorFormatter formatter;
 
@@ -39,7 +39,7 @@ public class ParseErrorFormatterTest {
   }
 
   @Test
-  public void test() {
+  void test() {
     InputBuffer inputBuffer = new ImmutableInputBuffer("\t2+4*10-0*\n".toCharArray());
     var result = formatter.format(new ParseError(inputBuffer, 10));
     System.out.print(result);

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/parser/ParseRunnerTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/parser/ParseRunnerTest.java
@@ -28,10 +28,10 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sslr.internal.grammar.MutableParsingRule;
 
-public class ParseRunnerTest {
+class ParseRunnerTest {
 
   @Test
-  public void should_not_accept_null() {
+  void should_not_accept_null() {
     var thrown = catchThrowableOfType(
       () -> new ParseRunner(null),
       NullPointerException.class);
@@ -39,7 +39,7 @@ public class ParseRunnerTest {
   }
 
   @Test
-  public void should_report_error_at_rule_level() {
+  void should_report_error_at_rule_level() {
     var rule = new MutableParsingRule("rule").is("foo", "bar");
     var runner = new ParseRunner(rule);
     var result = runner.parse("foo".toCharArray());
@@ -50,7 +50,7 @@ public class ParseRunnerTest {
   }
 
   @Test
-  public void should_report_error_at_end_of_input() {
+  void should_report_error_at_end_of_input() {
     var endOfInput = new MutableParsingRule("endOfInput").is(GrammarOperators.endOfInput());
     var rule = new MutableParsingRule("rule").is("foo", endOfInput);
     var runner = new ParseRunner(rule);
@@ -62,7 +62,7 @@ public class ParseRunnerTest {
   }
 
   @Test
-  public void should_not_report_error_inside_of_predicate_not() {
+  void should_not_report_error_inside_of_predicate_not() {
     var subRule = new MutableParsingRule("subRule").is("foo");
     var rule = new MutableParsingRule("rule").is(GrammarOperators.nextNot(subRule), "bar");
     var runner = new ParseRunner(rule);
@@ -70,22 +70,22 @@ public class ParseRunnerTest {
     assertThat(result.isMatched()).isFalse();
     var parseError = result.getParseError();
     System.out.println(new ParseErrorFormatter().format(parseError));
-    assertThat(parseError.getErrorIndex()).isEqualTo(0);
+    assertThat(parseError.getErrorIndex()).isZero();
   }
 
   @Test
-  public void should_report_error_at_correct_index() {
+  void should_report_error_at_correct_index() {
     var rule = new MutableParsingRule("rule").is(GrammarOperators.nextNot("foo"));
     var runner = new ParseRunner(rule);
     var result = runner.parse("foo".toCharArray());
     assertThat(result.isMatched()).isFalse();
     var parseError = result.getParseError();
     System.out.println(new ParseErrorFormatter().format(parseError));
-    assertThat(parseError.getErrorIndex()).isEqualTo(0);
+    assertThat(parseError.getErrorIndex()).isZero();
   }
 
   @Test
-  public void should_report_error_inside_of_predicate_next() {
+  void should_report_error_inside_of_predicate_next() {
     var subRule = new MutableParsingRule("subRule").is("foo");
     var rule = new MutableParsingRule("rule").is(GrammarOperators.next(subRule), "bar");
     var runner = new ParseRunner(rule);
@@ -93,11 +93,11 @@ public class ParseRunnerTest {
     assertThat(result.isMatched()).isFalse();
     var parseError = result.getParseError();
     System.out.println(new ParseErrorFormatter().format(parseError));
-    assertThat(parseError.getErrorIndex()).isEqualTo(0);
+    assertThat(parseError.getErrorIndex()).isZero();
   }
 
   @Test
-  public void should_not_report_error_inside_of_token() {
+  void should_not_report_error_inside_of_token() {
     var subRule = new MutableParsingRule("subRule").is("foo");
     var rule = new MutableParsingRule("rule").is(GrammarOperators.token(GenericTokenType.IDENTIFIER, subRule), "bar");
     var runner = new ParseRunner(rule);
@@ -105,11 +105,11 @@ public class ParseRunnerTest {
     assertThat(result.isMatched()).isFalse();
     var parseError = result.getParseError();
     System.out.println(new ParseErrorFormatter().format(parseError));
-    assertThat(parseError.getErrorIndex()).isEqualTo(0);
+    assertThat(parseError.getErrorIndex()).isZero();
   }
 
   @Test
-  public void should_not_report_error_inside_of_trivia() {
+  void should_not_report_error_inside_of_trivia() {
     var subRule = new MutableParsingRule("subRule").is("foo");
     var rule = new MutableParsingRule("rule").is(GrammarOperators.skippedTrivia(subRule), "bar");
     var runner = new ParseRunner(rule);
@@ -117,11 +117,11 @@ public class ParseRunnerTest {
     assertThat(result.isMatched()).isFalse();
     var parseError = result.getParseError();
     System.out.println(new ParseErrorFormatter().format(parseError));
-    assertThat(parseError.getErrorIndex()).isEqualTo(0);
+    assertThat(parseError.getErrorIndex()).isZero();
   }
 
   @Test
-  public void should_report_error_at_several_paths() {
+  void should_report_error_at_several_paths() {
     var subRule1 = new MutableParsingRule("subRule1").is("foo");
     var subRule2 = new MutableParsingRule("subRule2").is("bar");
     var rule = new MutableParsingRule("rule").is(GrammarOperators.firstOf(subRule1, subRule2));
@@ -130,7 +130,7 @@ public class ParseRunnerTest {
     assertThat(result.isMatched()).isFalse();
     var parseError = result.getParseError();
     System.out.println(new ParseErrorFormatter().format(parseError));
-    assertThat(parseError.getErrorIndex()).isEqualTo(0);
+    assertThat(parseError.getErrorIndex()).isZero();
   }
 
 }

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/parser/ParserAdapterTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/parser/ParserAdapterTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonar.cxx.sslr.internal.matchers.ExpressionGrammar;
 
-public class ParserAdapterTest {
+class ParserAdapterTest {
 
   @TempDir
   File tempDir;
@@ -54,17 +54,17 @@ public class ParserAdapterTest {
   }
 
   @Test
-  public void should_return_grammar() {
+  void should_return_grammar() {
     assertThat(parser.getGrammar()).isSameAs(grammar);
   }
 
   @Test
-  public void should_parse_string() {
+  void should_parse_string() {
     parser.parse("1+1");
   }
 
   @Test
-  public void should_not_parse_invalid_string() {
+  void should_not_parse_invalid_string() {
     var thrown = catchThrowableOfType(
       () -> parser.parse(""),
       RecognitionException.class);
@@ -72,7 +72,7 @@ public class ParserAdapterTest {
   }
 
   @Test
-  public void should_parse_file() throws Exception {
+  void should_parse_file() throws Exception {
     var file = new File(tempDir, "file.txt");
     try (
       var fileOutputStream = new FileOutputStream(file);
@@ -83,7 +83,7 @@ public class ParserAdapterTest {
   }
 
   @Test
-  public void should_not_parse_invalid_file() {
+  void should_not_parse_invalid_file() {
     var file = new File("notfound");
     var thrown = catchThrowableOfType(
       () -> parser.parse(file),
@@ -92,12 +92,12 @@ public class ParserAdapterTest {
   }
 
   @Test
-  public void builder_should_not_create_new_instance_from_adapter() {
+  void builder_should_not_create_new_instance_from_adapter() {
     assertThat(Parser.builder(parser).build()).isSameAs(parser);
   }
 
   @Test
-  public void parse_tokens_unsupported() {
+  void parse_tokens_unsupported() {
     List<Token> tokens = Collections.emptyList();
     var thrown = catchThrowableOfType(
       () -> parser.parse(tokens),
@@ -106,7 +106,7 @@ public class ParserAdapterTest {
   }
 
   @Test
-  public void getRootRule_unsupported() {
+  void getRootRule_unsupported() {
     var thrown = catchThrowableOfType(
       () -> parser.getRootRule(),
       UnsupportedOperationException.class);

--- a/cxx-sslr/sslr-testing-harness/pom.xml
+++ b/cxx-sslr/sslr-testing-harness/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <!-- in addition, a dependency must be set in 'integration-tests/pom.xml' to aggregate the results -->
-    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <dependencies>

--- a/cxx-sslr/sslr-testing-harness/src/test/java/org/sonar/cxx/sslr/test/channel/ChannelMatchersTest.java
+++ b/cxx-sslr/sslr-testing-harness/src/test/java/org/sonar/cxx/sslr/test/channel/ChannelMatchersTest.java
@@ -31,10 +31,10 @@ import org.sonar.cxx.sslr.channel.CodeReader;
 import static org.sonar.cxx.sslr.test.channel.ChannelMatchers.consume;
 import static org.sonar.cxx.sslr.test.channel.ChannelMatchers.hasNextChar;
 
-public class ChannelMatchersTest {
+class ChannelMatchersTest {
 
   @Test
-  public void testConsumeMatcher() {
+  void testConsumeMatcher() {
     Channel<StringBuilder> numberChannel = new Channel<StringBuilder>() {
 
       @Override
@@ -48,17 +48,17 @@ public class ChannelMatchersTest {
     };
     var output = new StringBuilder();
     AssertionsForClassTypes.assertThat(numberChannel).has(consume("3", output));
-    assertThat(output.toString()).isEqualTo("3");
+    assertThat(output).hasToString("3");
     AssertionsForClassTypes.assertThat(numberChannel).has(consume(new CodeReader("333333"), output));
 
     output = new StringBuilder();
     AssertionsForClassTypes.assertThat(numberChannel).isNot(consume("n", output));
-    assertThat(output.toString()).isEqualTo("");
+    assertThat(output).hasToString("");
     AssertionsForClassTypes.assertThat(numberChannel).isNot(consume(new CodeReader("n"), output));
   }
 
   @Test
-  public void testHasNextChar() {
+  void testHasNextChar() {
     AssertionsForClassTypes.assertThat(new CodeReader("123")).is(hasNextChar('1'));
     AssertionsForClassTypes.assertThat(new CodeReader("123")).isNot(hasNextChar('n'));
   }

--- a/cxx-sslr/sslr-testing-harness/src/test/java/org/sonar/cxx/sslr/tests/AssertionsTest.java
+++ b/cxx-sslr/sslr-testing-harness/src/test/java/org/sonar/cxx/sslr/tests/AssertionsTest.java
@@ -29,16 +29,16 @@ import java.lang.reflect.Constructor;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class AssertionsTest {
+class AssertionsTest {
 
   @Test
-  public void test() {
+  void test() {
     assertThat(Assertions.assertThat((Parser) null)).isInstanceOf(ParserAssert.class);
     assertThat(Assertions.assertThat((Rule) null)).isInstanceOf(RuleAssert.class);
   }
 
   @Test
-  public void private_constructor() throws Exception {
+  void private_constructor() throws Exception {
     Constructor constructor = Assertions.class.getDeclaredConstructor();
     assertThat(constructor.isAccessible()).isFalse();
     constructor.setAccessible(true);

--- a/cxx-sslr/sslr-testing-harness/src/test/java/org/sonar/cxx/sslr/tests/ParserAssertTest.java
+++ b/cxx-sslr/sslr-testing-harness/src/test/java/org/sonar/cxx/sslr/tests/ParserAssertTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ParserAssertTest {
+class ParserAssertTest {
 
   private Rule rule;
   private Parser parser;
@@ -58,7 +58,7 @@ public class ParserAssertTest {
   }
 
   @Test
-  public void ok() {
+  void ok() {
     new ParserAssert(parser)
       .matches("foo")
       .notMatches("bar")
@@ -66,7 +66,7 @@ public class ParserAssertTest {
   }
 
   @Test
-  public void test_matches_failure() {
+  void test_matches_failure() {
     var thrown = catchThrowableOfType(
       () -> new ParserAssert(parser).matches("bar"),
       ParsingResultComparisonFailure.class
@@ -75,7 +75,7 @@ public class ParserAssertTest {
   }
 
   @Test
-  public void test2_matches_failure() {
+  void test2_matches_failure() {
     var thrown = catchThrowableOfType(
       () -> new ParserAssert(parser).matches("foo bar"),
       ParsingResultComparisonFailure.class);
@@ -83,7 +83,7 @@ public class ParserAssertTest {
   }
 
   @Test
-  public void test_notMatches_failure() {
+  void test_notMatches_failure() {
     var thrown = catchThrowableOfType(
       () -> new ParserAssert(parser).notMatches("foo"),
       AssertionError.class);
@@ -91,7 +91,7 @@ public class ParserAssertTest {
   }
 
   @Test
-  public void test_notMatches_failure2() {
+  void test_notMatches_failure2() {
     rule.override("foo", GenericTokenType.EOF);
     var thrown = catchThrowableOfType(
       () -> new ParserAssert(parser).notMatches("foo"),
@@ -100,7 +100,7 @@ public class ParserAssertTest {
   }
 
   @Test
-  public void should_not_accept_null() {
+  void should_not_accept_null() {
     var thrown = catchThrowableOfType(
       () -> new ParserAssert((Parser) null).matches(""),
       AssertionError.class);
@@ -108,7 +108,7 @@ public class ParserAssertTest {
   }
 
   @Test
-  public void should_not_accept_null_root_rule() {
+  void should_not_accept_null_root_rule() {
     parser.setRootRule(null);
     var thrown = catchThrowableOfType(
       () -> new ParserAssert(parser).matches(""),
@@ -117,7 +117,7 @@ public class ParserAssertTest {
   }
 
   @Test
-  public void test_lexer_failure() {
+  void test_lexer_failure() {
     var thrown = catchThrowableOfType(
       () -> new ParserAssert(parser).matches("_"),
       ParsingResultComparisonFailure.class);

--- a/cxx-sslr/sslr-testing-harness/src/test/java/org/sonar/cxx/sslr/tests/ParsingResultComparisonFailureTest.java
+++ b/cxx-sslr/sslr-testing-harness/src/test/java/org/sonar/cxx/sslr/tests/ParsingResultComparisonFailureTest.java
@@ -26,10 +26,10 @@ package org.sonar.cxx.sslr.tests;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class ParsingResultComparisonFailureTest {
+class ParsingResultComparisonFailureTest {
 
   @Test
-  public void test_implicit_message() {
+  void test_implicit_message() {
     var failure = new ParsingResultComparisonFailure("expected", "actual");
     assertThat(failure)
       .isInstanceOf(AssertionError.class)
@@ -38,7 +38,7 @@ public class ParsingResultComparisonFailureTest {
   }
 
   @Test
-  public void test_explicit_message() {
+  void test_explicit_message() {
     var failure = new ParsingResultComparisonFailure("foo", "expected", "actual");
     assertThat(failure)
       .isInstanceOf(AssertionError.class)

--- a/cxx-sslr/sslr-testing-harness/src/test/java/org/sonar/cxx/sslr/tests/RuleAssertTest.java
+++ b/cxx-sslr/sslr-testing-harness/src/test/java/org/sonar/cxx/sslr/tests/RuleAssertTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sslr.internal.grammar.MutableParsingRule;
 
-public class RuleAssertTest {
+class RuleAssertTest {
 
   private Rule rule;
 
@@ -39,14 +39,14 @@ public class RuleAssertTest {
   }
 
   @Test
-  public void ok() {
+  void ok() {
     new RuleAssert(rule)
       .matches("foo")
       .notMatches("bar");
   }
 
   @Test
-  public void test_matches_failure() {
+  void test_matches_failure() {
     var thrown = catchThrowableOfType(
       () -> new RuleAssert(rule).matches("bar"),
       ParsingResultComparisonFailure.class);
@@ -54,7 +54,7 @@ public class RuleAssertTest {
   }
 
   @Test
-  public void test_notMatches_failure() {
+  void test_notMatches_failure() {
     var thrown = catchThrowableOfType(
       () -> new RuleAssert(rule).notMatches("foo"),
       AssertionError.class);
@@ -62,7 +62,7 @@ public class RuleAssertTest {
   }
 
   @Test
-  public void should_not_accept_null() {
+  void should_not_accept_null() {
     var thrown = catchThrowableOfType(
       () -> new RuleAssert((Rule) null).matches(""),
       AssertionError.class);
@@ -70,19 +70,19 @@ public class RuleAssertTest {
   }
 
   @Test
-  public void notMatches_should_not_accept_prefix_match() {
+  void notMatches_should_not_accept_prefix_match() {
     new RuleAssert(rule)
       .notMatches("foo bar");
   }
 
   @Test
-  public void matchesPrefix_ok() {
+  void matchesPrefix_ok() {
     new RuleAssert(rule)
       .matchesPrefix("foo", " bar");
   }
 
   @Test
-  public void matchesPrefix_full_mistmatch() {
+  void matchesPrefix_full_mistmatch() {
     var thrown = catchThrowableOfType(
       () -> new RuleAssert(rule).matchesPrefix("bar", " baz"),
       ParsingResultComparisonFailure.class
@@ -91,7 +91,7 @@ public class RuleAssertTest {
   }
 
   @Test
-  public void matchesPrefix_wrong_prefix() {
+  void matchesPrefix_wrong_prefix() {
     var thrown = catchThrowableOfType(
       () -> new RuleAssert(rule).matchesPrefix("foo bar", " baz"),
       ParsingResultComparisonFailure.class

--- a/cxx-sslr/sslr-tests/pom.xml
+++ b/cxx-sslr/sslr-tests/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <!-- in addition, a dependency must be set in 'integration-tests/pom.xml' to aggregate the results -->
-    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <dependencies>

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/api/AstNodeTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/api/AstNodeTest.java
@@ -30,10 +30,10 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AstNodeTest {
+class AstNodeTest {
 
   @Test
-  public void testAddChild() {
+  void testAddChild() {
     var expr = new AstNode(new NodeType(), "expr", null);
     var stat = new AstNode(new NodeType(), "stat", null);
     var assign = new AstNode(new NodeType(), "assign", null);
@@ -44,7 +44,7 @@ public class AstNodeTest {
   }
 
   @Test
-  public void testAddNullChild() {
+  void testAddNullChild() {
     var expr = new AstNode(new NodeType(), "expr", null);
     expr.addChild(null);
 
@@ -52,7 +52,7 @@ public class AstNodeTest {
   }
 
   @Test
-  public void testAddChildWhichMustBeSkippedFromAst() {
+  void testAddChildWhichMustBeSkippedFromAst() {
     var expr = new AstNode(new NodeType(), "expr", null);
     var all = new AstNode(new NodeType(true), "all", null);
     var stat = new AstNode(new NodeType(), "stat", null);
@@ -68,22 +68,22 @@ public class AstNodeTest {
   }
 
   @Test
-  public void testAddMatcherChildWithoutChildren() {
+  void testAddMatcherChildWithoutChildren() {
     var expr = new AstNode(new NodeType(), "expr", null);
     var all = new AstNode(new NodeType(true), "all", null);
     expr.addChild(all);
 
-    assertThat(expr.getChildren().size()).isEqualTo(0);
+    assertThat(expr.getChildren()).isEmpty();
   }
 
   @Test
-  public void testHasChildren() {
+  void testHasChildren() {
     var expr = new AstNode(new NodeType(), "expr", null);
     assertThat(expr.hasChildren()).isFalse();
   }
 
   @Test
-  public void testGetChild() {
+  void testGetChild() {
     var parent = new AstNode(new NodeType(), "parent", null);
     var child1 = new AstNode(new NodeType(), "child1", null);
     var child2 = new AstNode(new NodeType(), "child2", null);
@@ -95,7 +95,7 @@ public class AstNodeTest {
   }
 
   @Test
-  public void testGetLastToken() {
+  void testGetLastToken() {
     var lastToken = mock(Token.class);
     when(lastToken.getType()).thenReturn(GenericTokenType.IDENTIFIER);
     when(lastToken.getValue()).thenReturn("LAST_TOKEN");
@@ -110,7 +110,7 @@ public class AstNodeTest {
   }
 
   @Test
-  public void testGetTokens() {
+  void testGetTokens() {
     var child1Token = mock(Token.class);
     when(child1Token.getType()).thenReturn(GenericTokenType.IDENTIFIER);
     when(child1Token.getValue()).thenReturn("CHILD 1");
@@ -123,13 +123,13 @@ public class AstNodeTest {
     parent.addChild(child1);
     parent.addChild(child2);
 
-    assertThat(parent.getTokens().size()).isEqualTo(2);
+    assertThat(parent.getTokens()).hasSize(2);
     assertThat(parent.getTokens().get(0)).isSameAs(child1Token);
     assertThat(parent.getTokens().get(1)).isSameAs(child2Token);
   }
 
   @Test
-  public void testGetChildWithBadIndex() {
+  void testGetChildWithBadIndex() {
     var thrown = catchThrowableOfType(() -> {
       var token = mock(Token.class);
       when(token.getType()).thenReturn(GenericTokenType.IDENTIFIER);
@@ -143,7 +143,7 @@ public class AstNodeTest {
   }
 
   @Test
-  public void testNextSibling() {
+  void testNextSibling() {
     var expr1 = new AstNode(new NodeType(), "expr1", null);
     var expr2 = new AstNode(new NodeType(), "expr2", null);
     var statement = new AstNode(new NodeType(), "statement", null);
@@ -156,7 +156,7 @@ public class AstNodeTest {
   }
 
   @Test
-  public void testPreviousSibling() {
+  void testPreviousSibling() {
     var expr1 = new AstNode(new NodeType(), "expr1", null);
     var expr2 = new AstNode(new NodeType(), "expr2", null);
     var statement = new AstNode(new NodeType(), "statement", null);
@@ -169,7 +169,7 @@ public class AstNodeTest {
   }
 
   @Test
-  public void testFindFirstDirectChild() {
+  void testFindFirstDirectChild() {
     var expr = new AstNode(new NodeType(), "expr", null);
     var statRule = new NodeType();
     var stat = new AstNode(statRule, "stat", null);
@@ -183,7 +183,7 @@ public class AstNodeTest {
   }
 
   @Test
-  public void testIs() {
+  void testIs() {
     var declarationNode = parseString("int a = 0;").getFirstChild();
 
     assertThat(declarationNode.is(MiniCGrammar.DEFINITION)).isTrue();
@@ -193,7 +193,7 @@ public class AstNodeTest {
   }
 
   @Test
-  public void testIsNot() {
+  void testIsNot() {
     var declarationNode = parseString("int a = 0;").getFirstChild();
 
     assertThat(declarationNode.isNot(MiniCGrammar.DEFINITION)).isFalse();
@@ -203,42 +203,42 @@ public class AstNodeTest {
   }
 
   @Test
-  public void testFindChildren() {
+  void testFindChildren() {
     var fileNode = parseString("int a = 0; int myFunction() { int b = 0; { int c = 0; } }");
 
     var binVariableDeclarationNodes = fileNode.findChildren(MiniCGrammar.BIN_VARIABLE_DEFINITION);
-    assertThat(binVariableDeclarationNodes.size()).isEqualTo(3);
+    assertThat(binVariableDeclarationNodes).hasSize(3);
     assertThat(binVariableDeclarationNodes.get(0).getTokenValue()).isEqualTo("a");
     assertThat(binVariableDeclarationNodes.get(1).getTokenValue()).isEqualTo("b");
     assertThat(binVariableDeclarationNodes.get(2).getTokenValue()).isEqualTo("c");
 
     var binVDeclarationNodes = fileNode.findChildren(MiniCGrammar.BIN_VARIABLE_DEFINITION,
                                                  MiniCGrammar.BIN_FUNCTION_DEFINITION);
-    assertThat(binVDeclarationNodes.size()).isEqualTo(4);
+    assertThat(binVDeclarationNodes).hasSize(4);
     assertThat(binVDeclarationNodes.get(0).getTokenValue()).isEqualTo("a");
     assertThat(binVDeclarationNodes.get(1).getTokenValue()).isEqualTo("myFunction");
     assertThat(binVDeclarationNodes.get(2).getTokenValue()).isEqualTo("b");
     assertThat(binVDeclarationNodes.get(3).getTokenValue()).isEqualTo("c");
 
-    assertThat(fileNode.findChildren(MiniCGrammar.MULTIPLICATIVE_EXPRESSION).size()).isEqualTo(0);
+    assertThat(fileNode.findChildren(MiniCGrammar.MULTIPLICATIVE_EXPRESSION)).isEmpty();
   }
 
   @Test
-  public void testFindDirectChildren() {
+  void testFindDirectChildren() {
     var fileNode = parseString("int a = 0; void myFunction() { int b = 0*3; { int c = 0; } }");
 
     var declarationNodes = fileNode.findDirectChildren(MiniCGrammar.DEFINITION);
-    assertThat(declarationNodes.size()).isEqualTo(2);
+    assertThat(declarationNodes).hasSize(2);
     assertThat(declarationNodes.get(0).getTokenValue()).isEqualTo("int");
     assertThat(declarationNodes.get(1).getTokenValue()).isEqualTo("void");
 
     var binVDeclarationNodes = fileNode.findDirectChildren(MiniCGrammar.BIN_VARIABLE_DEFINITION,
                                                        MiniCGrammar.BIN_FUNCTION_DEFINITION);
-    assertThat(binVDeclarationNodes.size()).isEqualTo(0);
+    assertThat(binVDeclarationNodes).isEmpty();
   }
 
   @Test
-  public void testFindFirstChildAndHasChildren() {
+  void testFindFirstChildAndHasChildren() {
     var expr = new AstNode(new NodeType(), "expr", null);
     var stat = new AstNode(new NodeType(), "stat", null);
     var indentifierRule = new NodeType();
@@ -254,7 +254,7 @@ public class AstNodeTest {
   }
 
   @Test
-  public void testHasParents() {
+  void testHasParents() {
     var exprRule = new NodeType();
     var expr = new AstNode(exprRule, "expr", null);
     var stat = new AstNode(new NodeType(), "stat", null);
@@ -267,7 +267,7 @@ public class AstNodeTest {
   }
 
   @Test
-  public void testGetLastChild() {
+  void testGetLastChild() {
     var expr1 = new AstNode(new NodeType(), "expr1", null);
     var expr2 = new AstNode(new NodeType(), "expr2", null);
     var statement = new AstNode(new NodeType(), "statement", null);
@@ -288,7 +288,7 @@ public class AstNodeTest {
    * </pre>
    */
   @Test
-  public void test_getDescendants() {
+  void test_getDescendants() {
     var a = new NodeType();
     var b = new NodeType();
     var c = new NodeType();

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/ParserTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/ParserTest.java
@@ -30,10 +30,10 @@ import static com.sonar.cxx.sslr.test.minic.MiniCParser.parseString;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class ParserTest {
+class ParserTest {
 
   @Test
-  public void lexerErrorStringWrappedInRecognitionException() {
+  void lexerErrorStringWrappedInRecognitionException() {
     var thrown = catchThrowableOfType(() -> {
       parseString(".");
     }, RecognitionException.class);
@@ -41,7 +41,7 @@ public class ParserTest {
   }
 
   @Test
-  public void lexerErrorFileWrappedInRecognitionException() {
+  void lexerErrorFileWrappedInRecognitionException() {
     var thrown = catchThrowableOfType(() -> {
       parseFile("/OwnExamples/lexererror.mc");
     }, RecognitionException.class);
@@ -49,7 +49,7 @@ public class ParserTest {
   }
 
   @Test
-  public void parse() {
+  void parse() {
     var compilationUnit = parseString("");
     assertThat(compilationUnit.getNumberOfChildren()).isEqualTo(1);
     assertThat(compilationUnit.getFirstChild().is(EOF)).isTrue();

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/ast/AstWalkerTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/ast/AstWalkerTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.*;
 
-public class AstWalkerTest {
+class AstWalkerTest {
 
   private final AstWalker walker = new AstWalker();
   private AstNode ast1;
@@ -79,7 +79,7 @@ public class AstWalkerTest {
   }
 
   @Test
-  public void testVisitFileAndLeaveFileCalls() {
+  void testVisitFileAndLeaveFileCalls() {
     when(astVisitor.getAstNodeTypesToVisit()).thenReturn(new ArrayList<>());
     walker.addVisitor(astVisitor);
     walker.walkAndVisit(ast1);
@@ -89,7 +89,7 @@ public class AstWalkerTest {
   }
 
   @Test
-  public void testVisitToken() {
+  void testVisitToken() {
     when(astAndTokenVisitor.getAstNodeTypesToVisit()).thenReturn(new ArrayList<>());
     walker.addVisitor(astAndTokenVisitor);
     walker.walkAndVisit(astNodeWithToken);
@@ -99,7 +99,7 @@ public class AstWalkerTest {
   }
 
   @Test
-  public void testVisitNodeAndLeaveNodeCalls() {
+  void testVisitNodeAndLeaveNodeCalls() {
     when(astVisitor.getAstNodeTypesToVisit()).thenReturn(Arrays.asList(tiger));
     walker.addVisitor(astVisitor);
     walker.walkAndVisit(ast1);
@@ -110,7 +110,7 @@ public class AstWalkerTest {
   }
 
   @Test
-  public void testAddVisitor() {
+  void testAddVisitor() {
     var walker = new AstWalker();
 
     var astNodeType = mock(AstNodeType.class);

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/ast/AstXmlPrinterTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/ast/AstXmlPrinterTest.java
@@ -32,10 +32,10 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AstXmlPrinterTest {
+class AstXmlPrinterTest {
 
   @Test
-  public void testPrintRuleAstNode() {
+  void testPrintRuleAstNode() {
     var token = mock(Token.class);
     when(token.getType()).thenReturn(new WordTokenType());
     when(token.getValue()).thenReturn("word");
@@ -49,7 +49,7 @@ public class AstXmlPrinterTest {
   }
 
   @Test
-  public void testPrintWordAstNode() {
+  void testPrintWordAstNode() {
     var token = mock(Token.class);
     when(token.getType()).thenReturn(new WordTokenType());
     when(token.getValue()).thenReturn("myword");
@@ -60,7 +60,7 @@ public class AstXmlPrinterTest {
   }
 
   @Test
-  public void testPrintFullAstNode() {
+  void testPrintFullAstNode() {
     var astNode = new AstNode(new RuleDefinition("expr"), "expr", null);
 
     var tokenX = mock(Token.class);

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/BlackHoleChannelTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/BlackHoleChannelTest.java
@@ -29,13 +29,13 @@ import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sslr.channel.CodeReader;
 import static org.sonar.cxx.sslr.test.channel.ChannelMatchers.*;
 
-public class BlackHoleChannelTest {
+class BlackHoleChannelTest {
 
   private final Lexer lexer = Lexer.builder().build();
   private final BlackHoleChannel channel = new BlackHoleChannel("[ \\t]+");
 
   @Test
-  public void testConsumeOneCharacter() {
+  void testConsumeOneCharacter() {
     AssertionsForClassTypes.assertThat(channel).is(consume(" ", lexer));
     AssertionsForClassTypes.assertThat(channel).is(consume("\t", lexer));
     AssertionsForClassTypes.assertThat(channel).isNot(consume("g", lexer));
@@ -44,7 +44,7 @@ public class BlackHoleChannelTest {
   }
 
   @Test
-  public void consumeSeveralCharacters() {
+  void consumeSeveralCharacters() {
     var reader = new CodeReader("   \t123");
     AssertionsForClassTypes.assertThat(channel).is(consume(reader, lexer));
     AssertionsForClassTypes.assertThat(reader).has(hasNextChar('1'));

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/BomCharacterChannelTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/BomCharacterChannelTest.java
@@ -28,21 +28,21 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sslr.channel.CodeReader;
 
-public class BomCharacterChannelTest {
+class BomCharacterChannelTest {
 
   private final Lexer lexer = Lexer.builder().build();
   private final BomCharacterChannel channel = new BomCharacterChannel();
 
   @Test
-  public void shouldConsumeBomCharacter() {
+  void shouldConsumeBomCharacter() {
     assertThat(channel.consume(new CodeReader("\uFEFF"), lexer)).isTrue();
-    assertThat(lexer.getTokens().size()).isEqualTo(0);
+    assertThat(lexer.getTokens()).isEmpty();
   }
 
   @Test
-  public void shouldNotConsumeOtherCharacters() {
+  void shouldNotConsumeOtherCharacters() {
     assertThat(channel.consume(new CodeReader(" "), lexer)).isFalse();
-    assertThat(lexer.getTokens().size()).isEqualTo(0);
+    assertThat(lexer.getTokens()).isEmpty();
   }
 
 }

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/CommentChannelTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/CommentChannelTest.java
@@ -34,13 +34,13 @@ import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
 import static org.sonar.cxx.sslr.test.channel.ChannelMatchers.*;
 
-public class CommentChannelTest {
+class CommentChannelTest {
 
   private CommentRegexpChannel channel;
   private final Lexer lexer = Lexer.builder().build();
 
   @Test
-  public void testCommentRegexp() {
+  void testCommentRegexp() {
     channel = new CommentRegexpChannel("//.*");
     AssertionsForClassTypes.assertThat(channel).isNot(consume("This is not a comment", lexer));
     AssertionsForClassTypes.assertThat(channel).is(consume("//My Comment\n second line", lexer));

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/IdentifierAndKeywordChannelTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/IdentifierAndKeywordChannelTest.java
@@ -34,20 +34,20 @@ import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sslr.channel.CodeReader;
 import static org.sonar.cxx.sslr.test.channel.ChannelMatchers.consume;
 
-public class IdentifierAndKeywordChannelTest {
+class IdentifierAndKeywordChannelTest {
 
   private IdentifierAndKeywordChannel channel;
   private final Lexer lexer = Lexer.builder().build();
 
   @Test
-  public void testConsumeWord() {
+  void testConsumeWord() {
     channel = new IdentifierAndKeywordChannel("[a-zA-Z_][a-zA-Z_0-9]*", true, MyKeywords.values());
     AssertionsForClassTypes.assertThat(channel).has(consume("word", lexer));
     AssertionsForClassTypes.assertThat(lexer.getTokens()).has(hasToken("word", GenericTokenType.IDENTIFIER));
   }
 
   @Test
-  public void testConsumeCaseSensitiveKeywords() {
+  void testConsumeCaseSensitiveKeywords() {
     channel = new IdentifierAndKeywordChannel("[a-zA-Z_][a-zA-Z_0-9]*", true, MyKeywords.values());
     AssertionsForClassTypes.assertThat(channel).has(consume("KEYWORD1", lexer));
     AssertionsForClassTypes.assertThat(lexer.getTokens()).has(hasToken("KEYWORD1", MyKeywords.KEYWORD1));
@@ -60,7 +60,7 @@ public class IdentifierAndKeywordChannelTest {
   }
 
   @Test
-  public void testConsumeNotCaseSensitiveKeywords() {
+  void testConsumeNotCaseSensitiveKeywords() {
     channel = new IdentifierAndKeywordChannel("[a-zA-Z_][a-zA-Z_0-9]*", false, MyKeywords.values());
     AssertionsForClassTypes.assertThat(channel).has(consume("keyword1", lexer));
     AssertionsForClassTypes.assertThat(lexer.getTokens()).has(hasToken("KEYWORD1", MyKeywords.KEYWORD1));
@@ -72,7 +72,7 @@ public class IdentifierAndKeywordChannelTest {
   }
 
   @Test
-  public void testColumnAndLineNumbers() {
+  void testColumnAndLineNumbers() {
     channel = new IdentifierAndKeywordChannel("[a-zA-Z_][a-zA-Z_0-9]*", false, MyKeywords.values());
     var reader = new CodeReader("\n\n  keyword1");
     reader.pop();
@@ -86,7 +86,7 @@ public class IdentifierAndKeywordChannelTest {
   }
 
   @Test
-  public void testNotConsumNumber() {
+  void testNotConsumNumber() {
     channel = new IdentifierAndKeywordChannel("[a-zA-Z_][a-zA-Z_0-9]*", false, MyKeywords.values());
     AssertionsForClassTypes.assertThat(channel).isNot(consume("1234", lexer));
   }

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/PunctuatorChannelTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/PunctuatorChannelTest.java
@@ -33,13 +33,13 @@ import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sslr.channel.CodeReader;
 import static org.sonar.cxx.sslr.test.channel.ChannelMatchers.consume;
 
-public class PunctuatorChannelTest {
+class PunctuatorChannelTest {
 
   private final PunctuatorChannel channel = new PunctuatorChannel(MyPunctuatorAndOperator.values());
   private final Lexer lexer = Lexer.builder().build();
 
   @Test
-  public void testConsumeSpecialCharacters() {
+  void testConsumeSpecialCharacters() {
     AssertionsForClassTypes.assertThat(channel).has(consume("**=", lexer));
     AssertionsForClassTypes.assertThat(lexer.getTokens()).has(hasToken("*", MyPunctuatorAndOperator.STAR));
 
@@ -59,7 +59,7 @@ public class PunctuatorChannelTest {
   }
 
   @Test
-  public void testNotConsumeWord() {
+  void testNotConsumeWord() {
     assertThat(channel.consume(new CodeReader("word"), lexer)).isFalse();
   }
 

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/RegexpChannelBuilderTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/RegexpChannelBuilderTest.java
@@ -27,36 +27,36 @@ import static com.sonar.cxx.sslr.impl.channel.RegexpChannelBuilder.*;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class RegexpChannelBuilderTest {
+class RegexpChannelBuilderTest {
 
   @Test
-  public void testOpt() {
+  void testOpt() {
     assertThat(opt("L")).isEqualTo("L?+");
   }
 
   @Test
-  public void testOne2n() {
+  void testOne2n() {
     assertThat(one2n("L")).isEqualTo("L++");
   }
 
   @Test
-  public void testO2n() {
+  void testO2n() {
     assertThat(o2n("L")).isEqualTo("L*+");
   }
 
   @Test
-  public void testg() {
+  void testg() {
     assertThat(g("L")).isEqualTo("(L)");
     assertThat(g("L", "l")).isEqualTo("(Ll)");
   }
 
   @Test
-  public void testOr() {
+  void testOr() {
     assertThat(or("L", "l", "U", "u")).isEqualTo("(L|l|U|u)");
   }
 
   @Test
-  public void testAnyButNot() {
+  void testAnyButNot() {
     assertThat(anyButNot("L", "l")).isEqualTo("[^Ll]");
   }
 

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/RegexpChannelTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/RegexpChannelTest.java
@@ -32,13 +32,13 @@ import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sslr.channel.CodeReader;
 import static org.sonar.cxx.sslr.test.channel.ChannelMatchers.*;
 
-public class RegexpChannelTest {
+class RegexpChannelTest {
 
   private RegexpChannel channel;
   private final Lexer lexer = Lexer.builder().build();
 
   @Test
-  public void testRegexpToHandleNumber() {
+  void testRegexpToHandleNumber() {
     channel = new RegexpChannel(GenericTokenType.CONSTANT, "[0-9]*");
     AssertionsForClassTypes.assertThat(channel).isNot(consume("Not a number", lexer));
     AssertionsForClassTypes.assertThat(channel).has(consume(new CodeReader("56;"), lexer));
@@ -46,9 +46,9 @@ public class RegexpChannelTest {
   }
 
   @Test
-  public void testColumnNumber() {
+  void testColumnNumber() {
     channel = new RegexpChannel(GenericTokenType.CONSTANT, "[0-9]*");
     AssertionsForClassTypes.assertThat(channel).has(consume("56;", lexer));
-    assertThat(lexer.getTokens().get(0).getColumn()).isEqualTo(0);
+    assertThat(lexer.getTokens().get(0).getColumn()).isZero();
   }
 }

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/UnknownCharacterChannelTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/channel/UnknownCharacterChannelTest.java
@@ -32,18 +32,18 @@ import org.junit.jupiter.api.Test;
 import org.sonar.cxx.sslr.channel.Channel;
 import org.sonar.cxx.sslr.channel.CodeReader;
 
-public class UnknownCharacterChannelTest {
+class UnknownCharacterChannelTest {
 
   private final UnknownCharacterChannel channel = new UnknownCharacterChannel();
 
   @Test
-  public void shouldConsumeAnyCharacter() {
+  void shouldConsumeAnyCharacter() {
     check("'", channel, UNKNOWN_CHAR, "'", Lexer.builder().build());
     check("a", channel, UNKNOWN_CHAR, "a", Lexer.builder().build());
   }
 
   @Test
-  public void shouldConsumeEofCharacter() {
+  void shouldConsumeEofCharacter() {
     assertThat(channel.consume(new CodeReader(""), null)).isFalse();
   }
 
@@ -52,7 +52,7 @@ public class UnknownCharacterChannelTest {
     var code = new CodeReader(new StringReader(input));
 
     assertThat(channel.consume(code, lexer)).isTrue();
-    assertThat(lexer.getTokens().size()).isEqualTo(1);
+    assertThat(lexer.getTokens()).hasSize(1);
     assertThat(lexer.getTokens().get(0).getType()).isEqualTo(expectedTokenType);
     assertThat(lexer.getTokens().get(0).getValue()).isEqualTo(expectedTokenValue);
   }

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/matcher/RuleDefinitionTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/matcher/RuleDefinitionTest.java
@@ -31,17 +31,17 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class RuleDefinitionTest {
+class RuleDefinitionTest {
 
   @Test
-  public void testEmptyIs() {
+  void testEmptyIs() {
     var javaClassDefinition = new RuleDefinition("JavaClassDefinition");
     var thrown = catchThrowableOfType(javaClassDefinition::is, IllegalStateException.class);
     assertThat(thrown.getMessage()).isEqualTo("The rule 'JavaClassDefinition' should at least contains one matcher.");
   }
 
   @Test
-  public void testMoreThanOneDefinitionForASigleRuleWithIs() {
+  void testMoreThanOneDefinitionForASigleRuleWithIs() {
     var javaClassDefinition = new RuleDefinition("JavaClassDefinition");
     javaClassDefinition.is("option1");
     var thrown = catchThrowableOfType(
@@ -53,7 +53,7 @@ public class RuleDefinitionTest {
   }
 
   @Test
-  public void testSkipFromAst() {
+  void testSkipFromAst() {
     var ruleBuilder = new RuleDefinition("MyRule");
     assertThat(ruleBuilder.hasToBeSkippedFromAst(null)).isFalse();
 
@@ -62,7 +62,7 @@ public class RuleDefinitionTest {
   }
 
   @Test
-  public void testSkipFromAstIf() {
+  void testSkipFromAstIf() {
     var ruleBuilder = new RuleDefinition("MyRule");
     ruleBuilder.skipIfOneChild();
 

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/matcher/RuleMatcherTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/impl/matcher/RuleMatcherTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class RuleMatcherTest {
+class RuleMatcherTest {
 
   private RuleDefinition javaClassDefinition;
   private Matcher opMatcher;
@@ -44,12 +44,12 @@ public class RuleMatcherTest {
   }
 
   @Test
-  public void getName() {
+  void getName() {
     assertThat(javaClassDefinition.getName()).isEqualTo("JavaClassDefinition");
   }
 
   @Test
-  public void getToString() {
+  void getToString() {
     assertThat(javaClassDefinition.getName()).isEqualTo("JavaClassDefinition");
   }
 

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/test/minic/MiniCLexerTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/test/minic/MiniCLexerTest.java
@@ -32,12 +32,12 @@ import static com.sonar.cxx.sslr.test.minic.MiniCLexer.Punctuators.*;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
 
-public class MiniCLexerTest {
+class MiniCLexerTest {
 
   Lexer lexer = MiniCLexer.create();
 
   @Test
-  public void lexIdentifiers() {
+  void lexIdentifiers() {
     AssertionsForClassTypes.assertThat(lexer.lex("abc")).has(hasToken("abc", IDENTIFIER));
     AssertionsForClassTypes.assertThat(lexer.lex("abc0")).has(hasToken("abc0", IDENTIFIER));
     AssertionsForClassTypes.assertThat(lexer.lex("abc_0")).has(hasToken("abc_0", IDENTIFIER));
@@ -45,14 +45,14 @@ public class MiniCLexerTest {
   }
 
   @Test
-  public void lexIntegers() {
+  void lexIntegers() {
     AssertionsForClassTypes.assertThat(lexer.lex("0")).has(hasToken("0", INTEGER));
     AssertionsForClassTypes.assertThat(lexer.lex("000")).has(hasToken("000", INTEGER));
     AssertionsForClassTypes.assertThat(lexer.lex("1234")).has(hasToken("1234", INTEGER));
   }
 
   @Test
-  public void lexKeywords() {
+  void lexKeywords() {
     AssertionsForClassTypes.assertThat(lexer.lex("int")).has(hasToken(INT));
     AssertionsForClassTypes.assertThat(lexer.lex("void")).has(hasToken(VOID));
     AssertionsForClassTypes.assertThat(lexer.lex("return")).has(hasToken(RETURN));
@@ -65,7 +65,7 @@ public class MiniCLexerTest {
   }
 
   @Test
-  public void lexComments() {
+  void lexComments() {
     AssertionsForClassTypes.assertThat(lexer.lex("/*test*/")).has(hasComment("/*test*/"));
     AssertionsForClassTypes.assertThat(lexer.lex("/*test*/*/")).has(hasComment("/*test*/"));
     AssertionsForClassTypes.assertThat(lexer.lex("/*test/* /**/")).has(hasComment("/*test/* /**/"));
@@ -73,7 +73,7 @@ public class MiniCLexerTest {
   }
 
   @Test
-  public void lexPunctuators() {
+  void lexPunctuators() {
     AssertionsForClassTypes.assertThat(lexer.lex("(")).has(hasToken(PAREN_L));
     AssertionsForClassTypes.assertThat(lexer.lex(")")).has(hasToken(PAREN_R));
     AssertionsForClassTypes.assertThat(lexer.lex("{")).has(hasToken(BRACE_L));

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/test/minic/integration/MiniCOwnExamplesTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/test/minic/integration/MiniCOwnExamplesTest.java
@@ -31,12 +31,12 @@ import org.apache.commons.io.FileUtils;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class MiniCOwnExamplesTest {
+class MiniCOwnExamplesTest {
 
   private static final Parser<Grammar> parser = MiniCParser.create();
 
   @Test
-  public void test() throws Exception {
+  void test() throws Exception {
     var files = FileUtils.listFiles(new File("src/test/resources/MiniCIntegration"), null, true);
     assertThat(files).isNotEmpty();
     for (var file : files) {

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/test/minic/rules/ExpressionTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/test/minic/rules/ExpressionTest.java
@@ -37,7 +37,7 @@ public class ExpressionTest extends RuleTest {
   }
 
   @Test
-  public void reallife() {
+  void reallife() {
     assertThat(p)
       .matches("1")
       .matches("1 + 1")

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/test/minic/rules/StructTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/test/minic/rules/StructTest.java
@@ -37,7 +37,7 @@ public class StructTest extends RuleTest {
   }
 
   @Test
-  public void reallife() {
+  void reallife() {
     assertThat(p)
       .matches("struct my { int a; }")
       .matches("struct my { int a; int b; }");

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/xpath/BasicQueriesTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/xpath/BasicQueriesTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BasicQueriesTest {
+class BasicQueriesTest {
 
   private AstNode fileNode;
 
@@ -42,61 +42,61 @@ public class BasicQueriesTest {
   }
 
   @Test
-  public void compilationUnitTest() {
+  void compilationUnitTest() {
     var xpath = AstNodeXPathQuery.create("/COMPILATION_UNIT");
     assertThat(xpath.selectSingleNode(fileNode)).isEqualTo(fileNode);
   }
 
   @Test
-  public void anyCompilationUnitTest() {
+  void anyCompilationUnitTest() {
     var xpath = AstNodeXPathQuery.create("//COMPILATION_UNIT");
     assertThat(xpath.selectSingleNode(fileNode)).isEqualTo(fileNode);
   }
 
   @Test
-  public void compilationUnitWithPredicateWithEOFTest() {
+  void compilationUnitWithPredicateWithEOFTest() {
     var xpath = AstNodeXPathQuery.create("/COMPILATION_UNIT[not(not(EOF))]");
     assertThat(xpath.selectSingleNode(fileNode)).isEqualTo(fileNode);
   }
 
   @Test
-  public void compilationUnitWithPredicateWithoutEOFTest() {
+  void compilationUnitWithPredicateWithoutEOFTest() {
     var xpath = AstNodeXPathQuery.create("/COMPILATION_UNIT[not(EOF)]");
     assertThat(xpath.selectSingleNode(fileNode)).isNull();
   }
 
   @Test
-  public void EOFTest() {
+  void EOFTest() {
     var xpath = AstNodeXPathQuery.create("/COMPILATION_UNIT/EOF");
     assertThat(xpath.selectSingleNode(fileNode)).isEqualTo(fileNode.findFirstChild(EOF));
   }
 
   @Test
-  public void anyEOFTest() {
+  void anyEOFTest() {
     var xpath = AstNodeXPathQuery.create("//EOF");
     assertThat(xpath.selectSingleNode(fileNode)).isEqualTo(fileNode.findFirstChild(EOF));
   }
 
   @Test
-  public void getTokenValueAttributeTest() {
+  void getTokenValueAttributeTest() {
     var xpath = AstNodeXPathQuery.create("string(/COMPILATION_UNIT/@tokenValue)");
     assertThat(xpath.selectSingleNode(fileNode)).isEqualTo("int");
   }
 
   @Test
-  public void getTokenLineAttributeTest() {
+  void getTokenLineAttributeTest() {
     var xpath = AstNodeXPathQuery.create("string(/COMPILATION_UNIT/@tokenLine)");
     assertThat(xpath.selectSingleNode(fileNode)).isEqualTo("2");
   }
 
   @Test
-  public void getTokenColumnAttributeTest() {
+  void getTokenColumnAttributeTest() {
     var xpath = AstNodeXPathQuery.create("string(/COMPILATION_UNIT/@tokenColumn)");
     assertThat(xpath.selectSingleNode(fileNode)).isEqualTo("0");
   }
 
   @Test
-  public void getSecondDeclarationTest() {
+  void getSecondDeclarationTest() {
     var xpath1 = AstNodeXPathQuery.create("/COMPILATION_UNIT/DEFINITION[@tokenLine=4]");
     var xpath2 = AstNodeXPathQuery.create("/COMPILATION_UNIT/DEFINITION[2]");
     var declarationAtLineFour = fileNode.getChildren().get(1);
@@ -107,16 +107,16 @@ public class BasicQueriesTest {
   }
 
   @Test
-  public void identifiersCountTest() {
+  void identifiersCountTest() {
     var xpath = AstNodeXPathQuery.create("/COMPILATION_UNIT[count(//IDENTIFIER) = 2]");
     assertThat(xpath.selectSingleNode(fileNode)).isEqualTo(fileNode);
   }
 
   @Test
-  public void getIdentifiersTest() {
+  void getIdentifiersTest() {
     AstNodeXPathQuery<AstNode> xpath = AstNodeXPathQuery.create("//IDENTIFIER");
     var nodes = xpath.selectNodes(fileNode);
-    assertThat(nodes.size()).isEqualTo(2);
+    assertThat(nodes).hasSize(2);
     assertThat(nodes.get(0).getTokenValue()).isEqualTo("a");
     assertThat(nodes.get(1).getTokenValue()).isEqualTo("b");
   }

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/xpath/IdentifiersTooLongTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/xpath/IdentifiersTooLongTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class IdentifiersTooLongTest {
+class IdentifiersTooLongTest {
 
   private AstNode fileNode;
 
@@ -40,12 +40,12 @@ public class IdentifiersTooLongTest {
   }
 
   @Test
-  public void valuesTest() {
+  void valuesTest() {
     AstNodeXPathQuery<AstNode> xpath = AstNodeXPathQuery.create("//IDENTIFIER[string-length(@tokenValue) > 10]");
 
     var nodes = xpath.selectNodes(fileNode);
 
-    assertThat(nodes.size()).isEqualTo(3);
+    assertThat(nodes).hasSize(3);
     assertThat(nodes.get(0).getTokenValue()).isEqualTo("aaaaaaaaa11");
     assertThat(nodes.get(0).getTokenLine()).isEqualTo(3);
     assertThat(nodes.get(1).getTokenValue()).isEqualTo("bbbbbbbbbbbbb15");
@@ -55,12 +55,12 @@ public class IdentifiersTooLongTest {
   }
 
   @Test
-  public void noResultValuesTest() {
+  void noResultValuesTest() {
     AstNodeXPathQuery<AstNode> xpath = AstNodeXPathQuery.create("//IDENTIFIER[string-length(@tokenValue) > 50]");
 
     var nodes = xpath.selectNodes(fileNode);
 
-    assertThat(nodes.size()).isEqualTo(0);
+    assertThat(nodes).isEmpty();
   }
 
 }

--- a/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/xpath/IfSMustUseBracesTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/com/sonar/cxx/sslr/xpath/IfSMustUseBracesTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class IfSMustUseBracesTest {
+class IfSMustUseBracesTest {
 
   private AstNode fileNode;
 
@@ -41,24 +41,24 @@ public class IfSMustUseBracesTest {
   }
 
   @Test
-  public void firstValueEqualsOnlyValueTest() {
+  void firstValueEqualsOnlyValueTest() {
     AstNodeXPathQuery<AstNode> xpath = AstNodeXPathQuery.create(
       "//IF_STATEMENT/STATEMENT[not(COMPOUND_STATEMENT)]/..|//ELSE_CLAUSE/STATEMENT[not(COMPOUND_STATEMENT)]/..");
 
     var nodes = xpath.selectNodes(fileNode);
 
-    assertThat(nodes.size()).isEqualTo(2);
+    assertThat(nodes).hasSize(2);
     assertThat(nodes.get(0)).isEqualTo(xpath.selectSingleNode(fileNode));
   }
 
   @Test
-  public void valuesTest() {
+  void valuesTest() {
     AstNodeXPathQuery<AstNode> xpath = AstNodeXPathQuery.create(
       "//IF_STATEMENT/STATEMENT[not(COMPOUND_STATEMENT)]/..|//ELSE_CLAUSE/STATEMENT[not(COMPOUND_STATEMENT)]/..");
 
     var nodes = xpath.selectNodes(fileNode);
 
-    assertThat(nodes.size()).isEqualTo(2);
+    assertThat(nodes).hasSize(2);
     assertThat(nodes.get(0).is(MiniCGrammar.IF_STATEMENT)).isTrue();
     assertThat(nodes.get(0).getTokenLine()).isEqualTo(3);
     assertThat(nodes.get(1).is(MiniCGrammar.ELSE_CLAUSE)).isTrue();

--- a/cxx-sslr/sslr-tests/src/test/java/org/sonar/cxx/sslr/ast/CollapsibleIfSelectTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/org/sonar/cxx/sslr/ast/CollapsibleIfSelectTest.java
@@ -34,13 +34,13 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class CollapsibleIfSelectTest {
+class CollapsibleIfSelectTest {
 
   private final Parser<Grammar> p = MiniCParser.create();
   private final Grammar g = p.getGrammar();
 
   @Test
-  public void test() {
+  void test() {
     var fileNode = p.parse(new File("src/test/resources/queries/collapsible_if.mc"));
     var ifStatements = fileNode.getDescendants(MiniCGrammar.IF_STATEMENT);
 

--- a/cxx-sslr/sslr-tests/src/test/java/org/sonar/cxx/sslr/ast/CollapsibleIfVisitorTest.java
+++ b/cxx-sslr/sslr-tests/src/test/java/org/sonar/cxx/sslr/ast/CollapsibleIfVisitorTest.java
@@ -34,13 +34,13 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class CollapsibleIfVisitorTest {
+class CollapsibleIfVisitorTest {
 
   private final Parser<Grammar> p = MiniCParser.create();
   private final Grammar g = p.getGrammar();
 
   @Test
-  public void test() {
+  void test() {
     var fileNode = p.parse(new File("src/test/resources/queries/collapsible_if.mc"));
     var ifStatements = fileNode.getDescendants(MiniCGrammar.IF_STATEMENT);
 

--- a/cxx-sslr/sslr-toolkit/pom.xml
+++ b/cxx-sslr/sslr-toolkit/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <!-- in addition, a dependency must be set in 'integration-tests/pom.xml' to aggregate the results -->
-    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <dependencies>

--- a/cxx-sslr/sslr-toolkit/src/test/java/org/sonar/cxx/sslr/internal/toolkit/CssLoaderTest.java
+++ b/cxx-sslr/sslr-toolkit/src/test/java/org/sonar/cxx/sslr/internal/toolkit/CssLoaderTest.java
@@ -26,10 +26,10 @@ package org.sonar.cxx.sslr.internal.toolkit;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class CssLoaderTest {
+class CssLoaderTest {
 
   @Test
-  public void getCss() {
+  void getCss() {
     assertThat(CssLoader.getCss()).contains("/* constants */").contains(".code {");
   }
 

--- a/cxx-sslr/sslr-toolkit/src/test/java/org/sonar/cxx/sslr/internal/toolkit/LineOffsetsTest.java
+++ b/cxx-sslr/sslr-toolkit/src/test/java/org/sonar/cxx/sslr/internal/toolkit/LineOffsetsTest.java
@@ -30,10 +30,10 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class LineOffsetsTest {
+class LineOffsetsTest {
 
   @Test
-  public void getStartOffset() {
+  void getStartOffset() {
     var foo = mock(Token.class);
     when(foo.getType()).thenReturn(GenericTokenType.IDENTIFIER);
     when(foo.getValue()).thenReturn("foo");
@@ -48,12 +48,12 @@ public class LineOffsetsTest {
 
     var lineOffsets = new LineOffsets("foo\n??bar");
 
-    assertThat(lineOffsets.getStartOffset(foo)).isEqualTo(0);
+    assertThat(lineOffsets.getStartOffset(foo)).isZero();
     assertThat(lineOffsets.getStartOffset(bar)).isEqualTo(6);
   }
 
   @Test
-  public void getEndOffsetSingleLine() {
+  void getEndOffsetSingleLine() {
     var foo = mock(Token.class);
     when(foo.getType()).thenReturn(GenericTokenType.IDENTIFIER);
     when(foo.getValue()).thenReturn("foo");
@@ -75,7 +75,7 @@ public class LineOffsetsTest {
   }
 
   @Test
-  public void getEndOffsetMultiLine() {
+  void getEndOffsetMultiLine() {
     var foo = mock(Token.class);
     when(foo.getType()).thenReturn(GenericTokenType.IDENTIFIER);
     when(foo.getValue()).thenReturn("foo");
@@ -97,7 +97,7 @@ public class LineOffsetsTest {
   }
 
   @Test
-  public void getEndOffsetMultiLineRNSingleOffsetIncrement() {
+  void getEndOffsetMultiLineRNSingleOffsetIncrement() {
     var foo = mock(Token.class);
     when(foo.getType()).thenReturn(GenericTokenType.IDENTIFIER);
     when(foo.getValue()).thenReturn("foo");
@@ -119,7 +119,7 @@ public class LineOffsetsTest {
   }
 
   @Test
-  public void getEndOffsetMultiLineRNewLine() {
+  void getEndOffsetMultiLineRNewLine() {
     var foo = mock(Token.class);
     when(foo.getType()).thenReturn(GenericTokenType.IDENTIFIER);
     when(foo.getValue()).thenReturn("foo");
@@ -141,7 +141,7 @@ public class LineOffsetsTest {
   }
 
   @Test
-  public void getOffset() {
+  void getOffset() {
     var lineOffsets = new LineOffsets("int a = 0;\nint b = 0;");
 
     assertThat(lineOffsets.getOffset(2, 4)).isEqualTo(15);
@@ -150,23 +150,23 @@ public class LineOffsetsTest {
   }
 
   @Test
-  public void getOffsetCariageReturnAsNewLine() {
+  void getOffsetCariageReturnAsNewLine() {
     var lineOffsets = new LineOffsets("\rfoo");
 
-    assertThat(lineOffsets.getOffset(1, 0)).isEqualTo(0);
+    assertThat(lineOffsets.getOffset(1, 0)).isZero();
     assertThat(lineOffsets.getOffset(2, 0)).isEqualTo(1);
   }
 
   @Test
-  public void getOffsetCariageReturnAndLineFeedAsSingleOffset() {
+  void getOffsetCariageReturnAndLineFeedAsSingleOffset() {
     var lineOffsets = new LineOffsets("\r\nfoo");
 
-    assertThat(lineOffsets.getOffset(1, 0)).isEqualTo(0);
+    assertThat(lineOffsets.getOffset(1, 0)).isZero();
     assertThat(lineOffsets.getOffset(2, 0)).isEqualTo(1);
   }
 
   @Test
-  public void getOffsetBadLine() {
+  void getOffsetBadLine() {
     var thrown = catchThrowableOfType(() -> {
       var lineOffsets = new LineOffsets("");
       lineOffsets.getOffset(0, 0);
@@ -175,7 +175,7 @@ public class LineOffsetsTest {
   }
 
   @Test
-  public void getOffsetBadColumn() {
+  void getOffsetBadColumn() {
     var thrown = catchThrowableOfType(() -> {
       var lineOffsets = new LineOffsets("");
       lineOffsets.getOffset(1, -1);

--- a/cxx-sslr/sslr-toolkit/src/test/java/org/sonar/cxx/sslr/internal/toolkit/ToolkitPresenterTest.java
+++ b/cxx-sslr/sslr-toolkit/src/test/java/org/sonar/cxx/sslr/internal/toolkit/ToolkitPresenterTest.java
@@ -46,10 +46,10 @@ import static org.mockito.Mockito.when;
 import org.sonar.cxx.sslr.toolkit.ConfigurationModel;
 import org.sonar.cxx.sslr.toolkit.ConfigurationProperty;
 
-public class ToolkitPresenterTest {
+class ToolkitPresenterTest {
 
   @Test
-  public void checkInitializedBad() {
+  void checkInitializedBad() {
     var thrown = catchThrowableOfType(() -> {
       var presenter = new ToolkitPresenter(mock(ConfigurationModel.class), mock(SourceCodeModel.class));
       presenter.checkInitialized();
@@ -60,14 +60,14 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void checkInitializedGood() {
+  void checkInitializedGood() {
     var presenter = new ToolkitPresenter(mock(ConfigurationModel.class), mock(SourceCodeModel.class));
     presenter.setView(mock(ToolkitView.class));
     presenter.checkInitialized();
   }
 
   @Test
-  public void initUncaughtExceptionsHandler() throws InterruptedException {
+  void initUncaughtExceptionsHandler() throws InterruptedException {
     var view = mock(ToolkitView.class);
 
     var presenter = new ToolkitPresenter(mock(ConfigurationModel.class), mock(SourceCodeModel.class));
@@ -87,7 +87,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void initConfigurationTab() {
+  void initConfigurationTab() {
     var view = mock(ToolkitView.class);
 
     var presenter = new ToolkitPresenter(mock(ConfigurationModel.class), mock(SourceCodeModel.class));
@@ -120,7 +120,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void run() {
+  void run() {
     var view = mock(ToolkitView.class);
 
     var presenter = new ToolkitPresenter(mock(ConfigurationModel.class), mock(SourceCodeModel.class));
@@ -138,7 +138,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void run_should_call_initConfigurationTab() {
+  void run_should_call_initConfigurationTab() {
     var view = mock(ToolkitView.class);
 
     var presenter = new ToolkitPresenter(mock(ConfigurationModel.class), mock(SourceCodeModel.class));
@@ -155,7 +155,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void runFailsWithoutView() {
+  void runFailsWithoutView() {
     var thrown = catchThrowableOfType(() -> {
       new ToolkitPresenter(mock(ConfigurationModel.class), mock(SourceCodeModel.class)).run("foo");
     }, IllegalStateException.class);
@@ -163,7 +163,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void onSourceCodeOpenButtonClick() {
+  void onSourceCodeOpenButtonClick() {
     var view = mock(ToolkitView.class);
     var file = new File("src/test/resources/parse_error.txt");
     when(view.pickFileToParse()).thenReturn(file);
@@ -192,7 +192,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void onSourceCodeOpenButtonClick_with_parse_error_should_clear_console_and_display_code() {
+  void onSourceCodeOpenButtonClick_with_parse_error_should_clear_console_and_display_code() {
     var view = mock(ToolkitView.class);
     var file = new File("src/test/resources/parse_error.txt");
     when(view.pickFileToParse()).thenReturn(file);
@@ -214,7 +214,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void onSourceCodeOpenButtonClick_should_no_operation_when_no_file() {
+  void onSourceCodeOpenButtonClick_should_no_operation_when_no_file() {
     var view = mock(ToolkitView.class);
     when(view.pickFileToParse()).thenReturn(null);
 
@@ -237,7 +237,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void onSourceCodeParseButtonClick() {
+  void onSourceCodeParseButtonClick() {
     var view = mock(ToolkitView.class);
     when(view.getSourceCode()).thenReturn("my_mocked_source");
     var point = mock(Point.class);
@@ -265,7 +265,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void onXPathEvaluateButtonClickAstNodeResults() {
+  void onXPathEvaluateButtonClickAstNodeResults() {
     var view = mock(ToolkitView.class);
     when(view.getXPath()).thenReturn("//foo");
     var model = mock(SourceCodeModel.class);
@@ -287,7 +287,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void onXPathEvaluateButtonClickScrollToFirstAstNode() {
+  void onXPathEvaluateButtonClickScrollToFirstAstNode() {
     var view = mock(ToolkitView.class);
     when(view.getXPath()).thenReturn("//foo");
     var model = mock(SourceCodeModel.class);
@@ -309,7 +309,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void onXPathEvaluateButtonClickStringResult() throws Exception {
+  void onXPathEvaluateButtonClickStringResult() throws Exception {
     var view = mock(ToolkitView.class);
     when(view.getXPath()).thenReturn("//foo/@tokenValue");
     var model = mock(SourceCodeModel.class);
@@ -342,7 +342,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void onSourceCodeKeyTyped() {
+  void onSourceCodeKeyTyped() {
     var view = mock(ToolkitView.class);
 
     var presenter = new ToolkitPresenter(mock(ConfigurationModel.class), mock(SourceCodeModel.class));
@@ -357,7 +357,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void onSourceCodeTextCursorMoved() {
+  void onSourceCodeTextCursorMoved() {
     var view = mock(ToolkitView.class);
     var astNode = mock(AstNode.class);
     when(view.getAstNodeFollowingCurrentSourceCodeTextCursorPosition()).thenReturn(astNode);
@@ -373,7 +373,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void onAstSelectionChanged() {
+  void onAstSelectionChanged() {
     var view = mock(ToolkitView.class);
     var firstAstNode = mock(AstNode.class);
     var secondAstNode = mock(AstNode.class);
@@ -395,7 +395,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void onConfigurationPropertyFocusLost_when_validation_successes() {
+  void onConfigurationPropertyFocusLost_when_validation_successes() {
     var view = mock(ToolkitView.class);
 
     var property = mock(ConfigurationProperty.class);
@@ -419,7 +419,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void onConfigurationPropertyFocusLost_when_validation_fails() {
+  void onConfigurationPropertyFocusLost_when_validation_fails() {
     var view = mock(ToolkitView.class);
 
     var property = mock(ConfigurationProperty.class);
@@ -443,7 +443,7 @@ public class ToolkitPresenterTest {
   }
 
   @Test
-  public void onConfigurationPropertyFocusLost_with_invalid_name() {
+  void onConfigurationPropertyFocusLost_with_invalid_name() {
     var thrown = catchThrowableOfType(() -> {
       var view = mock(ToolkitView.class);
       var presenter = new ToolkitPresenter(mock(ConfigurationModel.class), mock(SourceCodeModel.class));

--- a/cxx-sslr/sslr-toolkit/src/test/java/org/sonar/cxx/sslr/toolkit/AbstractConfigurationModelTest.java
+++ b/cxx-sslr/sslr-toolkit/src/test/java/org/sonar/cxx/sslr/toolkit/AbstractConfigurationModelTest.java
@@ -31,10 +31,10 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import org.sonar.colorizer.Tokenizer;
 
-public class AbstractConfigurationModelTest {
+class AbstractConfigurationModelTest {
 
   @Test
-  public void getParser_should_return_parser_instance() {
+  void getParser_should_return_parser_instance() {
     var model = new MyConfigurationModel();
     Parser<? extends Grammar> p = mock(Parser.class);
     model.setParser(p);
@@ -42,7 +42,7 @@ public class AbstractConfigurationModelTest {
   }
 
   @Test
-  public void getParser_should_return_same_parser_instance_when_flag_not_set() {
+  void getParser_should_return_same_parser_instance_when_flag_not_set() {
     var model = new MyConfigurationModel();
     Parser<? extends Grammar> p = mock(Parser.class);
     model.setParser(p);
@@ -53,7 +53,7 @@ public class AbstractConfigurationModelTest {
   }
 
   @Test
-  public void getParser_should_return_different_parser_instance_when_flag_set() {
+  void getParser_should_return_different_parser_instance_when_flag_set() {
     var model = new MyConfigurationModel();
     Parser<? extends Grammar> p = mock(Parser.class);
     model.setParser(p);
@@ -67,7 +67,7 @@ public class AbstractConfigurationModelTest {
   }
 
   @Test
-  public void getTokenizers_should_return_parser_instance() {
+  void getTokenizers_should_return_parser_instance() {
     var model = new MyConfigurationModel();
     List<Tokenizer> t = mock(List.class);
     model.setTokenizers(t);
@@ -75,7 +75,7 @@ public class AbstractConfigurationModelTest {
   }
 
   @Test
-  public void getTokenizers_should_return_same_parser_instance_when_flag_not_set() {
+  void getTokenizers_should_return_same_parser_instance_when_flag_not_set() {
     var model = new MyConfigurationModel();
     List<Tokenizer> t = mock(List.class);
     model.setTokenizers(t);
@@ -86,7 +86,7 @@ public class AbstractConfigurationModelTest {
   }
 
   @Test
-  public void getTokenizers_should_return_different_parser_instance_when_flag_set() {
+  void getTokenizers_should_return_different_parser_instance_when_flag_set() {
     var model = new MyConfigurationModel();
     List<Tokenizer> t = mock(List.class);
     model.setTokenizers(t);

--- a/cxx-sslr/sslr-toolkit/src/test/java/org/sonar/cxx/sslr/toolkit/ConfigurationPropertyTest.java
+++ b/cxx-sslr/sslr-toolkit/src/test/java/org/sonar/cxx/sslr/toolkit/ConfigurationPropertyTest.java
@@ -26,22 +26,22 @@ package org.sonar.cxx.sslr.toolkit;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class ConfigurationPropertyTest {
+class ConfigurationPropertyTest {
 
   @Test
-  public void getName() {
+  void getName() {
     assertThat(new ConfigurationProperty("foo", "", "").getName()).isEqualTo("foo");
     assertThat(new ConfigurationProperty("bar", "", "").getName()).isEqualTo("bar");
   }
 
   @Test
-  public void getDescription() {
+  void getDescription() {
     assertThat(new ConfigurationProperty("", "foo", "").getDescription()).isEqualTo("foo");
     assertThat(new ConfigurationProperty("", "bar", "").getDescription()).isEqualTo("bar");
   }
 
   @Test
-  public void validate() {
+  void validate() {
     assertThat(new ConfigurationProperty("", "", "").validate("")).isEmpty();
     assertThat(new ConfigurationProperty("", "", "").validate("foo")).isEmpty();
 
@@ -54,13 +54,13 @@ public class ConfigurationPropertyTest {
   }
 
   @Test
-  public void setValue_should_succeed_if_validation_passes() {
+  void setValue_should_succeed_if_validation_passes() {
     new ConfigurationProperty("", "", "").setValue("");
     new ConfigurationProperty("", "", "").setValue("foo");
   }
 
   @Test
-  public void setValue_should_fail_if_validation_fails() {
+  void setValue_should_fail_if_validation_fails() {
     var thrown = catchThrowableOfType(
       () -> new ConfigurationProperty("", "", "", (String newValueCandidate) -> newValueCandidate.isEmpty() ? ""
                                                                                 : "The value \"" + newValueCandidate
@@ -71,7 +71,7 @@ public class ConfigurationPropertyTest {
   }
 
   @Test
-  public void getValue() {
+  void getValue() {
     assertThat(new ConfigurationProperty("", "", "").getValue()).isEqualTo("");
     assertThat(new ConfigurationProperty("", "", "foo").getValue()).isEqualTo("foo");
 

--- a/cxx-sslr/sslr-toolkit/src/test/java/org/sonar/cxx/sslr/toolkit/ValidatorsTest.java
+++ b/cxx-sslr/sslr-toolkit/src/test/java/org/sonar/cxx/sslr/toolkit/ValidatorsTest.java
@@ -26,10 +26,10 @@ package org.sonar.cxx.sslr.toolkit;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class ValidatorsTest {
+class ValidatorsTest {
 
   @Test
-  public void charsetValidator() {
+  void charsetValidator() {
     var validator = Validators.charsetValidator();
     assertThat(validator.validate("UTF-8")).isEmpty();
     assertThat(validator.validate("ISO-8859-15")).isEmpty();
@@ -38,12 +38,12 @@ public class ValidatorsTest {
   }
 
   @Test
-  public void charsetValidator_single_instance() {
+  void charsetValidator_single_instance() {
     assertThat(Validators.charsetValidator()).isSameAs(Validators.charsetValidator());
   }
 
   @Test
-  public void integerRangeValidator() {
+  void integerRangeValidator() {
     var validator = Validators.integerRangeValidator(0, 42);
     assertThat(validator.validate("24")).isEmpty();
     assertThat(validator.validate("-100")).isEqualTo("Must be between 0 and 42: -100");
@@ -66,7 +66,7 @@ public class ValidatorsTest {
   }
 
   @Test
-  public void integerRangeValidator_should_fail_with_upper_smaller_than_lower_bound() {
+  void integerRangeValidator_should_fail_with_upper_smaller_than_lower_bound() {
     var thrown = catchThrowableOfType(
       () -> Validators.integerRangeValidator(42, 0),
       IllegalArgumentException.class);
@@ -74,7 +74,7 @@ public class ValidatorsTest {
   }
 
   @Test
-  public void booleanValidator() {
+  void booleanValidator() {
     var validator = Validators.booleanValidator();
     assertThat(validator.validate("true")).isEmpty();
     assertThat(validator.validate("false")).isEmpty();
@@ -82,7 +82,7 @@ public class ValidatorsTest {
   }
 
   @Test
-  public void booleanValidator_single_instance() {
+  void booleanValidator_single_instance() {
     assertThat(Validators.booleanValidator()).isSameAs(Validators.booleanValidator());
   }
 

--- a/cxx-sslr/sslr-xpath/pom.xml
+++ b/cxx-sslr/sslr-xpath/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <!-- in addition, a dependency must be set in 'integration-tests/pom.xml' to aggregate the results -->
-    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <dependencies>

--- a/cxx-sslr/sslr-xpath/src/test/java/com/sonar/cxx/sslr/impl/xpath/AstNodeNavigatorTest.java
+++ b/cxx-sslr/sslr-xpath/src/test/java/com/sonar/cxx/sslr/impl/xpath/AstNodeNavigatorTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AstNodeNavigatorTest {
+class AstNodeNavigatorTest {
 
   private AstNodeNavigator navigator;
 
@@ -44,7 +44,7 @@ public class AstNodeNavigatorTest {
   }
 
   @Test
-  public void getTextStringValue() {
+  void getTextStringValue() {
     var thrown = catchThrowableOfType(
       () -> navigator.getTextStringValue(null),
       UnsupportedOperationException.class);
@@ -52,7 +52,7 @@ public class AstNodeNavigatorTest {
   }
 
   @Test
-  public void getCommentStringValue() {
+  void getCommentStringValue() {
     var thrown = catchThrowableOfType(
       () -> navigator.getCommentStringValue(null),
       UnsupportedOperationException.class);
@@ -60,7 +60,7 @@ public class AstNodeNavigatorTest {
   }
 
   @Test
-  public void getAttributeStringValue() throws Exception {
+  void getAttributeStringValue() throws Exception {
     var astNode = new AstNode(Token.builder()
       .setURI(new URI("tests://unittest"))
       .setType(GenericTokenType.IDENTIFIER)
@@ -74,7 +74,7 @@ public class AstNodeNavigatorTest {
   }
 
   @Test
-  public void getAttributeStringValue2() {
+  void getAttributeStringValue2() {
     var attribute = mock(Attribute.class);
     when(attribute.getName()).thenReturn("foo");
     var thrown = catchThrowableOfType(
@@ -84,7 +84,7 @@ public class AstNodeNavigatorTest {
   }
 
   @Test
-  public void getElementStringValue() {
+  void getElementStringValue() {
     var thrown = catchThrowableOfType(
       () -> navigator.getElementStringValue(null),
       UnsupportedOperationException.class);
@@ -94,7 +94,7 @@ public class AstNodeNavigatorTest {
 
   /* Namespaces */
   @Test
-  public void getNamespacePrefix() {
+  void getNamespacePrefix() {
     var thrown = catchThrowableOfType(
       () -> navigator.getNamespacePrefix(null),
       UnsupportedOperationException.class);
@@ -102,7 +102,7 @@ public class AstNodeNavigatorTest {
   }
 
   @Test
-  public void getNamespaceStringValue() {
+  void getNamespaceStringValue() {
     var thrown = catchThrowableOfType(
       () -> navigator.getNamespaceStringValue(null),
       UnsupportedOperationException.class);
@@ -111,14 +111,14 @@ public class AstNodeNavigatorTest {
 
   /* Attributes */
   @Test
-  public void getAttributeName() {
+  void getAttributeName() {
     var attribute = mock(Attribute.class);
     when(attribute.getName()).thenReturn("foo");
     assertThat(navigator.getAttributeName(attribute)).isEqualTo("foo");
   }
 
   @Test
-  public void getAttributeQName() {
+  void getAttributeQName() {
     var attribute = mock(Attribute.class);
     when(attribute.getName()).thenReturn("foo");
     assertThat(navigator.getAttributeQName(attribute)).isEqualTo("foo");
@@ -126,43 +126,43 @@ public class AstNodeNavigatorTest {
 
   /* Elements */
   @Test
-  public void getAttributeNamespaceUri() {
+  void getAttributeNamespaceUri() {
     assertThat(navigator.getAttributeNamespaceUri(null)).isEqualTo("");
   }
 
   @Test
-  public void getElementName() {
+  void getElementName() {
     var astNode = mock(AstNode.class);
     when(astNode.getName()).thenReturn("foo");
     assertThat(navigator.getElementName(astNode)).isEqualTo("foo");
   }
 
   @Test
-  public void getElementQName() {
+  void getElementQName() {
     var astNode = mock(AstNode.class);
     when(astNode.getName()).thenReturn("foo");
     assertThat(navigator.getElementQName(astNode)).isEqualTo("foo");
   }
 
   @Test
-  public void getElementNamespaceUri() {
+  void getElementNamespaceUri() {
     assertThat(navigator.getElementNamespaceUri(null)).isEqualTo("");
   }
 
   /* Types */
   @Test
-  public void isAttribute() {
+  void isAttribute() {
     assertThat(navigator.isAttribute(mock(AstNodeNavigator.Attribute.class))).isTrue();
     assertThat(navigator.isAttribute(null)).isFalse();
   }
 
   @Test
-  public void isComment() {
+  void isComment() {
     assertThat(navigator.isComment(null)).isFalse();
   }
 
   @Test
-  public void isDocument() {
+  void isDocument() {
     var astNode = mock(AstNode.class);
     var attribute = mock(Attribute.class);
     when(attribute.getAstNode()).thenReturn(astNode);
@@ -172,34 +172,34 @@ public class AstNodeNavigatorTest {
   }
 
   @Test
-  public void isDocument2() {
+  void isDocument2() {
     assertThat(navigator.isDocument(null)).isFalse();
   }
 
   @Test
-  public void isElement() {
+  void isElement() {
     assertThat(navigator.isElement(mock(AstNode.class))).isTrue();
     assertThat(navigator.isElement(null)).isFalse();
   }
 
   @Test
-  public void isNamespace() {
+  void isNamespace() {
     assertThat(navigator.isNamespace(null)).isFalse();
   }
 
   @Test
-  public void isProcessingInstruction() {
+  void isProcessingInstruction() {
     assertThat(navigator.isProcessingInstruction(null)).isFalse();
   }
 
   @Test
-  public void isText() {
+  void isText() {
     assertThat(navigator.isText(null)).isFalse();
   }
 
   /* Navigation */
   @Test
-  public void getDocumentNode() {
+  void getDocumentNode() {
     var rootAstNode = mock(AstNode.class);
     var astNode = mock(AstNode.class);
     when(astNode.getParent()).thenReturn(rootAstNode);
@@ -210,13 +210,13 @@ public class AstNodeNavigatorTest {
   }
 
   @Test
-  public void getChildAxisIterator() {
+  void getChildAxisIterator() {
     var attribute = mock(Attribute.class);
     assertThat(navigator.getChildAxisIterator(attribute).hasNext()).isFalse();
   }
 
   @Test
-  public void getChildAxisIterator2() {
+  void getChildAxisIterator2() {
     var thrown = catchThrowableOfType(
       () -> navigator.getChildAxisIterator(new Object()),
       UnsupportedOperationException.class);
@@ -224,7 +224,7 @@ public class AstNodeNavigatorTest {
   }
 
   @Test
-  public void getParentNode() {
+  void getParentNode() {
     var rootAstNode = mock(AstNode.class);
     var astNode = mock(AstNode.class);
     when(astNode.getParent()).thenReturn(rootAstNode);
@@ -235,7 +235,7 @@ public class AstNodeNavigatorTest {
   }
 
   @Test
-  public void getParentNode2() {
+  void getParentNode2() {
     var thrown = catchThrowableOfType(
       () -> navigator.getParentNode(new Object()),
       UnsupportedOperationException.class);
@@ -243,7 +243,7 @@ public class AstNodeNavigatorTest {
   }
 
   @Test
-  public void getParentAxisIterator() {
+  void getParentAxisIterator() {
     var thrown = catchThrowableOfType(
       () -> navigator.getParentAxisIterator(new Object()),
       UnsupportedOperationException.class);
@@ -251,7 +251,7 @@ public class AstNodeNavigatorTest {
   }
 
   @Test
-  public void getAttributeAxisIterator() {
+  void getAttributeAxisIterator() {
     var thrown = catchThrowableOfType(
       () -> navigator.getAttributeAxisIterator(new Object()),
       UnsupportedOperationException.class);
@@ -260,7 +260,7 @@ public class AstNodeNavigatorTest {
 
   /* Unknown */
   @Test
-  public void parseXPath() {
+  void parseXPath() {
     assertThat(navigator.parseXPath(null)).isNull();
   }
 

--- a/cxx-sslr/sslr-xpath/src/test/java/com/sonar/cxx/sslr/xpath/api/AstNodeXPathQueryTest.java
+++ b/cxx-sslr/sslr-xpath/src/test/java/com/sonar/cxx/sslr/xpath/api/AstNodeXPathQueryTest.java
@@ -28,10 +28,10 @@ import com.sonar.cxx.sslr.api.AstNodeType;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class AstNodeXPathQueryTest {
+class AstNodeXPathQueryTest {
 
   @Test
-  public void selectSingleNodeTest() {
+  void selectSingleNodeTest() {
     var expr = AstNodeXPathQuery.create("branch/leaf");
     var tree = new AstNode(new NodeType(), "tree", null);
     var branch = new AstNode(new NodeType(), "branch", null);
@@ -43,7 +43,7 @@ public class AstNodeXPathQueryTest {
   }
 
   @Test
-  public void selectSingleNodeNoResultTest() {
+  void selectSingleNodeNoResultTest() {
     var expr = AstNodeXPathQuery.create("branch");
     var tree = new AstNode(new NodeType(), "tree", null);
 
@@ -51,7 +51,7 @@ public class AstNodeXPathQueryTest {
   }
 
   @Test
-  public void selectNodesTest() {
+  void selectNodesTest() {
     var expr = AstNodeXPathQuery.create("//leaf");
     var tree = new AstNode(new NodeType(), "tree", null);
     var branch = new AstNode(new NodeType(), "branch", null);
@@ -61,19 +61,19 @@ public class AstNodeXPathQueryTest {
     branch.addChild(leaf1);
     branch.addChild(leaf2);
 
-    assertThat(expr.selectNodes(tree).size()).isEqualTo(2);
+    assertThat(expr.selectNodes(tree)).hasSize(2);
   }
 
   @Test
-  public void selectNodesNoResultTest() {
+  void selectNodesNoResultTest() {
     var expr = AstNodeXPathQuery.create("//branch");
     var tree = new AstNode(new NodeType(), "tree", null);
 
-    assertThat(expr.selectNodes(tree).size()).isEqualTo(0);
+    assertThat(expr.selectNodes(tree)).isEmpty();
   }
 
   @Test
-  public void relativePathTest() {
+  void relativePathTest() {
     var expr = AstNodeXPathQuery.create("leaf");
     var tree = new AstNode(new NodeType(), "tree", null);
     var branch = new AstNode(new NodeType(), "branch", null);
@@ -86,7 +86,7 @@ public class AstNodeXPathQueryTest {
   }
 
   @Test
-  public void parentPathTest() {
+  void parentPathTest() {
     var expr = AstNodeXPathQuery.create("..");
     var tree = new AstNode(new NodeType(), "tree", null);
     var branch = new AstNode(new NodeType(), "branch", null);
@@ -99,7 +99,7 @@ public class AstNodeXPathQueryTest {
   }
 
   @Test
-  public void parentAndDescendingPathTest() {
+  void parentAndDescendingPathTest() {
     var expr = AstNodeXPathQuery.create("../branch2");
     var tree = new AstNode(new NodeType(), "tree", null);
 
@@ -117,7 +117,7 @@ public class AstNodeXPathQueryTest {
   }
 
   @Test
-  public void absolutePathTest() {
+  void absolutePathTest() {
     var expr = AstNodeXPathQuery.create("/tree");
     var tree = new AstNode(new NodeType(), "tree", null);
     var branch = new AstNode(new NodeType(), "branch", null);
@@ -130,7 +130,7 @@ public class AstNodeXPathQueryTest {
   }
 
   @Test
-  public void currentPathTest() {
+  void currentPathTest() {
     var expr = AstNodeXPathQuery.create(".");
     var tree = new AstNode(new NodeType(), "tree", null);
     var branch = new AstNode(new NodeType(), "branch", null);
@@ -143,7 +143,7 @@ public class AstNodeXPathQueryTest {
   }
 
   @Test
-  public void currentPathWithDescendantTest() {
+  void currentPathWithDescendantTest() {
     var expr = AstNodeXPathQuery.create("./leaf");
     var tree = new AstNode(new NodeType(), "tree", null);
     var branch = new AstNode(new NodeType(), "branch", null);
@@ -156,7 +156,7 @@ public class AstNodeXPathQueryTest {
   }
 
   @Test
-  public void singleDocumentRoot() {
+  void singleDocumentRoot() {
     var expr = AstNodeXPathQuery.create("//tree");
     var tree = new AstNode(new NodeType(), "tree", null);
     var branch = new AstNode(new NodeType(), "branch", null);
@@ -165,11 +165,11 @@ public class AstNodeXPathQueryTest {
     tree.addChild(branch);
     branch.addChild(leaf);
 
-    assertThat(expr.selectNodes(tree).size()).isEqualTo(1);
+    assertThat(expr.selectNodes(tree)).hasSize(1);
   }
 
   @Test
-  public void relativeNamePredicate() {
+  void relativeNamePredicate() {
     var expr = AstNodeXPathQuery.create(".[name() = \"tree\"]");
     var tree = new AstNode(new NodeType(), "tree", null);
 
@@ -177,7 +177,7 @@ public class AstNodeXPathQueryTest {
   }
 
   @Test
-  public void relativeCountPredicate() {
+  void relativeCountPredicate() {
     var expr = AstNodeXPathQuery.create(".[count(*) = 3]");
     var tree = new AstNode(new NodeType(), "tree", null);
 
@@ -193,7 +193,7 @@ public class AstNodeXPathQueryTest {
   }
 
   @Test
-  public void noCacheTest() {
+  void noCacheTest() {
     var expr = AstNodeXPathQuery.create("//branch");
 
     var tree1 = new AstNode(new NodeType(), "tree", null);
@@ -204,13 +204,13 @@ public class AstNodeXPathQueryTest {
     tree1.addChild(branch12);
     tree1.addChild(branch13);
 
-    assertThat(expr.selectNodes(tree1).size()).isEqualTo(3);
+    assertThat(expr.selectNodes(tree1)).hasSize(3);
 
     var tree2 = new AstNode(new NodeType(), "tree", null);
     var branch21 = new AstNode(new NodeType(), "branch", null);
     tree2.addChild(branch21);
 
-    assertThat(expr.selectNodes(tree2).size()).isEqualTo(1);
+    assertThat(expr.selectNodes(tree2)).hasSize(1);
   }
 
   static class NodeType implements AstNodeType {

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -20,8 +20,35 @@
 
   <dependencies>
 
-    <!-- set dependencies to aggregate coverage results -->
+    <!-- Set dependencies to aggregate coverage results:
+    Explicitly include modules for JaCoCo's report-aggregate goal,
+    although it's already transitively included -->
 
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sslr-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sslr-testing-harness</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sslr-tests</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sslr-toolkit</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sslr-xpath</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>cxx-squid-bridge</artifactId>

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CustomCxxRulesDefinitionTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CustomCxxRulesDefinitionTest.java
@@ -30,7 +30,7 @@ import org.sonar.check.RuleProperty;
 import org.sonar.cxx.tag.Tag;
 import org.sonar.cxx.squidbridge.checks.SquidCheck;
 
-public class CustomCxxRulesDefinitionTest {
+class CustomCxxRulesDefinitionTest {
 
   private static final Language LANGUAGE = new CxxLanguage(new MapSettings().asConfig());
   private static final String REPOSITORY_NAME = "Custom Rule Repository";
@@ -40,7 +40,7 @@ public class CustomCxxRulesDefinitionTest {
   private static final String RULE_KEY = "MyCustomRule";
 
   @Test
-  public void test() {
+  void test() {
     var rulesDefinition = new MyCustomPlSqlRulesDefinition();
     var context = new RulesDefinition.Context();
     rulesDefinition.define(context);

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxCheckListTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxCheckListTest.java
@@ -23,10 +23,10 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.sonar.cxx.checks.CheckList;
 
-public class CxxCheckListTest {
+class CxxCheckListTest {
 
   @Test
-  public void count() {
+  void count() {
     assertThat(CheckList.getChecks()).hasSize(27);
   }
 

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxChecksTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxChecksTest.java
@@ -37,7 +37,7 @@ import org.sonar.check.Rule;
 import org.sonar.cxx.squidbridge.SquidAstVisitor;
 import org.sonar.cxx.squidbridge.checks.SquidCheck;
 
-public class CxxChecksTest {
+class CxxChecksTest {
 
   private static final String DEFAULT_REPOSITORY_KEY = "DefaultRuleRepository";
   private static final String DEFAULT_RULE_KEY = "MyRule";
@@ -66,7 +66,7 @@ public class CxxChecksTest {
 
   @SuppressWarnings("rawtypes")
   @Test
-  public void shouldReturnDefaultChecks() {
+  void shouldReturnDefaultChecks() {
     var checks = CxxChecks.createCxxCheck(checkFactory);
     checks.addChecks(DEFAULT_REPOSITORY_KEY, new ArrayList<>(Collections.singletonList(MyRule.class)));
 
@@ -79,7 +79,7 @@ public class CxxChecksTest {
   }
 
   @Test
-  public void shouldReturnCustomChecks() {
+  void shouldReturnCustomChecks() {
     var checks = CxxChecks.createCxxCheck(checkFactory);
     checks.addCustomChecks(new CustomCxxRulesDefinition[]{customRulesDefinition});
 
@@ -92,7 +92,7 @@ public class CxxChecksTest {
   }
 
   @Test
-  public void shouldWorkWithoutCustomChecks() {
+  void shouldWorkWithoutCustomChecks() {
     var checks = CxxChecks.createCxxCheck(checkFactory);
     checks.addCustomChecks(null);
     assertThat(checks.all()).isEmpty();
@@ -100,7 +100,7 @@ public class CxxChecksTest {
 
   @SuppressWarnings("rawtypes")
   @Test
-  public void shouldNotReturnRuleKeyIfCheckDoesNotExists() {
+  void shouldNotReturnRuleKeyIfCheckDoesNotExists() {
     var checks = CxxChecks.createCxxCheck(checkFactory);
     checks.addChecks(DEFAULT_REPOSITORY_KEY, new ArrayList<>(Collections.singletonList(MyRule.class)));
     assertThat(checks.ruleKey(new MyCustomRule())).isNull();

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxFileLinesContextTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxFileLinesContextTest.java
@@ -41,7 +41,7 @@ import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
 
-public class CxxFileLinesContextTest {
+class CxxFileLinesContextTest {
 
   private FileLinesContextForTesting fileLinesContext;
 
@@ -63,7 +63,7 @@ public class CxxFileLinesContextTest {
   }
 
   @Test
-  public void TestLinesOfCode() throws UnsupportedEncodingException, IOException {
+  void TestLinesOfCode() throws UnsupportedEncodingException, IOException {
     Set<Integer> linesOfCode = Stream.of(
       8, 10, 14, 16, 17, 21, 22, 23, 26, 31, 34, 35, 42, 44, 45, 49, 51, 53, 55, 56,
       58, 59, 63, 65, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 79, 82, 84, 86, 87, 89,
@@ -74,7 +74,7 @@ public class CxxFileLinesContextTest {
   }
 
   @Test
-  public void TestExecutableLinesOfCode() throws UnsupportedEncodingException, IOException {
+  void TestExecutableLinesOfCode() throws UnsupportedEncodingException, IOException {
     assertThat(fileLinesContext.executableLines).containsExactlyInAnyOrder(
       10, 26, 34, 35, 56, 59, 69, 70, 72, 73,
       75, 76, 79, 87, 90, 98, 102, 118, 119, 126);

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxHighlighterTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxHighlighterTest.java
@@ -38,7 +38,7 @@ import org.sonar.api.batch.sensor.issue.internal.DefaultNoSonarFilter;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
 
-public class CxxHighlighterTest {
+class CxxHighlighterTest {
 
   private CxxSquidSensor sensor;
   private SensorContextTester context;

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxLanguageTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxLanguageTest.java
@@ -23,18 +23,18 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.config.internal.MapSettings;
 
-public class CxxLanguageTest {
+class CxxLanguageTest {
 
   private final MapSettings settings = new MapSettings();
 
   @Test
-  public void testCxxLanguageStringConfiguration() throws Exception {
+  void testCxxLanguageStringConfiguration() throws Exception {
     var language = new CxxLanguage(settings.asConfig());
     assertThat(language.getKey()).isEqualTo("cxx");
   }
 
   @Test
-  public void shouldReturnConfiguredFileSuffixes() {
+  void shouldReturnConfiguredFileSuffixes() {
     settings.setProperty(CxxLanguage.FILE_SUFFIXES_KEY, ".C,.c,.H,.h");
     var cxx = new CxxLanguage(settings.asConfig());
     String[] expected = {".C", ".c", ".H", ".h"};
@@ -42,14 +42,14 @@ public class CxxLanguageTest {
   }
 
   @Test
-  public void shouldReturnDefaultFileSuffixes1() {
+  void shouldReturnDefaultFileSuffixes1() {
     var cxx = new CxxLanguage(settings.asConfig());
     String[] expected = {"disabled"};
     assertThat(cxx.getFileSuffixes()).contains(expected);
   }
 
   @Test
-  public void shouldReturnDefaultFileSuffixes2() {
+  void shouldReturnDefaultFileSuffixes2() {
     settings.setProperty(CxxLanguage.FILE_SUFFIXES_KEY, "");
     var cxx = new CxxLanguage(settings.asConfig());
     String[] expected = {"disabled"};
@@ -57,7 +57,7 @@ public class CxxLanguageTest {
   }
 
   @Test
-  public void shouldBeDisabled() {
+  void shouldBeDisabled() {
     settings.setProperty(CxxLanguage.FILE_SUFFIXES_KEY, "-");
     var cxx = new CxxLanguage(settings.asConfig());
     String[] expected = {"disabled"};

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxMetricDefinitionTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxMetricDefinitionTest.java
@@ -22,10 +22,10 @@ package org.sonar.plugins.cxx;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class CxxMetricDefinitionTest {
+class CxxMetricDefinitionTest {
 
   @Test
-  public void metrics_defined() {
+  void metrics_defined() {
     assertThat(new CxxMetricDefinition().getMetrics()).hasSize(12);
   }
 

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -28,10 +28,10 @@ import org.sonar.api.SonarRuntime;
 import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
 
-public class CxxPluginTest {
+class CxxPluginTest {
 
   @Test
-  public void testGetExtensions() throws Exception {
+  void testGetExtensions() throws Exception {
     SonarRuntime runtime = SonarRuntimeImpl.forSonarQube(
       Version.create(8, 6),
       SonarQubeSide.SCANNER,

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxRuleRepositoryTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxRuleRepositoryTest.java
@@ -23,10 +23,10 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.server.rule.RulesDefinition;
 
-public class CxxRuleRepositoryTest {
+class CxxRuleRepositoryTest {
 
   @Test
-  public void rulesTest() {
+  void rulesTest() {
     var context = new RulesDefinition.Context();
     assertThat(context.repositories()).isEmpty();
     new CxxRuleRepository().define(context);

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxSonarWayProfileTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxSonarWayProfileTest.java
@@ -24,10 +24,10 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
 
-public class CxxSonarWayProfileTest {
+class CxxSonarWayProfileTest {
 
   @Test
-  public void should_create_sonar_way_profile() {
+  void should_create_sonar_way_profile() {
     var profileDef = new CxxSonarWayProfile();
     var context = new BuiltInQualityProfilesDefinition.Context();
     profileDef.define(context);

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxSquidSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxSquidSensorTest.java
@@ -41,7 +41,7 @@ import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.cxx.CxxMetrics;
 
-public class CxxSquidSensorTest {
+class CxxSquidSensorTest {
 
   private CxxSquidSensor sensor;
   private final MapSettings settings = new MapSettings();
@@ -58,7 +58,7 @@ public class CxxSquidSensorTest {
   }
 
   @Test
-  public void testCollectingSquidMetrics() throws IOException {
+  void testCollectingSquidMetrics() throws IOException {
     File baseDir = TestUtils.loadResource("/org/sonar/plugins/cxx/codechunks-project");
     var inputFile0 = TestUtils.buildInputFile(baseDir, "code_chunks.cc");
 
@@ -78,7 +78,7 @@ public class CxxSquidSensorTest {
   }
 
   @Test
-  public void testCpdTokens() throws Exception {
+  void testCpdTokens() throws Exception {
     File baseDir = TestUtils.loadResource("/org/sonar/plugins/cxx");
     var context = SensorContextTester.create(baseDir);
     settings.setProperty(CxxSquidSensor.CPD_IGNORE_IDENTIFIERS_KEY, true);
@@ -118,7 +118,7 @@ public class CxxSquidSensorTest {
   }
 
   @Test
-  public void testComplexitySquidMetrics() throws IOException {
+  void testComplexitySquidMetrics() throws IOException {
     File baseDir = TestUtils.loadResource("/org/sonar/plugins/cxx/complexity-project");
     var context = SensorContextTester.create(baseDir);
     settings.setProperty(CxxSquidSensor.FUNCTION_COMPLEXITY_THRESHOLD_KEY, 3);
@@ -150,7 +150,7 @@ public class CxxSquidSensorTest {
   }
 
   @Test
-  public void testDocumentationSquidMetrics() throws IOException {
+  void testDocumentationSquidMetrics() throws IOException {
     File baseDir = TestUtils.loadResource("/org/sonar/plugins/cxx/documentation-project");
     var inputFile = TestUtils.buildInputFile(baseDir, "documentation0.hh");
 
@@ -171,7 +171,7 @@ public class CxxSquidSensorTest {
   }
 
   @Test
-  public void testReplacingOfExtenalMacros() throws IOException {
+  void testReplacingOfExtenalMacros() throws IOException {
     File baseDir = TestUtils.loadResource("/org/sonar/plugins/cxx/external-macro-project");
     var context = SensorContextTester.create(baseDir);
     settings.setProperty(CxxSquidSensor.DEFINES_KEY, "MACRO class A{};");
@@ -190,7 +190,7 @@ public class CxxSquidSensorTest {
   }
 
   @Test
-  public void testFindingIncludedFiles() throws IOException {
+  void testFindingIncludedFiles() throws IOException {
     File baseDir = TestUtils.loadResource("/org/sonar/plugins/cxx/include-directories-project");
     var context = SensorContextTester.create(baseDir);
     settings.setProperty(CxxSquidSensor.INCLUDE_DIRECTORIES_KEY, "include");
@@ -210,7 +210,7 @@ public class CxxSquidSensorTest {
   }
 
   @Test
-  public void testForceIncludedFiles() throws IOException {
+  void testForceIncludedFiles() throws IOException {
     File baseDir = TestUtils.loadResource("/org/sonar/plugins/cxx/force-include-project");
     var context = SensorContextTester.create(baseDir);
     settings.setProperty(CxxSquidSensor.INCLUDE_DIRECTORIES_KEY, "include");
@@ -231,7 +231,7 @@ public class CxxSquidSensorTest {
   }
 
   @Test
-  public void testBehaviourOnCircularIncludes() throws IOException {
+  void testBehaviourOnCircularIncludes() throws IOException {
     // especially: when two files, both belonging to the set of
     // files to analyse, include each other, the preprocessor guards have to be disabled
     // and both have to be counted in terms of metrics

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/DroppedPropertiesSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/DroppedPropertiesSensorTest.java
@@ -31,7 +31,7 @@ import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.utils.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
 
-public class DroppedPropertiesSensorTest {
+class DroppedPropertiesSensorTest {
 
   @TempDir
   File tempDir;
@@ -40,7 +40,7 @@ public class DroppedPropertiesSensorTest {
   public LogTesterJUnit5 logTester = new LogTesterJUnit5();
 
   @Test
-  public void testNoMsg() throws Exception {
+  void testNoMsg() throws Exception {
     var contextTester = SensorContextTester.create(tempDir);
     var mapSettings = new MapSettings().setProperty("sonar.cxx.xxx", "value");
     contextTester.setSettings(mapSettings);
@@ -53,7 +53,7 @@ public class DroppedPropertiesSensorTest {
   }
 
   @Test
-  public void testNoLongerSupported() throws Exception {
+  void testNoLongerSupported() throws Exception {
     var contextTester = SensorContextTester.create(tempDir);
     var mapSettings = new MapSettings().setProperty("sonar.cxx.cppncss.reportPaths", "value");
     contextTester.setSettings(mapSettings);
@@ -67,7 +67,7 @@ public class DroppedPropertiesSensorTest {
   }
 
   @Test
-  public void testNoLongerSupportedWithInfo() throws Exception {
+  void testNoLongerSupportedWithInfo() throws Exception {
     var contextTester = SensorContextTester.create(tempDir);
     var mapSettings = new MapSettings().setProperty("sonar.cxx.suffixes.sources", "value");
     contextTester.setSettings(mapSettings);


### PR DESCRIPTION
- JUnit5 test classes and methods should have default package visibility
- remove chained AssertJ assertions
- set dependencies to aggregate coverage results of cxx-sslr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2355)
<!-- Reviewable:end -->
