### PR TITLE
LLVM 16 support

### DIFF
--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -3,7 +3,7 @@
   C and C++ rules from
   * https://clang.llvm.org/extra/clang-tidy/checks/list.html
   * https://clang-analyzer.llvm.org/available_checks.html
-  * last update: llvmorg-15-init-2831-geb3e09c9bf1d (git describe)
+  * last update: llvmorg-16-init-15404-g61be26154924 (git describe)
 -->
 <rules>
 
@@ -72,7 +72,7 @@ int result = absl::ToUnixSeconds(t) + x;
 // Suggestion - Addition in the absl::Time domain
 int result = absl::ToUnixSeconds(t + absl::Seconds(x));</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-duration-addition.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/duration-addition.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -105,7 +105,7 @@ if (x &lt; absl::ToInt64Microseconds(d)) ...
 // Suggested - Compare in the absl::Duration domain instead
 if (absl::Microseconds(x) &lt; d) ...</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-duration-comparison.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/duration-comparison.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -136,7 +136,7 @@ double x = static_cast&lt;double&gt;(absl::ToInt64Seconds(d));
 double x = absl::ToDoubleSeconds(d);</code></pre>
 <p>Note: In the second example, the suggested fix could yield a different result, as the conversion to integer could truncate. In practice, this is very rare, and you should use <code>absl::Trunc</code> to perform this operation explicitly instead.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-duration-conversion-cast.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/duration-conversion-cast.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -165,7 +165,7 @@ double dsec2 = absl::ToDoubleSeconds(d);                 // GOOD: No truncation.
 assert(dsec1 == 3.5 &amp;&amp; dsec2 == 3.5);</code></pre>
 <p>This check looks for uses of <code>absl::Duration</code> division that is done in a floating-point context, and recommends the use of a function that returns a floating-point value.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-duration-division.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/duration-division.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -194,7 +194,7 @@ absl::Duration d = absl::Seconds(static_cast&lt;double&gt;(10));
 // Suggested - Remove the explicit cast
 absl::Duration d = absl::Seconds(10);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-duration-factory-float.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/duration-factory-float.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -231,7 +231,7 @@ absl::Duration d = absl::Hours(0);
 // Suggested = Use absl::ZeroDuration instead
 absl::Duration d = absl::ZeroDuration();</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-duration-factory-scale.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/duration-factory-scale.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -262,7 +262,7 @@ double result = absl::ToDoubleSeconds(d1) - absl::ToDoubleSeconds(d2);
 double result = absl::ToDoubleSeconds(d1 - d2);</code></pre>
 <p>Note: As with other <code>clang-tidy</code> checks, it is possible that multiple fixes may overlap (as in the case of nested expressions), so not all occurrences can be transformed in one run. In particular, this may occur for nested subtraction expressions. Running <code>clang-tidy</code> multiple times will find and fix these overlaps.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-duration-subtraction.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/duration-subtraction.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -311,7 +311,7 @@ absl::Duration d2 = absl::Seconds(absl::ToInt64Seconds(d1) * 2);
 absl::Duration d2 = d1 * 2;</code></pre>
 <p>Note: Converting to an integer and back to an <code>absl::Duration</code> might be a truncating operation if the value is not aligned to the scale of conversion. In the rare case where this is the intended result, callers should use <code>absl::Trunc</code> to truncate explicitly.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-duration-unnecessary-conversion.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/duration-unnecessary-conversion.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -351,7 +351,7 @@ for (auto piece : absl::StrSplit(str, absl::MaxSplits(&quot;B&quot;, 1))) {
 // overload of absl::StrSplit() to be used.
 for (auto piece : absl::StrSplit(str, absl::MaxSplits(&#39;B&#39;, 1))) {</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-faster-strsplit-delimiter.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/faster-strsplit-delimiter.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -360,7 +360,9 @@ for (auto piece : absl::StrSplit(str, absl::MaxSplits(&#39;B&#39;, 1))) {</code>
     <key>abseil-no-internal-dependencies</key>
     <name>abseil-no-internal-dependencies</name>
     <description>
-      <![CDATA[<p>subl.. title:: clang-tidy - abseil-no-internal-dependencies</p>
+      <![CDATA[<div class="title">
+<p>clang-tidy - abseil-no-internal-dependencies</p>
+</div>
 <h1 id="abseil-no-internal-dependencies">abseil-no-internal-dependencies</h1>
 <p>Warns if code using Abseil depends on internal details. If something is in a namespace that includes the word "internal", code is not allowed to depend upon it because it's an implementation detail. They cannot friend it, include it, you mention it or refer to it in any way. Doing so violates Abseil's compatibility guidelines and may result in breakage. See <a href="https://abseil.io/about/compatibility">https://abseil.io/about/compatibility</a> for more information.</p>
 <p>The following cases will result in warnings:</p>
@@ -373,7 +375,7 @@ class foo {
 absl::memory_internal::MakeUniqueResult();
 // warning triggered on this line</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-no-internal-dependencies.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/no-internal-dependencies.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -394,7 +396,7 @@ absl::memory_internal::MakeUniqueResult();
 <p>will be prompted with a warning.</p>
 <p>See <a href="https://abseil.io/about/compatibility">the full Abseil compatibility guidelines</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-no-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/no-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -422,7 +424,7 @@ absl::StrAppend(&amp;s, absl::StrCat(&quot;E&quot;, &quot;F&quot;, &quot;G&quot;
 absl::StrAppend(&amp;s, &quot;E&quot;, &quot;F&quot;, &quot;G&quot;);
 //after</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-redundant-strcat-calls.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/redundant-strcat-calls.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -442,7 +444,7 @@ absl::StrAppend(&amp;s, &quot;E&quot;, &quot;F&quot;, &quot;G&quot;);
 <pre class="c++"><code>a = absl::StrCat(a, b); // Use absl::StrAppend(&amp;a, b) instead.</code></pre>
 <p>Does not diagnose cases where <code>absl::StrCat()</code> is used as a template argument for a functor.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-str-cat-append.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/str-cat-append.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -479,7 +481,7 @@ if (absl::StartsWith(s, &quot;Hello World&quot;)) { /* do something */ }</code><
 <p>The location of Abseil's <code>strings/match.h</code>. Defaults to <code>absl/strings/match.h</code>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-string-find-startswith.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/string-find-startswith.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -522,7 +524,7 @@ if (absl::StrContains(a, &quot;Hello World&quot;)) { /* do something */ }</code>
 <p>The location of Abseil's <code>strings/match.h</code>. Defaults to <code>absl/strings/match.h</code>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-string-find-str-contains.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/string-find-str-contains.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -546,7 +548,7 @@ if (x &lt; absl::ToUnixSeconds(t)) ...
 // Suggested - Compare in the absl::Time domain instead
 if (absl::FromUnixSeconds(x) &lt; t) ...</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-time-comparison.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/time-comparison.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -583,7 +585,7 @@ int i = x - absl::ToUnixSeconds(t);
 // Suggestion - Perform subtraction in the Time domain instead.
 int i = absl::ToInt64Seconds(absl::FromUnixSeconds(x) - t);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-time-subtraction.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/time-subtraction.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -610,7 +612,7 @@ absl::Duration d = absl::Milliseconds(static_cast&lt;int64_t&gt;(a));
 d *= static_cast&lt;int64_t&gt;(a);</code></pre>
 <p>Note that this check always adds a cast to <code>int64_t</code> in order to preserve the current behavior of user code. It is possible that this uncovers unintended behavior due to types implicitly convertible to a floating-point type.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil-upgrade-duration-conversions.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/upgrade-duration-conversions.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -639,7 +641,7 @@ for (int i = 0; i &lt; 100; ++i) {
 }</code></pre>
 <p>Based on the <a href="https://www.altera.com/en_US/pdfs/literature/hb/opencl-sdk/aocl_optimization_guide.pdf">Altera SDK for OpenCL: Best Practices Guide</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/altera-id-dependent-backward-branch.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/altera/id-dependent-backward-branch.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -656,7 +658,7 @@ for (int i = 0; i &lt; 100; ++i) {
 <p>Such kernel file names cause the offline compiler to generate intermediate design files that have the same names as certain internal files, which leads to a compilation error.</p>
 <p>Based on the <span class="title-ref">Guidelines for Naming the Kernel</span> section in the <a href="https://www.intel.com/content/www/us/en/programmable/documentation/mwh1391807965224.html#ewa1412973930963">Intel FPGA SDK for OpenCL Pro Edition: Programming Guide</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/altera-kernel-name-restriction.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/altera/kernel-name-restriction.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -706,7 +708,7 @@ void __kernel barrier_with_id(__global int * foo, int size) {
 <p>Defines the version of the Altera Offline Compiler. Defaults to <code>1600</code> (corresponding to version 16.00).</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/altera-single-work-item-barrier.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/altera/single-work-item-barrier.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -759,7 +761,7 @@ struct badly_aligned_example {
   char c;    // 1 byte
 } __attribute__((packed)) __attribute__((aligned(32)));</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/altera-struct-pack-align.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/altera/struct-pack-align.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -851,7 +853,7 @@ while (i &lt; someVector.size()) {
 <p>In practice, this refers to the integer value of the upper bound within the loop statement's condition expression.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/altera-unroll-loops.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/altera/unroll-loops.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -872,7 +874,7 @@ while (i &lt; someVector.size()) {
 
 accept4(sockfd, addr, addrlen, SOCK_CLOEXEC);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-accept.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-accept.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -893,7 +895,7 @@ accept4(sockfd, addr, addrlen, SOCK_CLOEXEC);</code></pre>
 
 accept4(sockfd, addr, addrlen, SOCK_NONBLOCK | SOCK_CLOEXEC);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-accept4.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-accept4.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>VULNERABILITY</type>
@@ -916,7 +918,7 @@ accept4(sockfd, addr, addrlen, SOCK_NONBLOCK | SOCK_CLOEXEC);</code></pre>
 
 int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, mode);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-creat.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-creat.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -937,7 +939,7 @@ int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, mode);</code></pre
 
 int fd = fcntl(oldfd, F_DUPFD_CLOEXEC);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-dup.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-dup.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>VULNERABILITY</type>
@@ -960,7 +962,7 @@ int fd = fcntl(oldfd, F_DUPFD_CLOEXEC);</code></pre>
 
 epoll_create1(EPOLL_CLOEXEC);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-epoll-create.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-epoll-create.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>VULNERABILITY</type>
@@ -983,7 +985,7 @@ epoll_create1(EPOLL_CLOEXEC);</code></pre>
 
 epoll_create1(EPOLL_CLOEXEC);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-epoll-create1.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-epoll-create1.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>VULNERABILITY</type>
@@ -1006,7 +1008,7 @@ epoll_create1(EPOLL_CLOEXEC);</code></pre>
 
 fopen(&quot;fn&quot;, &quot;re&quot;);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-fopen.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-fopen.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>VULNERABILITY</type>
@@ -1029,7 +1031,7 @@ fopen(&quot;fn&quot;, &quot;re&quot;);</code></pre>
 
 inotify_init1(IN_CLOEXEC);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-inotify-init.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-inotify-init.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>VULNERABILITY</type>
@@ -1052,7 +1054,7 @@ inotify_init1(IN_CLOEXEC);</code></pre>
 
 inotify_init1(IN_NONBLOCK | IN_CLOEXEC);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-inotify-init1.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-inotify-init1.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>VULNERABILITY</type>
@@ -1075,7 +1077,7 @@ inotify_init1(IN_NONBLOCK | IN_CLOEXEC);</code></pre>
 
 memfd_create(name, MFD_ALLOW_SEALING | MFD_CLOEXEC);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-memfd-create.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-memfd-create.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>VULNERABILITY</type>
@@ -1102,7 +1104,7 @@ open(&quot;filename&quot;, O_RDWR | O_CLOEXEC);
 open64(&quot;filename&quot;, O_RDWR | O_CLOEXEC);
 openat(0, &quot;filename&quot;, O_RDWR | O_CLOEXEC);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-open.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-open.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>VULNERABILITY</type>
@@ -1123,7 +1125,7 @@ openat(0, &quot;filename&quot;, O_RDWR | O_CLOEXEC);</code></pre>
 <p>Suggested replacement:</p>
 <pre class="c++"><code>pipe2(pipefd, O_CLOEXEC);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-pipe.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-pipe.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -1142,7 +1144,7 @@ openat(0, &quot;filename&quot;, O_RDWR | O_CLOEXEC);</code></pre>
 <p>Suggested replacement:</p>
 <pre class="c++"><code>pipe2(pipefd, O_NONBLOCK | O_CLOEXEC);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-pipe2.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-pipe2.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -1163,7 +1165,7 @@ openat(0, &quot;filename&quot;, O_RDWR | O_CLOEXEC);</code></pre>
 
 socket(domain, type, SOCK_STREAM | SOCK_CLOEXEC);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-cloexec-socket.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/cloexec-socket.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>VULNERABILITY</type>
@@ -1197,7 +1199,7 @@ while (TEMP_FAILURE_RETRY(read(STDIN_FILENO, cs, sizeof(cs))) != 0) {
 <p>A comma-separated list of the names of retry macros to be checked.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android-comparison-in-temp-failure-retry.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/android/comparison-in-temp-failure-retry.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -1219,7 +1221,7 @@ auto wstr = boost::lexical_cast&lt;std::wstring&gt;(2137LL);
 auto str = std::to_string(42);
 auto wstr = std::to_wstring(2137LL);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/boost-use-to-string.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/boost/use-to-string.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -1343,7 +1345,7 @@ foo(nullptr);</code></pre>
 
 foo(/*Value=*/nullptr);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-argument-comment.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/argument-comment.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -1374,7 +1376,7 @@ foo(/*Value=*/nullptr);</code></pre>
 <p>A semicolon-separated list of the names of functions or methods to be considered as not having side-effects. Regular expressions are accepted, e.g. <span class="title-ref">[Rr]ef(erence)?$</span> matches every type with suffix <span class="title-ref">Ref</span>, <span class="title-ref">ref</span>, <span class="title-ref">Reference</span> and <span class="title-ref">reference</span>. The default is empty. If a name in the list contains the sequence <span class="title-ref">::</span> it is matched against the qualified typename (i.e. <span class="title-ref">namespace::Type</span>, otherwise it is matched against only the type name (i.e. <span class="title-ref">Type</span>).</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-assert-side-effect.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/assert-side-effect.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -1395,7 +1397,7 @@ foo(/*Value=*/nullptr);</code></pre>
 </blockquote>
 <p>This check corresponds to the CERT C Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/c/POS44-C.+Do+not+use+signals+to+terminate+threads">POS44-C. Do not use signals to terminate threads</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-bad-signal-to-kill-thread.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/bad-signal-to-kill-thread.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -1417,7 +1419,7 @@ if (p) {
   // Never used in a pointer-specific way.
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-bool-pointer-implicit-conversion.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/bool-pointer-implicit-conversion.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -1476,7 +1478,7 @@ default:
 <p>Unlike if statements, the check does not detect chains of conditional operators.</p>
 <p>Note: This check also reports situations where branches become identical only after preprocessing.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-branch-clone.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/branch-clone.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -1504,7 +1506,7 @@ class X2 : public Copyable {
 };</code></pre>
 <p>The check also suggests a fix-its in some cases.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-copy-constructor-init.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/copy-constructor-init.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -1543,7 +1545,7 @@ string_view f() {
 <p>A semicolon-separated list of class names that should be treated as handles. By default only <code>std::basic_string_view</code> and <code>std::experimental::basic_string_view</code> are considered.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-dangling-handle.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/dangling-handle.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -1567,7 +1569,7 @@ string_view f() {
 }</code></pre>
 <p>When synchronization of static initialization is disabled, if two threads both call <span class="title-ref">foo</span> for the first time, there is the possibility that <span class="title-ref">k</span> will be double initialized, creating a race condition.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-dynamic-static-initializers.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/dynamic-static-initializers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -1697,7 +1699,7 @@ void strs(String Str, StringView SV) { /* ... */ }
 // Diagnosed: StringView implicitly converts to and from a buffer.
 void cStr(StringView SV, const char *Buf() { /* ... */ }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-easily-swappable-parameters.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/easily-swappable-parameters.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -1732,7 +1734,7 @@ void cStr(StringView SV, const char *Buf() { /* ... */ }</code></pre>
 <p>Comma separated list containing type names which are not counted as thrown exceptions in the check. Default value is an empty string.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-exception-escape.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/exception-escape.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -1759,7 +1761,7 @@ return std::accumulate(std::begin(a), std::end(a), 0);</code></pre>
 <pre class="c++"><code>auto a = {65536LL * 65536 * 65536};
 return std::accumulate(std::begin(a), std::end(a), 0);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-fold-init-type.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/fold-init-type.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -1783,7 +1785,7 @@ nb::A a;
 // &#39;A&#39; found in another namespace &#39;nb::&#39;</code></pre>
 <p>This check can only generate warnings, but it can't suggest a fix at this point.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-forward-declaration-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/forward-declaration-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -1825,7 +1827,7 @@ public:
 <h2 id="background">Background</h2>
 <p>For deciding whether a constructor is guarded with enable_if, we consider the types of the constructor parameters, the default values of template type parameters and the types of non-type template parameters with a default literal value. If any part of these types is <code>std::enable_if</code> or <code>std::enable_if_t</code>, we assume the constructor is guarded.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-forwarding-reference-overload.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/forwarding-reference-overload.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -1872,7 +1874,7 @@ char ptr_subscript(char *base, int a, int b) {
   return base[a * b]; // warning: result of multiplication in type &#39;int&#39; is used as a pointer offset after an implicit widening conversion to type &#39;ssize_t&#39;
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-implicit-widening-of-multiplication-result.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -1896,7 +1898,7 @@ xs.erase(std::remove(xs.begin(), xs.end(), 10));</code></pre>
 ...
 xs.erase(std::remove(xs.begin(), xs.end(), 10), xs.end());</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-inaccurate-erase.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/inaccurate-erase.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -1919,7 +1921,7 @@ xs.erase(std::remove(xs.begin(), xs.end(), 10), xs.end());</code></pre>
 <li>It is incorrect. The number 0.499999975 (smallest representable float number below 0.5) rounds to 1.0. Even worse behavior for negative numbers where both -0.5f and -1.4f both round to 0.0.</li>
 </ol>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-incorrect-roundings.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/incorrect-roundings.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>BUG</type>
@@ -1948,7 +1950,7 @@ while (i &lt; 10) {
   ++j;
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-infinite-loop.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/infinite-loop.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -1992,7 +1994,7 @@ d = 1 &lt;&lt; (i / 2);
 d = 9 + intFunc(6 * i / 32);
 d = (int)(i / 32) - 8;</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-integer-division.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/integer-division.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2020,7 +2022,7 @@ Now called from operator()</code></pre>
 <pre><code>Called from FancyFunction
 Now called from FancyFunction</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-lambda-function-name.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/lambda-function-name.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2040,7 +2042,7 @@ Now called from FancyFunction</code></pre>
 <p>When the replacement list has an expression, it is recommended to surround it with parentheses. This ensures that the macro result is evaluated completely before it is used.</p>
 <p>It is also recommended to surround macro arguments in the replacement list with parentheses. This ensures that the argument value is calculated properly.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-macro-parentheses.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/macro-parentheses.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2057,7 +2059,7 @@ Now called from FancyFunction</code></pre>
 <h1 id="bugprone-macro-repeated-side-effects">bugprone-macro-repeated-side-effects</h1>
 <p>Checks for repeated argument with side effects in macros.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-macro-repeated-side-effects.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/macro-repeated-side-effects.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2090,7 +2092,7 @@ Now called from FancyFunction</code></pre>
   char *c = (char*) malloc(strlen((str + 1)));
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-misplaced-operator-in-strlen-in-alloc.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/misplaced-operator-in-strlen-in-alloc.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>BUG</type>
@@ -2113,7 +2115,7 @@ Now called from FancyFunction</code></pre>
 <p>The suggested fix is to add the integer expression to the argument of <code>malloc</code> and not to its result. In the example above the fix would be</p>
 <pre class="c"><code>char *p = (char*) malloc(n + 10);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-misplaced-pointer-arithmetic-in-alloc.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/misplaced-pointer-arithmetic-in-alloc.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>BUG</type>
@@ -2155,7 +2157,7 @@ Now called from FancyFunction</code></pre>
 <p>If <span class="title-ref">true</span>, enables detection of implicit casts. Default is <span class="title-ref">false</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-misplaced-widening-cast.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/misplaced-widening-cast.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -2188,7 +2190,7 @@ foo(s);</code></pre>
 <p>If <code>foo()</code> is called on an lvalue (as in the example above), then <code>T</code> is deduced to be an lvalue reference. In the example, <code>T</code> is deduced to be <code>std::string &amp;</code>. The type of the argument <code>t</code> therefore becomes <code>std::string&amp; &amp;&amp;</code>; by the reference collapsing rules, this collapses to <code>std::string&amp;</code>.</p>
 <p>This means that the <code>foo(s)</code> call passes <code>s</code> as an lvalue reference, and <code>foo()</code> ends up moving <code>s</code> and thereby placing it into an indeterminate state.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-move-forwarding-reference.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/move-forwarding-reference.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2209,7 +2211,7 @@ foo(s);</code></pre>
 if (do_increment)
   INCREMENT_TWO(a, b);  // (b)++ will be executed unconditionally.</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-multiple-statement-macro.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/multiple-statement-macro.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2234,7 +2236,7 @@ if (do_increment)
 });</code></pre>
 </blockquote>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-no-escape.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/no-escape.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -2302,7 +2304,7 @@ if (do_increment)
 <p>The value <span class="title-ref">true</span> specifies that the target environment is considered to implement '_s' suffixed memory and string handler functions which are safer than older versions (e.g. 'memcpy_s()'). The default value is <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-not-null-terminated-result.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/not-null-terminated-result.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2332,7 +2334,7 @@ struct C: public B {
 // warning: qualified name A::foo refers to a member overridden in subclass; did you mean &#39;B&#39;?  [bugprone-parent-virtual-call]
 };</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-parent-virtual-call.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/parent-virtual-call.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -2353,7 +2355,7 @@ struct C: public B {
 <p>This will never happen as the return value is always non-negative. A simple fix could be:</p>
 <pre class="c"><code>if (posix_fadvise(...) &gt; 0) {</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-posix-return.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/posix-return.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2422,7 +2424,7 @@ if (onFire) {
   }
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-redundant-branch-condition.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/redundant-branch-condition.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2452,7 +2454,7 @@ if (onFire) {
   #define cool__macro // also this
 }
 int _g(); // disallowed in global namespace only</code></pre>
-<p>The check can also be inverted, i.e. it can be configured to flag any identifier that is not a reserved identifier. This mode is for use by e.g. standard library implementors, to ensure they don't infringe on the user namespace.</p>
+<p>The check can also be inverted, i.e. it can be configured to flag any identifier that is _<a href="">not</a> a reserved identifier. This mode is for use by e.g. standard library implementors, to ensure they don't infringe on the user namespace.</p>
 <p>This check does not (yet) check for other reserved names, e.g. macro names identical to language keywords, and names specifically reserved by language standards, e.g. C++ 'zombie names' and C future library directions.</p>
 <p>This check corresponds to CERT C Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/c/DCL37-C.+Do+not+declare+or+define+a+reserved+identifier">DCL37-C. Do not declare or define a reserved identifier</a> as well as its C++ counterpart, <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL51-CPP.+Do+not+declare+or+define+a+reserved+identifier">DCL51-CPP. Do not declare or define a reserved identifier</a>.</p>
 <h2 id="options">Options</h2>
@@ -2465,7 +2467,7 @@ int _g(); // disallowed in global namespace only</code></pre>
 <p>Semicolon-separated list of names that the check ignores. Default is an empty list.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-reserved-identifier.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/reserved-identifier.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -2493,8 +2495,9 @@ struct S {
   std::shared_ptr&lt;Foo&gt; x(new Foo[10]); // no replacement in this case
   //                     ^ warning: shared pointer to non-array is initialized with array [bugprone-shared-ptr-array-mismatch]
 };</code></pre>
+<p>This check partially covers the CERT C++ Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/MEM51-CPP.+Properly+deallocate+dynamically+allocated+resources">MEM51-CPP. Properly deallocate dynamically allocated resources</a> However, only the <code>std::shared_ptr</code> case is detected by this check.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-shared-ptr-array-mismatch.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/shared-ptr-array-mismatch.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -2507,15 +2510,37 @@ struct S {
 <p>clang-tidy - bugprone-signal-handler</p>
 </div>
 <h1 id="bugprone-signal-handler">bugprone-signal-handler</h1>
-<p>Finds functions registered as signal handlers that call non asynchronous-safe functions. Any function that cannot be determined to be an asynchronous-safe function call is assumed to be non-asynchronous-safe by the checker, including user functions for which only the declaration is visible. User function calls with visible definition are checked recursively. The check handles only C code. Only the function names are considered and the fact that the function is a system-call, but no other restrictions on the arguments passed to the functions (the <code>signal</code> call is allowed without restrictions).</p>
-<p>This check corresponds to the CERT C Coding Standard rule <a href="https://www.securecoding.cert.org/confluence/display/c/SIG30-C.+Call+only+asynchronous-safe+functions+within+signal+handlers">SIG30-C. Call only asynchronous-safe functions within signal handlers</a> and has an alias name <code>cert-sig30-c</code>.</p>
+<p>Finds specific constructs in signal handler functions that can cause undefined behavior. The rules for what is allowed differ between C++ language versions.</p>
+<p>Checked signal handler rules for C:</p>
+<ul>
+<li>Calls to non-asynchronous-safe functions are not allowed.</li>
+</ul>
+<p>Checked signal handler rules for up to and including C++14:</p>
+<ul>
+<li>Calls to non-asynchronous-safe functions are not allowed.</li>
+<li>C++-specific code constructs are not allowed in signal handlers. In other words, only the common subset of C and C++ is allowed to be used.</li>
+<li>Calls to functions with non-C linkage are not allowed (including the signal handler itself).</li>
+</ul>
+<p>The check is disabled on C++17 and later.</p>
+<p>Asnychronous-safety is determined by comparing the function's name against a set of known functions. In addition, the function must come from a system header include and in a global namespace. The (possible) arguments passed to the function are not checked. Any function that cannot be determined to be asynchronous-safe is assumed to be non-asynchronous-safe by the check, including user functions for which only the declaration is visible. Calls to user-defined functions with visible definitions are checked recursively.</p>
+<p>This check implements the CERT C Coding Standard rule <a href="https://www.securecoding.cert.org/confluence/display/c/SIG30-C.+Call+only+asynchronous-safe+functions+within+signal+handlers">SIG30-C. Call only asynchronous-safe functions within signal handlers</a> and the rule <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/MSC54-CPP.+A+signal+handler+must+be+a+plain+old+function">MSC54-CPP. A signal handler must be a plain old function</a>. It has the alias names <code>cert-sig30-c</code> and <code>cert-msc54-cpp</code>.</p>
+<h2 id="options">Options</h2>
 <div class="option">
 <p>AsyncSafeFunctionSet</p>
-<p>Selects which set of functions is considered as asynchronous-safe (and therefore allowed in signal handlers). Value <code>minimal</code> selects a minimal set that is defined in the CERT SIG30-C rule and includes functions <code>abort()</code>, <code>_Exit()</code>, <code>quick_exit()</code> and <code>signal()</code>. Value <code>POSIX</code> selects a larger set of functions that is listed in POSIX.1-2017 (see <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_04_03">this link</a> for more information). The function <code>quick_exit</code> is not included in the shown list. It is assumable that the reason is that the list was not updated for C11. The checker includes <code>quick_exit</code> in the set of safe functions. Functions registered as exit handlers are not checked.</p>
-<p>Default is <code>POSIX</code>.</p>
+<p>Selects which set of functions is considered as asynchronous-safe (and therefore allowed in signal handlers). It can be set to the following values:</p>
+<dl>
+<dt><code>minimal</code></dt>
+<dd><p>Selects a minimal set that is defined in the CERT SIG30-C rule. and includes functions <code>abort()</code>, <code>_Exit()</code>, <code>quick_exit()</code> and <code>signal()</code>.</p>
+</dd>
+<dt><code>POSIX</code></dt>
+<dd><p>Selects a larger set of functions that is listed in POSIX.1-2017 (see <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_04_03">this link</a> for more information). The following functions are included: <code>_Exit</code>, <code>_exit</code>, <code>abort</code>, <code>accept</code>, <code>access</code>, <code>aio_error</code>, <code>aio_return</code>, <code>aio_suspend</code>, <code>alarm</code>, <code>bind</code>, <code>cfgetispeed</code>, <code>cfgetospeed</code>, <code>cfsetispeed</code>, <code>cfsetospeed</code>, <code>chdir</code>, <code>chmod</code>, <code>chown</code>, <code>clock_gettime</code>, <code>close</code>, <code>connect</code>, <code>creat</code>, <code>dup</code>, <code>dup2</code>, <code>execl</code>, <code>execle</code>, <code>execv</code>, <code>execve</code>, <code>faccessat</code>, <code>fchdir</code>, <code>fchmod</code>, <code>fchmodat</code>, <code>fchown</code>, <code>fchownat</code>, <code>fcntl</code>, <code>fdatasync</code>, <code>fexecve</code>, <code>ffs</code>, <code>fork</code>, <code>fstat</code>, <code>fstatat</code>, <code>fsync</code>, <code>ftruncate</code>, <code>futimens</code>, <code>getegid</code>, <code>geteuid</code>, <code>getgid</code>, <code>getgroups</code>, <code>getpeername</code>, <code>getpgrp</code>, <code>getpid</code>, <code>getppid</code>, <code>getsockname</code>, <code>getsockopt</code>, <code>getuid</code>, <code>htonl</code>, <code>htons</code>, <code>kill</code>, <code>link</code>, <code>linkat</code>, <code>listen</code>, <code>longjmp</code>, <code>lseek</code>, <code>lstat</code>, <code>memccpy</code>, <code>memchr</code>, <code>memcmp</code>, <code>memcpy</code>, <code>memmove</code>, <code>memset</code>, <code>mkdir</code>, <code>mkdirat</code>, <code>mkfifo</code>, <code>mkfifoat</code>, <code>mknod</code>, <code>mknodat</code>, <code>ntohl</code>, <code>ntohs</code>, <code>open</code>, <code>openat</code>, <code>pause</code>, <code>pipe</code>, <code>poll</code>, <code>posix_trace_event</code>, <code>pselect</code>, <code>pthread_kill</code>, <code>pthread_self</code>, <code>pthread_sigmask</code>, <code>quick_exit</code>, <code>raise</code>, <code>read</code>, <code>readlink</code>, <code>readlinkat</code>, <code>recv</code>, <code>recvfrom</code>, <code>recvmsg</code>, <code>rename</code>, <code>renameat</code>, <code>rmdir</code>, <code>select</code>, <code>sem_post</code>, <code>send</code>, <code>sendmsg</code>, <code>sendto</code>, <code>setgid</code>, <code>setpgid</code>, <code>setsid</code>, <code>setsockopt</code>, <code>setuid</code>, <code>shutdown</code>, <code>sigaction</code>, <code>sigaddset</code>, <code>sigdelset</code>, <code>sigemptyset</code>, <code>sigfillset</code>, <code>sigismember</code>, <code>siglongjmp</code>, <code>signal</code>, <code>sigpause</code>, <code>sigpending</code>, <code>sigprocmask</code>, <code>sigqueue</code>, <code>sigset</code>, <code>sigsuspend</code>, <code>sleep</code>, <code>sockatmark</code>, <code>socket</code>, <code>socketpair</code>, <code>stat</code>, <code>stpcpy</code>, <code>stpncpy</code>, <code>strcat</code>, <code>strchr</code>, <code>strcmp</code>, <code>strcpy</code>, <code>strcspn</code>, <code>strlen</code>, <code>strncat</code>, <code>strncmp</code>, <code>strncpy</code>, <code>strnlen</code>, <code>strpbrk</code>, <code>strrchr</code>, <code>strspn</code>, <code>strstr</code>, <code>strtok_r</code>, <code>symlink</code>, <code>symlinkat</code>, <code>tcdrain</code>, <code>tcflow</code>, <code>tcflush</code>, <code>tcgetattr</code>, <code>tcgetpgrp</code>, <code>tcsendbreak</code>, <code>tcsetattr</code>, <code>tcsetpgrp</code>, <code>time</code>, <code>timer_getoverrun</code>, <code>timer_gettime</code>, <code>timer_settime</code>, <code>times</code>, <code>umask</code>, <code>uname</code>, <code>unlink</code>, <code>unlinkat</code>, <code>utime</code>, <code>utimensat</code>, <code>utimes</code>, <code>wait</code>, <code>waitpid</code>, <code>wcpcpy</code>, <code>wcpncpy</code>, <code>wcscat</code>, <code>wcschr</code>, <code>wcscmp</code>, <code>wcscpy</code>, <code>wcscspn</code>, <code>wcslen</code>, <code>wcsncat</code>, <code>wcsncmp</code>, <code>wcsncpy</code>, <code>wcsnlen</code>, <code>wcspbrk</code>, <code>wcsrchr</code>, <code>wcsspn</code>, <code>wcsstr</code>, <code>wcstok</code>, <code>wmemchr</code>, <code>wmemcmp</code>, <code>wmemcpy</code>, <code>wmemmove</code>, <code>wmemset</code>, <code>write</code></p>
+<p>The function <code>quick_exit</code> is not included in the POSIX list but it is included here in the set of safe functions.</p>
+</dd>
+</dl>
+<p>The default value is <code>POSIX</code>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-signal-handler.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/signal-handler.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2537,7 +2562,7 @@ struct S {
 <p>It depends on the actual platform whether plain <code>char</code> is handled as <code>signed char</code> by default and so it is caught by this check or not. To change the default behavior you can use <code>-funsigned-char</code> and <code>-fsigned-char</code> compilation options.</p>
 <p>Currently, this check warns in the following cases: - <code>signed char</code> is assigned to an integer variable - <code>signed char</code> and <code>unsigned char</code> are compared with equality/inequality operator - <code>signed char</code> is converted to an integer in the array subscript</p>
 <p>See also: <a href="https://wiki.sei.cmu.edu/confluence/display/c/STR34-C.+Cast+characters+to+unsigned+char+before+converting+to+larger+integer+sizes">STR34-C. Cast characters to unsigned char before converting to larger integer sizes</a></p>
-<p>A good example from the CERT description when a <code>char</code> variable is used to read from a file that might contain non-ASCII characters. The problem comes up when the code uses the <code>-1</code> integer value as EOF, while the 255 character code is also stored as <code>-1</code> in two's complement form of char type. See a simple example of this bellow. This code stops not only when it reaches the end of the file, but also when it gets a character with the 255 code.</p>
+<p>A good example from the CERT description when a <code>char</code> variable is used to read from a file that might contain non-ASCII characters. The problem comes up when the code uses the <code>-1</code> integer value as EOF, while the 255 character code is also stored as <code>-1</code> in two's complement form of char type. See a simple example of this below. This code stops not only when it reaches the end of the file, but also when it gets a character with the 255 code.</p>
 <pre class="c++"><code>#define EOF (-1)
 
 int read(void) {
@@ -2582,7 +2607,7 @@ int read(void) {
 <p>When <span class="title-ref">true</span>, the check will warn on <code>signed char</code>/<code>unsigned char</code> comparisons, otherwise these comparisons are ignored. By default, this option is set to <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-signed-char-misuse.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/signed-char-misuse.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2611,7 +2636,7 @@ int c = sizeof(array_of_strings) / sizeof(array_of_strings[0]); // no warning, d
 std::array&lt;int, 3&gt; std_array;
 int d = sizeof(std_array); // no warning, probably intended.</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-sizeof-container.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/sizeof-container.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2720,8 +2745,12 @@ void getInt(int* dst) {
 <p>WarnOnSizeOfCompareToConstant</p>
 <p>When <span class="title-ref">true</span>, the check will warn on an expression like <code>sizeof(expr) &lt;= k</code> for a suspicious constant <span class="title-ref">k</span> while <span class="title-ref">k</span> is <span class="title-ref">0</span> or greater than <span class="title-ref">0x8000</span>. Default is <span class="title-ref">true</span>.</p>
 </div>
+<div class="option">
+<p>WarnOnSizeOfPointerToAggregate</p>
+<p>When <span class="title-ref">true, the check will warn on an expression like </span><span class="title-ref">sizeof(expr)</span><span class="title-ref"> where the expression is a pointer to aggregate. Default is `true</span>.</p>
+</div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-sizeof-expression.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/sizeof-expression.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -2755,7 +2784,7 @@ void getInt(int* dst) {
 </blockquote>
 <p>This check corresponds to the CERT C++ Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/CON54-CPP.+Wrap+functions+that+can+spuriously+wake+up+in+a+loop">CON54-CPP. Wrap functions that can spuriously wake up in a loop</a>. and CERT C Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/c/CON36-C.+Wrap+functions+that+can+spuriously+wake+up+in+a+loop">CON36-C. Wrap functions that can spuriously wake up in a loop</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-spuriously-wake-up-functions.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/spuriously-wake-up-functions.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2797,7 +2826,7 @@ std::string_view(&quot;test&quot;, 0);</code></pre>
 <p>Semicolon-delimited list of class names to apply this check to. By default <span class="title-ref">::std::basic_string</span> applies to <code>std::string</code> and <code>std::wstring</code>. Set to e.g. <span class="title-ref">::std::basic_string;llvm::StringRef;QString</span> to perform this check on custom classes.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-string-constructor.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/string-constructor.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2828,7 +2857,7 @@ s = std::to_string(x);</code></pre>
 <pre class="c++"><code>std::string s;
 s = static_cast&lt;char&gt;(6);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-string-integer-assignment.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/string-integer-assignment.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -2855,7 +2884,7 @@ const char* Bytes[] = &quot;\x03\0x02\0x01\0x00\0xFF\0xFF\0xFF&quot;;</code></pr
 str += &quot;\0&quot;;                  // This statement is doing nothing
 if (str == &quot;\0abc&quot;) return;   // This expression is always true</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-string-literal-with-embedded-nul.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/string-literal-with-embedded-nul.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>BUG</type>
@@ -2911,7 +2940,7 @@ accepts_sv({nullptr, 0});  // B</code></pre>
 <p>The source pattern with trailing comment "B" selects the <code>(const CharT*, size_type)</code> constructor which is perfectly valid, since the length argument is <code>0</code>. It is not changed by this ClangTidy check.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-stringview-nullptr.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/stringview-nullptr.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -2982,7 +3011,7 @@ flag |=
 <p>Default value: 0. When non-null the suspicious bitmask usage will be investigated additionally to the different enum usage check.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-enum-usage.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-enum-usage.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -3011,7 +3040,7 @@ flag |=
 <p>Default value: <code>"c;cc;cpp;cxx"</code> Likewise, a semicolon-separated list of filename extensions of implementation files.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-include.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-include.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3034,7 +3063,7 @@ flag |=
 <p>See also: <a href="https://wiki.sei.cmu.edu/confluence/display/c/EXP42-C.+Do+not+compare+padding+data">EXP42-C. Do not compare padding data</a> and <a href="https://wiki.sei.cmu.edu/confluence/display/c/FLP37-C.+Do+not+use+object+representations+to+compare+floating-point+values">FLP37-C. Do not use object representations to compare floating-point values</a></p>
 <p>This check is also related to and partially overlaps the CERT C++ Coding Standard rules <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP57-CPP.+Prefer+special+member+functions+and+overloaded+operators+to+C+Standard+Library+functions">OOP57-CPP. Prefer special member functions and overloaded operators to C Standard Library functions</a> and <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/EXP62-CPP.+Do+not+access+the+bits+of+an+object+representation+that+are+not+part+of+the+object%27s+value+representation">EXP62-CPP. Do not access the bits of an object representation that are not part of the object's value representation</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-memory-comparison.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-memory-comparison.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -3076,7 +3105,7 @@ flag |=
   memset(ip, 0, 1);           // OK
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-memset-usage.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-memset-usage.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3124,7 +3153,7 @@ const char* B[] = &quot;This&quot; &quot; is a &quot;    &quot;test&quot;;</code
 <p>An unsigned integer specifying the maximum number of concatenated tokens. Default is <code>5U</code>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-missing-comma.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-missing-comma.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3165,7 +3194,7 @@ Token t = readNextToken();</code></pre>
   Token t = readNextToken();</code></pre>
 <p>In this case the check will assume that you know what you are doing, and will not raise a warning.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-semicolon.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-semicolon.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>BUG</type>
@@ -3207,7 +3236,7 @@ if (strcmp(...) != 0)  // Won&#39;t warn</code></pre>
 <p>A string specifying the comma-separated names of the extra string comparison functions. Default is an empty string. The check will detect the following string comparison functions: <span class="title-ref">__builtin_memcmp</span>, <span class="title-ref">__builtin_strcasecmp</span>, <span class="title-ref">__builtin_strcmp</span>, <span class="title-ref">__builtin_strncasecmp</span>, <span class="title-ref">__builtin_strncmp</span>, <span class="title-ref">_mbscmp</span>, <span class="title-ref">_mbscmp_l</span>, <span class="title-ref">_mbsicmp</span>, <span class="title-ref">_mbsicmp_l</span>, <span class="title-ref">_mbsnbcmp</span>, <span class="title-ref">_mbsnbcmp_l</span>, <span class="title-ref">_mbsnbicmp</span>, <span class="title-ref">_mbsnbicmp_l</span>, <span class="title-ref">_mbsncmp</span>, <span class="title-ref">_mbsncmp_l</span>, <span class="title-ref">_mbsnicmp</span>, <span class="title-ref">_mbsnicmp_l</span>, <span class="title-ref">_memicmp</span>, <span class="title-ref">_memicmp_l</span>, <span class="title-ref">_stricmp</span>, <span class="title-ref">_stricmp_l</span>, <span class="title-ref">_strnicmp</span>, <span class="title-ref">_strnicmp_l</span>, <span class="title-ref">_wcsicmp</span>, <span class="title-ref">_wcsicmp_l</span>, <span class="title-ref">_wcsnicmp</span>, <span class="title-ref">_wcsnicmp_l</span>, <span class="title-ref">lstrcmp</span>, <span class="title-ref">lstrcmpi</span>, <span class="title-ref">memcmp</span>, <span class="title-ref">memicmp</span>, <span class="title-ref">strcasecmp</span>, <span class="title-ref">strcmp</span>, <span class="title-ref">strcmpi</span>, <span class="title-ref">stricmp</span>, <span class="title-ref">strncasecmp</span>, <span class="title-ref">strncmp</span>, <span class="title-ref">strnicmp</span>, <span class="title-ref">wcscasecmp</span>, <span class="title-ref">wcscmp</span>, <span class="title-ref">wcsicmp</span>, <span class="title-ref">wcsncmp</span>, <span class="title-ref">wcsnicmp</span>, <span class="title-ref">wmemcmp</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-suspicious-string-compare.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-string-compare.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3224,7 +3253,7 @@ if (strcmp(...) != 0)  // Won&#39;t warn</code></pre>
 <h1 id="bugprone-swapped-arguments">bugprone-swapped-arguments</h1>
 <p>Finds potentially swapped arguments by looking at implicit conversions.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-swapped-arguments.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/swapped-arguments.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3247,7 +3276,7 @@ do {
   // some other code
 } while(false);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-terminating-continue.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/terminating-continue.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3271,7 +3300,7 @@ do {
   }
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-throw-keyword-missing.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/throw-keyword-missing.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3307,7 +3336,7 @@ do {
   for (int i = 0; i &lt; size; ++i) {} // warning with MagnitudeBitsUpperLimit = 31 on a system where int is 32-bit
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-too-small-loop-variable.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/too-small-loop-variable.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3324,7 +3353,7 @@ do {
 <h1 id="bugprone-undefined-memory-manipulation">bugprone-undefined-memory-manipulation</h1>
 <p>Finds calls of memory manipulation functions <code>memset()</code>, <code>memcpy()</code> and <code>memmove()</code> on not TriviallyCopyable objects resulting in undefined behavior.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-undefined-memory-manipulation.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/undefined-memory-manipulation.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>BUG</type>
@@ -3342,7 +3371,7 @@ do {
 <p>Finds creation of temporary objects in constructors that look like a function call to another constructor of the same class.</p>
 <p>The user most likely meant to use a delegating constructor or base class initializer.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-undelegated-constructor.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/undelegated-constructor.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3389,7 +3418,7 @@ int *f3() noexcept {
   return p;
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-unhandled-exception-at-new.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/unhandled-exception-at-new.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -3488,7 +3517,7 @@ public:
 <p>When <span class="title-ref">true</span>, the check will warn only if the container class of the copy assignment operator has any suspicious fields (pointer or C array). This option is set to <span class="title-ref">true</span> by default.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-unhandled-self-assignment.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/unhandled-self-assignment.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3518,7 +3547,7 @@ public:
 <li>Ignore objects returned from a call.</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-unused-raii.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/unused-raii.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3546,9 +3575,9 @@ public:
 <li><code>std::basic_string::empty()</code> and <code>std::vector::empty()</code>. Not using the return value often indicates that the programmer confused the function with <code>clear()</code>.</li>
 </ul>
 </div>
-<p><a href="cert-err33-c.html">cert-err33-c</a> is an alias of this check that checks a fixed and large set of standard library functions.</p>
+<p><a href="../cert/err33-c.html">cert-err33-c</a> is an alias of this check that checks a fixed and large set of standard library functions.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-unused-return-value.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/unused-return-value.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3665,7 +3694,7 @@ s.str = &quot;Lorem ipsum&quot;;
 s.i = 99;</code></pre>
 <p>The check will not consider <code>s</code> to be reinitialized after the last line; instead, the line that assigns to <code>s.str</code> will be flagged as a use-after-move. This is intentional as this pattern of reinitializing a struct is error-prone. For example, if an additional member variable is added to <code>S</code>, it is easy to forget to add the reinitialization for this additional member. Instead, it is safer to assign to the entire struct in one go, and this will also avoid the use-after-move warning.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-use-after-move.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/use-after-move.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>BUG</type>
@@ -3691,7 +3720,7 @@ struct Derived : Base {
   // warning: &#39;Derived::funk&#39; has a similar name and the same signature as virtual method &#39;Base::func&#39;; did you mean to override it?
 };</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone-virtual-near-miss.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/virtual-near-miss.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -3705,13 +3734,13 @@ struct Derived : Base {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-con36-c</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=bugprone-spuriously-wake-up-functions.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/spuriously-wake-up-functions.html">
 
 </div>
 <h1 id="cert-con36-c">cert-con36-c</h1>
-<p>The cert-con36-c check is an alias, please see <a href="bugprone-spuriously-wake-up-functions.html">bugprone-spuriously-wake-up-functions</a> for more information.</p>
+<p>The cert-con36-c check is an alias, please see <a href="../bugprone/spuriously-wake-up-functions.html">bugprone-spuriously-wake-up-functions</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-con36-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/con36-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -3723,13 +3752,13 @@ struct Derived : Base {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-con54-cpp</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=bugprone-spuriously-wake-up-functions.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/spuriously-wake-up-functions.html">
 
 </div>
 <h1 id="cert-con54-cpp">cert-con54-cpp</h1>
-<p>The cert-con54-cpp check is an alias, please see <a href="bugprone-spuriously-wake-up-functions.html">bugprone-spuriously-wake-up-functions</a> for more information.</p>
+<p>The cert-con54-cpp check is an alias, please see <a href="../bugprone/spuriously-wake-up-functions.html">bugprone-spuriously-wake-up-functions</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-con54-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/con54-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -3741,13 +3770,13 @@ struct Derived : Base {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-dcl03-c</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=misc-static-assert.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../misc/static-assert.html">
 
 </div>
 <h1 id="cert-dcl03-c">cert-dcl03-c</h1>
-<p>The cert-dcl03-c check is an alias, please see <a href="misc-static-assert.html">misc-static-assert</a> for more information.</p>
+<p>The cert-dcl03-c check is an alias, please see <a href="../misc/static-assert.html">misc-static-assert</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl03-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl03-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -3761,13 +3790,13 @@ struct Derived : Base {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-dcl16-c</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=readability-uppercase-literal-suffix.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../readability/uppercase-literal-suffix.html">
 
 </div>
 <h1 id="cert-dcl16-c">cert-dcl16-c</h1>
-<p>The cert-dcl16-c check is an alias, please see <a href="readability-uppercase-literal-suffix.html">readability-uppercase-literal-suffix</a> for more information.</p>
+<p>The cert-dcl16-c check is an alias, please see <a href="../readability/uppercase-literal-suffix.html">readability-uppercase-literal-suffix</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl16-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl16-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -3784,7 +3813,7 @@ struct Derived : Base {
 <p>The object returned by a postfix increment or decrement operator is supposed to be a snapshot of the object's value prior to modification. With such an implementation, any modifications made to the resulting object from calling operator++(int) would be modifying a temporary object. Thus, such an implementation of a postfix increment or decrement operator should instead return a const object, prohibiting accidental mutation of a temporary object. Similarly, it is unexpected for the postfix operator to return a reference to its previous state, and any subsequent modifications would be operating on a stale object.</p>
 <p>This check corresponds to the CERT C++ Coding Standard recommendation DCL21-CPP. Overloaded postfix increment and decrement operators should return a const object. However, all of the CERT recommendations have been removed from public view, and so their justification for the behavior of this check requires an account on their wiki to view.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl21-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl21-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3798,13 +3827,13 @@ struct Derived : Base {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-dcl37-c</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=bugprone-reserved-identifier.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/reserved-identifier.html">
 
 </div>
 <h1 id="cert-dcl37-c">cert-dcl37-c</h1>
-<p>The cert-dcl37-c check is an alias, please see <a href="bugprone-reserved-identifier.html">bugprone-reserved-identifier</a> for more information.</p>
+<p>The cert-dcl37-c check is an alias, please see <a href="../bugprone/reserved-identifier.html">bugprone-reserved-identifier</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl37-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl37-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -3820,7 +3849,7 @@ struct Derived : Base {
 <p>This check flags all function definitions (but not declarations) of C-style variadic functions.</p>
 <p>This check corresponds to the CERT C++ Coding Standard rule <a href="https://www.securecoding.cert.org/confluence/display/cplusplus/DCL50-CPP.+Do+not+define+a+C-style+variadic+function">DCL50-CPP. Do not define a C-style variadic function</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl50-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl50-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -3834,13 +3863,13 @@ struct Derived : Base {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-dcl51-cpp</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=bugprone-reserved-identifier.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/reserved-identifier.html">
 
 </div>
 <h1 id="cert-dcl51-cpp">cert-dcl51-cpp</h1>
-<p>The cert-dcl51-cpp check is an alias, please see <a href="bugprone-reserved-identifier.html">bugprone-reserved-identifier</a> for more information.</p>
+<p>The cert-dcl51-cpp check is an alias, please see <a href="../bugprone/reserved-identifier.html">bugprone-reserved-identifier</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl51-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl51-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -3852,13 +3881,13 @@ struct Derived : Base {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-dcl54-cpp</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=misc-new-delete-overloads.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../misc/new-delete-overloads.html">
 
 </div>
 <h1 id="cert-dcl54-cpp">cert-dcl54-cpp</h1>
-<p>The cert-dcl54-cpp check is an alias, please see <a href="misc-new-delete-overloads.html">misc-new-delete-overloads</a> for more information.</p>
+<p>The cert-dcl54-cpp check is an alias, please see <a href="../misc/new-delete-overloads.html">misc-new-delete-overloads</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl54-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl54-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -3873,14 +3902,45 @@ struct Derived : Base {
 <p>clang-tidy - cert-dcl58-cpp</p>
 </div>
 <h1 id="cert-dcl58-cpp">cert-dcl58-cpp</h1>
-<p>Modification of the <code>std</code> or <code>posix</code> namespace can result in undefined behavior. This check warns for such modifications.</p>
+<p>Modification of the <code>std</code> or <code>posix</code> namespace can result in undefined behavior. This check warns for such modifications. The <code>std</code> (or <code>posix</code>) namespace is allowed to be extended with (class or function) template specializations that depend on an user-defined type (a type that is not defined in the standard system headers).</p>
+<p>The check detects the following (user provided) declarations in namespace <code>std</code> or <code>posix</code>:</p>
+<ul>
+<li>Anything that is not a template specialization.</li>
+<li>Explicit specializations of any standard library function template or class template, if it does not have any user-defined type as template argument.</li>
+<li>Explicit specializations of any member function of a standard library class template.</li>
+<li>Explicit specializations of any member function template of a standard library class or class template.</li>
+<li>Explicit or partial specialization of any member class template of a standard library class or class template.</li>
+</ul>
 <p>Examples:</p>
 <pre class="c++"><code>namespace std {
-  int x; // May cause undefined behavior.
+  int x; // warning: modification of &#39;std&#39; namespace can result in undefined behavior [cert-dcl58-cpp]
+}
+namespace posix::a { // warning: modification of &#39;posix&#39; namespace can result in undefined behavior
+}
+template &lt;&gt;
+struct ::std::hash&lt;long&gt; { // warning: modification of &#39;std&#39; namespace can result in undefined behavior
+  unsigned long operator()(const long &amp;K) const {
+    return K;
+  }
+};
+struct MyData { long data; };
+template &lt;&gt;
+struct ::std::hash&lt;MyData&gt; { // no warning: specialization with user-defined type
+  unsigned long operator()(const MyData &amp;K) const {
+    return K.data;
+  }
+};
+namespace std {
+  template &lt;&gt;
+  void swap&lt;bool&gt;(bool &amp;a, bool &amp;b); // warning: modification of &#39;std&#39; namespace can result in undefined behavior
+  template &lt;&gt;
+  bool less&lt;void&gt;::operator()&lt;MyData &amp;&amp;, MyData &amp;&amp;&gt;(MyData &amp;&amp;, MyData &amp;&amp;) const { // warning: modification of &#39;std&#39; namespace can result in undefined behavior
+    return true;
+  }
 }</code></pre>
 <p>This check corresponds to the CERT C++ Coding Standard rule <a href="https://www.securecoding.cert.org/confluence/display/cplusplus/DCL58-CPP.+Do+not+modify+the+standard+namespaces">DCL58-CPP. Do not modify the standard namespaces</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl58-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl58-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -3894,13 +3954,13 @@ struct Derived : Base {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-dcl59-cpp</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=google-build-namespaces.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../google/build-namespaces.html">
 
 </div>
 <h1 id="cert-dcl59-cpp">cert-dcl59-cpp</h1>
-<p>The cert-dcl59-cpp check is an alias, please see <a href="google-build-namespaces.html">google-build-namespaces</a> for more information.</p>
+<p>The cert-dcl59-cpp check is an alias, please see <a href="../google/build-namespaces.html">google-build-namespaces</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-dcl59-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl59-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -3916,7 +3976,7 @@ struct Derived : Base {
 <p>This check flags calls to <code>system()</code>, <code>popen()</code>, and <code>_popen()</code>, which execute a command processor. It does not flag calls to <code>system()</code> with a null pointer argument, as such a call checks for the presence of a command processor but does not actually attempt to execute a command.</p>
 <p>This check corresponds to the CERT C Coding Standard rule <a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=2130132">ENV33-C. Do not call system()</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-env33-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/env33-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -3928,14 +3988,14 @@ struct Derived : Base {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-err09-cpp</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=misc-throw-by-value-catch-by-reference.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../misc/throw-by-value-catch-by-reference.html">
 
 </div>
 <h1 id="cert-err09-cpp">cert-err09-cpp</h1>
-<p>The cert-err09-cpp check is an alias, please see <a href="misc-throw-by-value-catch-by-reference.html">misc-throw-by-value-catch-by-reference</a> for more information.</p>
+<p>The cert-err09-cpp check is an alias, please see <a href="../misc/throw-by-value-catch-by-reference.html">misc-throw-by-value-catch-by-reference</a> for more information.</p>
 <p>This check corresponds to the CERT C++ Coding Standard recommendation ERR09-CPP. Throw anonymous temporaries. However, all of the CERT recommendations have been removed from public view, and so their justification for the behavior of this check requires an account on their wiki to view.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err09-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/err09-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -3950,7 +4010,7 @@ struct Derived : Base {
 <p>clang-tidy - cert-err33-c</p>
 </div>
 <h1 id="cert-err33-c">cert-err33-c</h1>
-<p>Warns on unused function return values. Many of the standard library functions return a value that indicates if the call was successful. Ignoring the returned value can cause unexpected behavior if an error has occured. The following functions are checked:</p>
+<p>Warns on unused function return values. Many of the standard library functions return a value that indicates if the call was successful. Ignoring the returned value can cause unexpected behavior if an error has occurred. The following functions are checked:</p>
 <ul>
 <li>aligned_alloc()</li>
 <li>asctime_s()</li>
@@ -4130,13 +4190,13 @@ struct Derived : Base {
 <li>wscanf()</li>
 <li>wscanf_s()</li>
 </ul>
-<p>This check is an alias of check <a href="bugprone-unused-return-value.html">bugprone-unused-return-value</a> with a fixed set of functions.</p>
+<p>This check is an alias of check <a href="../bugprone/unused-return-value.html">bugprone-unused-return-value</a> with a fixed set of functions.</p>
 <p>The check corresponds to a part of CERT C Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/c/ERR33-C.+Detect+and+handle+standard+library+errors">ERR33-C. Detect and handle standard library errors</a>. The list of checked functions is taken from the rule, with following exception:</p>
 <ul>
 <li>The check can not differentiate if a function is called with <code>NULL</code> argument. Therefore the following functions are not checked: <code>mblen</code>, <code>mbrlen</code>, <code>mbrtowc</code>, <code>mbtowc</code>, <code>wctomb</code>, <code>wctomb_s</code></li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err33-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/err33-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4164,7 +4224,7 @@ void func(const char *buff) {
 }</code></pre>
 <p>This check corresponds to the CERT C Coding Standard rule <a href="https://www.securecoding.cert.org/confluence/display/c/ERR34-C.+Detect+errors+when+converting+a+string+to+a+number">ERR34-C. Detect errors when converting a string to a number</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err34-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/err34-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -4182,7 +4242,7 @@ void func(const char *buff) {
 <p>This check flags all call expressions involving <code>setjmp()</code> and <code>longjmp()</code>.</p>
 <p>This check corresponds to the CERT C++ Coding Standard rule <a href="https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=1834">ERR52-CPP. Do not use setjmp() or longjmp()</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err52-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/err52-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4198,7 +4258,7 @@ void func(const char *buff) {
 <p>This check flags all <code>static</code> or <code>thread_local</code> variable declarations where the initializer for the object may throw an exception.</p>
 <p>This check corresponds to the CERT C++ Coding Standard rule <a href="https://www.securecoding.cert.org/confluence/display/cplusplus/ERR58-CPP.+Handle+all+exceptions+thrown+before+main%28%29+begins+executing">ERR58-CPP. Handle all exceptions thrown before main() begins executing</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err58-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/err58-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4214,7 +4274,7 @@ void func(const char *buff) {
 <p>This check flags all throw expressions where the exception object is not nothrow copy constructible.</p>
 <p>This check corresponds to the CERT C++ Coding Standard rule <a href="https://www.securecoding.cert.org/confluence/display/cplusplus/ERR60-CPP.+Exception+objects+must+be+nothrow+copy+constructible">ERR60-CPP. Exception objects must be nothrow copy constructible</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err60-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/err60-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -4228,13 +4288,13 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-err61-cpp</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=misc-throw-by-value-catch-by-reference.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../misc/throw-by-value-catch-by-reference.html">
 
 </div>
 <h1 id="cert-err61-cpp">cert-err61-cpp</h1>
-<p>The cert-err61-cpp check is an alias, please see <a href="misc-throw-by-value-catch-by-reference.html">misc-throw-by-value-catch-by-reference</a> for more information.</p>
+<p>The cert-err61-cpp check is an alias, please see <a href="../misc/throw-by-value-catch-by-reference.html">misc-throw-by-value-catch-by-reference</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-err61-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/err61-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -4245,12 +4305,12 @@ void func(const char *buff) {
     <key>cert-exp42-c</key>
     <name>cert-exp42-c</name>
     <description>
-      <![CDATA[<div class="meta" data-http-equiv=refresh="5;URL=bugprone-suspicious-memory-comparison.html">
+      <![CDATA[<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/suspicious-memory-comparison.html">
 </div>
 <h1 id="cert-exp42-c">cert-exp42-c</h1>
-<p>The cert-exp42-c check is an alias, please see <a href="bugprone-suspicious-memory-comparison.html">bugprone-suspicious-memory-comparison</a> for more information.</p>
+<p>The cert-exp42-c check is an alias, please see <a href="../bugprone/suspicious-memory-comparison.html">bugprone-suspicious-memory-comparison</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-exp42-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/exp42-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4262,13 +4322,13 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-fio38-c</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=misc-non-copyable-objects.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../misc/non-copyable-objects.html">
 
 </div>
 <h1 id="cert-fio38-c">cert-fio38-c</h1>
-<p>The cert-fio38-c check is an alias, please see <a href="misc-non-copyable-objects.html">misc-non-copyable-objects</a> for more information.</p>
+<p>The cert-fio38-c check is an alias, please see <a href="../misc/non-copyable-objects.html">misc-non-copyable-objects</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-fio38-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/fio38-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -4286,7 +4346,7 @@ void func(const char *buff) {
 <p>This check flags <code>for</code> loops where the induction expression has a floating-point type.</p>
 <p>This check corresponds to the CERT C Coding Standard rule <a href="https://www.securecoding.cert.org/confluence/display/c/FLP30-C.+Do+not+use+floating-point+variables+as+loop+counters">FLP30-C. Do not use floating-point variables as loop counters</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-flp30-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/flp30-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -4297,12 +4357,12 @@ void func(const char *buff) {
     <key>cert-flp37-c</key>
     <name>cert-flp37-c</name>
     <description>
-      <![CDATA[<div class="meta" data-http-equiv=refresh="5;URL=bugprone-suspicious-memory-comparison.html">
+      <![CDATA[<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/suspicious-memory-comparison.html">
 </div>
 <h1 id="cert-flp37-c">cert-flp37-c</h1>
-<p>The cert-flp37-c check is an alias, please see <a href="bugprone-suspicious-memory-comparison.html">bugprone-suspicious-memory-comparison</a> for more information.</p>
+<p>The cert-flp37-c check is an alias, please see <a href="../bugprone/suspicious-memory-comparison.html">bugprone-suspicious-memory-comparison</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-flp37-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/flp37-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4318,7 +4378,7 @@ void func(const char *buff) {
 <p>This check flags uses of default <code>operator new</code> where the type has extended alignment (an alignment greater than the fundamental alignment). (The default <code>operator new</code> is guaranteed to provide the correct alignment if the requested alignment is less or equal to the fundamental alignment). Only cases are detected (by design) where the <code>operator new</code> is not user-defined and is not a placement new (the reason is that in these cases we assume that the user provided the correct memory allocation).</p>
 <p>This check corresponds to the CERT C++ Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/MEM57-CPP.+Avoid+using+default+operator+new+for+over-aligned+types">MEM57-CPP. Avoid using default operator new for over-aligned types</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-mem57-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/mem57-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -4332,13 +4392,13 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-msc30-c</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=cert-msc50-cpp.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../cert/msc50-cpp.html">
 
 </div>
 <h1 id="cert-msc30-c">cert-msc30-c</h1>
-<p>The cert-msc30-c check is an alias, please see <a href="cert-msc50-cpp.html">cert-msc50-cpp</a> for more information.</p>
+<p>The cert-msc30-c check is an alias, please see <a href="../cert/msc50-cpp.html">cert-msc50-cpp</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-msc30-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/msc30-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4350,13 +4410,13 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-msc32-c</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=cert-msc51-cpp.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../cert/msc51-cpp.html">
 
 </div>
 <h1 id="cert-msc32-c">cert-msc32-c</h1>
-<p>The cert-msc32-c check is an alias, please see <a href="cert-msc51-cpp.html">cert-msc51-cpp</a> for more information.</p>
+<p>The cert-msc32-c check is an alias, please see <a href="../cert/msc51-cpp.html">cert-msc51-cpp</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-msc32-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/msc32-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4371,7 +4431,7 @@ void func(const char *buff) {
 <h1 id="cert-msc50-cpp">cert-msc50-cpp</h1>
 <p>Pseudorandom number generators use mathematical algorithms to produce a sequence of numbers with good statistical properties, but the numbers produced are not genuinely random. The <code>std::rand()</code> function takes a seed (number), runs a mathematical operation on it and returns the result. By manipulating the seed the result can be predictable. This check warns for the usage of <code>std::rand()</code>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-msc50-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/msc50-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4404,7 +4464,7 @@ void func(const char *buff) {
 <p>A comma-separated list of the type names which are disallowed. Default values are <code>time_t</code>, <code>std::time_t</code>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-msc51-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/msc51-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4416,14 +4476,14 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-oop11-cpp</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=performance-move-constructor-init.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../performance/move-constructor-init.html">
 
 </div>
 <h1 id="cert-oop11-cpp">cert-oop11-cpp</h1>
-<p>The cert-oop11-cpp check is an alias, please see <a href="performance-move-constructor-init.html">performance-move-constructor-init</a> for more information.</p>
+<p>The cert-oop11-cpp check is an alias, please see <a href="../performance/move-constructor-init.html">performance-move-constructor-init</a> for more information.</p>
 <p>This check corresponds to the CERT C++ Coding Standard recommendation OOP11-CPP. Do not copy-initialize members or base classes from a move constructor. However, all of the CERT recommendations have been removed from public view, and so their justification for the behavior of this check requires an account on their wiki to view.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-oop11-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/oop11-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -4437,13 +4497,13 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-oop54-cpp</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=bugprone-unhandled-self-assignment.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/unhandled-self-assignment.html">
 
 </div>
 <h1 id="cert-oop54-cpp">cert-oop54-cpp</h1>
-<p>The cert-oop54-cpp check is an alias, please see <a href="bugprone-unhandled-self-assignment.html">bugprone-unhandled-self-assignment</a> for more information.</p>
+<p>The cert-oop54-cpp check is an alias, please see <a href="../bugprone/unhandled-self-assignment.html">bugprone-unhandled-self-assignment</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-oop54-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/oop54-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4474,7 +4534,7 @@ void func(const char *buff) {
 </div>
 <p>This check corresponds to the CERT C++ Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP57-CPP.+Prefer+special+member+functions+and+overloaded+operators+to+C+Standard+Library+functions">OOP57-CPP. Prefer special member functions and overloaded operators to C Standard Library functions</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-oop57-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/oop57-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -4492,7 +4552,7 @@ void func(const char *buff) {
 <p>Finds assignments to the copied object and its direct or indirect members in copy constructors and copy assignment operators.</p>
 <p>This check corresponds to the CERT C Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP58-CPP.+Copy+operations+must+not+mutate+the+source+object">OOP58-CPP. Copy operations must not mutate the source object</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-oop58-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/oop58-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -4506,13 +4566,13 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-pos44-c</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=bugprone-bad-signal-to-kill-thread.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/bad-signal-to-kill-thread.html">
 
 </div>
 <h1 id="cert-pos44-c">cert-pos44-c</h1>
-<p>The cert-pos44-c check is an alias, please see <a href="bugprone-bad-signal-to-kill-thread.html">bugprone-bad-signal-to-kill-thread</a> for more information.</p>
+<p>The cert-pos44-c check is an alias, please see <a href="../bugprone/bad-signal-to-kill-thread.html">bugprone-bad-signal-to-kill-thread</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-pos44-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/pos44-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4524,13 +4584,13 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-pos47-c</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=concurrency-thread-canceltype-asynchronous.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../concurrency/thread-canceltype-asynchronous.html">
 
 </div>
 <h1 id="cert-pos47-c">cert-pos47-c</h1>
-<p>The cert-pos47-c check is an alias, please see <a href="concurrency-thread-canceltype-asynchronous.html">concurrency-thread-canceltype-asynchronous</a> for more information.</p>
+<p>The cert-pos47-c check is an alias, please see <a href="../concurrency/thread-canceltype-asynchronous.html">concurrency-thread-canceltype-asynchronous</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-pos47-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/pos47-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4542,13 +4602,13 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-sig30-c</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=bugprone-signal-handler.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/signal-handler.html">
 
 </div>
 <h1 id="cert-sig30-c">cert-sig30-c</h1>
-<p>The cert-sig30-c check is an alias, please see <a href="bugprone-signal-handler.html">bugprone-signal-handler</a> for more information.</p>
+<p>The cert-sig30-c check is an alias, please see <a href="../bugprone/signal-handler.html">bugprone-signal-handler</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-sig30-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/sig30-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4560,13 +4620,13 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - cert-str34-c</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=bugprone-signed-char-misuse.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/signed-char-misuse.html">
 
 </div>
 <h1 id="cert-str34-c">cert-str34-c</h1>
-<p>The cert-str34-c check is an alias, please see <a href="bugprone-signed-char-misuse.html">bugprone-signed-char-misuse</a> for more information.</p>
+<p>The cert-str34-c check is an alias, please see <a href="../bugprone/signed-char-misuse.html">bugprone-signed-char-misuse</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert-str34-c.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/str34-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4584,7 +4644,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-core.callandmessage">clang-analyzer-core.CallAndMessage</h1>
 <p>The clang-analyzer-core.CallAndMessage check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-callandmessage">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-core.CallAndMessage.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.CallAndMessage.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4602,7 +4662,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-core.dividezero">clang-analyzer-core.DivideZero</h1>
 <p>The clang-analyzer-core.DivideZero check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-dividezero">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-core.DivideZero.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.DivideZero.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4617,7 +4677,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-core.dynamictypepropagation">clang-analyzer-core.DynamicTypePropagation</h1>
 <p>Generate dynamic type information</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-core.DynamicTypePropagation.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.DynamicTypePropagation.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4635,7 +4695,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-core.nonnullparamchecker">clang-analyzer-core.NonNullParamChecker</h1>
 <p>The clang-analyzer-core.NonNullParamChecker check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-nonnullparamchecker">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-core.NonNullParamChecker.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.NonNullParamChecker.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4653,7 +4713,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-core.nulldereference">clang-analyzer-core.NullDereference</h1>
 <p>The clang-analyzer-core.NullDereference check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-nulldereference">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-core.NullDereference.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.NullDereference.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4671,7 +4731,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-core.stackaddressescape">clang-analyzer-core.StackAddressEscape</h1>
 <p>The clang-analyzer-core.StackAddressEscape check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-stackaddressescape">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-core.StackAddressEscape.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.StackAddressEscape.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4689,7 +4749,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-core.undefinedbinaryoperatorresult">clang-analyzer-core.UndefinedBinaryOperatorResult</h1>
 <p>The clang-analyzer-core.UndefinedBinaryOperatorResult check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-undefinedbinaryoperatorresult">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-core.UndefinedBinaryOperatorResult.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.UndefinedBinaryOperatorResult.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4707,7 +4767,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-core.uninitialized.arraysubscript">clang-analyzer-core.uninitialized.ArraySubscript</h1>
 <p>The clang-analyzer-core.uninitialized.ArraySubscript check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-arraysubscript">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-core.uninitialized.ArraySubscript.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.uninitialized.ArraySubscript.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4725,7 +4785,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-core.uninitialized.assign">clang-analyzer-core.uninitialized.Assign</h1>
 <p>The clang-analyzer-core.uninitialized.Assign check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-assign">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-core.uninitialized.Assign.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.uninitialized.Assign.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4743,7 +4803,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-core.uninitialized.branch">clang-analyzer-core.uninitialized.Branch</h1>
 <p>The clang-analyzer-core.uninitialized.Branch check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-branch">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-core.uninitialized.Branch.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.uninitialized.Branch.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4758,7 +4818,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-core.uninitialized.capturedblockvariable">clang-analyzer-core.uninitialized.CapturedBlockVariable</h1>
 <p>Check for blocks that capture uninitialized values</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-core.uninitialized.CapturedBlockVariable.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.uninitialized.CapturedBlockVariable.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4776,7 +4836,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-core.uninitialized.undefreturn">clang-analyzer-core.uninitialized.UndefReturn</h1>
 <p>The clang-analyzer-core.uninitialized.UndefReturn check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-undefreturn">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-core.uninitialized.UndefReturn.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.uninitialized.UndefReturn.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4794,7 +4854,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-core.vlasize">clang-analyzer-core.VLASize</h1>
 <p>The clang-analyzer-core.VLASize check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-vlasize">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-core.VLASize.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.VLASize.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4809,7 +4869,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-cplusplus.innerpointer">clang-analyzer-cplusplus.InnerPointer</h1>
 <p>Check for inner pointers of C++ containers used after re/deallocation</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-cplusplus.InnerPointer.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.InnerPointer.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4827,7 +4887,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-cplusplus.move">clang-analyzer-cplusplus.Move</h1>
 <p>The clang-analyzer-cplusplus.Move check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-move">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-cplusplus.Move.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.Move.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4845,7 +4905,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-cplusplus.newdelete">clang-analyzer-cplusplus.NewDelete</h1>
 <p>The clang-analyzer-cplusplus.NewDelete check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdelete">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-cplusplus.NewDelete.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.NewDelete.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4863,7 +4923,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-cplusplus.newdeleteleaks">clang-analyzer-cplusplus.NewDeleteLeaks</h1>
 <p>The clang-analyzer-cplusplus.NewDeleteLeaks check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdeleteleaks">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-cplusplus.NewDeleteLeaks.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.NewDeleteLeaks.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4881,7 +4941,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-deadcode.deadstores">clang-analyzer-deadcode.DeadStores</h1>
 <p>The clang-analyzer-deadcode.DeadStores check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#deadcode-deadstores">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-deadcode.DeadStores.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/deadcode.DeadStores.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4899,7 +4959,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-nullability.nullabledereferenced">clang-analyzer-nullability.NullableDereferenced</h1>
 <p>The clang-analyzer-nullability.NullableDereferenced check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullabledereferenced">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-nullability.NullableDereferenced.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/nullability.NullableDereferenced.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4917,7 +4977,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-nullability.nullablepassedtononnull">clang-analyzer-nullability.NullablePassedToNonnull</h1>
 <p>The clang-analyzer-nullability.NullablePassedToNonnull check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablepassedtononnull">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-nullability.NullablePassedToNonnull.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/nullability.NullablePassedToNonnull.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4932,7 +4992,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-nullability.nullablereturnedfromnonnull">clang-analyzer-nullability.NullableReturnedFromNonnull</h1>
 <p>Warns when a nullable pointer is returned from a function that has _Nonnull return type.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-nullability.NullableReturnedFromNonnull.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/nullability.NullableReturnedFromNonnull.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4950,7 +5010,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-nullability.nullpassedtononnull">clang-analyzer-nullability.NullPassedToNonnull</h1>
 <p>The clang-analyzer-nullability.NullPassedToNonnull check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullpassedtononnull">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-nullability.NullPassedToNonnull.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/nullability.NullPassedToNonnull.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4968,7 +5028,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-nullability.nullreturnedfromnonnull">clang-analyzer-nullability.NullReturnedFromNonnull</h1>
 <p>The clang-analyzer-nullability.NullReturnedFromNonnull check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullreturnedfromnonnull">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-nullability.NullReturnedFromNonnull.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/nullability.NullReturnedFromNonnull.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -4986,7 +5046,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-optin.cplusplus.uninitializedobject">clang-analyzer-optin.cplusplus.UninitializedObject</h1>
 <p>The clang-analyzer-optin.cplusplus.UninitializedObject check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-uninitializedobject">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-optin.cplusplus.UninitializedObject.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.cplusplus.UninitializedObject.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5004,7 +5064,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-optin.cplusplus.virtualcall">clang-analyzer-optin.cplusplus.VirtualCall</h1>
 <p>The clang-analyzer-optin.cplusplus.VirtualCall check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-virtualcall">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-optin.cplusplus.VirtualCall.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.cplusplus.VirtualCall.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5022,7 +5082,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-optin.mpi.mpi-checker">clang-analyzer-optin.mpi.MPI-Checker</h1>
 <p>The clang-analyzer-optin.mpi.MPI-Checker check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-mpi-mpi-checker">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-optin.mpi.MPI-Checker.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.mpi.MPI-Checker.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5040,7 +5100,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-optin.osx.cocoa.localizability.emptylocalizationcontextchecker">clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker</h1>
 <p>The clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-emptylocalizationcontextchecker">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.osx.cocoa.localizability.EmptyLocalizationContextChecker.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5058,7 +5118,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-optin.osx.cocoa.localizability.nonlocalizedstringchecker">clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker</h1>
 <p>The clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-nonlocalizedstringchecker">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.osx.cocoa.localizability.NonLocalizedStringChecker.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5073,7 +5133,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-optin.osx.osobjectcstylecast">clang-analyzer-optin.osx.OSObjectCStyleCast</h1>
 <p>Checker for C-style casts of OSObjects</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-optin.osx.OSObjectCStyleCast.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.osx.OSObjectCStyleCast.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5088,7 +5148,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-optin.performance.gcdantipattern">clang-analyzer-optin.performance.GCDAntipattern</h1>
 <p>Check for performance anti-patterns when using Grand Central Dispatch</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-optin.performance.GCDAntipattern.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.performance.GCDAntipattern.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5103,7 +5163,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-optin.performance.padding">clang-analyzer-optin.performance.Padding</h1>
 <p>Check for excessively padded structs.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-optin.performance.Padding.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.performance.Padding.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5118,7 +5178,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-optin.portability.unixapi">clang-analyzer-optin.portability.UnixAPI</h1>
 <p>Finds implementation-defined behavior in UNIX/Posix functions</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-optin.portability.UnixAPI.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.portability.UnixAPI.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5136,7 +5196,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.api">clang-analyzer-osx.API</h1>
 <p>The clang-analyzer-osx.API check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-api">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.API.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.API.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5154,7 +5214,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.atsync">clang-analyzer-osx.cocoa.AtSync</h1>
 <p>The clang-analyzer-osx.cocoa.AtSync check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-atsync">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.AtSync.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.AtSync.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5169,7 +5229,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.autoreleasewrite">clang-analyzer-osx.cocoa.AutoreleaseWrite</h1>
 <p>Warn about potentially crashing writes to autoreleasing objects from different autoreleasing pools in Objective-C</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.AutoreleaseWrite.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.AutoreleaseWrite.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5187,7 +5247,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.classrelease">clang-analyzer-osx.cocoa.ClassRelease</h1>
 <p>The clang-analyzer-osx.cocoa.ClassRelease check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-classrelease">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.ClassRelease.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.ClassRelease.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5205,7 +5265,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.dealloc">clang-analyzer-osx.cocoa.Dealloc</h1>
 <p>The clang-analyzer-osx.cocoa.Dealloc check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-dealloc">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.Dealloc.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.Dealloc.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5223,7 +5283,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.incompatiblemethodtypes">clang-analyzer-osx.cocoa.IncompatibleMethodTypes</h1>
 <p>The clang-analyzer-osx.cocoa.IncompatibleMethodTypes check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-incompatiblemethodtypes">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.IncompatibleMethodTypes.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.IncompatibleMethodTypes.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5238,7 +5298,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.loops">clang-analyzer-osx.cocoa.Loops</h1>
 <p>Improved modeling of loops using Cocoa collection types</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.Loops.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.Loops.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5253,7 +5313,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.missingsupercall">clang-analyzer-osx.cocoa.MissingSuperCall</h1>
 <p>Warn about Objective-C methods that lack a necessary call to super</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.MissingSuperCall.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.MissingSuperCall.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5271,7 +5331,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.nilarg">clang-analyzer-osx.cocoa.NilArg</h1>
 <p>The clang-analyzer-osx.cocoa.NilArg check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nilarg">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.NilArg.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.NilArg.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5286,7 +5346,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.nonnilreturnvalue">clang-analyzer-osx.cocoa.NonNilReturnValue</h1>
 <p>Model the APIs that are guaranteed to return a non-nil value</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.NonNilReturnValue.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.NonNilReturnValue.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5304,7 +5364,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.nsautoreleasepool">clang-analyzer-osx.cocoa.NSAutoreleasePool</h1>
 <p>The clang-analyzer-osx.cocoa.NSAutoreleasePool check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nsautoreleasepool">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.NSAutoreleasePool.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.NSAutoreleasePool.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5322,7 +5382,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.nserror">clang-analyzer-osx.cocoa.NSError</h1>
 <p>The clang-analyzer-osx.cocoa.NSError check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nserror">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.NSError.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.NSError.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5340,7 +5400,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.objcgenerics">clang-analyzer-osx.cocoa.ObjCGenerics</h1>
 <p>The clang-analyzer-osx.cocoa.ObjCGenerics check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-objcgenerics">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.ObjCGenerics.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.ObjCGenerics.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5358,7 +5418,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.retaincount">clang-analyzer-osx.cocoa.RetainCount</h1>
 <p>The clang-analyzer-osx.cocoa.RetainCount check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-retaincount">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.RetainCount.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.RetainCount.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5373,7 +5433,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.runloopautoreleaseleak">clang-analyzer-osx.cocoa.RunLoopAutoreleaseLeak</h1>
 <p>Check for leaked memory in autorelease pools that will never be drained</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.RunLoopAutoreleaseLeak.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.RunLoopAutoreleaseLeak.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5391,7 +5451,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.selfinit">clang-analyzer-osx.cocoa.SelfInit</h1>
 <p>The clang-analyzer-osx.cocoa.SelfInit check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-selfinit">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.SelfInit.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.SelfInit.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5409,7 +5469,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.superdealloc">clang-analyzer-osx.cocoa.SuperDealloc</h1>
 <p>The clang-analyzer-osx.cocoa.SuperDealloc check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-superdealloc">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.SuperDealloc.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.SuperDealloc.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5427,7 +5487,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.unusedivars">clang-analyzer-osx.cocoa.UnusedIvars</h1>
 <p>The clang-analyzer-osx.cocoa.UnusedIvars check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-unusedivars">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.UnusedIvars.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.UnusedIvars.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5445,7 +5505,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.cocoa.variadicmethodtypes">clang-analyzer-osx.cocoa.VariadicMethodTypes</h1>
 <p>The clang-analyzer-osx.cocoa.VariadicMethodTypes check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-variadicmethodtypes">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.cocoa.VariadicMethodTypes.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.VariadicMethodTypes.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5463,7 +5523,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.corefoundation.cferror">clang-analyzer-osx.coreFoundation.CFError</h1>
 <p>The clang-analyzer-osx.coreFoundation.CFError check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cferror">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.coreFoundation.CFError.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFError.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5481,7 +5541,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.corefoundation.cfnumber">clang-analyzer-osx.coreFoundation.CFNumber</h1>
 <p>The clang-analyzer-osx.coreFoundation.CFNumber check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfnumber">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.coreFoundation.CFNumber.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFNumber.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5499,7 +5559,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.corefoundation.cfretainrelease">clang-analyzer-osx.coreFoundation.CFRetainRelease</h1>
 <p>The clang-analyzer-osx.coreFoundation.CFRetainRelease check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfretainrelease">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.coreFoundation.CFRetainRelease.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFRetainRelease.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5517,7 +5577,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.corefoundation.containers.outofbounds">clang-analyzer-osx.coreFoundation.containers.OutOfBounds</h1>
 <p>The clang-analyzer-osx.coreFoundation.containers.OutOfBounds check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-outofbounds">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.coreFoundation.containers.OutOfBounds.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.coreFoundation.containers.OutOfBounds.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5535,7 +5595,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.corefoundation.containers.pointersizedvalues">clang-analyzer-osx.coreFoundation.containers.PointerSizedValues</h1>
 <p>The clang-analyzer-osx.coreFoundation.containers.PointerSizedValues check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-pointersizedvalues">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.coreFoundation.containers.PointerSizedValues.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.coreFoundation.containers.PointerSizedValues.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5550,7 +5610,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.mig">clang-analyzer-osx.MIG</h1>
 <p>Find violations of the Mach Interface Generator calling convention</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.MIG.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.MIG.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5565,7 +5625,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.numberobjectconversion">clang-analyzer-osx.NumberObjectConversion</h1>
 <p>Check for erroneous conversions of objects representing numbers into numbers</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.NumberObjectConversion.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.NumberObjectConversion.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5580,7 +5640,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.objcproperty">clang-analyzer-osx.ObjCProperty</h1>
 <p>Check for proper uses of Objective-C properties</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.ObjCProperty.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.ObjCProperty.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5595,7 +5655,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.osobjectretaincount">clang-analyzer-osx.OSObjectRetainCount</h1>
 <p>Check for leaks and improper reference count management for OSObject</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.OSObjectRetainCount.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.OSObjectRetainCount.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5613,7 +5673,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-osx.seckeychainapi">clang-analyzer-osx.SecKeychainAPI</h1>
 <p>The clang-analyzer-osx.SecKeychainAPI check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-seckeychainapi">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-osx.SecKeychainAPI.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.SecKeychainAPI.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5631,7 +5691,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-security.floatloopcounter">clang-analyzer-security.FloatLoopCounter</h1>
 <p>The clang-analyzer-security.FloatLoopCounter check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-floatloopcounter">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-security.FloatLoopCounter.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.FloatLoopCounter.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5649,7 +5709,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-security.insecureapi.bcmp">clang-analyzer-security.insecureAPI.bcmp</h1>
 <p>The clang-analyzer-security.insecureAPI.bcmp check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcmp">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-security.insecureAPI.bcmp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.bcmp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5667,7 +5727,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-security.insecureapi.bcopy">clang-analyzer-security.insecureAPI.bcopy</h1>
 <p>The clang-analyzer-security.insecureAPI.bcopy check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcopy">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-security.insecureAPI.bcopy.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.bcopy.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5685,7 +5745,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-security.insecureapi.bzero">clang-analyzer-security.insecureAPI.bzero</h1>
 <p>The clang-analyzer-security.insecureAPI.bzero check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bzero">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-security.insecureAPI.bzero.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.bzero.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5703,7 +5763,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-security.insecureapi.deprecatedorunsafebufferhandling">clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling</h1>
 <p>The clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-deprecatedorunsafebufferhandling">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.DeprecatedOrUnsafeBufferHandling.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5721,7 +5781,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-security.insecureapi.getpw">clang-analyzer-security.insecureAPI.getpw</h1>
 <p>The clang-analyzer-security.insecureAPI.getpw check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-getpw">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-security.insecureAPI.getpw.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.getpw.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5739,7 +5799,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-security.insecureapi.gets">clang-analyzer-security.insecureAPI.gets</h1>
 <p>The clang-analyzer-security.insecureAPI.gets check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-gets">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-security.insecureAPI.gets.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.gets.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5757,7 +5817,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-security.insecureapi.mkstemp">clang-analyzer-security.insecureAPI.mkstemp</h1>
 <p>The clang-analyzer-security.insecureAPI.mkstemp check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mkstemp">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-security.insecureAPI.mkstemp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.mkstemp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5775,7 +5835,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-security.insecureapi.mktemp">clang-analyzer-security.insecureAPI.mktemp</h1>
 <p>The clang-analyzer-security.insecureAPI.mktemp check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mktemp">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-security.insecureAPI.mktemp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.mktemp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5793,7 +5853,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-security.insecureapi.rand">clang-analyzer-security.insecureAPI.rand</h1>
 <p>The clang-analyzer-security.insecureAPI.rand check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-rand">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-security.insecureAPI.rand.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.rand.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5811,7 +5871,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-security.insecureapi.strcpy">clang-analyzer-security.insecureAPI.strcpy</h1>
 <p>The clang-analyzer-security.insecureAPI.strcpy check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-strcpy">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-security.insecureAPI.strcpy.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.strcpy.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5829,7 +5889,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-security.insecureapi.uncheckedreturn">clang-analyzer-security.insecureAPI.UncheckedReturn</h1>
 <p>The clang-analyzer-security.insecureAPI.UncheckedReturn check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-uncheckedreturn">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-security.insecureAPI.UncheckedReturn.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.UncheckedReturn.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5847,7 +5907,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-security.insecureapi.vfork">clang-analyzer-security.insecureAPI.vfork</h1>
 <p>The clang-analyzer-security.insecureAPI.vfork check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-vfork">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-security.insecureAPI.vfork.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.vfork.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5865,7 +5925,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-unix.api">clang-analyzer-unix.API</h1>
 <p>The clang-analyzer-unix.API check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-api">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-unix.API.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.API.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5883,7 +5943,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-unix.cstring.badsizearg">clang-analyzer-unix.cstring.BadSizeArg</h1>
 <p>The clang-analyzer-unix.cstring.BadSizeArg check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-badsizearg">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-unix.cstring.BadSizeArg.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.cstring.BadSizeArg.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5901,7 +5961,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-unix.cstring.nullarg">clang-analyzer-unix.cstring.NullArg</h1>
 <p>The clang-analyzer-unix.cstring.NullArg check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-nullarg">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-unix.cstring.NullArg.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.cstring.NullArg.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5919,7 +5979,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-unix.malloc">clang-analyzer-unix.Malloc</h1>
 <p>The clang-analyzer-unix.Malloc check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-malloc">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-unix.Malloc.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.Malloc.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5937,7 +5997,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-unix.mallocsizeof">clang-analyzer-unix.MallocSizeof</h1>
 <p>The clang-analyzer-unix.MallocSizeof check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-mallocsizeof">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-unix.MallocSizeof.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.MallocSizeof.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5955,7 +6015,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-unix.mismatcheddeallocator">clang-analyzer-unix.MismatchedDeallocator</h1>
 <p>The clang-analyzer-unix.MismatchedDeallocator check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-mismatcheddeallocator">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-unix.MismatchedDeallocator.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.MismatchedDeallocator.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5973,7 +6033,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-unix.vfork">clang-analyzer-unix.Vfork</h1>
 <p>The clang-analyzer-unix.Vfork check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-vfork">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-unix.Vfork.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.Vfork.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -5988,7 +6048,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-valist.copytoself">clang-analyzer-valist.CopyToSelf</h1>
 <p>Check for va_lists which are copied onto itself.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-valist.CopyToSelf.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/valist.CopyToSelf.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6003,7 +6063,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-valist.uninitialized">clang-analyzer-valist.Uninitialized</h1>
 <p>Check for usages of uninitialized (or already released) va_lists.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-valist.Uninitialized.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/valist.Uninitialized.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6018,7 +6078,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-valist.unterminated">clang-analyzer-valist.Unterminated</h1>
 <p>Check for va_lists which are not released by a va_end call.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer-valist.Unterminated.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/valist.Unterminated.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6050,7 +6110,7 @@ sleep(1); // implementation may use SIGALRM</code></pre>
 <p>If you want to identify thread-unsafe API for at least one libc or unsure which libc will be used, use <span class="title-ref">any</span> (default).</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/concurrency-mt-unsafe.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/concurrency/mt-unsafe.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6069,7 +6129,7 @@ sleep(1); // implementation may use SIGALRM</code></pre>
 </blockquote>
 <p>This check corresponds to the CERT C Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/c/POS47-C.+Do+not+use+threads+that+can+be+canceled+asynchronously">POS47-C. Do not use threads that can be canceled asynchronously</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/concurrency-thread-canceltype-asynchronous.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/concurrency/thread-canceltype-asynchronous.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6081,13 +6141,13 @@ sleep(1); // implementation may use SIGALRM</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - cppcoreguidelines-avoid-c-arrays</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=modernize-avoid-c-arrays.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/avoid-c-arrays.html">
 
 </div>
 <h1 id="cppcoreguidelines-avoid-c-arrays">cppcoreguidelines-avoid-c-arrays</h1>
-<p>The cppcoreguidelines-avoid-c-arrays check is an alias, please see <a href="modernize-avoid-c-arrays.html">modernize-avoid-c-arrays</a> for more information.</p>
+<p>The cppcoreguidelines-avoid-c-arrays check is an alias, please see <a href="../modernize/avoid-c-arrays.html">modernize-avoid-c-arrays</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-avoid-c-arrays.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-c-arrays.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6130,7 +6190,7 @@ early_exit:
 some_operation();</code></pre>
 <p>All other uses of <code>goto</code> are diagnosed in <span class="title-ref">C++</span>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-avoid-goto.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-goto.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -6144,13 +6204,13 @@ some_operation();</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - cppcoreguidelines-avoid-magic-numbers</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=readability-magic-numbers.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../readability/magic-numbers.html">
 
 </div>
 <h1 id="cppcoreguidelines-avoid-magic-numbers">cppcoreguidelines-avoid-magic-numbers</h1>
-<p>The cppcoreguidelines-avoid-magic-numbers check is an alias, please see <a href="readability-magic-numbers.html">readability-magic-numbers</a> for more information.</p>
+<p>The cppcoreguidelines-avoid-magic-numbers check is an alias, please see <a href="../readability/magic-numbers.html">readability-magic-numbers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-avoid-magic-numbers.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-magic-numbers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6189,7 +6249,7 @@ private:
 };</code></pre>
 <p>Variables: <code>a</code>, <code>c</code>, <code>c_ptr1</code>, <code>c_ptr2</code>, <code>c_const_ptr</code> and <code>c_reference</code>, will all generate warnings since they are either: a globally accessible variable and non-const, a pointer or reference providing global access to non-const data or both.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-avoid-non-const-global-variables.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-non-const-global-variables.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6201,13 +6261,13 @@ private:
       <![CDATA[<div class="title">
 <p>clang-tidy - cppcoreguidelines-c-copy-assignment-signature</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=misc-unconventional-assign-operator.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../misc/unconventional-assign-operator.html">
 
 </div>
 <h1 id="cppcoreguidelines-c-copy-assignment-signature">cppcoreguidelines-c-copy-assignment-signature</h1>
-<p>The cppcoreguidelines-c-copy-assignment-signature check is an alias, please see <a href="misc-unconventional-assign-operator.html">misc-unconventional-assign-operator</a> for more information.</p>
+<p>The cppcoreguidelines-c-copy-assignment-signature check is an alias, please see <a href="../misc/unconventional-assign-operator.html">misc-unconventional-assign-operator</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-c-copy-assignment-signature.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/c-copy-assignment-signature.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -6221,13 +6281,13 @@ private:
       <![CDATA[<div class="title">
 <p>clang-tidy - cppcoreguidelines-explicit-virtual-functions</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=modernize-use-override.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/use-override.html">
 
 </div>
 <h1 id="cppcoreguidelines-explicit-virtual-functions">cppcoreguidelines-explicit-virtual-functions</h1>
-<p>The cppcoreguidelines-explicit-virtual-functions check is an alias, please see <a href="modernize-use-override.html">modernize-use-override</a> for more information.</p>
+<p>The cppcoreguidelines-explicit-virtual-functions check is an alias, please see <a href="../modernize/use-override.html">modernize-use-override</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-explicit-virtual-functions.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/explicit-virtual-functions.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6281,7 +6341,7 @@ void function() {
 <p>A string specifying the header to include to get the definition of <span class="title-ref">NAN</span>. Default is <span class="title-ref">&lt;math.h&gt;</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-init-variables.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/init-variables.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -6300,7 +6360,7 @@ void function() {
 <p>This rule is part of the "Interfaces" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-global-init">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-global-init</a></p>
 <p>Note that currently this does not flag calls to non-constexpr functions, and therefore globals could still be accessed from functions themselves.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-interfaces-global-init.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/interfaces-global-init.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -6354,7 +6414,7 @@ test.cpp:3:9: warning: variadic macro &#39;F2&#39; used; consider using a &#39;c
 <p>Boolean flag to toggle ignoring command-line-defined macros. Default value is <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-macro-usage.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/macro-usage.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6430,7 +6490,7 @@ test.cpp:3:9: warning: variadic macro &#39;F2&#39; used; consider using a &#39;c
 </blockquote>
 <p>You may have encountered messages like "narrowing conversion from 'unsigned int' to signed type 'int' is implementation-defined". The C/C++ standard does not mandate two's complement for signed integers, and so the compiler is free to define what the semantics are for converting an unsigned integer to signed integer. Clang's implementation uses the two's complement format.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-narrowing-conversions.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/narrowing-conversions.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -6471,7 +6531,7 @@ struct some_struct* s = (struct some_struct*) malloc(sizeof(struct some_struct))
 <p>Semicolon-separated list of fully qualified names of memory allocation functions. Defaults to <code>::realloc</code>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-no-malloc.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/no-malloc.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6483,13 +6543,13 @@ struct some_struct* s = (struct some_struct*) malloc(sizeof(struct some_struct))
       <![CDATA[<div class="title">
 <p>clang-tidy - cppcoreguidelines-non-private-member-variables-in-classes</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=misc-non-private-member-variables-in-classes.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../misc/non-private-member-variables-in-classes.html">
 
 </div>
 <h1 id="cppcoreguidelines-non-private-member-variables-in-classes">cppcoreguidelines-non-private-member-variables-in-classes</h1>
-<p>The cppcoreguidelines-non-private-member-variables-in-classes check is an alias, please see <a href="misc-non-private-member-variables-in-classes.html">misc-non-private-member-variables-in-classes</a> for more information.</p>
+<p>The cppcoreguidelines-non-private-member-variables-in-classes check is an alias, please see <a href="../misc/non-private-member-variables-in-classes.html">misc-non-private-member-variables-in-classes</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-non-private-member-variables-in-classes.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/non-private-member-variables-in-classes.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6615,7 +6675,7 @@ Owner2 = Owner1; // Conceptual Leak of initial resource of Owner2!
 Owner1 = nullptr;</code></pre>
 <p>The semantic of a <code>gsl::owner&lt;T*&gt;</code> is mostly like a <code>std::unique_ptr&lt;T&gt;</code>, therefore assignment of two <code>gsl::owner&lt;T*&gt;</code> is considered a move, which requires that the resource <code>Owner2</code> must have been released before the assignment. This kind of condition could be caught in later improvements of this check with flowsensitive analysis. Currently, the <span class="title-ref">Clang Static Analyzer</span> catches this bug for dynamic memory, but not for general types of resources.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-owning-memory.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/owning-memory.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -6634,7 +6694,7 @@ Owner1 = nullptr;</code></pre>
 <p>This check implements <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c49-prefer-initialization-to-assignment-in-constructors">C.49</a> from the CppCoreGuidelines.</p>
 <p>If the language version is <span class="title-ref">C++ 11</span> or above, the constructor is the default constructor of the class, the field is not a bitfield (only in case of earlier language version than <span class="title-ref">C++ 20</span>), furthermore the assigned value is a literal, negated literal or <code>enum</code> constant then the preferred place of the initialization is at the class member declaration.</p>
 <p>This latter rule is <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c48-prefer-in-class-initializers-to-member-initializers-in-constructors-for-constant-initializers">C.48</a> from CppCoreGuidelines.</p>
-<p>Please note, that this check does not enforce this latter rule for initializations already implemented as member initializers. For that purpose see check <a href="modernize-use-default-member-init.html">modernize-use-default-member-init</a>.</p>
+<p>Please note, that this check does not enforce this latter rule for initializations already implemented as member initializers. For that purpose see check <a href="../modernize/use-default-member-init.html">modernize-use-default-member-init</a>.</p>
 <h2 id="example-1">Example 1</h2>
 <pre class="c++"><code>class C {
   int n;
@@ -6690,7 +6750,7 @@ public:
   }
 };</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-prefer-member-initializer.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/prefer-member-initializer.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -6709,7 +6769,7 @@ public:
 <p>Pointers should not be used as arrays. <code>span&lt;T&gt;</code> is a bounds-checked, safe alternative to using pointers to access arrays.</p>
 <p>This rule is part of the "Bounds safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-decay">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-decay</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-bounds-array-to-pointer-decay.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-bounds-array-to-pointer-decay.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6735,7 +6795,7 @@ public:
 <p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-bounds-constant-array-index.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-bounds-constant-array-index.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6752,7 +6812,7 @@ public:
 <p>Pointers should only refer to single objects, and pointer arithmetic is fragile and easy to get wrong. <code>span&lt;T&gt;</code> is a bounds-checked, safe type for accessing arrays of data.</p>
 <p>This rule is part of the "Bounds safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-arithmetic">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-arithmetic</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-bounds-pointer-arithmetic.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-bounds-pointer-arithmetic.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6769,7 +6829,7 @@ public:
 <p>Modifying a variable that was declared const is undefined behavior, even with <code>const_cast</code>.</p>
 <p>This rule is part of the "Type safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-constcast">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-constcast</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-const-cast.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-const-cast.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6786,7 +6846,7 @@ public:
 <p>Use of these casts can violate type safety and cause the program to access a variable that is actually of type X to be accessed as if it were of an unrelated type Z. Note that a C-style <code>(T)expression</code> cast means to perform the first of the following that is possible: a <code>const_cast</code>, a <code>static_cast</code>, a <code>static_cast</code> followed by a <code>const_cast</code>, a <code>reinterpret_cast</code>, or a <code>reinterpret_cast</code> followed by a <code>const_cast</code>. This rule bans <code>(T)expression</code> only when used to perform an unsafe cast.</p>
 <p>This rule is part of the "Type safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-cstylecast">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-cstylecast</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-cstyle-cast.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-cstyle-cast.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6814,7 +6874,7 @@ public:
 </div>
 <p>This rule is part of the "Type safety" profile of the C++ Core Guidelines, corresponding to rule Type.6. See <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-memberinit">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-memberinit</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-member-init.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -6833,7 +6893,7 @@ public:
 <p>Use of these casts can violate type safety and cause the program to access a variable that is actually of type <code>X</code> to be accessed as if it were of an unrelated type <code>Z</code>.</p>
 <p>This rule is part of the "Type safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-reinterpretcast">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-reinterpretcast</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-reinterpret-cast.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-reinterpret-cast.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6850,7 +6910,7 @@ public:
 <p>Use of these casts can violate type safety and cause the program to access a variable that is actually of type <code>X</code> to be accessed as if it were of an unrelated type <code>Z</code>.</p>
 <p>This rule is part of the "Type safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-downcast">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-downcast</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-static-cast-downcast.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-static-cast-downcast.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6867,7 +6927,7 @@ public:
 <p>Reading from a union member assumes that member was the last one written, and writing to a union member assumes another member with a nontrivial destructor had its destructor called. This is fragile because it cannot generally be enforced to be safe in the language and so relies on programmer discipline to get it right.</p>
 <p>This rule is part of the "Type safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-unions">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-unions</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-union-access.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-union-access.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6885,7 +6945,7 @@ public:
 <p>Passing to varargs assumes the correct type will be read. This is fragile because it cannot generally be enforced to be safe in the language and so relies on programmer discipline to get it right.</p>
 <p>This rule is part of the "Type safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-varargs">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-varargs</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-vararg.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-vararg.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -6910,7 +6970,7 @@ D d;
 use(d);  // Slice.</code></pre>
 <p>See the relevant C++ Core Guidelines sections for details: <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es63-dont-slice">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es63-dont-slice</a> <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c145-access-polymorphic-objects-through-pointers-and-references">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c145-access-polymorphic-objects-through-pointers-and-references</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-slicing.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/slicing.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -6957,7 +7017,7 @@ use(d);  // Slice.</code></pre>
 };</code></pre>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-special-member-functions.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/special-member-functions.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -7000,7 +7060,7 @@ public:
   virtual ~Bar(){}
 };</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-virtual-class-destructor.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/virtual-class-destructor.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7022,7 +7082,7 @@ public:
 </ul>
 <p>The corresponding information about the problem of <code>OSSpinlock</code>: <a href="https://blog.postmates.com/why-spinlocks-are-bad-on-ios-b69fc5221058">https://blog.postmates.com/why-spinlocks-are-bad-on-ios-b69fc5221058</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/darwin-avoid-spinlock.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/darwin/avoid-spinlock.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7040,7 +7100,7 @@ public:
 <p>Programmers have also been known to make <code>dispatch_once_t</code> variables be members of structs or classes, with the intent to lazily perform some expensive struct or class member initialization only once; however, this violates the libdispatch requirements.</p>
 <p>See the discussion section of <a href="https://developer.apple.com/documentation/dispatch/1447169-dispatch_once">Apple's dispatch_once documentation</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/darwin-dispatch-once-nonstatic.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/darwin/dispatch-once-nonstatic.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7061,7 +7121,7 @@ public:
 foo(0); // no warning</code></pre>
 <p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-default-arguments-calls.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/default-arguments-calls.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7080,7 +7140,7 @@ foo(0); // no warning</code></pre>
 <p>will cause a warning.</p>
 <p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-default-arguments-declarations.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/default-arguments-declarations.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7092,13 +7152,13 @@ foo(0); // no warning</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - fuchsia-header-anon-namespaces</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=google-build-namespaces.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../google/build-namespaces.html">
 
 </div>
 <h1 id="fuchsia-header-anon-namespaces">fuchsia-header-anon-namespaces</h1>
-<p>The fuchsia-header-anon-namespaces check is an alias, please see <a href="google-build-namespaces.html">google-build-namespace</a> for more information.</p>
+<p>The fuchsia-header-anon-namespaces check is an alias, please see <a href="../google/build-namespaces.html">google-build-namespace</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-header-anon-namespaces.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/header-anon-namespaces.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7143,7 +7203,7 @@ class Good_Child1 : public Interface_A, Interface_B {
 };</code></pre>
 <p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-multiple-inheritance.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/multiple-inheritance.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7164,7 +7224,7 @@ B &amp;operator=(const B &amp;Other);  // No warning
 B &amp;operator=(B &amp;&amp;Other) // No warning</code></pre>
 <p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-overloaded-operator.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/overloaded-operator.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7209,7 +7269,7 @@ extern int get_i();
 static C(get_i())   // Warning, as the constructor is dynamically initialized</code></pre>
 <p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-statically-constructed-objects.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/statically-constructed-objects.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -7244,7 +7304,7 @@ auto fn(const T1 &amp;lhs, const T2 &amp;rhs) -&gt; decltype(lhs + rhs) {
 }</code></pre>
 <p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-trailing-return.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/trailing-return.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7262,7 +7322,7 @@ auto fn(const T1 &amp;lhs, const T2 &amp;rhs) -&gt; decltype(lhs + rhs) {
 <pre class="c++"><code>class B : public virtual A {};   // warning</code></pre>
 <p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia-virtual-inheritance.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/virtual-inheritance.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7279,7 +7339,7 @@ auto fn(const T1 &amp;lhs, const T2 &amp;rhs) -&gt; decltype(lhs + rhs) {
 <p>G++ 4.6 in C++11 mode fails badly if <code>make_pair</code>'s template arguments are specified explicitly, and such use isn't intended in any case.</p>
 <p>Corresponding cpplint.py check name: <span class="title-ref">build/explicit_make_pair</span>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-build-explicit-make-pair.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/build-explicit-make-pair.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7302,7 +7362,7 @@ auto fn(const T1 &amp;lhs, const T2 &amp;rhs) -&gt; decltype(lhs + rhs) {
 <p>A comma-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is "h,hh,hpp,hxx". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. e.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-build-namespaces.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/build-namespaces.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7324,7 +7384,7 @@ auto fn(const T1 &amp;lhs, const T2 &amp;rhs) -&gt; decltype(lhs + rhs) {
 using namespace foo;</code></pre>
 <p>Corresponding cpplint.py check name: <span class="title-ref">build/namespaces</span>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-build-using-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/build-using-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7340,7 +7400,7 @@ using namespace foo;</code></pre>
 <p>Checks that default arguments are not given for virtual methods.</p>
 <p>See <a href="https://google.github.io/styleguide/cppguide.html#Default_Arguments">https://google.github.io/styleguide/cppguide.html#Default_Arguments</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-default-arguments.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/default-arguments.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7381,7 +7441,7 @@ bool f() {
   ...</code></pre>
 <p>See <a href="https://google.github.io/styleguide/cppguide.html#Explicit_Constructors">https://google.github.io/styleguide/cppguide.html#Explicit_Constructors</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-explicit-constructor.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/explicit-constructor.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7402,7 +7462,7 @@ bool f() {
 <p>A comma-separated list of filename extensions of header files (the filename extensions should not contain "." prefix). Default is "h". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. e.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-global-names-in-headers.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/global-names-in-headers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7425,7 +7485,7 @@ Foo *bar = [Foo new];</code></pre>
 Foo *bar = [[Foo alloc] init];</code></pre>
 <p>This check corresponds to the Google Objective-C Style Guide rule <a href="https://google.github.io/styleguide/objcguide.html#do-not-use-new">Do Not Use +new</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-objc-avoid-nsobject-new.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/objc-avoid-nsobject-new.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7458,7 +7518,7 @@ Foo *bar = [[Foo alloc] init];</code></pre>
 }</code></pre>
 <p>The corresponding style guide rule: <a href="https://google.github.io/styleguide/objcguide.html#avoid-throwing-exceptions">https://google.github.io/styleguide/objcguide.html#avoid-throwing-exceptions</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-objc-avoid-throwing-exception.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/objc-avoid-throwing-exception.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7481,7 +7541,7 @@ bool IsNegative(int i) { return i &lt; 0; }</code></pre>
 <pre class="objc"><code>static bool IsPositive(int i) { return i &gt; 0; }
 bool *ABCIsNegative(int i) { return i &lt; 0; }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-objc-function-naming.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/objc-function-naming.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7509,7 +7569,7 @@ bool *ABCIsNegative(int i) { return i &lt; 0; }</code></pre>
 <pre class="objc"><code>static NSString* __anotherString = @&quot;world&quot;;</code></pre>
 <p>The check will give a warning message but will not be able to suggest a fix. The user needs to fix it on their own.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-objc-global-variable-declaration.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/objc-global-variable-declaration.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7534,11 +7594,11 @@ bool *ABCIsNegative(int i) { return i &lt; 0; }</code></pre>
 <p>For example:</p>
 <pre class="c++"><code>TEST(TestCaseName, Illegal_TestName) {}
 TEST(Illegal_TestCaseName, TestName) {}</code></pre>
-<p>would trigger the check. <a href="https://github.com/google/googletest/blob/master/googletest/docs/faq.md#why-should-test-suite-names-and-test-names-not-contain-underscore">Underscores are not allowed</a> in test names nor test case names.</p>
-<p>The <code>DISABLED_</code> prefix, which may be used to <a href="https://github.com/google/googletest/blob/master/googletest/docs/faq.md#why-should-test-suite-names-and-test-names-not-contain-underscore">disable individual tests</a>, is ignored when checking test names, but the rest of the rest of the test name is still checked.</p>
+<p>would trigger the check. <a href="https://google.github.io/googletest/faq.html#why-should-test-suite-names-and-test-names-not-contain-underscore">Underscores are not allowed</a> in test names nor test case names.</p>
+<p>The <code>DISABLED_</code> prefix, which may be used to <a href="https://google.github.io/googletest/advanced.html#temporarily-disabling-tests">disable individual tests</a>, is ignored when checking test names, but the rest of the rest of the test name is still checked.</p>
 <p>This check does not propose any fixes.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-readability-avoid-underscore-in-googletest-name.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/readability-avoid-underscore-in-googletest-name.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7550,13 +7610,13 @@ TEST(Illegal_TestCaseName, TestName) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - google-readability-braces-around-statements</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=readability-braces-around-statements.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../readability/braces-around-statements.html">
 
 </div>
 <h1 id="google-readability-braces-around-statements">google-readability-braces-around-statements</h1>
-<p>The google-readability-braces-around-statements check is an alias, please see <a href="readability-braces-around-statements.html">readability-braces-around-statements</a> for more information.</p>
+<p>The google-readability-braces-around-statements check is an alias, please see <a href="../readability/braces-around-statements.html">readability-braces-around-statements</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-readability-braces-around-statements.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/readability-braces-around-statements.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7574,7 +7634,7 @@ TEST(Illegal_TestCaseName, TestName) {}</code></pre>
 <p>Corresponding cpplint.py check name: <span class="title-ref">readability/casting</span>.</p>
 <p>This check is similar to <code>-Wold-style-cast</code>, but it suggests automated fixes in some cases. The reported locations should not be different from the ones generated by <code>-Wold-style-cast</code>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-readability-casting.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/readability-casting.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7586,13 +7646,13 @@ TEST(Illegal_TestCaseName, TestName) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - google-readability-function-size</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=readability-function-size.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../readability/function-size.html">
 
 </div>
 <h1 id="google-readability-function-size">google-readability-function-size</h1>
-<p>The google-readability-function-size check is an alias, please see <a href="readability-function-size.html">readability-function-size</a> for more information.</p>
+<p>The google-readability-function-size check is an alias, please see <a href="../readability/function-size.html">readability-function-size</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-readability-function-size.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/readability-function-size.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7604,13 +7664,13 @@ TEST(Illegal_TestCaseName, TestName) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - google-readability-namespace-comments</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=llvm-namespace-comment.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../llvm/namespace-comment.html">
 
 </div>
 <h1 id="google-readability-namespace-comments">google-readability-namespace-comments</h1>
-<p>The google-readability-namespace-comments check is an alias, please see <a href="llvm-namespace-comment.html">llvm-namespace-comment</a> for more information.</p>
+<p>The google-readability-namespace-comments check is an alias, please see <a href="../llvm/namespace-comment.html">llvm-namespace-comment</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-readability-namespace-comments.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/readability-namespace-comments.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7627,7 +7687,7 @@ TEST(Illegal_TestCaseName, TestName) {}</code></pre>
 <p>The relevant style guide section is <a href="https://google.github.io/styleguide/cppguide.html#TODO_Comments">https://google.github.io/styleguide/cppguide.html#TODO_Comments</a>.</p>
 <p>Corresponding cpplint.py check: <span class="title-ref">readability/todo</span></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-readability-todo.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/readability-todo.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7657,7 +7717,7 @@ TEST(Illegal_TestCaseName, TestName) {}</code></pre>
 <p>A string specifying the type suffix. Default is an empty string.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-runtime-int.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/runtime-int.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7674,7 +7734,7 @@ TEST(Illegal_TestCaseName, TestName) {}</code></pre>
 <p><a href="https://google.github.io/styleguide/cppguide.html#Operator_Overloading">https://google.github.io/styleguide/cppguide.html#Operator_Overloading</a></p>
 <p>Corresponding cpplint.py check name: <span class="title-ref">runtime/operator</span>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-runtime-operator.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/runtime-operator.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7714,7 +7774,7 @@ public:
 TYPED_TEST_SUITE(BarTest, BarTypes);</code></pre>
 <p>For better consistency of user code, the check renames both virtual and non-virtual member functions with matching names in derived types. The check tries to provide only a warning when a fix cannot be made safely, as is the case with some template and macro uses.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google-upgrade-googletest-case.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/upgrade-googletest-case.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7726,13 +7786,13 @@ TYPED_TEST_SUITE(BarTest, BarTypes);</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-avoid-c-arrays</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=modernize-avoid-c-arrays.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/avoid-c-arrays.html">
 
 </div>
 <h1 id="hicpp-avoid-c-arrays">hicpp-avoid-c-arrays</h1>
-<p>The hicpp-avoid-c-arrays check is an alias, please see <a href="modernize-avoid-c-arrays.html">modernize-avoid-c-arrays</a> for more information.</p>
+<p>The hicpp-avoid-c-arrays check is an alias, please see <a href="../modernize/avoid-c-arrays.html">modernize-avoid-c-arrays</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-avoid-c-arrays.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/avoid-c-arrays.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7745,10 +7805,10 @@ TYPED_TEST_SUITE(BarTest, BarTypes);</code></pre>
 <p>clang-tidy - hicpp-avoid-goto</p>
 </div>
 <h1 id="hicpp-avoid-goto">hicpp-avoid-goto</h1>
-<p>The <span class="title-ref">hicpp-avoid-goto</span> check is an alias to <a href="cppcoreguidelines-avoid-goto.html">cppcoreguidelines-avoid-goto</a>. Rule <a href="http://www.codingstandard.com/rule/6-3-1-ensure-that-the-labels-for-a-jump-statement-or-a-switch-condition-appear-later-in-the-same-or-an-enclosing-block/">6.3.1 High Integrity C++</a> requires that <code>goto</code> only skips parts of a block and is not used for other reasons.</p>
+<p>The <span class="title-ref">hicpp-avoid-goto</span> check is an alias to <a href="../cppcoreguidelines/avoid-goto.html">cppcoreguidelines-avoid-goto</a>. Rule <a href="http://www.codingstandard.com/rule/6-3-1-ensure-that-the-labels-for-a-jump-statement-or-a-switch-condition-appear-later-in-the-same-or-an-enclosing-block/">6.3.1 High Integrity C++</a> requires that <code>goto</code> only skips parts of a block and is not used for other reasons.</p>
 <p>Both coding guidelines implement the same exception to the usage of <code>goto</code>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-avoid-goto.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/avoid-goto.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -7762,13 +7822,13 @@ TYPED_TEST_SUITE(BarTest, BarTypes);</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-braces-around-statements</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=readability-braces-around-statements.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../readability/braces-around-statements.html">
 
 </div>
 <h1 id="hicpp-braces-around-statements">hicpp-braces-around-statements</h1>
-<p>The <span class="title-ref">hicpp-braces-around-statements</span> check is an alias, please see <a href="readability-braces-around-statements.html">readability-braces-around-statements</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/6-1-1-enclose-the-body-of-a-selection-or-an-iteration-statement-in-a-compound-statement/">rule 6.1.1</a>.</p>
+<p>The <span class="title-ref">hicpp-braces-around-statements</span> check is an alias, please see <a href="../readability/braces-around-statements.html">readability-braces-around-statements</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/6-1-1-enclose-the-body-of-a-selection-or-an-iteration-statement-in-a-compound-statement/">rule 6.1.1</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-braces-around-statements.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/braces-around-statements.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7780,13 +7840,13 @@ TYPED_TEST_SUITE(BarTest, BarTypes);</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-deprecated-headers</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=modernize-deprecated-headers.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/deprecated-headers.html">
 
 </div>
 <h1 id="hicpp-deprecated-headers">hicpp-deprecated-headers</h1>
-<p>The <span class="title-ref">hicpp-deprecated-headers</span> check is an alias, please see <a href="modernize-deprecated-headers.html">modernize-deprecated-headers</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/1-3-3-do-not-use-the-c-standard-library-h-headers/">rule 1.3.3</a>.</p>
+<p>The <span class="title-ref">hicpp-deprecated-headers</span> check is an alias, please see <a href="../modernize/deprecated-headers.html">modernize-deprecated-headers</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/1-3-3-do-not-use-the-c-standard-library-h-headers/">rule 1.3.3</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-deprecated-headers.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/deprecated-headers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7818,7 +7878,7 @@ void throwing2() noexcept(false) {
   throw std::exception();
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-exception-baseclass.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/exception-baseclass.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7830,19 +7890,19 @@ void throwing2() noexcept(false) {
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-explicit-conversions</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=google-explicit-constructor.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../google/explicit-constructor.html">
 
 </div>
 <h1 id="hicpp-explicit-conversions">hicpp-explicit-conversions</h1>
-<p>This check is an alias for <a href="google-explicit-constructor.html">google-explicit-constructor</a>. Used to enforce parts of <a href="http://www.codingstandard.com/rule/5-4-1-only-use-casting-forms-static_cast-excl-void-dynamic_cast-or-explicit-constructor-call/">rule 5.4.1</a>. This check will enforce that constructors and conversion operators are marked <span class="title-ref">explicit</span>. Other forms of casting checks are implemented in other places. The following checks can be used to check for more forms of casting:</p>
+<p>This check is an alias for <a href="../google/explicit-constructor.html">google-explicit-constructor</a>. Used to enforce parts of <a href="http://www.codingstandard.com/rule/5-4-1-only-use-casting-forms-static_cast-excl-void-dynamic_cast-or-explicit-constructor-call/">rule 5.4.1</a>. This check will enforce that constructors and conversion operators are marked <span class="title-ref">explicit</span>. Other forms of casting checks are implemented in other places. The following checks can be used to check for more forms of casting:</p>
 <ul>
-<li><a href="cppcoreguidelines-pro-type-static-cast-downcast.html">cppcoreguidelines-pro-type-static-cast-downcast</a></li>
-<li><a href="cppcoreguidelines-pro-type-reinterpret-cast.html">cppcoreguidelines-pro-type-reinterpret-cast</a></li>
-<li><a href="cppcoreguidelines-pro-type-const-cast.html">cppcoreguidelines-pro-type-const-cast</a></li>
-<li><a href="cppcoreguidelines-pro-type-cstyle-cast.html">cppcoreguidelines-pro-type-cstyle-cast</a></li>
+<li><a href="../cppcoreguidelines/pro-type-static-cast-downcast.html">cppcoreguidelines-pro-type-static-cast-downcast</a></li>
+<li><a href="../cppcoreguidelines/pro-type-reinterpret-cast.html">cppcoreguidelines-pro-type-reinterpret-cast</a></li>
+<li><a href="../cppcoreguidelines/pro-type-const-cast.html">cppcoreguidelines-pro-type-const-cast</a></li>
+<li><a href="../cppcoreguidelines/pro-type-cstyle-cast.html">cppcoreguidelines-pro-type-cstyle-cast</a></li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-explicit-conversions.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/explicit-conversions.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -7856,18 +7916,18 @@ void throwing2() noexcept(false) {
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-function-size</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=readability-function-size.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../readability/function-size.html">
 
 </div>
 <h1 id="hicpp-function-size">hicpp-function-size</h1>
-<p>This check is an alias for <a href="readability-function-size.html">readability-function-size</a>. Useful to enforce multiple sections on function complexity.</p>
+<p>This check is an alias for <a href="../readability/function-size.html">readability-function-size</a>. Useful to enforce multiple sections on function complexity.</p>
 <ul>
 <li><a href="http://www.codingstandard.com/rule/8-2-2-do-not-declare-functions-with-an-excessive-number-of-parameters/">rule 8.2.2</a></li>
 <li><a href="http://www.codingstandard.com/rule/8-3-1-do-not-write-functions-with-an-excessive-mccabe-cyclomatic-complexity/">rule 8.3.1</a></li>
 <li><a href="http://www.codingstandard.com/rule/8-3-2-do-not-write-functions-with-a-high-static-program-path-count/">rule 8.3.2</a></li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-function-size.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/function-size.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -7879,14 +7939,14 @@ void throwing2() noexcept(false) {
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-invalid-access-moved</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=bugprone-use-after-move.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/use-after-move.html">
 
 </div>
 <h1 id="hicpp-invalid-access-moved">hicpp-invalid-access-moved</h1>
-<p>This check is an alias for <a href="bugprone-use-after-move.html">bugprone-use-after-move</a>.</p>
+<p>This check is an alias for <a href="../bugprone/use-after-move.html">bugprone-use-after-move</a>.</p>
 <p>Implements parts of the <a href="http://www.codingstandard.com/rule/8-4-1-do-not-access-an-invalid-object-or-an-object-with-indeterminate-value/">rule 8.4.1</a> to check if moved-from objects are accessed.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-invalid-access-moved.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/invalid-access-moved.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>BUG</type>
@@ -7900,13 +7960,13 @@ void throwing2() noexcept(false) {
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-member-init</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=cppcoreguidelines-pro-type-member-init.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../cppcoreguidelines/pro-type-member-init.html">
 
 </div>
 <h1 id="hicpp-member-init">hicpp-member-init</h1>
-<p>This check is an alias for <a href="cppcoreguidelines-pro-type-member-init.html">cppcoreguidelines-pro-type-member-init</a>. Implements the check for <a href="http://www.codingstandard.com/rule/12-4-2-ensure-that-a-constructor-initializes-explicitly-all-base-classes-and-non-static-data-members/">rule 12.4.2</a> to initialize class members in the right order.</p>
+<p>This check is an alias for <a href="../cppcoreguidelines/pro-type-member-init.html">cppcoreguidelines-pro-type-member-init</a>. Implements the check for <a href="http://www.codingstandard.com/rule/12-4-2-ensure-that-a-constructor-initializes-explicitly-all-base-classes-and-non-static-data-members/">rule 12.4.2</a> to initialize class members in the right order.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-member-init.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/member-init.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -7920,13 +7980,13 @@ void throwing2() noexcept(false) {
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-move-const-arg</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=performance-move-const-arg.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../performance/move-const-arg.html">
 
 </div>
 <h1 id="hicpp-move-const-arg">hicpp-move-const-arg</h1>
-<p>The <span class="title-ref">hicpp-move-const-arg</span> check is an alias, please see <a href="performance-move-const-arg.html">performance-move-const-arg</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/17-3-1-do-not-use-stdmove-on-objects-declared-with-const-or-const-type/">rule 17.3.1</a>.</p>
+<p>The <span class="title-ref">hicpp-move-const-arg</span> check is an alias, please see <a href="../performance/move-const-arg.html">performance-move-const-arg</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/17-3-1-do-not-use-stdmove-on-objects-declared-with-const-or-const-type/">rule 17.3.1</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-move-const-arg.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/move-const-arg.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -8001,7 +8061,7 @@ switch(i) {}</code></pre>
 <p>Boolean flag that activates a warning for missing <code>else</code> branches. Default is <span class="title-ref">false</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-multiway-paths-covered.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/multiway-paths-covered.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8013,14 +8073,14 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-named-parameter</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=readability-named-parameter.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../readability/named-parameter.html">
 
 </div>
 <h1 id="hicpp-named-parameter">hicpp-named-parameter</h1>
-<p>This check is an alias for <a href="readability-named-parameter.html">readability-named-parameter</a>.</p>
+<p>This check is an alias for <a href="../readability/named-parameter.html">readability-named-parameter</a>.</p>
 <p>Implements <a href="http://www.codingstandard.com/rule/8-2-1-make-parameter-names-absent-or-identical-in-all-declarations/">rule 8.2.1</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-named-parameter.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/named-parameter.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8032,13 +8092,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-new-delete-operators</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=misc-new-delete-overloads.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../misc/new-delete-overloads.html">
 
 </div>
 <h1 id="hicpp-new-delete-operators">hicpp-new-delete-operators</h1>
-<p>This check is an alias for <a href="misc-new-delete-overloads.html">misc-new-delete-overloads</a>. Implements <a href="http://www.codingstandard.com/section/12-3-free-store/">rule 12.3.1</a> to ensure the <span class="title-ref">new</span> and <span class="title-ref">delete</span> operators have the correct signature.</p>
+<p>This check is an alias for <a href="../misc/new-delete-overloads.html">misc-new-delete-overloads</a>. Implements <a href="http://www.codingstandard.com/section/12-3-free-store/">rule 12.3.1</a> to ensure the <span class="title-ref">new</span> and <span class="title-ref">delete</span> operators have the correct signature.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-new-delete-operators.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/new-delete-operators.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8050,13 +8110,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-no-array-decay</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=cppcoreguidelines-pro-bounds-array-to-pointer-decay.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../cppcoreguidelines/pro-bounds-array-to-pointer-decay.html">
 
 </div>
 <h1 id="hicpp-no-array-decay">hicpp-no-array-decay</h1>
-<p>The <span class="title-ref">hicpp-no-array-decay</span> check is an alias, please see <a href="cppcoreguidelines-pro-bounds-array-to-pointer-decay.html">cppcoreguidelines-pro-bounds-array-to-pointer-decay</a> for more information. It enforces the <a href="http://www.codingstandard.com/section/4-1-array-to-pointer-conversion/">rule 4.1.1</a>.</p>
+<p>The <span class="title-ref">hicpp-no-array-decay</span> check is an alias, please see <a href="../cppcoreguidelines/pro-bounds-array-to-pointer-decay.html">cppcoreguidelines-pro-bounds-array-to-pointer-decay</a> for more information. It enforces the <a href="http://www.codingstandard.com/section/4-1-array-to-pointer-conversion/">rule 4.1.1</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-no-array-decay.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/no-array-decay.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8072,7 +8132,7 @@ switch(i) {}</code></pre>
 <p>Check for assembler statements. No fix is offered.</p>
 <p>Inline assembler is forbidden by the <a href="http://www.codingstandard.com/section/7-5-the-asm-declaration/">High Integrity C++ Coding Standard</a> as it restricts the portability of code.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-no-assembler.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/no-assembler.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8084,13 +8144,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-no-malloc</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=cppcoreguidelines-no-malloc.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../cppcoreguidelines/no-malloc.html">
 
 </div>
 <h1 id="hicpp-no-malloc">hicpp-no-malloc</h1>
-<p>The <span class="title-ref">hicpp-no-malloc</span> check is an alias, please see <a href="cppcoreguidelines-no-malloc.html">cppcoreguidelines-no-malloc</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/5-3-2-allocate-memory-using-new-and-release-it-using-delete/">rule 5.3.2</a>.</p>
+<p>The <span class="title-ref">hicpp-no-malloc</span> check is an alias, please see <a href="../cppcoreguidelines/no-malloc.html">cppcoreguidelines-no-malloc</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/5-3-2-allocate-memory-using-new-and-release-it-using-delete/">rule 5.3.2</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-no-malloc.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/no-malloc.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8102,13 +8162,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-noexcept-move</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=performance-noexcept-move-constructor.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../performance/noexcept-move-constructor.html">
 
 </div>
 <h1 id="hicpp-noexcept-move">hicpp-noexcept-move</h1>
-<p>This check is an alias for <a href="performance-noexcept-move-constructor.html">performance-noexcept-move-constructor</a>. Checks <a href="http://www.codingstandard.com/rule/12-5-4-declare-noexcept-the-move-constructor-and-move-assignment-operator">rule 12.5.4</a> to mark move assignment and move construction <span class="title-ref">noexcept</span>.</p>
+<p>This check is an alias for <a href="../performance/noexcept-move-constructor.html">performance-noexcept-move-constructor</a>. Checks <a href="http://www.codingstandard.com/rule/12-5-4-declare-noexcept-the-move-constructor-and-move-assignment-operator">rule 12.5.4</a> to mark move assignment and move construction <span class="title-ref">noexcept</span>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-noexcept-move.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/noexcept-move.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -8131,7 +8191,7 @@ switch(i) {}</code></pre>
 <p>If this option is set to <span class="title-ref">true</span>, the check will not warn on bitwise operations with positive integer literals, e.g. <span class="title-ref">~0</span>, <span class="title-ref">2 &lt;&lt; 1</span>, etc. Default value is <span class="title-ref">false</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-signed-bitwise.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/signed-bitwise.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8143,13 +8203,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-special-member-functions</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=cppcoreguidelines-special-member-functions.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../cppcoreguidelines/special-member-functions.html">
 
 </div>
 <h1 id="hicpp-special-member-functions">hicpp-special-member-functions</h1>
-<p>This check is an alias for <a href="cppcoreguidelines-special-member-functions.html">cppcoreguidelines-special-member-functions</a>. Checks that special member functions have the correct signature, according to <a href="http://www.codingstandard.com/rule/12-5-7-declare-assignment-operators-with-the-ref-qualifier/">rule 12.5.7</a>.</p>
+<p>This check is an alias for <a href="../cppcoreguidelines/special-member-functions.html">cppcoreguidelines-special-member-functions</a>. Checks that special member functions have the correct signature, according to <a href="http://www.codingstandard.com/rule/12-5-7-declare-assignment-operators-with-the-ref-qualifier/">rule 12.5.7</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-special-member-functions.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/special-member-functions.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -8163,13 +8223,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-static-assert</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=misc-static-assert.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../misc/static-assert.html">
 
 </div>
 <h1 id="hicpp-static-assert">hicpp-static-assert</h1>
-<p>The <span class="title-ref">hicpp-static-assert</span> check is an alias, please see <a href="misc-static-assert.html">misc-static-assert</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/6-1-1-enclose-the-body-of-a-selection-or-an-iteration-statement-in-a-compound-statement/">rule 7.1.10</a>.</p>
+<p>The <span class="title-ref">hicpp-static-assert</span> check is an alias, please see <a href="../misc/static-assert.html">misc-static-assert</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/6-1-1-enclose-the-body-of-a-selection-or-an-iteration-statement-in-a-compound-statement/">rule 7.1.10</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-static-assert.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/static-assert.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -8183,11 +8243,11 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-undelegated-constructor</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=bugprone-undelegated-constructor.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/undelegated-constructor.html">
 
 </div>
 <h1 id="hicpp-undelegated-constructor">hicpp-undelegated-constructor</h1>
-<p>This check is an alias for <a href="bugprone-undelegated-constructor.html">bugprone-undelegated-constructor</a>. Partially implements <a href="http://www.codingstandard.com/rule/12-4-5-use-delegating-constructors-to-reduce-code-duplication/">rule 12.4.5</a> to find misplaced constructor calls inside a constructor.</p>
+<p>This check is an alias for <a href="../bugprone/undelegated-constructor.html">bugprone-undelegated-constructor</a>. Partially implements <a href="http://www.codingstandard.com/rule/12-4-5-use-delegating-constructors-to-reduce-code-duplication/">rule 12.4.5</a> to find misplaced constructor calls inside a constructor.</p>
 <pre class="c++"><code>struct Ctor {
   Ctor();
   Ctor(int);
@@ -8201,7 +8261,7 @@ switch(i) {}</code></pre>
   }
 };</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-undelegated-constructor.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/undelegated-constructor.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -8215,13 +8275,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-uppercase-literal-suffix</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=readability-uppercase-literal-suffix.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../readability/uppercase-literal-suffix.html">
 
 </div>
 <h1 id="hicpp-uppercase-literal-suffix">hicpp-uppercase-literal-suffix</h1>
-<p>The hicpp-uppercase-literal-suffix check is an alias, please see <a href="readability-uppercase-literal-suffix.html">readability-uppercase-literal-suffix</a> for more information.</p>
+<p>The hicpp-uppercase-literal-suffix check is an alias, please see <a href="../readability/uppercase-literal-suffix.html">readability-uppercase-literal-suffix</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-uppercase-literal-suffix.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/uppercase-literal-suffix.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8233,13 +8293,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-use-auto</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=modernize-use-auto.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/use-auto.html">
 
 </div>
 <h1 id="hicpp-use-auto">hicpp-use-auto</h1>
-<p>The <span class="title-ref">hicpp-use-auto</span> check is an alias, please see <a href="modernize-use-auto.html">modernize-use-auto</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/7-1-8-use-auto-id-expr-when-declaring-a-variable-to-have-the-same-type-as-its-initializer-function-call/">rule 7.1.8</a>.</p>
+<p>The <span class="title-ref">hicpp-use-auto</span> check is an alias, please see <a href="../modernize/use-auto.html">modernize-use-auto</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/7-1-8-use-auto-id-expr-when-declaring-a-variable-to-have-the-same-type-as-its-initializer-function-call/">rule 7.1.8</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-use-auto.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-auto.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8251,13 +8311,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-use-emplace</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=modernize-use-emplace.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/use-emplace.html">
 
 </div>
 <h1 id="hicpp-use-emplace">hicpp-use-emplace</h1>
-<p>The <span class="title-ref">hicpp-use-emplace</span> check is an alias, please see <a href="modernize-use-emplace.html">modernize-use-emplace</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/17-4-2-use-api-calls-that-construct-objects-in-place/">rule 17.4.2</a>.</p>
+<p>The <span class="title-ref">hicpp-use-emplace</span> check is an alias, please see <a href="../modernize/use-emplace.html">modernize-use-emplace</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/17-4-2-use-api-calls-that-construct-objects-in-place/">rule 17.4.2</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-use-emplace.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-emplace.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8269,13 +8329,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-use-equals-defaults</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=modernize-use-equals-default.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/use-equals-default.html">
 
 </div>
 <h1 id="hicpp-use-equals-default">hicpp-use-equals-default</h1>
-<p>This check is an alias for <a href="modernize-use-equals-default.html">modernize-use-equals-default</a>. Implements <a href="http://www.codingstandard.com/rule/12-5-1-define-explicitly-default-or-delete-implicit-special-member-functions-of-concrete-classes/">rule 12.5.1</a> to explicitly default special member functions.</p>
+<p>This check is an alias for <a href="../modernize/use-equals-default.html">modernize-use-equals-default</a>. Implements <a href="http://www.codingstandard.com/rule/12-5-1-define-explicitly-default-or-delete-implicit-special-member-functions-of-concrete-classes/">rule 12.5.1</a> to explicitly default special member functions.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-use-equals-default.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-equals-default.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8287,13 +8347,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-use-equals-delete</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=modernize-use-equals-delete.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/use-equals-delete.html">
 
 </div>
 <h1 id="hicpp-use-equals-delete">hicpp-use-equals-delete</h1>
-<p>This check is an alias for <a href="modernize-use-equals-delete.html">modernize-use-equals-delete</a>. Implements <a href="http://www.codingstandard.com/rule/12-5-1-define-explicitly-default-or-delete-implicit-special-member-functions-of-concrete-classes/">rule 12.5.1</a> to explicitly default or delete special member functions.</p>
+<p>This check is an alias for <a href="../modernize/use-equals-delete.html">modernize-use-equals-delete</a>. Implements <a href="http://www.codingstandard.com/rule/12-5-1-define-explicitly-default-or-delete-implicit-special-member-functions-of-concrete-classes/">rule 12.5.1</a> to explicitly default or delete special member functions.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-use-equals-delete.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-equals-delete.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8305,13 +8365,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-use-noexcept</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=modernize-use-noexcept.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/use-noexcept.html">
 
 </div>
 <h1 id="hicpp-use-noexcept">hicpp-use-noexcept</h1>
-<p>The <span class="title-ref">hicpp-use-noexcept</span> check is an alias, please see <a href="modernize-use-noexcept.html">modernize-use-noexcept</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/1-3-5-do-not-use-throw-exception-specifications/">rule 1.3.5</a>.</p>
+<p>The <span class="title-ref">hicpp-use-noexcept</span> check is an alias, please see <a href="../modernize/use-noexcept.html">modernize-use-noexcept</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/1-3-5-do-not-use-throw-exception-specifications/">rule 1.3.5</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-use-noexcept.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-noexcept.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8323,13 +8383,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-use-nullptr</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=modernize-use-nullptr.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/use-nullptr.html">
 
 </div>
 <h1 id="hicpp-use-nullptr">hicpp-use-nullptr</h1>
-<p>The <span class="title-ref">hicpp-use-nullptr</span> check is an alias, please see <a href="modernize-use-nullptr.html">modernize-use-nullptr</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/2-5-3-use-nullptr-for-the-null-pointer-constant/">rule 2.5.3</a>.</p>
+<p>The <span class="title-ref">hicpp-use-nullptr</span> check is an alias, please see <a href="../modernize/use-nullptr.html">modernize-use-nullptr</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/2-5-3-use-nullptr-for-the-null-pointer-constant/">rule 2.5.3</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-use-nullptr.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-nullptr.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8341,13 +8401,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-use-override</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=modernize-use-override.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/use-override.html">
 
 </div>
 <h1 id="hicpp-use-override">hicpp-use-override</h1>
-<p>This check is an alias for <a href="modernize-use-override.html">modernize-use-override</a>. Implements <a href="http://www.codingstandard.com/section/10-2-virtual-functions/">rule 10.2.1</a> to declare a virtual function <span class="title-ref">override</span> when overriding.</p>
+<p>This check is an alias for <a href="../modernize/use-override.html">modernize-use-override</a>. Implements <a href="http://www.codingstandard.com/section/10-2-virtual-functions/">rule 10.2.1</a> to declare a virtual function <span class="title-ref">override</span> when overriding.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-use-override.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-override.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8359,13 +8419,13 @@ switch(i) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-vararg</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=cppcoreguidelines-pro-type-vararg.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../cppcoreguidelines/pro-type-vararg.html">
 
 </div>
 <h1 id="hicpp-vararg">hicpp-vararg</h1>
-<p>The <span class="title-ref">hicpp-vararg</span> check is an alias, please see <a href="cppcoreguidelines-pro-type-vararg.html">cppcoreguidelines-pro-type-vararg</a> for more information. It enforces the <a href="http://www.codingstandard.com/section/14-1-template-declarations/">rule 14.1.1</a>.</p>
+<p>The <span class="title-ref">hicpp-vararg</span> check is an alias, please see <a href="../cppcoreguidelines/pro-type-vararg.html">cppcoreguidelines-pro-type-vararg</a> for more information. It enforces the <a href="http://www.codingstandard.com/section/14-1-template-declarations/">rule 14.1.1</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp-vararg.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/vararg.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -8392,7 +8452,7 @@ void *fn() { ERR_PTR(-EINVAL); }
 /* An invalid use of fn. */
 fn();</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/linuxkernel-must-use-errs.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/linuxkernel/must-use-errs.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8404,13 +8464,13 @@ fn();</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - llvm-else-after-return</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=readability-else-after-return.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../readability/else-after-return.html">
 
 </div>
 <h1 id="llvm-else-after-return">llvm-else-after-return</h1>
-<p>The llvm-else-after-return check is an alias, please see <a href="readability-else-after-return.html">readability-else-after-return</a> for more information.</p>
+<p>The llvm-else-after-return check is an alias, please see <a href="../readability/else-after-return.html">readability-else-after-return</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-else-after-return.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm/else-after-return.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8427,10 +8487,10 @@ fn();</code></pre>
 <h2 id="options">Options</h2>
 <div class="option">
 <p>HeaderFileExtensions</p>
-<p>A comma-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is "h,hh,hpp,hxx". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. e.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
+<p>A comma-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is "h,hh,hpp,hxx". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. E.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-header-guard.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm/header-guard.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8446,7 +8506,7 @@ fn();</code></pre>
 <p>Checks the correct order of <code>#includes</code>.</p>
 <p>See <a href="https://llvm.org/docs/CodingStandards.html#include-style">https://llvm.org/docs/CodingStandards.html#include-style</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-include-order.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm/include-order.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8482,7 +8542,7 @@ void f();
 <p>An unsigned integer specifying the number of spaces before the comment closing a namespace definition. Default is <span class="title-ref">1U</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-namespace-comment.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm/namespace-comment.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8518,7 +8578,7 @@ if (auto f = cast&lt;Z&gt;(y)-&gt;foo()) {}
 if (cast&lt;Z&gt;(y)-&gt;foo()) {}
 if (X.cast(y)) {}</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-prefer-isa-or-dyn-cast-in-conditionals.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm/prefer-isa-or-dyn-cast-in-conditionals.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8543,7 +8603,7 @@ if (X.cast(y)) {}</code></pre>
   ...
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-prefer-register-over-unsigned.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm/prefer-register-over-unsigned.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8555,13 +8615,13 @@ if (X.cast(y)) {}</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - llvm-qualified-auto</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=readability-qualified-auto.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../readability/qualified-auto.html">
 
 </div>
 <h1 id="llvm-qualified-auto">llvm-qualified-auto</h1>
-<p>The llvm-qualified-auto check is an alias, please see <a href="readability-qualified-auto.html">readability-qualified-auto</a> for more information.</p>
+<p>The llvm-qualified-auto check is an alias, please see <a href="../readability/qualified-auto.html">readability-qualified-auto</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-qualified-auto.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm/qualified-auto.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8581,7 +8641,7 @@ if (X.cast(y)) {}</code></pre>
 
 static std::string Moo = (Twine(&quot;bark&quot;) + &quot;bah&quot;).str();</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm-twine-local.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm/twine-local.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8611,7 +8671,7 @@ strlen(&quot;world&quot;);
 
 } // namespace __llvm_libc</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvmlibc-callee-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvmlibc/callee-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8644,7 +8704,7 @@ namespace something_else {
     void LLVM_LIBC_ENTRYPOINT(strcpy)(char *dest, const char *src) {}
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvmlibc-implementation-in-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvmlibc/implementation-in-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8667,10 +8727,10 @@ namespace something_else {
 <p>Includes</p>
 <p>A string containing a comma separated glob list of allowed include filenames. Similar to the -checks glob list for running clang-tidy itself, the two wildcard characters are <span class="title-ref">*</span> and <span class="title-ref">-</span>, to include and exclude globs, respectively. The default is <span class="title-ref">-*</span>, which disallows all includes.</p>
 <p>This can be used to allow known safe includes such as Linux development headers. See <code class="interpreted-text" role="doc">portability-restrict-system-includes
-&lt;portability-restrict-system-includes&gt;</code> for more details.</p>
+&lt;../portability/restrict-system-includes&gt;</code> for more details.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvmlibc-restrict-system-libc-headers.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvmlibc/restrict-system-libc-headers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8764,14 +8824,14 @@ constexpr T pi = T(3.1415926L);</code></pre>
 <h2 id="options">Options</h2>
 <div class="option">
 <p>HeaderFileExtensions</p>
-<p>A comma-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is "h,hh,hpp,hxx". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. e.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
+<p>A comma-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is "h,hh,hpp,hxx". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. E.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
 </div>
 <div class="option">
 <p>UseHeaderFileExtension</p>
 <p>When <span class="title-ref">true</span>, the check will use the file extension to distinguish header files. Default is <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-definitions-in-headers.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/definitions-in-headers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -8792,13 +8852,13 @@ constexpr T pi = T(3.1415926L);</code></pre>
 
 int main() {
     bool isAdmin = false;
-    /* } if (isAdmin)  begin admins only */
+    /* } if (isAdmin) begin admins only */
         std::cout &lt;&lt; &quot;You are an admin.\n&quot;;
-    /* end admins only  { */
+    /* end admins only { */
     return 0;
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-misleading-bidirectional.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/misleading-bidirectional.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8815,16 +8875,16 @@ int main() {
 <p>An example of such misleading code follows:</p>
 <pre class="text"><code>#include &lt;stdio.h&gt;
 
-short int  = (short int)0;
-short int  = (short int)12345;
+short int N = (short int)0;
+short int l = (short int)12345;
 
 int main() {
-  int  = ; // a local variable, set to zero?
-  printf(&quot; is %d\n&quot;, );
-  printf(&quot; is %d\n&quot;, );
+  int N = N; // a local variable, set to zero?
+  printf(&quot;l is %d\n&quot;, l);
+  printf(&quot;N is %d\n&quot;, N);
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-misleading-identifier.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/misleading-identifier.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8846,7 +8906,7 @@ void f(const int_ptr ptr) {
 }</code></pre>
 <p>The check does not diagnose when the underlying <code>typedef</code>/<code>using</code> type is a pointer to a <code>const</code> type or a function pointer type. This is because the <code>const</code> qualifier is less likely to be mistaken because it would be redundant (or disallowed) on the underlying pointee type.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-misplaced-const.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/misplaced-const.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8864,7 +8924,7 @@ void f(const int_ptr ptr) {
 <p>The check does not flag implicitly-defined operators, deleted or private operators, or placement operators.</p>
 <p>This check corresponds to CERT C++ Coding Standard rule <a href="https://www.securecoding.cert.org/confluence/display/cplusplus/DCL54-CPP.+Overload+allocation+and+deallocation+functions+as+a+pair+in+the+same+scope">DCL54-CPP. Overload allocation and deallocation functions as a pair in the same scope</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-new-delete-overloads.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/new-delete-overloads.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -8892,7 +8952,7 @@ void f(const int_ptr ptr) {
 <li>The check does not handle C++ destructors</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-no-recursion.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/no-recursion.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8909,7 +8969,7 @@ void f(const int_ptr ptr) {
 <p>The check flags dereferences and non-pointer declarations of objects that are not meant to be passed by value, such as C FILE objects or POSIX <code>pthread_mutex_t</code> objects.</p>
 <p>This check corresponds to CERT C++ Coding Standard rule <a href="https://www.securecoding.cert.org/confluence/display/c/FIO38-C.+Do+not+copy+a+FILE+object">FIO38-C. Do not copy a FILE object</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-non-copyable-objects.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/non-copyable-objects.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -8936,7 +8996,7 @@ void f(const int_ptr ptr) {
 <p>Allows to ignore (not diagnose) <strong>all</strong> the member variables declared with a <code>public</code> access specifier.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-non-private-member-variables-in-classes.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/non-private-member-variables-in-classes.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8963,7 +9023,7 @@ void f(const int_ptr ptr) {
 (p-&gt;x &lt; p-&gt;x)               // always false
 (speed - speed + 1 == 12)   // speed - speed is always zero</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-redundant-expression.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/redundant-expression.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8980,7 +9040,7 @@ void f(const int_ptr ptr) {
 <p>Replaces <code>assert()</code> with <code>static_assert()</code> if the condition is evaluable at compile time.</p>
 <p>The condition of <code>static_assert()</code> is evaluated at compile time which is safer and more efficient.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-static-assert.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/static-assert.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -8999,7 +9059,7 @@ void f(const int_ptr ptr) {
 <dt>Exceptions:</dt>
 <dd><ul>
 <li>Throwing string literals will not be flagged despite being a pointer. They are not susceptible to slicing and the usage of string literals is idiomatic.</li>
-<li>Catching character pointers (<code>char</code>, <code>wchar_t</code>, unicode character types) will not be flagged to allow catching sting literals.</li>
+<li>Catching character pointers (<code>char</code>, <code>wchar_t</code>, unicode character types) will not be flagged to allow catching string literals.</li>
 <li>Moved named values will not be flagged as not throwing an anonymous temporary. In this case we can be sure that the user knows that the object can't be accessed outside catch blocks handling the error.</li>
 <li>Throwing function parameters will not be flagged as not throwing an anonymous temporary. This allows helper functions for throwing.</li>
 <li>Re-throwing caught exception variables will not be flagged as not throwing an anonymous temporary. Although this can usually be done by just writing <code>throw;</code> it happens often enough in real code.</li>
@@ -9020,7 +9080,7 @@ void f(const int_ptr ptr) {
 <p>Determines the maximum size of an object allowed to be caught without warning. Only applicable if <code class="interpreted-text" role="option">WarnOnLargeObject</code> is set to <span class="title-ref">true</span>. If the option is set by the user to <span class="title-ref">std::numeric_limits&lt;uint64_t&gt;::max()</span> then it reverts to the default value. Default is the size of <span class="title-ref">size_t</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-throw-by-value-catch-by-reference.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/throw-by-value-catch-by-reference.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -9045,7 +9105,7 @@ void f(const int_ptr ptr) {
 </ul>
 </blockquote>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-unconventional-assign-operator.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/unconventional-assign-operator.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -9071,7 +9131,7 @@ x.reset(y.release()); -&gt; x = std::move(y);</code></pre>
 <p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-uniqueptr-reset-release.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/uniqueptr-reset-release.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -9092,7 +9152,7 @@ class C {};
 }
 namespace unused_alias = ::my_namespace;</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-unused-alias-decls.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/unused-alias-decls.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -9125,7 +9185,7 @@ static void staticFunctionA() { /*some code that doesn&#39;t use `i`*/ }</code><
 <p>When <span class="title-ref">false</span> (default value), the check will ignore trivially unused parameters, i.e. when the corresponding function has an empty body (and in case of constructors - no constructor initializers). When the function body is empty, an unused parameter is unlikely to be unnoticed by a human reader, and there's basically no place for a bug to hide.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-unused-parameters.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/unused-parameters.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -9143,7 +9203,7 @@ static void staticFunctionA() { /*some code that doesn&#39;t use `i`*/ }</code><
 <pre class="c++"><code>namespace n { class C; }
 using n::C;  // Never actually used.</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc-unused-using-decls.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/unused-using-decls.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -9196,7 +9256,7 @@ int foo() {
 <p>which is correct.</p>
 <p>This check requires using C++14 or higher to run.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-avoid-bind.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/avoid-bind.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -9246,9 +9306,9 @@ inline void bar() {
 }
 
 }</code></pre>
-<p>Similarly, the <code>main()</code> function is ignored. Its second and third parameters can be either <code>char* argv[]</code> or <code>char** argv</code>, but can not be <code>std::array&lt;&gt;</code>.</p>
+<p>Similarly, the <code>main()</code> function is ignored. Its second and third parameters can be either <code>char* argv[]</code> or <code>char** argv</code>, but cannot be <code>std::array&lt;&gt;</code>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-avoid-c-arrays.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/avoid-c-arrays.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -9295,7 +9355,7 @@ void t();
 }
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-concat-nested-namespaces.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/concat-nested-namespaces.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -9310,6 +9370,14 @@ void t();
 <h1 id="modernize-deprecated-headers">modernize-deprecated-headers</h1>
 <p>Some headers from C library were deprecated in C++ and are no longer welcome in C++ codebases. Some have no effect in C++. For more details refer to the C++ 14 Standard [depr.c.headers] section.</p>
 <p>This check replaces C standard library headers with their C++ alternatives and removes redundant ones.</p>
+<pre class="c++"><code>// C++ source file...
+#include &lt;assert.h&gt;
+#include &lt;stdbool.h&gt;
+
+// becomes
+
+#include &lt;cassert&gt;
+// No &#39;stdbool.h&#39; here.</code></pre>
 <p>Important note: the Standard doesn't guarantee that the C++ headers declare all the same functions in the global namespace. The check in its current form can break the code that uses library symbols from the global namespace.</p>
 <ul>
 <li><span class="title-ref">&lt;assert.h&gt;</span></li>
@@ -9343,8 +9411,19 @@ void t();
 <li><span class="title-ref">&lt;stdalign.h&gt;</span></li>
 <li><span class="title-ref">&lt;stdbool.h&gt;</span></li>
 </ul>
+<p>The checker ignores <span class="title-ref">include</span> directives within <span class="title-ref">extern "C" { ... }</span> blocks, since a library might want to expose some API for C and C++ libraries.</p>
+<pre class="c++"><code>// C++ source file...
+extern &quot;C&quot; {
+#include &lt;assert.h&gt;  // Left intact.
+#include &lt;stdbool.h&gt; // Left intact.
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>CheckHeaderFile</p>
+<p><span class="title-ref">clang-tidy</span> cannot know if the header file included by the currently analyzed C++ source file is not included by any other C source files. Hence, to omit false-positives and wrong fixit-hints, we ignore emitting reports into header files. One can set this option to <span class="title-ref">true</span> if they know that the header files in the project are only used by C++ source file. Default is <span class="title-ref">false</span>.</p>
+</div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-deprecated-headers.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/deprecated-headers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -9383,7 +9462,7 @@ void t();
 </tbody>
 </table>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-deprecated-ios-base-aliases.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/deprecated-ios-base-aliases.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -9557,7 +9636,7 @@ for (vector&lt;int&gt;::iterator it = vec.begin(), e = vec.end(); it != e; ++it)
 <p>As range-based for loops are only available since OpenMP 5, this check should not be used on code with a compatibility requirement of OpenMP prior to version 5. It is <strong>intentional</strong> that this check does not make any attempts to exclude incorrect diagnostics on OpenMP for loops prior to OpenMP 5.</p>
 <p>To prevent this check to be applied (and to break) OpenMP for loops but still be applied to non-OpenMP for loops the usage of <code>NOLINT</code> (see <code class="interpreted-text" role="ref">clang-tidy-nolint</code>) on the specific for loops is recommended.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-loop-convert.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/loop-convert.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -9606,7 +9685,7 @@ my_ptr = std::make_shared&lt;MyPair&gt;(1, 2);</code></pre>
 <p>If set to non-zero, the check does not suggest edits that will transform default initialization into value initialization, as this can cause performance regressions. Default is <span class="title-ref">1</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-make-shared.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/make-shared.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -9653,7 +9732,7 @@ my_ptr = std::make_unique&lt;MyPair&gt;(1, 2);</code></pre>
 <p>If set to non-zero, the check does not suggest edits that will transform default initialization into value initialization, as this can cause performance regressions. Default is <span class="title-ref">1</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-make-unique.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/make-unique.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -9757,7 +9836,7 @@ public:
 +  C(std::string S) : S(std::move(S)) {}
 };</code></pre>
 <div class="seealso">
-<p>For more information about the pass-by-value idiom, read: Want Speed? Pass by Value.</p>
+<p>For more information about the pass-by-value idiom, read: <a href="">Want Speed? Pass by Value</a>.</p>
 </div>
 <h2 id="options">Options</h2>
 <div class="option">
@@ -9769,7 +9848,7 @@ public:
 <p>When <span class="title-ref">true</span>, the check only warns about copied parameters that are already passed by value. Default is <span class="title-ref">false</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-pass-by-value.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/pass-by-value.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -9805,7 +9884,7 @@ const char *const RegEx{R&quot;(\w\([a-z]\))&quot;};</code></pre>
 <p>A string literal containing only escaped newlines is a common way of writing lines of text output. Introducing physical newlines with raw string literals in this case is likely to impede readability. These string literals are left unchanged.</p>
 <p>An escaped horizontal tab, form feed, or vertical tab prevents the string literal from being converted. The presence of a horizontal tab, form feed or vertical tab in source code is not visually obvious.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-raw-string-literal.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/raw-string-literal.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -9858,7 +9937,7 @@ const char *const RegEx{R&quot;(\w\([a-z]\))&quot;};</code></pre>
 </dd>
 </dl>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-redundant-void-arg.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/redundant-void-arg.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -9920,7 +9999,7 @@ void f() {
 <p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-replace-auto-ptr.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/replace-auto-ptr.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -9950,7 +10029,7 @@ private:
 <h2 id="known-limitations">Known Limitations</h2>
 <ul>
 <li>Notice that the migration example above leaves the <code>private</code> access specification untouched. You might want to run the check <code class="interpreted-text" role="doc">modernize-use-equals-delete
-&lt;modernize-use-equals-delete&gt;</code> to get warnings for deleted functions in private sections.</li>
+&lt;../modernize/use-equals-delete&gt;</code> to get warnings for deleted functions in private sections.</li>
 </ul>
 <h2 id="options">Options</h2>
 <div class="option">
@@ -9959,7 +10038,7 @@ private:
 </div>
 <p>See: <a href="https://en.cppreference.com/w/cpp/language/function#Deleted_functions">https://en.cppreference.com/w/cpp/language/function#Deleted_functions</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-replace-disallow-copy-and-assign-macro.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/replace-disallow-copy-and-assign-macro.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -9994,7 +10073,7 @@ std::random_shuffle(vec.begin(), vec.end(), randomFunc);</code></pre>
   return std::mt19937(seq);
 }());</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-replace-random-shuffle.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/replace-random-shuffle.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10020,7 +10099,7 @@ Foo bar() {
   return {baz};
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-return-braced-init-list.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/return-braced-init-list.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10036,7 +10115,7 @@ Foo bar() {
 <p>Replace copy and swap tricks on shrinkable containers with the <code>shrink_to_fit()</code> method call.</p>
 <p>The <code>shrink_to_fit()</code> method is more readable and more effective than the copy and swap trick to reduce the capacity of a shrinkable container. Note that, the <code>shrink_to_fit()</code> method is only available in C++11 and up.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-shrink-to-fit.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/shrink-to-fit.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10060,7 +10139,7 @@ Foo bar() {
   static_assert(sizeof(a) &lt;= 10);
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-unary-static-assert.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/unary-static-assert.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10222,7 +10301,7 @@ auto *my_first_pointer = new TypeName, *my_second_pointer = new TypeName;
 
 auto my_first_pointer = new TypeName, my_second_pointer = new TypeName;</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-auto.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-auto.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10253,7 +10332,7 @@ bool x = p ? true : false;</code></pre>
 <p>If set to <span class="title-ref">true</span>, the check will not give warnings inside macros. Default is <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-bool-literals.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-bool-literals.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10306,7 +10385,7 @@ struct A {
 <p>If this option is set to <span class="title-ref">true</span> (default is <span class="title-ref">true</span>), the check will not warn about members declared inside macros.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-default-member-init.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-default-member-init.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10315,7 +10394,8 @@ struct A {
     <key>modernize-use-default</key>
     <name>modernize-use-default</name>
     <description>
-      <![CDATA[<dl>
+      <![CDATA[
+      <dl>
 <dt>orphan</dt>
 <dd>
 </dd>
@@ -10323,13 +10403,13 @@ struct A {
 <div class="title">
 <p>clang-tidy - modernize-use-default</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=modernize-use-equals-default.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/use-equals-default.html">
 
 </div>
 <h1 id="modernize-use-default">modernize-use-default</h1>
-<p>This check has been renamed to <a href="modernize-use-equals-default.html">modernize-use-equals-default</a>.</p>
+<p>This check has been renamed to <a href="../modernize/use-equals-default.html">modernize-use-equals-default</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-default.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-default.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10342,22 +10422,32 @@ struct A {
 <p>clang-tidy - modernize-use-emplace</p>
 </div>
 <h1 id="modernize-use-emplace">modernize-use-emplace</h1>
-<p>The check flags insertions to an STL-style container done by calling the <code>push_back</code> method with an explicitly-constructed temporary of the container element type. In this case, the corresponding <code>emplace_back</code> method results in less verbose and potentially more efficient code. Right now the check doesn't support <code>push_front</code> and <code>insert</code>. It also doesn't support <code>insert</code> functions for associative containers because replacing <code>insert</code> with <code>emplace</code> may result in <a href="https://htmlpreview.github.io/?https://github.com/HowardHinnant/papers/blob/master/insert_vs_emplace.html">speed regression</a>, but it might get support with some addition flag in the future.</p>
-<p>By default only <code>std::vector</code>, <code>std::deque</code>, <code>std::list</code> are considered. This list can be modified using the <code class="interpreted-text" role="option">ContainersWithPushBack</code> option.</p>
+<p>The check flags insertions to an STL-style container done by calling the <code>push_back</code>, <code>push</code>, or <code>push_front</code> methods with an explicitly-constructed temporary of the container element type. In this case, the corresponding <code>emplace</code> equivalent methods result in less verbose and potentially more efficient code. Right now the check doesn't support <code>insert</code>. It also doesn't support <code>insert</code> functions for associative containers because replacing <code>insert</code> with <code>emplace</code> may result in <a href="https://htmlpreview.github.io/?https://github.com/HowardHinnant/papers/blob/master/insert_vs_emplace.html">speed regression</a>, but it might get support with some addition flag in the future.</p>
+<p>The <code class="interpreted-text" role="option">ContainersWithPushBack</code>, <code class="interpreted-text" role="option">ContainersWithPush</code>, and <code class="interpreted-text" role="option">ContainersWithPushFront</code> options are used to specify the container types that support the <code>push_back</code>, <code>push</code>, and <code>push_front</code> operations respectively. The default values for these options are as follows:</p>
+<ul>
+<li><code class="interpreted-text" role="option">ContainersWithPushBack</code>: <code>std::vector</code>, <code>std::deque</code>, and <code>std::list</code>.</li>
+<li><code class="interpreted-text" role="option">ContainersWithPush</code>: <code>std::stack</code>, <code>std::queue</code>, and <code>std::priority_queue</code>.</li>
+<li><code class="interpreted-text" role="option">ContainersWithPushFront</code>: <code>std::forward_list</code>, <code>std::list</code>, and <code>std::deque</code>.</li>
+</ul>
+<p>This check also reports when an <code>emplace</code>-like method is improperly used, for example using <code>emplace_back</code> while also calling a constructor. This creates a temporary that requires at best a move and at worst a copy. Almost all <code>emplace</code>-like functions in the STL are covered by this, with <code>try_emplace</code> on <code>std::map</code> and <code>std::unordered_map</code> being the exception as it behaves slightly differently than all the others. More containers can be added with the <code class="interpreted-text" role="option">EmplacyFunctions</code> option, so long as the container defines a <code>value_type</code> type, and the <code>emplace</code>-like functions construct a <code>value_type</code> object.</p>
 <p>Before:</p>
 <pre class="c++"><code>std::vector&lt;MyClass&gt; v;
 v.push_back(MyClass(21, 37));
+v.emplace_back(MyClass(21, 37));
 
 std::vector&lt;std::pair&lt;int, int&gt;&gt; w;
 
 w.push_back(std::pair&lt;int, int&gt;(21, 37));
-w.push_back(std::make_pair(21L, 37L));</code></pre>
+w.push_back(std::make_pair(21L, 37L));
+w.emplace_back(std::make_pair(21L, 37L));</code></pre>
 <p>After:</p>
 <pre class="c++"><code>std::vector&lt;MyClass&gt; v;
+v.emplace_back(21, 37);
 v.emplace_back(21, 37);
 
 std::vector&lt;std::pair&lt;int, int&gt;&gt; w;
 w.emplace_back(21, 37);
+w.emplace_back(21L, 37L);
 w.emplace_back(21L, 37L);</code></pre>
 <p>By default, the check is able to remove unnecessary <code>std::make_pair</code> and <code>std::make_tuple</code> calls from <code>push_back</code> calls on containers of <code>std::pair</code> and <code>std::tuple</code>. Custom tuple-like types can be modified by the <code class="interpreted-text" role="option">TupleTypes</code> option; custom make functions can be modified by the <code class="interpreted-text" role="option">TupleMakeFunctions</code> option.</p>
 <p>The other situation is when we pass arguments that will be converted to a type inside a container.</p>
@@ -10390,6 +10480,14 @@ v.push_back(std::unique_ptr&lt;int&gt;(ptr));</code></pre>
 <p>Semicolon-separated list of class names of custom containers that support <code>push_back</code>.</p>
 </div>
 <div class="option">
+<p>ContainersWithPush</p>
+<p>Semicolon-separated list of class names of custom containers that support <code>push</code>.</p>
+</div>
+<div class="option">
+<p>ContainersWithPushFront</p>
+<p>Semicolon-separated list of class names of custom containers that support <code>push_front</code>.</p>
+</div>
+<div class="option">
 <p>IgnoreImplicitConstructors</p>
 <p>When <span class="title-ref">true</span>, the check will ignore implicitly constructed arguments of <code>push_back</code>, e.g.</p>
 <pre class="c++"><code>std::vector&lt;std::string&gt; v;
@@ -10408,15 +10506,21 @@ v.push_back(&quot;a&quot;); // Ignored when IgnoreImplicitConstructors is `true`
 <p>TupleMakeFunctions</p>
 <p>Semicolon-separated list of <code>std::make_tuple</code>-like function names. Those function calls will be removed from <code>push_back</code> calls and turned into <code>emplace_back</code>.</p>
 </div>
+<div class="option">
+<p>EmplacyFunctions</p>
+<p>Semicolon-separated list of containers without their template parameters and some <code>emplace</code>-like method of the container. Example: <code>vector::emplace_back</code>. Those methods will be checked for improper use and the check will report when a temporary is unnecessarily created.</p>
+</div>
 <h3 id="example">Example</h3>
 <pre class="c++"><code>std::vector&lt;MyTuple&lt;int, bool, char&gt;&gt; x;
-x.push_back(MakeMyTuple(1, false, &#39;x&#39;));</code></pre>
+x.push_back(MakeMyTuple(1, false, &#39;x&#39;));
+x.emplace_back(MakeMyTuple(1, false, &#39;x&#39;));</code></pre>
 <p>transforms to:</p>
 <pre class="c++"><code>std::vector&lt;MyTuple&lt;int, bool, char&gt;&gt; x;
+x.emplace_back(1, false, &#39;x&#39;);
 x.emplace_back(1, false, &#39;x&#39;);</code></pre>
-<p>when <code class="interpreted-text" role="option">TupleTypes</code> is set to <code>MyTuple</code> and <code class="interpreted-text" role="option">TupleMakeFunctions</code> is set to <code>MakeMyTuple</code>.</p>
+<p>when <code class="interpreted-text" role="option">TupleTypes</code> is set to <code>MyTuple</code>, <code class="interpreted-text" role="option">TupleMakeFunctions</code> is set to <code>MakeMyTuple</code>, and <code class="interpreted-text" role="option">EmplacyFunctions</code> is set to <code>vector::emplace_back</code>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-emplace.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10455,7 +10559,7 @@ A::~A() = default;</code></pre>
 <p>If set to <span class="title-ref">true</span>, the check will not give warnings inside macros. Default is <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-equals-default.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10487,7 +10591,7 @@ private:
 <p>If this option is set to <span class="title-ref">true</span> (default is <span class="title-ref">true</span>), the check will not warn about functions declared inside macros.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-equals-delete.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-delete.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10550,7 +10654,7 @@ NO_DISCARD bool empty(int i) const;</code></pre>
 <p>For alternative <code>__attribute__</code> syntax options to mark functions as <code>[[nodiscard]]</code> in non-c++17 source code. See <a href="https://clang.llvm.org/docs/AttributeReference.html#nodiscard-warn-unused-result">https://clang.llvm.org/docs/AttributeReference.html#nodiscard-warn-unused-result</a></p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-nodiscard.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-nodiscard.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10606,7 +10710,7 @@ struct bar {
 }</code></pre>
 <p>if the <code class="interpreted-text" role="option">UseNoexceptFalse</code> option is set to <span class="title-ref">false</span>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-noexcept.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-noexcept.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10657,7 +10761,7 @@ void assignment() {
 }</code></pre>
 <p>if the <code class="interpreted-text" role="option">NullMacros</code> option is set to <code>MY_NULL</code>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-nullptr.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-nullptr.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -10706,7 +10810,7 @@ void assignment() {
 <p>For more information on the use of <code>override</code> see <a href="https://en.cppreference.com/w/cpp/language/override">https://en.cppreference.com/w/cpp/language/override</a></p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-override.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-override.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10754,7 +10858,7 @@ class CC {
 auto CC::m() -&gt; S { return {0}; } // error</code></pre>
 <p>This code fails to compile because the S in the context of f refers to the equally named function parameter. Similarly, the S in the context of m refers to the equally named class member. The check can currently only detect and avoid a clash with a function parameter name.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-trailing-return-type.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-trailing-return-type.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10786,7 +10890,7 @@ std::map&lt;const char *, std::string, std::greater&lt;std::string&gt;&gt; s;</c
 </div>
 <p>This check requires using C++14 or higher to run.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-transparent-functors.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-transparent-functors.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10848,7 +10952,7 @@ int main() {
   res = uncaught_exceptions();
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-uncaught-exceptions.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-uncaught-exceptions.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10884,7 +10988,7 @@ using R_p = R_t*;</code></pre>
 <p>If set to <span class="title-ref">true</span>, the check will not give warnings inside macros. Default is <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-using.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-using.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10911,7 +11015,7 @@ MPI_Send(buf, 1, MPI_SHORT, 0, 0, MPI_COMM_WORLD);
 short *buf[1];
 MPI_Send(buf, 1, MPI_SHORT, 0, 0, MPI_COMM_WORLD);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/mpi-buffer-deref.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/mpi/buffer-deref.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>CODE_SMELL</type>
@@ -10936,7 +11040,7 @@ MPI_Send(&amp;buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
 int buf;
 MPI_Send(&amp;buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/mpi-type-mismatch.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/mpi/type-mismatch.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -10954,7 +11058,7 @@ MPI_Send(&amp;buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);</code></pre>
 <p>Finds improper usages of <span class="title-ref">XCTAssertEqual</span> and <span class="title-ref">XCTAssertNotEqual</span> and replaces them with <span class="title-ref">XCTAssertEqualObjects</span> or <span class="title-ref">XCTAssertNotEqualObjects</span>.</p>
 <p>This makes tests less fragile, as many improperly rely on pointer equality for strings that have equal values. This assumption is not guarantted by the language.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc-assert-equals.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc/assert-equals.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -10971,7 +11075,7 @@ MPI_Send(&amp;buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);</code></pre>
 <p>According to Apple developer document, we should always use factory method <code>errorWithDomain:code:userInfo:</code> to create new NSError objects instead of <code>[NSError alloc] init]</code>. Otherwise it will lead to a warning message during runtime.</p>
 <p>The corresponding information about <code>NSError</code> creation: <a href="https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html">https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc-avoid-nserror-init.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc/avoid-nserror-init.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -10989,7 +11093,7 @@ MPI_Send(&amp;buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);</code></pre>
 <p>Finds implementations of <code>-dealloc</code> in Objective-C categories. The category implementation will override any <code>-dealloc</code> in the class implementation, potentially causing issues.</p>
 <p>Classes implement <code>-dealloc</code> to perform important actions to deallocate an object. If a category on the class implements <code>-dealloc</code>, it will override the class's implementation and unexpected deallocation behavior may occur.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc-dealloc-in-category.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc/dealloc-in-category.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11017,7 +11121,7 @@ MPI_Send(&amp;buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);</code></pre>
 <p>Defaults to <span class="title-ref">ABNewPersonViewController;ABPeoplePickerNavigationController;ABPersonViewController;ABUnknownPersonViewController;NSHashTable;NSMapTable;NSPointerArray;NSPointerFunctions;NSTimer;UIActionSheet;UIAlertView;UIImagePickerController;UITextInputMode;UIWebView</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc-forbidden-subclassing.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc/forbidden-subclassing.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
@@ -11036,7 +11140,7 @@ MPI_Send(&amp;buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);</code></pre>
 <p>Apple documentation highlights that objects that are equal must have the same hash value: <a href="https://developer.apple.com/documentation/objectivec/1418956-nsobject/1418795-isequal?language=objc">https://developer.apple.com/documentation/objectivec/1418956-nsobject/1418795-isequal?language=objc</a></p>
 <p>Note that the check only verifies the presence of <code>-hash</code> in scenarios where its omission could result in unexpected behavior. The verification of the implementation of <code>-hash</code> is the responsibility of the developer, e.g., through the addition of unit tests to verify the implementation.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc-missing-hash.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc/missing-hash.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11066,7 +11170,7 @@ __unsafe_unretained id returnValue;
 <pre class="objc"><code>// &quot;id _returnValue&quot; is declaration of instance variable of class.
 [invocation getReturnValue:&amp;self-&gt;_returnValue];</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc-nsinvocation-argument-lifetime.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc/nsinvocation-argument-lifetime.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11092,7 +11196,7 @@ __unsafe_unretained id returnValue;
 <pre class="objc"><code>@property(nonatomic, assign) int abc_lowerCamelCase;</code></pre>
 <p>The corresponding style rule: <a href="https://developer.apple.com/library/content/qa/qa1908/_index.html">https://developer.apple.com/library/content/qa/qa1908/_index.html</a></p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc-property-declaration.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc/property-declaration.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11108,7 +11212,7 @@ __unsafe_unretained id returnValue;
 <p>Finds invocations of <code>-self</code> on super instances in initializers of subclasses of <code>NSObject</code> and recommends calling a superclass initializer instead.</p>
 <p>Invoking <code>-self</code> on super instances in initializers is a common programmer error when the programmer's original intent is to call a superclass initializer. Failing to call a superclass initializer breaks initializer chaining and can result in invalid object initialization.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc-super-self.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc/super-self.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11131,7 +11235,7 @@ __unsafe_unretained id returnValue;
 <p>Comma-separated list containing type names which are not counted as thrown exceptions in the check. Default value is an empty string.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/openmp-exception-escape.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/openmp/exception-escape.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11147,7 +11251,7 @@ __unsafe_unretained id returnValue;
 <p>Finds OpenMP directives that are allowed to contain a <code>default</code> clause, but either don't specify it or the clause is specified but with the kind other than <code>none</code>, and suggests to use the <code>default(none)</code> clause.</p>
 <p>Using <code>default(none)</code> clause forces developers to explicitly specify data sharing attributes for the variables referenced in the construct, thus making it obvious which variables are referenced, and what is their data sharing attribute, thus increasing readability and possibly making errors easier to spot.</p>
 <h2 id="example">Example</h2>
-<pre class="c++"><code>// ``for`` directive can not have ``default`` clause, no diagnostics.
+<pre class="c++"><code>// ``for`` directive cannot have ``default`` clause, no diagnostics.
 void n0(const int a) {
 #pragma omp for
   for (int b = 0; b &lt; a; b++)
@@ -11190,7 +11294,7 @@ void p0_3() {
   //          clause. Consider using ``default(none)`` clause instead.
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/openmp-use-default-none.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/openmp/use-default-none.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11216,7 +11320,7 @@ str.find(&#39;A&#39;);</code></pre>
 <p>Semicolon-separated list of names of string-like classes. By default only <code>::std::basic_string</code> and <code>::std::basic_string_view</code> are considered. The check will only consider member functions named <code>find</code>, <code>rfind</code>, <code>find_first_of</code>, <code>find_first_not_of</code>, <code>find_last_of</code>, or <code>find_last_not_of</code> within these classes.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-faster-string-find.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/faster-string-find.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11248,7 +11352,7 @@ str.find(&#39;A&#39;);</code></pre>
 <p>A semicolon-separated list of names of types allowed to be copied in each iteration. Regular expressions are accepted, e.g. <span class="title-ref">[Rr]ef(erence)?$</span> matches every type with suffix <span class="title-ref">Ref</span>, <span class="title-ref">ref</span>, <span class="title-ref">Reference</span> and <span class="title-ref">reference</span>. The default is empty. If a name in the list contains the sequence <span class="title-ref">::</span> it is matched against the qualified typename (i.e. <span class="title-ref">namespace::Type</span>, otherwise it is matched against only the type name (i.e. <span class="title-ref">Type</span>).</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-for-range-copy.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/for-range-copy.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11259,7 +11363,8 @@ str.find(&#39;A&#39;);</code></pre>
     <key>performance-implicit-cast-in-loop</key>
     <name>performance-implicit-cast-in-loop</name>
     <description>
-      <![CDATA[<dl>
+      <![CDATA[
+      <dl>
 <dt>orphan</dt>
 <dd>
 </dd>
@@ -11267,13 +11372,13 @@ str.find(&#39;A&#39;);</code></pre>
 <div class="title">
 <p>clang-tidy - performance-implicit-cast-in-loop</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=performance-implicit-conversion-in-loop.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../performance/implicit-conversion-in-loop.html">
 
 </div>
 <h1 id="performance-implicit-cast-in-loop">performance-implicit-cast-in-loop</h1>
-<p>This check has been renamed to <a href="performance-implicit-conversion-in-loop.html">performance-implicit-conversion-in-loop</a>.</p>
+<p>This check has been renamed to <a href="../performance/implicit-conversion-in-loop.html">performance-implicit-conversion-in-loop</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-implicit-cast-in-loop.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/implicit-cast-in-loop.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11296,7 +11401,7 @@ for (const pair&lt;int, vector&lt;string&gt;&gt;&amp; p : my_map) {}
 // that the compiler added a conversion, resulting in a copy of the vectors.</code></pre>
 <p>The easiest solution is usually to use <code>const auto&amp;</code> instead of writing the type manually.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-implicit-conversion-in-loop.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/implicit-conversion-in-loop.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11326,7 +11431,7 @@ auto c = std::count(s.begin(), s.end(), 43);
 
 auto c = s.count(43);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-inefficient-algorithm.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/inefficient-algorithm.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11372,7 +11477,7 @@ void g() {
 <p>When <span class="title-ref">false</span>, the check will only check the string usage in <code>while</code>, <code>for</code> and <code>for-range</code> statements. Default is <span class="title-ref">false</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-inefficient-string-concatenation.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/inefficient-string-concatenation.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11430,7 +11535,7 @@ for (auto element : data) {
 <p>When <span class="title-ref">true</span>, the check will also warn on inefficient operations for proto repeated fields. Otherwise, the check only warns on inefficient vector operations. Default is <span class="title-ref">false</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-inefficient-vector-operation.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/inefficient-vector-operation.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11472,7 +11577,7 @@ f(std::move(s));  // Warning: passing result of std::move as a const reference a
 <p>If <span class="title-ref">true</span>, enables detection of <span class="title-ref">std::move()</span> passed as a const reference argument. Default is <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-move-const-arg.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/move-const-arg.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11490,7 +11595,7 @@ f(std::move(s));  // Warning: passing result of std::move as a const reference a
 <p>"cert-oop11-cpp" redirects here as an alias for this check.</p>
 <p>The check flags user-defined move constructors that have a ctor-initializer initializing a member or base class through a copy constructor instead of a move constructor.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-move-constructor-init.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/move-constructor-init.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11528,7 +11633,7 @@ StatusOr&lt;std::vector&lt;int&gt;&gt; NotCool() {
 }</code></pre>
 <p>In that case the fix is more consensual: just <span class="title-ref">return std::move(obj)</span>. This is handled by the <span class="title-ref">-Wreturn-std-move</span> warning.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-no-automatic-move.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/no-automatic-move.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11564,7 +11669,7 @@ tgt(char* maybe_underbiased_ptr) {
     return maybe_underbiased_ptr + bias;
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-no-int-to-ptr.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/no-int-to-ptr.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11582,7 +11687,7 @@ tgt(char* maybe_underbiased_ptr) {
 <p>The check flags user-defined move constructors and assignment operators not marked with <code>noexcept</code> or marked with <code>noexcept(expr)</code> where <code>expr</code> evaluates to <code>false</code> (but is not a <code>false</code> literal itself).</p>
 <p>Move constructors of all the types used with STL containers, for example, need to be declared <code>noexcept</code>. Otherwise STL will choose copy constructors instead. The same is valid for move assignment operations.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-noexcept-move-constructor.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/noexcept-move-constructor.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11604,7 +11709,7 @@ tgt(char* maybe_underbiased_ptr) {
 };
 A::~A() = default;</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-trivially-destructible.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/trivially-destructible.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11629,7 +11734,7 @@ asin(a);
 float a;
 std::asin(a);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-type-promotion-in-math-fn.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/type-promotion-in-math-fn.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11675,7 +11780,7 @@ void Function(const Foo&amp; foo) {
 <p>A semicolon-separated list of names of types whose methods are allowed to return the const reference the variable is copied from. When an expensive to copy variable is copy initialized by the return value from a type on this list the check does not trigger. This can be used to exclude types known to be const incorrect or where the lifetime or immutability of returned references is not tied to mutations of the container. An example are view types that don't own the underlying data. Like for <span class="title-ref">AllowedTypes</span> above, regular expressions are accepted and the inclusion of <span class="title-ref">::</span> determines whether the qualified typename is matched or not.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-copy-initialization.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/unnecessary-copy-initialization.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11728,7 +11833,7 @@ void setValue(string Value) {
 <p>A semicolon-separated list of names of types allowed to be passed by value. Regular expressions are accepted, e.g. <span class="title-ref">[Rr]ef(erence)?$</span> matches every type with suffix <span class="title-ref">Ref</span>, <span class="title-ref">ref</span>, <span class="title-ref">Reference</span> and <span class="title-ref">reference</span>. The default is empty. If a name in the list contains the sequence <span class="title-ref">::</span> it is matched against the qualified typename (i.e. <span class="title-ref">namespace::Type</span>, otherwise it is matched against only the type name (i.e. <span class="title-ref">Type</span>).</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-value-param.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/unnecessary-value-param.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11768,7 +11873,7 @@ void setValue(string Value) {
 <p>A string containing a comma separated glob list of allowed include filenames. Similar to the -checks glob list for running clang-tidy itself, the two wildcard characters are <span class="title-ref">*</span> and <span class="title-ref">-</span>, to include and exclude globs, respectively. The default is <span class="title-ref">*</span>, which allows all includes.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/portability-restrict-system-includes.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/portability/restrict-system-includes.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11802,7 +11907,7 @@ vec_add(a, b);       // Power</code></pre>
 <p>The namespace used to suggest <a href="https://wg21.link/p0214">P0214</a> alternatives. If not specified, <span class="title-ref">std::</span> for <span class="title-ref">-std=c++20</span> and <span class="title-ref">std::experimental::</span> for <span class="title-ref">-std=c++11</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/portability-simd-intrinsics.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/portability/simd-intrinsics.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11820,8 +11925,13 @@ vec_add(a, b);       // Power</code></pre>
 <p>Examples:</p>
 <pre class="c++"><code>void f(const string);   // Bad: const is top level.
 void f(const string&amp;);  // Good: const is not top level.</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>If set to <span class="title-ref">true</span>, the check will not give warnings inside macros. Default is <span class="title-ref">true</span>.</p>
+</div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-avoid-const-params-in-decls.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-const-params-in-decls.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11852,7 +11962,7 @@ void f(const string&amp;);  // Good: const is not top level.</code></pre>
 <p>The number of lines is counted from the end of condition or initial keyword (<code>do</code>/<code>else</code>) until the last line of the inner statement. Default value <span class="title-ref">0</span> means that braces will be added to all statements (not having them already).</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-braces-around-statements.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/braces-around-statements.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11876,8 +11986,13 @@ Clazz *const foo();</code></pre>
 <pre class="c++"><code>const int* foo();
 const int&amp; foo();
 const Clazz* foo();</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>If set to <span class="title-ref">true</span>, the check will not give warnings inside macros. Default is <span class="title-ref">true</span>.</p>
+</div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-const-return-type.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/const-return-type.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11935,7 +12050,7 @@ const Clazz* foo();</code></pre>
 </table>
 <p>This check applies to <code>std::set</code>, <code>std::unordered_set</code>, <code>std::map</code>, <code>std::unordered_map</code> and the corresponding multi-key variants. It is only active for C++20 and later, as the <code>contains</code> method was only added in C++20.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-container-contains.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/container-contains.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11951,7 +12066,7 @@ const Clazz* foo();</code></pre>
 <p>Finds cases where code could use <code>data()</code> rather than the address of the element at index 0 in a container. This pattern is commonly used to materialize a pointer to the backing data of a container. <code>std::vector</code> and <code>std::string</code> provide a <code>data()</code> accessor to retrieve the data pointer which should be preferred.</p>
 <p>This also ensures that in the case that the container is empty, the data pointer access does not perform an errant memory access.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-container-data-pointer.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/container-data-pointer.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -11971,7 +12086,7 @@ const Clazz* foo();</code></pre>
 bool empty() const;</code></pre>
 <p><span class="title-ref">size_type</span> can be any kind of integer type.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-container-size-empty.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/container-size-empty.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -11988,25 +12103,9 @@ bool empty() const;</code></pre>
 <h1 id="readability-convert-member-functions-to-static">readability-convert-member-functions-to-static</h1>
 <p>Finds non-static member functions that can be made <code>static</code> because the functions don't use <code>this</code>.</p>
 <p>After applying modifications as suggested by the check, running the check again might find more opportunities to mark member functions <code>static</code>.</p>
-<p>After making a member function <code>static</code>, you might want to run the check <a href="readability-static-accessed-through-instance.html">readability-static-accessed-through-instance</a> to replace calls like <code>Instance.method()</code> by <code>Class::method()</code>.</p>
+<p>After making a member function <code>static</code>, you might want to run the check <a href="../readability/static-accessed-through-instance.html">readability-static-accessed-through-instance</a> to replace calls like <code>Instance.method()</code> by <code>Class::method()</code>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-convert-member-functions-to-static.html" target="_blank">clang.llvm.org</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    <type>CODE_SMELL</type>
-    </rule>
-  <rule>
-    <key>readability-data-pointer</key>
-    <name>readability-data-pointer</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - readability-data-pointer</p>
-</div>
-<h1 id="readability-data-pointer">readability-data-pointer</h1>
-<p>Finds cases where code could use <code>data()</code> rather than the address of the element at index 0 in a container. This pattern is commonly used to materialize a pointer to the backing data of a container. <code>std::vector</code> and <code>std::string</code> provide a <code>data()</code> accessor to retrieve the data pointer which should be preferred.</p>
-<p>This also ensures that in the case that the container is empty, the data pointer access does not perform an errant memory access.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-data-pointer.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/convert-member-functions-to-static.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -12024,7 +12123,7 @@ bool empty() const;</code></pre>
 if (p)
   delete p;</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-delete-null-pointer.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/delete-null-pointer.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -12049,11 +12148,12 @@ if (p)
 <pre class="c++"><code>#undef NDEBUG
 #include &quot;assertion.h&quot;
 // ...code with assertions enabled
+
 #define NDEBUG
 #include &quot;assertion.h&quot;
 // ...code with assertions disabled</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-duplicate-include.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/duplicate-include.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -12121,7 +12221,7 @@ if (p)
 <p>There is an alias of this check called llvm-else-after-return. In that version the options <code class="interpreted-text" role="option">WarnOnUnfixable</code> and <code class="interpreted-text" role="option">WarnOnConditionVariables</code> are both set to <span class="title-ref">false</span> by default.</p>
 <p>This check helps to enforce this <a href="https://llvm.org/docs/CodingStandards.html#don-t-use-else-after-a-return">LLVM Coding Standards recommendation</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-else-after-return.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/else-after-return.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -12268,7 +12368,7 @@ if (p)
 </dd>
 </dl>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-function-cognitive-complexity.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/function-cognitive-complexity.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -12311,7 +12411,7 @@ if (p)
 <p>Flag functions exceeding this number of variables declared in the body. The default is <span class="title-ref">-1</span> (ignore the number of variables). Please note that function parameters and variables declared in lambdas, GNU Statement Expressions, and nested class inline functions are not counted.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-function-size.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/function-size.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -12400,7 +12500,7 @@ catch (const std::exception&amp; e) {
 }</code></pre>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-identifier-length.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/identifier-length.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -14565,7 +14665,7 @@ double   dValueDouble = 0.0;
 ULONG    ulValueUlong = 0;
 DWORD    dwValueDword = 0;</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-identifier-naming.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/identifier-naming.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -14576,7 +14676,8 @@ DWORD    dwValueDword = 0;</code></pre>
     <key>readability-implicit-bool-cast</key>
     <name>readability-implicit-bool-cast</name>
     <description>
-      <![CDATA[<dl>
+      <![CDATA[
+      <dl>
 <dt>orphan</dt>
 <dd>
 </dd>
@@ -14584,13 +14685,13 @@ DWORD    dwValueDword = 0;</code></pre>
 <div class="title">
 <p>clang-tidy - readability-implicit-bool-cast</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=readability-implicit-bool-conversion.html">
+<div class="meta" data-http-equiv=refresh="5;URL=../readability/implicit-bool-conversion.html">
 
 </div>
 <h1 id="readability-implicit-bool-cast">readability-implicit-bool-cast</h1>
-<p>This check has been renamed to <a href="readability-implicit-bool-conversion.html">readability-implicit-bool-conversion</a>.</p>
+<p>This check has been renamed to <a href="../readability/implicit-bool-conversion.html">readability-implicit-bool-conversion</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-implicit-bool-cast.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/implicit-bool-cast.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -14691,7 +14792,7 @@ void conversionsFromBool() {
 <p>When <span class="title-ref">true</span>, the check will allow conditional pointer conversions. Default is <span class="title-ref">false</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-implicit-bool-conversion.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/implicit-bool-conversion.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -14733,7 +14834,7 @@ int foo(int b) { return b + 2; } // definition with use of &quot;b&quot;</code><
 <p>If this option is set to <span class="title-ref">true</span> (default is <span class="title-ref">false</span>), then names must match exactly (or be absent).</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-inconsistent-declaration-parameter-name.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -14814,7 +14915,7 @@ void macros() {
   // Won&#39;t be transformed, but a diagnostic is emitted.
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-isolate-declaration.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/isolate-declaration.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -14893,7 +14994,7 @@ for (int mm = 1; mm &lt;= MONTHS_IN_A_YEAR; ++mm) {
 <p>Boolean value indicating whether to accept magic numbers as bit field widths without warning. This is useful for example for register definitions which are generated from hardware specifications. Default value is <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-magic-numbers.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/magic-numbers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -14925,7 +15026,7 @@ for (int mm = 1; mm &lt;= MONTHS_IN_A_YEAR; ++mm) {
 <li>contain a <code>const_cast</code></li>
 <li>are templated or part of a class template</li>
 <li>have an empty body</li>
-<li>do not (implicitly) use <code>this</code> at all (see <a href="readability-convert-member-functions-to-static.html">readability-convert-member-functions-to-static</a>).</li>
+<li>do not (implicitly) use <code>this</code> at all (see <a href="../readability/convert-member-functions-to-static.html">readability-convert-member-functions-to-static</a>).</li>
 </ul>
 <p>The following real-world examples will be preserved by the check:</p>
 <pre class="c++"><code>class E1 {
@@ -14949,7 +15050,7 @@ public:
 };</code></pre>
 <p>After applying modifications as suggested by the check, running the check again might find more opportunities to mark member functions <code>const</code>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-make-member-function-const.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/make-member-function-const.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -14980,7 +15081,7 @@ if (cond1)
 <h2 id="limitations">Limitations</h2>
 <p>Note that this check only works as expected when the tabs or spaces are used consistently and not mixed.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-misleading-indentation.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/misleading-indentation.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15011,7 +15112,7 @@ if (cond1)
 </dd>
 </dl>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-misplaced-array-index.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/misplaced-array-index.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15030,7 +15131,7 @@ if (cond1)
 <p>All parameters should be named, with identical names in the declaration and implementation.</p>
 <p>Corresponding cpplint.py check name: <span class="title-ref">readability/function</span>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-named-parameter.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/named-parameter.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15081,7 +15182,7 @@ void f4(int *p) {
   int &amp;x = *p;
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-non-const-parameter.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/non-const-parameter.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15137,7 +15238,7 @@ const auto *Foo2 = cast&lt;const int *&gt;(Bar2);
 const auto &amp;Foo3 = cast&lt;const int &amp;&gt;(Bar3);</code></pre>
 <p>Note in the LLVM alias, the default value is <span class="title-ref">false</span>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-qualified-auto.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/qualified-auto.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15176,7 +15277,7 @@ public:
 }</code></pre>
 <p>If <span class="title-ref">CheckFirstDeclaration</span> option is enabled, a warning about redundant access specifier will be emitted, because <code>public</code> is the default member access for structs.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-access-specifiers.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-access-specifiers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15215,7 +15316,7 @@ void f() {
   }
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-control-flow.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-control-flow.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15245,7 +15346,7 @@ extern int X;</code></pre>
 <p>If set to <span class="title-ref">true</span>, the check will not give warnings inside macros. Default is <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-declaration.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-declaration.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15270,7 +15371,7 @@ int (*p)(int, int) = &amp;f;
 
 int i = (*p)(10, 50);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-function-ptr-dereference.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-function-ptr-dereference.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15306,7 +15407,7 @@ struct Foo : public Bar {
   std::string s;
 };</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-member-init.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-member-init.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15362,7 +15463,7 @@ void f();
 #endif
 #endif</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-preprocessor.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-preprocessor.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15386,7 +15487,7 @@ if (ptr.get() == nullptr) ... =&gt; if (ptr == nullptr) ...</code></pre>
 <p>If this option is set to <span class="title-ref">true</span> (default is <span class="title-ref">true</span>), the check will not warn about calls inside macros.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-smartptr-get.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-smartptr-get.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -15403,7 +15504,7 @@ if (ptr.get() == nullptr) ... =&gt; if (ptr == nullptr) ...</code></pre>
 <h1 id="readability-redundant-string-cstr">readability-redundant-string-cstr</h1>
 <p>Finds unnecessary calls to <code>std::string::c_str()</code> and <code>std::string::data()</code>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-string-cstr.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-string-cstr.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>CODE_SMELL</type>
@@ -15444,7 +15545,7 @@ std::string_view b;</code></pre>
 <p>Semicolon-delimited list of class names to apply this check to. By default <span class="title-ref">::std::basic_string</span> applies to <code>std::string</code> and <code>std::wstring</code>. Set to e.g. <span class="title-ref">::std::basic_string;llvm::StringRef;QString</span> to perform this check on custom classes.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-string-init.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-string-init.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15457,7 +15558,7 @@ std::string_view b;</code></pre>
 <p>clang-tidy - readability-simplify-boolean-expr</p>
 </div>
 <h1 id="readability-simplify-boolean-expr">readability-simplify-boolean-expr</h1>
-<p>Looks for boolean expressions involving boolean constants and simplifies them to use the appropriate boolean expression directly.</p>
+<p>Looks for boolean expressions involving boolean constants and simplifies them to use the appropriate boolean expression directly. Simplifies boolean expressions by application of DeMorgan's Theorem.</p>
 <p>Examples:</p>
 <table>
 <thead>
@@ -15563,6 +15664,42 @@ std::string_view b;</code></pre>
 <p><code>return !e;</code></p>
 </blockquote></td>
 </tr>
+<tr class="odd">
+<td><code>!(!a || b)</code></td>
+<td><blockquote>
+<p><code>a &amp;&amp; !b</code></p>
+</blockquote></td>
+</tr>
+<tr class="even">
+<td><code>!(a || !b)</code></td>
+<td><blockquote>
+<p><code>!a &amp;&amp; b</code></p>
+</blockquote></td>
+</tr>
+<tr class="odd">
+<td><code>!(!a || !b)</code></td>
+<td><blockquote>
+<p><code>a &amp;&amp; b</code></p>
+</blockquote></td>
+</tr>
+<tr class="even">
+<td><code>!(!a &amp;&amp; b)</code></td>
+<td><blockquote>
+<p><code>a || !b</code></p>
+</blockquote></td>
+</tr>
+<tr class="odd">
+<td><code>!(a &amp;&amp; !b)</code></td>
+<td><blockquote>
+<p><code>!a || b</code></p>
+</blockquote></td>
+</tr>
+<tr class="even">
+<td><code>!(!a &amp;&amp; !b)</code></td>
+<td><blockquote>
+<p><code>a || b</code></p>
+</blockquote></td>
+</tr>
 </tbody>
 </table>
 <dl>
@@ -15599,8 +15736,22 @@ std::string_view b;</code></pre>
 <p>ChainedConditionalAssignment</p>
 <p>If <span class="title-ref">true</span>, conditional boolean assignments at the end of an <code>if/else if</code> chain will be transformed. Default is <span class="title-ref">false</span>.</p>
 </div>
+<div class="option">
+<p>SimplifyDeMorgan</p>
+<p>If <span class="title-ref">true</span>, DeMorgan's Theorem will be applied to simplify negated conjunctions and disjunctions. Default is <span class="title-ref">true</span>.</p>
+</div>
+<div class="option">
+<p>SimplifyDeMorganRelaxed</p>
+<p>If <span class="title-ref">true</span>, <code class="interpreted-text" role="option">SimplifyDeMorgan</code> will also transform negated conjunctions and disjunctions where there is no negation on either operand. This option has no effect if <code class="interpreted-text" role="option">SimplifyDeMorgan</code> is <span class="title-ref">false</span>. Default is <span class="title-ref">false</span>.</p>
+<p>When Enabled:</p>
+<pre class=""><code>bool X = !(A &amp;&amp; B)
+bool Y = !(A || B)</code></pre>
+<p>Would be transformed to:</p>
+<pre class=""><code>bool X = !A || !B
+bool Y = !A &amp;&amp; !B</code></pre>
+</div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-simplify-boolean-expr.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/simplify-boolean-expr.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15623,7 +15774,7 @@ char c = s.data()[i];  // char c = s[i];</code></pre>
 <p>The list of type(s) that triggers this check. Default is <span class="title-ref">::std::basic_string;::std::basic_string_view;::std::vector;::std::array</span></p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-simplify-subscript-expr.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/simplify-subscript-expr.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15652,7 +15803,7 @@ c1-&gt;x;</code></pre>
 C::foo();
 C::x;</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-static-accessed-through-instance.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/static-accessed-through-instance.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15676,7 +15827,7 @@ C::x;</code></pre>
 }</code></pre>
 <p>The check will apply a fix by removing the redundant <code>static</code> qualifier.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-static-definition-in-anonymous-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/static-definition-in-anonymous-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15724,7 +15875,7 @@ if (str1.compare(&quot;foo&quot;) == 0) {
 }</code></pre>
 <p>The above code examples show the list of if-statements that this check will give a warning for. All of them uses <code>compare</code> to check if equality or inequality of two strings instead of using the correct operators.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-string-compare.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/string-compare.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15748,6 +15899,7 @@ if (str1.compare(&quot;foo&quot;) == 0) {
 <h3 id="abbreviation_heuristic">Abbreviation</h3>
 <p>Common abbreviations can be specified which will deem the strings similar if the abbreviated and the abbreviation stand together. For example, if <code>src</code> is registered as an abbreviation for <code>source</code>, then the following code example will be warned about.</p>
 <pre class="c++"><code>void foo(int source, int x);
+
 foo(b, src);</code></pre>
 <p>The abbreviations to recognise can be configured with the <code class="interpreted-text" role="ref">Abbreviations&lt;opt_Abbreviations&gt;</code> check option. This heuristic is case-insensitive.</p>
 <h3 id="prefix">Prefix</h3>
@@ -15763,11 +15915,11 @@ foo(b, src);</code></pre>
 <p>The <a href="http://en.wikipedia.org/wiki/Levenshtein_distance">Levenshtein distance</a> describes how many single-character changes (additions, changes, or removals) must be applied to transform one string into another.</p>
 <p>The Levenshtein distance is translated into a similarity percentage by dividing it with the length of the <em>longer</em> string, and taking its complement with regards to <span class="title-ref">100</span>%. For example, given <code>something</code> and <code>anything</code>, the distance is <span class="title-ref">4</span> edits, and the similarity percentage is <span class="title-ref">100</span>% <span class="title-ref">- 4 / 9 = 55.55...</span>%.</p>
 <p>This heuristic can be configured with <code class="interpreted-text" role="ref">bounds&lt;opt_Bounds&gt;</code>. The default bounds are: below <span class="title-ref">50</span>% dissimilar and above <span class="title-ref">66</span>% similar. This heuristic is case-sensitive.</p>
-<h3 id="jaro-winkler-distance-as-jarowinkler">Jaro-Winkler distance (as <span class="title-ref">JaroWinkler</span>)</h3>
-<p>The Jaro-Winkler distance is an edit distance like the Levenshtein distance. It is calculated from the amount of common characters that are sufficiently close to each other in position, and to-be-changed characters. The original definition of Jaro has been extended by Winkler to weigh prefix similarities more. The similarity percentage is expressed as an average of the common and non-common characters against the length of both strings.</p>
+<h3 id="jaro--winkler-distance-as-jarowinkler">Jaro--Winkler distance (as <span class="title-ref">JaroWinkler</span>)</h3>
+<p>The <a href="http://en.wikipedia.org/wiki/Jaro-Winkler_distance">Jaro--Winkler distance</a> is an edit distance like the Levenshtein distance. It is calculated from the amount of common characters that are sufficiently close to each other in position, and to-be-changed characters. The original definition of Jaro has been extended by Winkler to weigh prefix similarities more. The similarity percentage is expressed as an average of the common and non-common characters against the length of both strings.</p>
 <p>This heuristic can be configured with <code class="interpreted-text" role="ref">bounds&lt;opt_Bounds&gt;</code>. The default bounds are: below <span class="title-ref">75</span>% dissimilar and above <span class="title-ref">85</span>% similar. This heuristic is case-insensitive.</p>
-<h3 id="sorensen-dice-coefficient-as-dice">Sorensen-Dice coefficient (as <span class="title-ref">Dice</span>)</h3>
-<p>The Sorensen-Dice coefficient was originally defined to measure the similarity of two sets. Formally, the coefficient is calculated by dividing <span class="title-ref">2 * #(intersection)</span> with <span class="title-ref">#(set1) + #(set2)</span>, where <span class="title-ref">#()</span> is the cardinality function of sets. This metric is applied to strings by creating bigrams (substring sequences of length 2) of the two strings and using the set of bigrams for the two strings as the two sets.</p>
+<h3 id="sorensen--dice-coefficient-as-dice">Sorensen--Dice coefficient (as <span class="title-ref">Dice</span>)</h3>
+<p>The <a href="http://en.wikipedia.org/wiki/Sorensen-Dice_coefficient">Sorensen--Dice coefficient</a> was originally defined to measure the similarity of two sets. Formally, the coefficient is calculated by dividing <span class="title-ref">2 * #(intersection)</span> with <span class="title-ref">#(set1) + #(set2)</span>, where <span class="title-ref">#()</span> is the cardinality function of sets. This metric is applied to strings by creating bigrams (substring sequences of length 2) of the two strings and using the set of bigrams for the two strings as the two sets.</p>
 <p>This heuristic can be configured with <code class="interpreted-text" role="ref">bounds&lt;opt_Bounds&gt;</code>. The default bounds are: below <span class="title-ref">60</span>% dissimilar and above <span class="title-ref">70</span>% similar. This heuristic is case-insensitive.</p>
 <h2 id="options">Options</h2>
 <div class="option">
@@ -15843,7 +15995,7 @@ foo(b, src);</code></pre>
 </blockquote>
 <p>Empty argument or parameter names are ignored by the heuristics.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-suspicious-call-argument.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/suspicious-call-argument.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15877,7 +16029,7 @@ std::unique_ptr&lt;int&gt; P;
 P.reset();</code></pre>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-uniqueptr-delete-release.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/uniqueptr-delete-release.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15923,7 +16075,7 @@ auto x = 1U; // OK, suffix is uppercase.
 <p>If this option is set to <span class="title-ref">true</span> (default is <span class="title-ref">true</span>), the check will not warn about literal suffixes inside macros.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-uppercase-literal-suffix.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/uppercase-literal-suffix.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15948,7 +16100,7 @@ auto x = 1U; // OK, suffix is uppercase.
   // return std::ranges::all_of(V, [](int I) { return I % 2 == 0; });
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability-use-anyofallof.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/use-anyofallof.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     <type>CODE_SMELL</type>
@@ -15989,12 +16141,776 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p>A semi-colon-separated list of fully-qualified names of C++ classes that should not be constructed as temporaries. Default is empty.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/zircon-temporary-objects.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/zircon/temporary-objects.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MAJOR</severity>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
     <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>abseil-cleanup-ctad</key>
+    <name>abseil-cleanup-ctad</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - abseil-cleanup-ctad</p>
+</div>
+<h1 id="abseil-cleanup-ctad">abseil-cleanup-ctad</h1>
+<p>Suggests switching the initialization pattern of <code>absl::Cleanup</code> instances from the factory function to class template argument deduction (CTAD), in C++17 and higher.</p>
+<pre class="c++"><code>auto c1 = absl::MakeCleanup([] {});
+
+const auto c2 = absl::MakeCleanup(std::function&lt;void()&gt;([] {}));</code></pre>
+<p>becomes</p>
+<pre class="c++"><code>absl::Cleanup c1 = [] {};
+
+const absl::Cleanup c2 = std::function&lt;void()&gt;([] {});</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/cleanup-ctad.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>bugprone-assignment-in-if-condition</key>
+    <name>bugprone-assignment-in-if-condition</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-assignment-in-if-condition</p>
+</div>
+<h1 id="bugprone-assignment-in-if-condition">bugprone-assignment-in-if-condition</h1>
+<p>Finds assignments within conditions of <span class="title-ref">if</span> statements. Such assignments are bug-prone because they may have been intended as equality tests.</p>
+<p>This check finds all assignments within <span class="title-ref">if</span> conditions, including ones that are not flagged by <span class="title-ref">-Wparentheses</span> due to an extra set of parentheses, and including assignments that call an overloaded <span class="title-ref">operator=()</span>. The identified assignments violate <a href="https://barrgroup.com/embedded-systems/books/embedded-c-coding-standard/statement-rules/if-else-statements">BARR group "Rule 8.2.c"</a>.</p>
+<pre class="c++"><code>int f = 3;
+if(f = 4) { // This is identified by both `Wparentheses` and this check - should it have been: `if (f == 4)` ?
+  f = f + 1;
+}
+
+if((f == 5) || (f = 6)) { // the assignment here `(f = 6)` is identified by this check, but not by `-Wparentheses`. Should it have been `(f == 6)` ?
+  f = f + 2;
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/assignment-in-if-condition.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>bugprone-narrowing-conversions</key>
+    <name>bugprone-narrowing-conversions</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-narrowing-conversions</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../cppcoreguidelines/narrowing-conversions.html">
+
+</div>
+<h1 id="bugprone-narrowing-conversions">bugprone-narrowing-conversions</h1>
+<p>The bugprone-narrowing-conversions check is an alias, please see <a href="../cppcoreguidelines/narrowing-conversions.html">cppcoreguidelines-narrowing-conversions</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/narrowing-conversions.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>bugprone-standalone-empty</key>
+    <name>bugprone-standalone-empty</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-standalone-empty</p>
+</div>
+<h1 id="bugprone-standalone-empty">bugprone-standalone-empty</h1>
+<p>Warns when <span class="title-ref">empty()</span> is used on a range and the result is ignored. Suggests <span class="title-ref">clear()</span> if it is an existing member function.</p>
+<p>The <code>empty()</code> method on several common ranges returns a Boolean indicating whether or not the range is empty, but is often mistakenly interpreted as a way to clear the contents of a range. Some ranges offer a <code>clear()</code> method for this purpose. This check warns when a call to empty returns a result that is ignored, and suggests replacing it with a call to <code>clear()</code> if it is available as a member function of the range.</p>
+<p>For example, the following code could be used to indicate whether a range is empty or not, but the result is ignored:</p>
+<pre class="c++"><code>std::vector&lt;int&gt; v;
+...
+v.empty();</code></pre>
+<p>A call to <code>clear()</code> would appropriately clear the contents of the range:</p>
+<pre class="c++"><code>std::vector&lt;int&gt; v;
+...
+v.clear();</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/standalone-empty.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>bugprone-suspicious-realloc-usage</key>
+    <name>bugprone-suspicious-realloc-usage</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-suspicious-realloc-usage</p>
+</div>
+<h1 id="bugprone-suspicious-realloc-usage">bugprone-suspicious-realloc-usage</h1>
+<p>This check finds usages of <code>realloc</code> where the return value is assigned to the same expression as passed to the first argument: <code>p = realloc(p, size);</code> The problem with this construct is that if <code>realloc</code> fails it returns a null pointer but does not deallocate the original memory. If no other variable is pointing to it, the original memory block is not available any more for the program to use or free. In either case <code>p = realloc(p, size);</code> indicates bad coding style and can be replaced by <code>q = realloc(p, size);</code>.</p>
+<p>The pointer expression (used at <code>realloc</code>) can be a variable or a field member of a data structure, but can not contain function calls or unresolved types.</p>
+<p>In obvious cases when the pointer used at realloc is assigned to another variable before the <code>realloc</code> call, no warning is emitted. This happens only if a simple expression in form of <code>q = p</code> or <code>void *q = p</code> is found in the same function where <code>p = realloc(p, ...)</code> is found. The assignment has to be before the call to realloc (but otherwise at any place) in the same function. This suppression works only if <code>p</code> is a single variable.</p>
+<p>Examples:</p>
+<pre class="c++"><code>struct A {
+  void *p;
+};
+
+A &amp;getA();
+
+void foo(void *p, A *a, int new_size) {
+  p = realloc(p, new_size); // warning: &#39;p&#39; may be set to null if &#39;realloc&#39; fails, which may result in a leak of the original buffer
+  a-&gt;p = realloc(a-&gt;p, new_size); // warning: &#39;a-&gt;p&#39; may be set to null if &#39;realloc&#39; fails, which may result in a leak of the original buffer
+  getA().p = realloc(getA().p, new_size); // no warning
+}
+
+void foo1(void *p, int new_size) {
+  void *p1 = p;
+  p = realloc(p, new_size); // no warning
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-realloc-usage.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>bugprone-unchecked-optional-access</key>
+    <name>bugprone-unchecked-optional-access</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-unchecked-optional-access</p>
+</div>
+<h1 id="bugprone-unchecked-optional-access">bugprone-unchecked-optional-access</h1>
+<p><em>Note</em>: This check uses a flow-sensitive static analysis to produce its results. Therefore, it may be more resource intensive (RAM, CPU) than the average clang-tidy check.</p>
+<p>This check identifies unsafe accesses to values contained in <code>std::optional&lt;T&gt;</code>, <code>absl::optional&lt;T&gt;</code>, or <code>base::Optional&lt;T&gt;</code> objects. Below we will refer to all these types collectively as <code>optional&lt;T&gt;</code>.</p>
+<p>An access to the value of an <code>optional&lt;T&gt;</code> occurs when one of its <code>value</code>, <code>operator*</code>, or <code>operator-&gt;</code> member functions is invoked. To align with common misconceptions, the check considers these member functions as equivalent, even though there are subtle differences related to exceptions versus undefined behavior. See go/optional-style-recommendations for more information on that topic.</p>
+<p>An access to the value of an <code>optional&lt;T&gt;</code> is considered safe if and only if code in the local scope (for example, a function body) ensures that the <code>optional&lt;T&gt;</code> has a value in all possible execution paths that can reach the access. That should happen either through an explicit check, using the <code>optional&lt;T&gt;::has_value</code> member function, or by constructing the <code>optional&lt;T&gt;</code> in a way that shows that it unambiguously holds a value (e.g using <code>std::make_optional</code> which always returns a populated <code>std::optional&lt;T&gt;</code>).</p>
+<p>Below we list some examples, starting with unsafe optional access patterns, followed by safe access patterns.</p>
+<h2 id="unsafe-access-patterns">Unsafe access patterns</h2>
+<h3 id="access-the-value-without-checking-if-it-exists">Access the value without checking if it exists</h3>
+<p>The check flags accesses to the value that are not locally guarded by existence check:</p>
+<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
+  use(*opt); // unsafe: it is unclear whether `opt` has a value.
+}</code></pre>
+<h3 id="access-the-value-in-the-wrong-branch">Access the value in the wrong branch</h3>
+<p>The check is aware of the state of an optional object in different branches of the code. For example:</p>
+<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
+  if (opt.has_value()) {
+  } else {
+    use(opt.value()); // unsafe: it is clear that `opt` does *not* have a value.
+  }
+}</code></pre>
+<h3 id="assume-a-function-result-to-be-stable">Assume a function result to be stable</h3>
+<p>The check is aware that function results might not be stable. That is, consecutive calls to the same function might return different values. For example:</p>
+<pre class="c++"><code>void f(Foo foo) {
+  if (foo.opt().has_value()) {
+    use(*foo.opt()); // unsafe: it is unclear whether `foo.opt()` has a value.
+  }
+}</code></pre>
+<h3 id="rely-on-invariants-of-uncommon-apis">Rely on invariants of uncommon APIs</h3>
+<p>The check is unaware of invariants of uncommon APIs. For example:</p>
+<pre class="c++"><code>void f(Foo foo) {
+  if (foo.HasProperty(&quot;bar&quot;)) {
+    use(*foo.GetProperty(&quot;bar&quot;)); // unsafe: it is unclear whether `foo.GetProperty(&quot;bar&quot;)` has a value.
+  }
+}</code></pre>
+<h3 id="check-if-a-value-exists-then-pass-the-optional-to-another-function">Check if a value exists, then pass the optional to another function</h3>
+<p>The check relies on local reasoning. The check and value access must both happen in the same function. An access is considered unsafe even if the caller of the function performing the access ensures that the optional has a value. For example:</p>
+<pre class="c++"><code>void g(std::optional&lt;int&gt; opt) {
+  use(*opt); // unsafe: it is unclear whether `opt` has a value.
+}
+
+void f(std::optional&lt;int&gt; opt) {
+  if (opt.has_value()) {
+    g(opt);
+  }
+}</code></pre>
+<h2 id="safe-access-patterns">Safe access patterns</h2>
+<h3 id="check-if-a-value-exists-then-access-the-value">Check if a value exists, then access the value</h3>
+<p>The check recognizes all straightforward ways for checking if a value exists and accessing the value contained in an optional object. For example:</p>
+<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
+  if (opt.has_value()) {
+    use(*opt);
+  }
+}</code></pre>
+<h3 id="check-if-a-value-exists-then-access-the-value-from-a-copy">Check if a value exists, then access the value from a copy</h3>
+<p>The criteria that the check uses is semantic, not syntactic. It recognizes when a copy of the optional object being accessed is known to have a value. For example:</p>
+<pre class="c++"><code>void f(std::optional&lt;int&gt; opt1) {
+  if (opt1.has_value()) {
+    std::optional&lt;int&gt; opt2 = opt1;
+    use(*opt2);
+  }
+}</code></pre>
+<h3 id="ensure-that-a-value-exists-using-common-macros">Ensure that a value exists using common macros</h3>
+<p>The check is aware of common macros like <code>CHECK</code>, <code>DCHECK</code>, and <code>ASSERT_THAT</code>. Those can be used to ensure that an optional object has a value. For example:</p>
+<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
+  DCHECK(opt.has_value());
+  use(*opt);
+}</code></pre>
+<h3 id="ensure-that-a-value-exists-then-access-the-value-in-a-correlated-branch">Ensure that a value exists, then access the value in a correlated branch</h3>
+<p>The check is aware of correlated branches in the code and can figure out when an optional object is ensured to have a value on all execution paths that lead to an access. For example:</p>
+<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
+  bool safe = false;
+  if (opt.has_value() &amp;&amp; SomeOtherCondition()) {
+    safe = true;
+  }
+  // ... more code...
+  if (safe) {
+    use(*opt);
+  }
+}</code></pre>
+<h2 id="stabilize-function-results">Stabilize function results</h2>
+<p>Since function results are not assumed to be stable across calls, it is best to store the result of the function call in a local variable and use that variable to access the value. For example:</p>
+<pre class="c++"><code>void f(Foo foo) {
+  if (const auto&amp; foo_opt = foo.opt(); foo_opt.has_value()) {
+    use(*foo_opt);
+  }
+}</code></pre>
+<h2 id="do-not-rely-on-uncommon-api-invariants">Do not rely on uncommon-API invariants</h2>
+<p>When uncommon APIs guarantee that an optional has contents, do not rely on it --instead, check explicitly that the optional object has a value. For example:</p>
+<pre class="c++"><code>void f(Foo foo) {
+  if (const auto&amp; property = foo.GetProperty(&quot;bar&quot;)) {
+    use(*property);
+  }
+}</code></pre>
+<p>instead of the <span class="title-ref">HasProperty</span>, <span class="title-ref">GetProperty</span> pairing we saw above.</p>
+<h2 id="do-not-rely-on-caller-performed-checks">Do not rely on caller-performed checks</h2>
+<p>If you know that all of a function's callers have checked that an optional argument has a value, either change the function to take the value directly or check the optional again in the local scope of the callee. For example:</p>
+<pre class="c++"><code>void g(int val) {
+  use(val);
+}
+
+void f(std::optional&lt;int&gt; opt) {
+  if (opt.has_value()) {
+    g(*opt);
+  }
+}</code></pre>
+<p>and</p>
+<pre class="c++"><code>struct S {
+  std::optional&lt;int&gt; opt;
+  int x;
+};
+
+void g(const S &amp;s) {
+  if (s.opt.has_value() &amp;&amp; s.x &gt; 10) {
+    use(*s.opt);
+}
+
+void f(S s) {
+  if (s.opt.has_value()) {
+    g(s);
+  }
+}</code></pre>
+<h2 id="additional-notes">Additional notes</h2>
+<h3 id="aliases-created-via-using-declarations">Aliases created via <code>using</code> declarations</h3>
+<p>The check is aware of aliases of optional types that are created via <code>using</code> declarations. For example:</p>
+<pre class="c++"><code>using OptionalInt = std::optional&lt;int&gt;;
+
+void f(OptionalInt opt) {
+  use(opt.value()); // unsafe: it is unclear whether `opt` has a value.
+}</code></pre>
+<h3 id="lambdas">Lambdas</h3>
+<p>The check does not currently report unsafe optional accesses in lambdas. A future version will expand the scope to lambdas, following the rules outlined above. It is best to follow the same principles when using optionals in lambdas.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/unchecked-optional-access.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>cert-msc54-cpp</key>
+    <name>cert-msc54-cpp</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cert-msc54-cpp</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/signal-handler.html">
+
+</div>
+<h1 id="cert-msc54-cpp">cert-msc54-cpp</h1>
+<p>The cert-msc54-cpp check is an alias, please see <a href="../bugprone/signal-handler.html">bugprone-signal-handler</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/msc54-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>cppcoreguidelines-avoid-const-or-ref-data-members</key>
+    <name>cppcoreguidelines-avoid-const-or-ref-data-members</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-avoid-const-or-ref-data-members</p>
+</div>
+<h1 id="cppcoreguidelines-avoid-const-or-ref-data-members">cppcoreguidelines-avoid-const-or-ref-data-members</h1>
+<p>This check warns when structs or classes have const-qualified or reference (lvalue or rvalue) data members. Having such members is rarely useful, and makes the class only copy-constructible but not copy-assignable.</p>
+<p>Examples:</p>
+<pre class="c++"><code>// Bad, const-qualified member
+struct Const {
+  const int x;
+}
+
+// Good:
+class Foo {
+ public:
+  int get() const { return x; }
+ private:
+  int x;
+};
+
+// Bad, lvalue reference member
+struct Ref {
+  int&amp; x;
+};
+
+// Good:
+struct Foo {
+  int* x;
+  std::unique_ptr&lt;int&gt; x;
+  std::shared_ptr&lt;int&gt; x;
+  gsl::not_null&lt;int&gt; x;
+};
+
+// Bad, rvalue reference member
+struct RefRef {
+  int&amp;&amp; x;
+};</code></pre>
+<p>The check implements <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c12-dont-make-data-members-const-or-references">rule C.12 of C++ Core Guidelines</a>.</p>
+<p>Further reading: <a href="https://quuxplusone.github.io/blog/2022/01/23/dont-const-all-the-things/#data-members-never-const">Data members: Never const</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-const-or-ref-data-members.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>cppcoreguidelines-avoid-do-while</key>
+    <name>cppcoreguidelines-avoid-do-while</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-avoid-do-while</p>
+</div>
+<h1 id="cppcoreguidelines-avoid-do-while">cppcoreguidelines-avoid-do-while</h1>
+<p>Warns when using <code>do-while</code> loops. They are less readable than plain <code>while</code> loops, since the termination condition is at the end and the condition is not checked prior to the first iteration. This can lead to subtle bugs.</p>
+<p>The check implements <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Res-do">rule ES.75 of C++ Core Guidelines</a>.</p>
+<p>Examples:</p>
+<pre class="c++"><code>int x;
+do {
+    std::cin &gt;&gt; x;
+    // ...
+} while (x &lt; 0);</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>Ignore the check when analyzing macros. This is useful for safely defining function-like macros:</p>
+<pre class="c++"><code>#define FOO_BAR(x) \
+do { \
+  foo(x); \
+  bar(x); \
+} while(0)</code></pre>
+<p>Defaults to <span class="title-ref">false</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-do-while.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>cppcoreguidelines-macro-to-enum</key>
+    <name>cppcoreguidelines-macro-to-enum</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-macro-to-enum</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/macro-to-enum.html">
+
+</div>
+<h1 id="cppcoreguidelines-macro-to-enum">cppcoreguidelines-macro-to-enum</h1>
+<p>The cppcoreguidelines-macro-to-enum check is an alias, please see <code class="interpreted-text" role="doc">modernize-macro-to-enum &lt;../modernize/macro-to-enum&gt;</code> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/macro-to-enum.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>misc-confusable-identifiers</key>
+    <name>misc-confusable-identifiers</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - misc-confusable-identifiers</p>
+</div>
+<h1 id="misc-confusable-identifiers">misc-confusable-identifiers</h1>
+<p>Warn about confusable identifiers, i.e. identifiers that are visually close to each other, but use different Unicode characters. This detects a potential attack described in <a href="https://www.cve.org/CVERecord?id=CVE-2021-42574">CVE-2021-42574</a>.</p>
+<p>Example:</p>
+<pre class="text"><code>int fo; // Initial character is U+0066 (LATIN SMALL LETTER F).
+int fo; // Initial character is U+1D41F (MATHEMATICAL BOLD SMALL F) not U+0066 (LATIN SMALL LETTER F).</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/confusable-identifiers.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>misc-const-correctness</key>
+    <name>misc-const-correctness</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - misc-const-correctness</p>
+</div>
+<h1 id="misc-const-correctness">misc-const-correctness</h1>
+<p>This check implements detection of local variables which could be declared as <code>const</code> but are not. Declaring variables as <code>const</code> is required or recommended by many coding guidelines, such as: <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es25-declare-an-object-const-or-constexpr-unless-you-want-to-modify-its-value-later-on">CppCoreGuidelines ES.25</a> and <a href="https://www.autosar.org/fileadmin/user_upload/standards/adaptive/17-03/AUTOSAR_RS_CPP14Guidelines.pdf">AUTOSAR C++14 Rule A7-1-1 (6.7.1 Specifiers)</a>.</p>
+<p>Please note that this check's analysis is type-based only. Variables that are not modified but used to create a non-const handle that might escape the scope are not diagnosed as potential <code>const</code>.</p>
+<pre class="c++"><code>// Declare a variable, which is not ``const`` ...
+int i = 42;
+// but use it as read-only. This means that `i` can be declared ``const``.
+int result = i * i;       // Before transformation
+int const result = i * i; // After transformation</code></pre>
+<p>The check can analyze values, pointers and references but not (yet) pointees:</p>
+<pre class="c++"><code>// Normal values like built-ins or objects.
+int potential_const_int = 42;       // Before transformation
+int const potential_const_int = 42; // After transformation
+int copy_of_value = potential_const_int;
+
+MyClass could_be_const;       // Before transformation
+MyClass const could_be_const; // After transformation
+could_be_const.const_qualified_method();
+
+// References can be declared const as well.
+int &amp;reference_value = potential_const_int;       // Before transformation
+int const&amp; reference_value = potential_const_int; // After transformation
+int another_copy = reference_value;
+
+// The similar semantics of pointers are not (yet) analyzed.
+int *pointer_variable = &amp;potential_const_int; // _NO_ &#39;const int *pointer_variable&#39; suggestion.
+int last_copy = *pointer_variable;</code></pre>
+<p>The automatic code transformation is only applied to variables that are declared in single declarations. You may want to prepare your code base with <a href="../readability/isolate-declaration.html">readability-isolate-declaration</a> first.</p>
+<p>Note that there is the check <a href="../cppcoreguidelines/avoid-non-const-global-variables.html">cppcoreguidelines-avoid-non-const-global-variables</a> to enforce <code>const</code> correctness on all globals.</p>
+<h2 id="known-limitations">Known Limitations</h2>
+<p>The check does not run on <span class="title-ref">C</span> code.</p>
+<p>The check will not analyze templated variables or variables that are instantiation dependent. Different instantiations can result in different <code>const</code> correctness properties and in general it is not possible to find all instantiations of a template. The template might be used differently in an independent translation unit.</p>
+<p>Pointees can not be analyzed for constness yet. The following code shows this limitation.</p>
+<pre class="c++"><code>// Declare a variable that will not be modified.
+int constant_value = 42;
+
+// Declare a pointer to that variable, that does not modify either, but misses &#39;const&#39;.
+// Could be &#39;const int *pointer_to_constant = &amp;constant_value;&#39;
+int *pointer_to_constant = &amp;constant_value;
+
+// Usage:
+int result = 520 * 120 * (*pointer_to_constant);</code></pre>
+<p>This limitation affects the capability to add <code>const</code> to methods which is not possible, too.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>AnalyzeValues (default = true)</p>
+<p>Enable or disable the analysis of ordinary value variables, like <code>int i = 42;</code></p>
+<pre class="c++"><code>// Warning
+int i = 42;
+// No warning
+int const i = 42;
+
+// Warning
+int a[] = {42, 42, 42};
+// No warning
+int const a[] = {42, 42, 42};</code></pre>
+</div>
+<div class="option">
+<p>AnalyzeReferences (default = true)</p>
+<p>Enable or disable the analysis of reference variables, like <code>int &amp;ref = i;</code></p>
+<pre class="c++"><code>int i = 42;
+// Warning
+int&amp; ref = i;
+// No warning
+int const&amp; ref = i;</code></pre>
+</div>
+<div class="option">
+<p>WarnPointersAsValues (default = false)</p>
+<p>This option enables the suggestion for <code>const</code> of the pointer itself. Pointer values have two possibilities to be <code>const</code>, the pointer and the value pointing to.</p>
+<pre class="c++"><code>int value = 42;
+
+// Warning
+const int * pointer_variable = &amp;value;
+// No warning
+const int *const pointer_variable = &amp;value;</code></pre>
+</div>
+<div class="option">
+<p>TransformValues (default = true)</p>
+<p>Provides fixit-hints for value types that automatically add <code>const</code> if its a single declaration.</p>
+<pre class="c++"><code>// Before
+int value = 42;
+// After
+int const value = 42;
+
+// Before
+int a[] = {42, 42, 42};
+// After
+int const a[] = {42, 42, 42};
+
+// Result is modified later in its life-time. No diagnostic and fixit hint will be emitted.
+int result = value * 3;
+result -= 10;</code></pre>
+</div>
+<div class="option">
+<p>TransformReferences (default = true)</p>
+<p>Provides fixit-hints for reference types that automatically add <code>const</code> if its a single declaration.</p>
+<pre class="c++"><code>// This variable could still be a constant. But because there is a non-const reference to
+// it, it can not be transformed (yet).
+int value = 42;
+// The reference &#39;ref_value&#39; is not modified and can be made &#39;const int &amp;ref_value = value;&#39;
+// Before
+int &amp;ref_value = value;
+// After
+int const &amp;ref_value = value;
+
+// Result is modified later in its life-time. No diagnostic and fixit hint will be emitted.
+int result = ref_value * 3;
+result -= 10;</code></pre>
+</div>
+<div class="option">
+<p>TransformPointersAsValues (default = false)</p>
+<p>Provides fixit-hints for pointers if their pointee is not changed. This does not analyze if the value-pointed-to is unchanged!</p>
+<p>Requires 'WarnPointersAsValues' to be 'true'.</p>
+<pre class="c++"><code>int value = 42;
+
+// Before
+const int * pointer_variable = &amp;value;
+// After
+const int *const pointer_variable = &amp;value;
+
+// Before
+const int * a[] = {&amp;value, &amp;value};
+// After
+const int *const a[] = {&amp;value, &amp;value};
+
+// Before
+int *ptr_value = &amp;value;
+// After
+int *const ptr_value = &amp;value;
+
+int result = 100 * (*ptr_value); // Does not modify the pointer itself.
+// This modification of the pointee is still allowed and not diagnosed.
+*ptr_value = 0;
+
+// The following pointer may not become a &#39;int *const&#39;.
+int *changing_pointee = &amp;value;
+changing_pointee = &amp;result;</code></pre>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/const-correctness.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>misc-use-anonymous-namespace</key>
+    <name>misc-use-anonymous-namespace</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - misc-use-anonymous-namespace</p>
+</div>
+<h1 id="misc-use-anonymous-namespace">misc-use-anonymous-namespace</h1>
+<p>Finds instances of <code>static</code> functions or variables declared at global scope that could instead be moved into an anonymous namespace.</p>
+<p>Anonymous namespaces are the "superior alternative" according to the C++ Standard. <code>static</code> was proposed for deprecation, but later un-deprecated to keep C compatibility [1]. <code>static</code> is an overloaded term with different meanings in different contexts, so it can create confusion.</p>
+<p>The following uses of <code>static</code> will <em>not</em> be diagnosed:</p>
+<ul>
+<li>Functions or variables in header files, since anonymous namespaces in headers is considered an antipattern. Allowed header file extensions can be configured via the <span class="title-ref">HeaderFileExtensions</span> option (see below).</li>
+<li><code>const</code> or <code>constexpr</code> variables, since they already have implicit internal linkage in C++.</li>
+</ul>
+<p>Examples:</p>
+<pre class="c++"><code>// Bad
+static void foo();
+static int x;
+
+// Good
+namespace {
+  void foo();
+  int x;
+} // namespace</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>HeaderFileExtensions</p>
+<p>A semicolon-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is ";h;hh;hpp;hxx". For extension-less header files, using an empty string or leaving an empty string between ";" if there are other filename extensions.</p>
+</div>
+<p>[1] <a href="https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1012">Undeprecating static</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/use-anonymous-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>modernize-macro-to-enum</key>
+    <name>modernize-macro-to-enum</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - modernize-macro-to-enum</p>
+</div>
+<h1 id="modernize-macro-to-enum">modernize-macro-to-enum</h1>
+<p>Replaces groups of adjacent macros with an unscoped anonymous enum. Using an unscoped anonymous enum ensures that everywhere the macro token was used previously, the enumerator name may be safely used.</p>
+<p>This check can be used to enforce the C++ core guideline <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#enum1-prefer-enumerations-over-macros">Enum.1: Prefer enumerations over macros</a>, within the constraints outlined below.</p>
+<p>Potential macros for replacement must meet the following constraints:</p>
+<ul>
+<li>Macros must expand only to integral literal tokens or expressions of literal tokens. The expression may contain any of the unary operators <code>-</code>, <code>+</code>, <code>~</code> or <code>!</code>, any of the binary operators <code>,</code>, <code>-</code>, <code>+</code>, <code>*</code>, <code>/</code>, <code>%</code>, <code>&amp;</code>, <code>|</code>, <code>^</code>, <code>&lt;</code>, <code>&gt;</code>, <code>&lt;=</code>, <code>&gt;=</code>, <code>==</code>, <code>!=</code>, <code>||</code>, <code>&amp;&amp;</code>, <code>&lt;&lt;</code>, <code>&gt;&gt;</code> or <code>&lt;=&gt;</code>, the ternary operator <code>?:</code> and its <a href="https://gcc.gnu.org/onlinedocs/gcc/Conditionals.html">GNU extension</a>. Parenthesized expressions are also recognized. This recognizes most valid expressions. In particular, expressions with the <code>sizeof</code> operator are not recognized.</li>
+<li>Macros must be defined on sequential source file lines, or with only comment lines in between macro definitions.</li>
+<li>Macros must all be defined in the same source file.</li>
+<li>Macros must not be defined within a conditional compilation block. (Conditional include guards are exempt from this constraint.)</li>
+<li>Macros must not be defined adjacent to other preprocessor directives.</li>
+<li>Macros must not be used in any conditional preprocessing directive.</li>
+<li>Macros must not be used as arguments to other macros.</li>
+<li>Macros must not be undefined.</li>
+<li>Macros must be defined at the top-level, not inside any declaration or definition.</li>
+</ul>
+<p>Each cluster of macros meeting the above constraints is presumed to be a set of values suitable for replacement by an anonymous enum. From there, a developer can give the anonymous enum a name and continue refactoring to a scoped enum if desired. Comments on the same line as a macro definition or between subsequent macro definitions are preserved in the output. No formatting is assumed in the provided replacements, although clang-tidy can optionally format all fixes.</p>
+<div class="warning">
+<div class="title">
+<p>Warning</p>
+</div>
+<p>Initializing expressions are assumed to be valid initializers for an enum. C requires that enum values fit into an <code>int</code>, but this may not be the case for some accepted constant expressions. For instance <code>1 &lt;&lt; 40</code> will not fit into an <code>int</code> when the size of an <code>int</code> is 32 bits.</p>
+</div>
+<p>Examples:</p>
+<pre class="c++"><code>#define RED   0xFF0000
+#define GREEN 0x00FF00
+#define BLUE  0x0000FF
+
+#define TM_NONE (-1) // No method selected.
+#define TM_ONE 1    // Use tailored method one.
+#define TM_TWO 2    // Use tailored method two.  Method two
+                    // is preferable to method one.
+#define TM_THREE 3  // Use tailored method three.</code></pre>
+<p>becomes</p>
+<pre class="c++"><code>enum {
+RED = 0xFF0000,
+GREEN = 0x00FF00,
+BLUE = 0x0000FF
+};
+
+enum {
+TM_NONE = (-1), // No method selected.
+TM_ONE = 1,    // Use tailored method one.
+TM_TWO = 2,    // Use tailored method two.  Method two
+                    // is preferable to method one.
+TM_THREE = 3  // Use tailored method three.
+};</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/macro-to-enum.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>objc-nsdate-formatter</key>
+    <name>objc-nsdate-formatter</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - objc-nsdate-formatter</p>
+</div>
+<h1 id="objc-nsdate-formatter">objc-nsdate-formatter</h1>
+<p>When <code>NSDateFormatter</code> is used to convert an <code>NSDate</code> type to a <code>String</code> type, the user can specify a custom format string. Certain format specifiers are undesirable despite being legal. See <a href="http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns">http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns</a> for all legal date patterns.</p>
+<p>This checker reports as warnings the following string patterns in a date format specifier:</p>
+<ol>
+<li>yyyy + ww : Calendar year specified with week of a week year (unless YYYY is also specified).
+<ul>
+<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">yyyy-ww</span>;<br />
+Output string: <span class="title-ref">2014-01</span> (Wrong because it's not the first week of 2014)</div></li>
+<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">dd-MM-yyyy (ww-YYYY)</span>;<br />
+Output string: <span class="title-ref">29-12-2014 (01-2015)</span> (This is correct)</div></li>
+</ul></li>
+<li>F without ee/EE : Numeric day of week in a month without actual day.
+<ul>
+<li><div class="line-block"><strong>Example:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">F-MM</span>;<br />
+Output string: <span class="title-ref">5-12</span> (Wrong because it reads as <em>5th ___ of Dec</em> in English)</div></li>
+</ul></li>
+<li>F without MM : Numeric day of week in a month without month.
+<ul>
+<li><div class="line-block"><strong>Example:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">F-EE</span><br />
+Output string: <span class="title-ref">5-Mon</span> (Wrong because it reads as <em>5th Mon of ___</em> in English)</div></li>
+</ul></li>
+<li>WW without MM : Week of the month without the month.
+<ul>
+<li><div class="line-block"><strong>Example:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">WW-yyyy</span><br />
+Output string: <span class="title-ref">05-2014</span> (Wrong because it reads as <em>5th Week of ___</em> in English)</div></li>
+</ul></li>
+<li>YYYY + QQ : Week year specified with quarter of normal year (unless yyyy is also specified).
+<ul>
+<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-QQ</span><br />
+Output string: <span class="title-ref">2015-04</span> (Wrong because it's not the 4th quarter of 2015)</div></li>
+<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (QQ-yyyy)</span><br />
+Output string: <span class="title-ref">01-2015 (04-2014)</span> (This is correct)</div></li>
+</ul></li>
+<li>YYYY + MM : Week year specified with Month of a calendar year (unless yyyy is also specified).
+<ul>
+<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-MM</span><br />
+Output string: <span class="title-ref">2015-12</span> (Wrong because it's not the 12th month of 2015)</div></li>
+<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (MM-yyyy)</span><br />
+Output string: <span class="title-ref">01-2015 (12-2014)</span> (This is correct)</div></li>
+</ul></li>
+<li>YYYY + DD : Week year with day of a calendar year (unless yyyy is also specified).
+<ul>
+<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-DD</span><br />
+Output string: <span class="title-ref">2015-363</span> (Wrong because it's not the 363rd day of 2015)</div></li>
+<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (DD-yyyy)</span><br />
+Output string: <span class="title-ref">01-2015 (363-2014)</span> (This is correct)</div></li>
+</ul></li>
+<li>YYYY + WW : Week year with week of a calendar year (unless yyyy is also specified).
+<ul>
+<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-WW</span><br />
+Output string: <span class="title-ref">2015-05</span> (Wrong because it's not the 5th week of 2015)</div></li>
+<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (WW-MM-yyyy)</span><br />
+Output string: <span class="title-ref">01-2015 (05-12-2014)</span> (This is correct)</div></li>
+</ul></li>
+<li>YYYY + F : Week year with day of week in a calendar month (unless yyyy is also specified).
+<ul>
+<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-ww-F-EE</span><br />
+Output string: <span class="title-ref">2015-01-5-Mon</span> (Wrong because it's not the 5th Monday of January in 2015)</div></li>
+<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (F-EE-MM-yyyy)</span><br />
+Output string: <span class="title-ref">01-2015 (5-Mon-12-2014)</span> (This is correct)</div></li>
+</ul></li>
+</ol>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc/nsdate-formatter.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
+    </rule>
+  <rule>
+    <key>portability-std-allocator-const</key>
+    <name>portability-std-allocator-const</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - portability-std-allocator-const</p>
+</div>
+<h1 id="portability-std-allocator-const">portability-std-allocator-const</h1>
+<p>Report use of <code>std::vector&lt;const T&gt;</code> (and similar containers of const elements). These are not allowed in standard C++, and should usually be <code>std::vector&lt;T&gt;</code> instead."</p>
+<p>Per C++ <code>[allocator.requirements.general]</code>: "T is any cv-unqualified object type", <code>std::allocator&lt;const T&gt;</code> is undefined. Many standard containers use <code>std::allocator</code> by default and therefore their <code>const T</code> instantiations are undefined.</p>
+<p>libc++ defines <code>std::allocator&lt;const T&gt;</code> as an extension which will be removed in the future.</p>
+<p>libstdc++ and MSVC do not support <code>std::allocator&lt;const T&gt;</code>:</p>
+<pre class="c++"><code>// libstdc++ has a better diagnostic since https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48101
+std::deque&lt;const int&gt; deque; // error: static assertion failed: std::deque must have a non-const, non-volatile value_type
+std::set&lt;const int&gt; set; // error: static assertion failed: std::set must have a non-const, non-volatile value_type
+std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::vector must have a non-const, non-volatile value_type
+
+// MSVC
+// error C2338: static_assert failed: &#39;The C++ Standard forbids containers of const elements because allocator&lt;const T&gt; is ill-formed.&#39;</code></pre>
+<p>Code bases only compiled with libc++ may accrue such undefined usage. This check finds such code and prevents backsliding while clean-up is ongoing.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/portability/std-allocator-const.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    <type>CODE_SMELL</type>
     </rule>
 
   <!-- Clang Diagnostic Rules -->  

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
@@ -36,7 +36,7 @@ class CxxClangTidyRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxClangTidyRuleRepository.KEY);
-    assertThat(repo.rules()).hasSize(1340);
+    assertThat(repo.rules()).hasSize(1355);
   }
 
 }

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -30,7 +30,7 @@ from utils_createrules import get_cdata_capable_xml_etree
 
 SEVERITY_MAP = {
 
-    # last update: llvmorg-14-init-8123-ga875e6e1225a (git describe)
+    # last update: llvmorg-16-init-15404-g61be26154924 (git describe)
     # rule keys are in alphabetical order
 
     "abseil-no-namespace": {"type": "CODE_SMELL", "severity": "INFO"},
@@ -317,10 +317,11 @@ def rstfile_to_rule(path, fix_urls):
 
     filename_with_extension = os.path.basename(path)
     filename = os.path.splitext(filename_with_extension)[0]
+    containing_folder = os.path.basename(os.path.dirname(path))
 
-    key = filename
-    name = filename
-    description = rstfile_to_description(path, filename, fix_urls)
+    key = containing_folder + '-' + filename
+    name = key
+    description = rstfile_to_description(path, containing_folder + '/' + filename, fix_urls)
 
     default_issue_type = "CODE_SMELL"
     default_issue_severity = "INFO"

--- a/cxx-sensors/src/tools/generate_clangtidy_resources.cmd
+++ b/cxx-sensors/src/tools/generate_clangtidy_resources.cmd
@@ -43,7 +43,7 @@ REM GENERATION OF RULES FROM CLANG-TIDY DOCUMENTATION (RST FILES)
 ECHO [INFO] generate the new version of the rules file...
 "%PYTHON_DIR%python.exe" "%SCRIPT_DIR%clangtidy_createrules.py" rules "%LLVM_DIR%clang-tools-extra\docs\clang-tidy\checks" > "%SCRIPT_DIR%clangtidy_new.xml"
 ECHO [INFO] compare the new version with the old one, extend the old XML...
-"%PYTHON_DIR%python.exe" "%SCRIPT_DIR%utils_createrules.py" comparerules "%SCRIPT_DIR%\..\main\resources\clangtidy.xml" "%SCRIPT_DIR%clangtidy_new.xml" > "%SCRIPT_DIR%clangtidy-comparison.md"
+"%PYTHON_DIR%python.exe" "%SCRIPT_DIR%utils_createrules.py" comparerules "%SCRIPT_DIR%..\main\resources\clangtidy.xml" "%SCRIPT_DIR%clangtidy_new.xml" > "%SCRIPT_DIR%clangtidy-comparison.md"
 
 REM GENERATION OF RULES FROM CLANG DIAGNOSTICS
 ECHO [INFO] generate the list of diagnostics...
@@ -53,7 +53,7 @@ POPD
 ECHO [INFO] generate the new version of the diagnostics file...
 "%PYTHON_DIR%python.exe" "%SCRIPT_DIR%clangtidy_createrules.py" diagnostics "%SCRIPT_DIR%diagnostic.json" > "%SCRIPT_DIR%diagnostic_new.xml"
 ECHO [INFO] compare the new version with the old one, extend the old XML...
-"%PYTHON_DIR%python.exe" "%SCRIPT_DIR%utils_createrules.py" comparerules "%SCRIPT_DIR%\..\main\resources\clangtidy.xml" "%SCRIPT_DIR%diagnostic_new.xml" > "%SCRIPT_DIR%diagnostic-comparison.md"
+"%PYTHON_DIR%python.exe" "%SCRIPT_DIR%utils_createrules.py" comparerules "%SCRIPT_DIR%..\main\resources\clangtidy.xml" "%SCRIPT_DIR%diagnostic_new.xml" > "%SCRIPT_DIR%diagnostic-comparison.md"
 
 REM exit
 GOTO END


### PR DESCRIPTION
new rules:
* abseil-cleanup-ctad
* bugprone-assignment-in-if-condition
* bugprone-narrowing-conversions
* bugprone-standalone-empty
* bugprone-suspicious-realloc-usage
* bugprone-unchecked-optional-access
* cert-msc54-cpp
* cppcoreguidelines-avoid-const-or-ref-data-members
* cppcoreguidelines-avoid-do-while
* cppcoreguidelines-macro-to-enum
* misc-confusable-identifiers
* misc-const-correctness
* misc-use-anonymous-namespace
* modernize-macro-to-enum
* objc-nsdate-formatter
* portability-std-allocator-const

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2456)
<!-- Reviewable:end -->
