### PR TITLE
sonar.cxx.jsonCompilationDatabase.analyzeOnlyContainedFiles=True/False

### DIFF
--- a/integration-tests/testdata/json_db_project/sonar-project.properties
+++ b/integration-tests/testdata/json_db_project/sonar-project.properties
@@ -15,3 +15,4 @@ sonar.sources=src
 
 # read a JSON Compilation Database file
 sonar.cxx.jsonCompilationDatabase=compile_commands.json
+sonar.cxx.jsonCompilationDatabase.analyzeOnlyContainedFiles=true

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -40,7 +40,7 @@ class CxxPluginTest {
     var context = new Plugin.Context(runtime);
     var plugin = new CxxPlugin();
     plugin.define(context);
-    assertThat(context.getExtensions()).hasSize(81);
+    assertThat(context.getExtensions()).hasSize(82);
   }
 
 }


### PR DESCRIPTION
If `analyzeOnlyContainedFiles=True` is used, the analyzed files will be limited to the files contained in the 'JSON Compilation Database' file - the intersection of the files configured via `sonar.projectBaseDir` and the files contained in the 'JSON Compilation Database' file (default is False).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2449)
<!-- Reviewable:end -->
