### PR TITLE
fix preprocessor: nested #ifdef ... #else

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/preprocessor/CxxPreprocessor.java
@@ -682,13 +682,9 @@ public class CxxPreprocessor extends Preprocessor {
     if (unitCodeProvider.doNotSkipBlock()) {
       Macro macro = getMacro(getMacroName(ast));
       var tokType = ast.getToken().getType();
-      if ((tokType.equals(IFDEF) && macro == null) || (tokType.equals(IFNDEF) && macro != null)) {
-        // evaluated to false
-        unitCodeProvider.skipBlock(true);
-      }
-      if (unitCodeProvider.doNotSkipBlock()) {
-        unitCodeProvider.expressionWas(true);
-      }
+      boolean result = (tokType.equals(IFDEF) && macro != null) || (tokType.equals(IFNDEF) && macro == null);
+      unitCodeProvider.expressionWas(result);
+      unitCodeProvider.skipBlock(!result);
     } else {
       unitCodeProvider.nestedBlock(+1);
     }

--- a/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithPreprocessingTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithPreprocessingTest.java
@@ -494,7 +494,7 @@ class CxxLexerWithPreprocessingTest {
   }
 
   @Test
-  void conditional_compilation_ifdef_nested() {
+  void conditional_compilation_ifdef_nested1() {
     List<Token> tokens = lexer.lex("#define B\n"
                                      + "#ifdef A\n"
                                      + "  a\n"
@@ -512,6 +512,24 @@ class CxxLexerWithPreprocessingTest {
     softly.assertThat(tokens).hasSize(2); // nota + EOF
     softly.assertThat(tokens)
       .anySatisfy(token -> assertThat(token).isValue("nota").hasType(GenericTokenType.IDENTIFIER));
+    softly.assertAll();
+  }
+
+  @Test
+  void conditional_compilation_ifdef_nested2() {
+    List<Token> tokens = lexer.lex("#if !defined A\n"
+                                     + "#define A\n"
+                                     + "#ifdef B\n"
+                                     + "  b\n"
+                                     + "#else\n"
+                                     + "  notb\n"
+                                     + "#endif\n"
+                                     + "#endif\n");
+
+    var softly = new SoftAssertions();
+    softly.assertThat(tokens).hasSize(2); // notb + EOF
+    softly.assertThat(tokens)
+      .anySatisfy(token -> assertThat(token).isValue("notb").hasType(GenericTokenType.IDENTIFIER));
     softly.assertAll();
   }
 

--- a/cxx-sslr-toolkit/pom.xml
+++ b/cxx-sslr-toolkit/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api</artifactId>
-      <scope>provided</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.sonar</groupId>


### PR DESCRIPTION
In case of nested `#ifdef ... #else` and false condition, the `#else` branch was not always parsed by the preprocessor.
This typically leads to syntax errors.

```C++
#if !defined A
#define A
#  ifdef B
      // branch a
#  else
      // branch b <== sometimes not parsed
#  endif
#endif
```
- close #2336

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2373)
<!-- Reviewable:end -->
