### PR TITLE
Only analyze files that are contained in the 'JSON Compilation Database'

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/config/CxxSquidConfiguration.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/config/CxxSquidConfiguration.java
@@ -25,6 +25,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -371,6 +372,22 @@ public class CxxSquidConfiguration extends SquidConfiguration {
       }
       eLevel = getParentElement(eLevel);
     } while (eLevel != null);
+    return result;
+  }
+
+  /**
+   * Read all file items from the database.
+   *
+   * @return list of file items
+   */
+  public List<Path> getFiles() {
+    List<Path> result = new ArrayList<>();
+    Element eLevel = findLevel(UNITS, null);
+    if (eLevel != null) {
+      for (var file : eLevel.getChildren(FILE)) {
+        result.add(Path.of(file.getAttributeValue(ATTR_PATH)));
+      }
+    }
     return result;
   }
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/config/CxxSquidConfigurationTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/config/CxxSquidConfigurationTest.java
@@ -251,6 +251,22 @@ class CxxSquidConfigurationTest {
   }
 
   @Test
+  void testGetFiles() {
+    var squidConfig = new CxxSquidConfiguration();
+    squidConfig.add("a/b/c", "key", "value1");
+    squidConfig.add("c/d/e", "key", "value2");
+    squidConfig.add("f/g/h", "key", "value3");
+    List<Path> values = squidConfig.getFiles();
+
+    var softly = new SoftAssertions();
+    softly.assertThat(values).hasSize(3);
+    softly.assertThat(values.get(0)).isEqualTo(Path.of("a/b/c"));
+    softly.assertThat(values.get(1)).isEqualTo(Path.of("c/d/e"));
+    softly.assertThat(values.get(2)).isEqualTo(Path.of("f/g/h"));
+    softly.assertAll();
+  }
+
+  @Test
   void testLevelValues() {
     var squidConfig = new CxxSquidConfiguration();
     squidConfig.add(CxxSquidConfiguration.GLOBAL, "key", "value1");

--- a/cxx-squid/src/test/java/org/sonar/cxx/config/JsonCompilationDatabaseTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/config/JsonCompilationDatabaseTest.java
@@ -44,13 +44,18 @@ class JsonCompilationDatabaseTest {
                                                  CxxSquidConfiguration.DEFINES);
     List<String> includes = squidConfig.getValues(CxxSquidConfiguration.GLOBAL,
                                                   CxxSquidConfiguration.INCLUDE_DIRECTORIES);
+    List<Path> files = squidConfig.getFiles();
 
-    assertThat(defines).isNotEmpty();
-    assertThat(defines).doesNotContain("UNIT_DEFINE 1");
-    assertThat(defines).contains("GLOBAL_DEFINE 1");
-    assertThat(includes).isNotEmpty();
-    assertThat(includes).doesNotContain(unifyPath("/usr/local/include"));
-    assertThat(includes).contains(unifyPath("/usr/include"));
+    assertThat(defines)
+      .isNotEmpty()
+      .doesNotContain("UNIT_DEFINE 1")
+      .contains("GLOBAL_DEFINE 1");
+    assertThat(includes)
+      .isNotEmpty()
+      .doesNotContain(unifyPath("/usr/local/include"))
+      .contains(unifyPath("/usr/include"));
+    assertThat(files)
+      .hasSize(7);
   }
 
   @Test

--- a/integration-tests/features/json-db.feature
+++ b/integration-tests/features/json-db.feature
@@ -1,0 +1,20 @@
+@SqApi79
+Feature: JSON Compilation Database support
+
+  As a CXX Plugin user, I want to use the JSON Compilation Database to analyze SonarQube projects
+
+  Scenario: Analyze only the source files contained in the JSON Compilation Database.
+    Given the project "json_db_project"
+    When I run sonar-scanner with "-X"
+    Then the analysis finishes successfully
+    And the analysis in server has completed
+    And the analysis log contains no error/warning messages except those matching:
+      """
+      .*WARN.*Unable to get a valid mac address, will use a dummy address
+      """
+    And the following metrics have following values:
+      | metric     | value |          
+      | ncloc      | 9     |
+      | lines      | 24    |
+      | statements | 3     |
+      | functions  | 3     |

--- a/integration-tests/features/steps/test_execution_statistics.py
+++ b/integration-tests/features/steps/test_execution_statistics.py
@@ -374,7 +374,7 @@ def _assert_measures(project, measures):
     assert diff == "", "\n" + diff
 
 def _run_command(context, command):
-    context.log = "_{context.project}_{context.scenariono}.log"
+    context.log = f"_{context.project}_{context.scenariono}.log"
 
     sonarhome = os.environ.get("SONARHOME", None)
     if sonarhome:

--- a/integration-tests/testdata/json_db_project/compile_commands.json
+++ b/integration-tests/testdata/json_db_project/compile_commands.json
@@ -1,0 +1,33 @@
+[
+  {
+    "_comment_": "example extension to define global defines and includes for headers and for files which are not compiled",
+    "file": "__global__",
+    "defines": {
+      "GLOBAL_DEFINE": "1"
+    },
+    "includes": [
+      "/usr/include"
+    ]
+  },
+  {
+    "_comment_": "source file to use",
+    "directory": "./src",
+    "file": "file1.cc",
+    "command": "gcc -o output1 -I/usr/local/include -I /another/include/dir -DSIMPLE1 -DCOMMAND_DEFINE=1 file1.cpp",
+    "output": "output1"
+  },
+  {
+    "_comment_": "source file to use",
+    "directory": "./src",
+    "file": "file2.cc",
+    "command": "gcc -o output2 -I/usr/local/include -I /another/include/dir -DSIMPLE2 -DCOMMAND_DEFINE=2 file2.cpp",
+    "output": "output2"
+  },
+  {
+    "_comment_": "source file to use",
+    "directory": "./src",
+    "file": "file3.cc",
+    "command": "gcc -o output3 -I/usr/local/include -I /another/include/dir -DSIMPLE3 -DCOMMAND_DEFINE=3 file3.cpp",
+    "output": "output3"
+  }
+]

--- a/integration-tests/testdata/json_db_project/sonar-project.properties
+++ b/integration-tests/testdata/json_db_project/sonar-project.properties
@@ -1,0 +1,17 @@
+# metadata
+sonar.projectKey=json_db_project
+
+# disable SCM support
+sonar.scm.disabled=true
+
+# disable XML sensor
+sonar.xml.file.suffixes=.disable-xml
+
+# file extensions assigned to the cxx programming language
+sonar.cxx.file.suffixes=.cxx,.cpp,.cc,.c,.hxx,.hpp,.hh,.h
+
+# comma-separated paths to directories containing source files
+sonar.sources=src
+
+# read a JSON Compilation Database file
+sonar.cxx.jsonCompilationDatabase=compile_commands.json

--- a/integration-tests/testdata/json_db_project/src/file1.cc
+++ b/integration-tests/testdata/json_db_project/src/file1.cc
@@ -1,0 +1,3 @@
+int func1(){
+    return 1;
+}

--- a/integration-tests/testdata/json_db_project/src/file2.cc
+++ b/integration-tests/testdata/json_db_project/src/file2.cc
@@ -1,0 +1,3 @@
+int func2(){
+    return 2;
+}

--- a/integration-tests/testdata/json_db_project/src/file3.cc
+++ b/integration-tests/testdata/json_db_project/src/file3.cc
@@ -1,0 +1,3 @@
+int func3(){
+    return 3;
+}

--- a/integration-tests/testdata/json_db_project/src/file4.cc
+++ b/integration-tests/testdata/json_db_project/src/file4.cc
@@ -1,0 +1,3 @@
+int func4(){
+    return 4;
+}

--- a/integration-tests/testdata/json_db_project/src/file5.cc
+++ b/integration-tests/testdata/json_db_project/src/file5.cc
@@ -1,0 +1,3 @@
+int func5(){
+    return 5;
+}

--- a/integration-tests/testdata/json_db_project/src/file6.cc
+++ b/integration-tests/testdata/json_db_project/src/file6.cc
@@ -1,0 +1,3 @@
+int func6(){
+    return 6;
+}


### PR DESCRIPTION
In case of `sonar.cxx.jsonCompilationDatabase` is used, limit the analyzed files to the files contained in the 'JSON Compilation Database' file. The sensor is an intersection of the files configured via `sonar.projectBaseDir` and the files contained in the 'JSON Compilation Database' file.

In the past, all files configured via `sonar.projectBaseDir` were always analyzed and only the configuration (INCLUDES, MACROS) was read from the 'JSON Compilation Database'.

- filter `sonar.projectBaseDir` files result
- add a 'JSON Compilation Database' support integration test

**Hint:** Unfortunately, the sensor cannot control the indexing of the source files. Therefore, all files that belong to language CXX and are located within the directory `sonar.projectBaseDir` are loaded onto the server, but are no longer analyzed, which saves time. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2430)
<!-- Reviewable:end -->
