### PR TITLE
Support new Visual Studio 2022 messages

### DIFF
--- a/cxx-sensors/src/main/resources/compiler-vc.xml
+++ b/cxx-sensors/src/main/resources/compiler-vc.xml
@@ -17,12 +17,12 @@
   </rule>
   <rule>
     <key>C1250</key>
-    <name>C1250: Unable to load plug-in</name>
+    <name>C1250: Unable to load plug-in 'plugin-name'</name>
     <description>
       <![CDATA[
-<p>The Code Analysis tool reports this warning when there is an internal error in the plugin, not in the code being analyzed.</p>
+<p>The Code Analysis tool reports this error when there's an internal error in the plugin, not in the code being analyzed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c1250?view=msvc-160" target="_blank">C1250</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c1250?view=msvc-170" target="_blank">C1250</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -33,9 +33,9 @@
     <name>C1251: Unable to load models</name>
     <description>
       <![CDATA[
-<p>The Code Analysis tool reports this warning when there is an internal error in the model file, not in the code being analyzed.</p>
+<p>The Code Analysis tool reports this error when there's an internal error in the model file, not in the code being analyzed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c1251?view=msvc-160" target="_blank">C1251</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c1251?view=msvc-170" target="_blank">C1251</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -43,12 +43,12 @@
   </rule>
   <rule>
     <key>C1252</key>
-    <name>C1252: Circular or missing dependency between plugins: requires GUID</name>
+    <name>C1252: Circular or missing dependency between plugins: 'plugin-name' requires GUID 'globally-unique-identifier'</name>
     <description>
       <![CDATA[
-<p>The Code Analysis tool reports this warning when there is an internal error with plugin dependencies, not in the code being analyzed.</p>
+<p>The Code Analysis tool reports this error when there's an internal error in the plugin dependencies. It's not caused by an issue in the code being analyzed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c1252?view=msvc-160" target="_blank">C1252</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c1252?view=msvc-170" target="_blank">C1252</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -59,9 +59,9 @@
     <name>C1253: Unable to load model file</name>
     <description>
       <![CDATA[
-<p>The Code Analysis tool reports this warning when there is an internal error in the model file, not in the code being analyzed.</p>
+<p>The Code Analysis tool reports this error when there's an internal error in the model file, not in the code being analyzed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c1253?view=msvc-160" target="_blank">C1253</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c1253?view=msvc-170" target="_blank">C1253</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -69,12 +69,12 @@
   </rule>
   <rule>
     <key>C1254</key>
-    <name>C1254: Plugin version mismatch : version doesn't match the version of the PREfast driver</name>
+    <name>C1254: Plugin version mismatch: 'module' version 'version-number' doesn't match the version 'version-number' of the PREfast driver</name>
     <description>
       <![CDATA[
-<p>The Code Analysis tool reports this warning when there is an internal error with the plugin version, not in the code being analyzed.</p>
+<p>The Code Analysis tool reports this error when there's an internal error with the plugin version, not in the code being analyzed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c1254?view=msvc-160" target="_blank">C1254</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c1254?view=msvc-170" target="_blank">C1254</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -82,12 +82,12 @@
   </rule>
   <rule>
     <key>C1255</key>
-    <name>C1255: PCH data for plugin has incorrect length</name>
+    <name>C1255: PCH data for plugin 'plugin-name' has incorrect length</name>
     <description>
       <![CDATA[
-<p>The Code Analysis tool reports this warning when there is an internal error in the tool, not in the code being analyzed.</p>
+<p>The Code Analysis tool reports this error when there's an internal error in the tool, not in the code being analyzed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c1255?view=msvc-160" target="_blank">C1255</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c1255?view=msvc-170" target="_blank">C1255</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -95,12 +95,12 @@
   </rule>
   <rule>
     <key>C1256</key>
-    <name>C1256: PCH must be both written and read</name>
+    <name>C1256: 'plugin-name': PCH must be both written and read</name>
     <description>
       <![CDATA[
-<p>The Code Analysis tool reports this warning when there is an internal error in the tool, not in the code being analyzed.</p>
+<p>The Code Analysis tool reports this error when there's an internal error in the tool, not in the code being analyzed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c1256?view=msvc-160" target="_blank">C1256</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c1256?view=msvc-170" target="_blank">C1256</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -108,12 +108,52 @@
   </rule>
   <rule>
     <key>C1257</key>
-    <name>C1257: Plugin Initialization Failure</name>
+    <name>C1257: 'Plugin-name': Initialization Failure</name>
     <description>
       <![CDATA[
-<p>The Code Analysis tool reports this warning when there is an internal error in the plugin, not in the code being analyzed.</p>
+<p>The Code Analysis tool reports this error when there's an internal error in the plugin, not in the code being analyzed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c1257?view=msvc-160" target="_blank">C1257</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c1257?view=msvc-170" target="_blank">C1257</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C1258</key>
+    <name>C1258: Failed to save XML Log file 'filename'</name>
+    <description>
+      <![CDATA[
+<p>The Code Analysis tool reports this error when there's an internal error in the plugin, not in the code being analyzed.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c1258?view=msvc-170" target="_blank">C1258</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C1259</key>
+    <name>C1259: A fatal error was issued by a plugin</name>
+    <description>
+      <![CDATA[
+<p>The Code Analysis tool reports this error when there's an internal error in the plugin, not in the code being analyzed.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c1259?view=msvc-170" target="_blank">C1259</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C1260</key>
+    <name>C1260: The plugins 'plugin-1' and 'plugin-2' share the same id</name>
+    <description>
+      <![CDATA[
+<p>The plugins 'plugin-1' and 'plugin-2' share the same id. It is not supported to load the same plugin twice.</p>
+<p>The Code Analysis tool reports this error when there's an internal error in the plugin, not in the code being analyzed.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c1260?view=msvc-170" target="_blank">C1260</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -125,9 +165,9 @@
     <description>
       <![CDATA[
 <p>Single-line comments are standard in C++ and standard in C starting with C99.
-Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Za</a>), C files that contain single-line comments, generate C4001 due to the usage of a nonstandard extension. Since single-line comments are standard in C++, C files containing single-line comments do not produce C4001 when compiling with Microsoft extensions (/Ze).</p>
+Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>), C files that contain single-line comments, generate C4001 due to the usage of a nonstandard extension. Since single-line comments are standard in C++, C files containing single-line comments do not produce C4001 when compiling with Microsoft extensions (/Ze).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4001?view=msvc-160" target="_blank">C4001</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4001?view=msvc-170" target="_blank">C4001</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -138,7 +178,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The number of actual parameters in the macro exceeds the number of formal parameters in the macro definition. The preprocessor collects the extra parameters but ignores them during macro expansion.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4002?view=msvc-160" target="_blank">C4002</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4002?view=msvc-170" target="_blank">C4002</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -149,7 +189,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The number of formal parameters in the macro definition exceeds the number of actual parameters in the macro. Macro expansion substitutes empty text for the missing parameters.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4003?view=msvc-160" target="_blank">C4003</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4003?view=msvc-170" target="_blank">C4003</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -160,7 +200,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The macro identifier is defined twice. The compiler uses the second macro definition.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4005?view=msvc-160" target="_blank">C4005</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4005?view=msvc-170" target="_blank">C4005</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -169,9 +209,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4006: #undef expected an identifier</name>
     <description>
       <![CDATA[
-<p>The <code>#undef</code> directive did not specify an identifier to undefine. The directive is ignored. To resolve the warning, be sure to specify an identifier. The following sample generates C4006:</p>
+<p>The <code>#undef</code> directive did not specify an identifier to undefine. The directive is ignored. To resolve the warning, be sure to specify an identifier.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4006?view=msvc-160" target="_blank">C4006</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4006?view=msvc-170" target="_blank">C4006</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -182,7 +222,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A required attribute for a function is not explicitly stated. For example, the function <strong>main</strong> must have the <strong><code>__cdecl</code></strong> attribute. The compiler forces the attribute.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4007?view=msvc-160" target="_blank">C4007</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4007?view=msvc-170" target="_blank">C4007</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -193,7 +233,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler ignored the <strong><code>__fastcall</code></strong>, <strong><code>static</code></strong>, or <strong><code>inline</code></strong> attribute for a function (level 3 warning) or data (level 2 warning).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-2-and-3-c4008?view=msvc-160" target="_blank">C4008</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-2-and-3-c4008?view=msvc-170" target="_blank">C4008</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -204,7 +244,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A single-line comment, which is introduced by //, contains a backslash (\) that serves as a line-continuation character. The compiler considers the next line to be a continuation and treats it as a comment.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4010?view=msvc-160" target="_blank">C4010</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4010?view=msvc-170" target="_blank">C4010</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -215,7 +255,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler encountered a call to an undefined function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4013?view=msvc-160" target="_blank">C4013</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4013?view=msvc-170" target="_blank">C4013</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -226,7 +266,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The bit field is not declared as an integer type. The compiler assumes the base type of the bit field to be unsigned. Bit fields must be declared as unsigned integer types.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4015?view=msvc-160" target="_blank">C4015</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4015?view=msvc-170" target="_blank">C4015</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -237,7 +277,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Using the <em>token</em> operator to compare <strong><code>signed</code></strong> and <strong><code>unsigned</code></strong> numbers required the compiler to convert the <strong><code>signed</code></strong> value to <strong><code>unsigned</code></strong>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4018?view=msvc-160" target="_blank">C4018</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4018?view=msvc-170" target="_blank">C4018</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -248,7 +288,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A semicolon at global scope is not preceded by a statement.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4019?view=msvc-160" target="_blank">C4019</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4019?view=msvc-170" target="_blank">C4019</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -259,7 +299,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The number of actual parameters in a function call exceeds the number of formal parameters in the function prototype or definition. The compiler passes the extra actual parameters according to the calling convention of the function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4020?view=msvc-160" target="_blank">C4020</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4020?view=msvc-170" target="_blank">C4020</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -272,7 +312,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The pointer type of the actual parameter differs from the pointer type of the corresponding formal parameter. The actual parameter is passed without change.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4022?view=msvc-160" target="_blank">C4022</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4022?view=msvc-170" target="_blank">C4022</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -283,7 +323,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Passing a based pointer to an unprototyped function causes the pointer to be normalized, with unpredictable results.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4023?view=msvc-160" target="_blank">C4023</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4023?view=msvc-170" target="_blank">C4023</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -294,7 +334,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Corresponding formal and actual parameters have different types. The compiler passes the actual parameter without change. The receiving function converts the parameter type to the type expected.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4024?view=msvc-160" target="_blank">C4024</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4024?view=msvc-170" target="_blank">C4024</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -305,7 +345,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Passing a based pointer to a function with variable arguments causes the pointer to be normalized, with unpredictable results. Do not pass based pointers to functions with variable arguments.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4025?view=msvc-160" target="_blank">C4025</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4025?view=msvc-170" target="_blank">C4025</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -316,7 +356,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The function declaration has formal parameters, but the function definition does not. Subsequent calls to this function assume that the function takes no parameters.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4026?view=msvc-160" target="_blank">C4026</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4026?view=msvc-170" target="_blank">C4026</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -325,9 +365,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4027: function declared without formal parameter list</name>
     <description>
       <![CDATA[
-<p>The function declaration no formal parameters, but there are formal parameters in the function definition or actual parameters in a call. Subsequent calls to this function assume that the function takes actual parameters of the types found in the function definition or call.</p>
+<p>The function declaration had no formal parameters, but there are formal parameters in the function definition or actual parameters in a call.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4027?view=msvc-160" target="_blank">C4027</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4027?view=msvc-170" target="_blank">C4027</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -338,7 +378,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The type of the formal parameter does not agree with the corresponding parameter in the declaration. The type in the original declaration is used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4028?view=msvc-160" target="_blank">C4028</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4028?view=msvc-170" target="_blank">C4028</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -349,7 +389,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Formal parameter types in the function declaration do not agree with those in the function definition. The compiler uses the parameter list from the definition.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4029?view=msvc-160" target="_blank">C4029</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4029?view=msvc-170" target="_blank">C4029</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -360,7 +400,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function was redeclared with different formal parameters. The compiler uses the formal parameters given in the first declaration.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4030?view=msvc-160" target="_blank">C4030</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4030?view=msvc-170" target="_blank">C4030</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -371,7 +411,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function is redeclared with different formal parameters. The compiler uses the formal parameters given in the first declaration.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4031?view=msvc-160" target="_blank">C4031</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4031?view=msvc-170" target="_blank">C4031</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -382,7 +422,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The parameter type is not compatible, through default promotions, with the type in a previous declaration.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4032?view=msvc-160" target="_blank">C4032</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4032?view=msvc-170" target="_blank">C4032</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -393,7 +433,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The function does not return a value. An undefined value is returned.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4033?view=msvc-160" target="_blank">C4033</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4033?view=msvc-170" target="_blank">C4033</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -404,7 +444,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <strong><code>sizeof</code></strong> operator is applied to an operand of size zero (an empty structure, union, class, or enumerated type, or type <strong><code>void</code></strong>).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4034?view=msvc-160" target="_blank">C4034</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4034?view=msvc-170" target="_blank">C4034</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -415,9 +455,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4036: unnamed 'type' as actual parameter</name>
     <description>
       <![CDATA[
-<p>No type name is given for a structure, union, enumeration, or class used as an actual parameter. If you are using <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/zg-generate-function-prototypes?view=msvc-160">/Zg</a> to generate function prototypes, the compiler issues this warning and comments out the formal parameter in the generated prototype.</p>
+<p>No type name is given for a structure, union, enumeration, or class used as an actual parameter. If you are using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/zg-generate-function-prototypes?view=msvc-170">/Zg</a> to generate function prototypes, the compiler issues this warning and comments out the formal parameter in the generated prototype.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4036?view=msvc-160" target="_blank">C4036</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4036?view=msvc-170" target="_blank">C4036</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -426,9 +466,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4038: 'modifier' : illegal ambient class modifier</name>
     <description>
       <![CDATA[
-<p>This modifier cannot be used for classes with <strong><code>dllimport</code></strong> or <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=msvc-160">dllexport</a> attributes.</p>
+<p>This modifier cannot be used for classes with <strong><code>dllimport</code></strong> or <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=msvc-170">dllexport</a> attributes.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4038?view=msvc-160" target="_blank">C4038</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4038?view=msvc-170" target="_blank">C4038</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -439,7 +479,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Browser information exceeded the compiler limit.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4041?view=msvc-160" target="_blank">C4041</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4041?view=msvc-170" target="_blank">C4041</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -448,9 +488,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4042: 'identifier' : has bad storage class</name>
     <description>
       <![CDATA[
-<p>The specified storage class cannot be used with this identifier in this context. The compiler uses the default storage class instead:</p>
+<p>The specified storage class cannot be used with this identifier in this context. The compiler uses the default storage class instead.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4042?view=msvc-160" target="_blank">C4042</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4042?view=msvc-170" target="_blank">C4042</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -461,7 +501,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The array has too many initializers. Extra initializers are ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4045?view=msvc-160" target="_blank">C4045</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4045?view=msvc-170" target="_blank">C4045</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -472,7 +512,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A pointer can point to a variable (one level of indirection), to another pointer that points to a variable (two levels of indirection), and so on.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4047?view=msvc-160" target="_blank">C4047</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4047?view=msvc-170" target="_blank">C4047</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -483,7 +523,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An expression involves pointers to arrays of different size. The pointers are used without conversion.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4048?view=msvc-160" target="_blank">C4048</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4048?view=msvc-170" target="_blank">C4048</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -494,7 +534,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The file contains more than 16,777,215 (2<sup>24</sup>-1) source lines. The compiler stops numbering at 16,777,215.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4049?view=msvc-160" target="_blank">C4049</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4049?view=msvc-170" target="_blank">C4049</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -505,7 +545,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An expression contains two data items with different base types. Converting one type causes the data item to be truncated.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4051?view=msvc-160" target="_blank">C4051</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4051?view=msvc-170" target="_blank">C4051</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -516,7 +556,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>One declaration of the function does not contain variable arguments. It is ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4052?view=msvc-160" target="_blank">C4052</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4052?view=msvc-170" target="_blank">C4052</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -527,7 +567,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <code>?:</code> operator is given an expression of type <strong><code>void</code></strong>. The value of the <strong><code>void</code></strong> operand is undefined.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4053?view=msvc-160" target="_blank">C4053</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4053?view=msvc-170" target="_blank">C4053</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -538,7 +578,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p><strong>Obsolete:</strong> This warning is not generated by Visual Studio 2017 and later versions.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4055?view=msvc-160" target="_blank">C4055</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4055?view=msvc-170" target="_blank">C4055</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -549,7 +589,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Floating-point constant arithmetic generates a result that exceeds the maximum allowable value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4056?view=msvc-160" target="_blank">C4056</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4056?view=msvc-170" target="_blank">C4056</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -562,7 +602,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Two pointer expressions refer to different base types. The expressions are used without conversion.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4057?view=msvc-160" target="_blank">C4057</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4057?view=msvc-170" target="_blank">C4057</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -571,9 +611,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4061: enumerator 'identifier' in switch of enum 'enumeration' is not explicitly handled by a case label</name>
     <description>
       <![CDATA[
-<p>The specified enumerator <em>identifier</em> has no associated handler in a <strong><code>switch</code></strong> statement that has a <strong><code>default</code></strong> case. The missing case might be an oversight, or it may not be an issue. It may depend on whether the enumerator is handled by the default case or not. For a related warning on unused enumerators in <strong><code>switch</code></strong> statements that have no <strong><code>default</code></strong> case, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4062?view=msvc-160">C4062</a>.</p>
+<p>The specified enumerator <em>identifier</em> has no associated handler in a <strong><code>switch</code></strong> statement that has a <strong><code>default</code></strong> case. The missing case might be an oversight, or it may not be an issue. It may depend on whether the enumerator is handled by the default case or not. For a related warning on unused enumerators in <strong><code>switch</code></strong> statements that have no <strong><code>default</code></strong> case, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4062?view=msvc-170">C4062</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4061?view=msvc-160" target="_blank">C4061</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4061?view=msvc-170" target="_blank">C4061</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -582,9 +622,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4062: enumerator 'identifier' in switch of enum 'enumeration' is not handled</name>
     <description>
       <![CDATA[
-<p>The enumerator <em>identifier</em> has no associated <code>case</code> handler in a <strong><code>switch</code></strong> statement, and there's no <strong><code>default</code></strong> label that can catch it. The missing case may be an oversight, and is a potential error in your code. For a related warning on unused enumerators in <strong><code>switch</code></strong> statements that have a <strong><code>default</code></strong> case, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4061?view=msvc-160">C4061</a>.</p>
+<p>The enumerator <em>identifier</em> has no associated <code>case</code> handler in a <strong><code>switch</code></strong> statement, and there's no <strong><code>default</code></strong> label that can catch it. The missing case may be an oversight, and is a potential error in your code. For a related warning on unused enumerators in <strong><code>switch</code></strong> statements that have a <strong><code>default</code></strong> case, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4061?view=msvc-170">C4061</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4062?view=msvc-160" target="_blank">C4062</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4062?view=msvc-170" target="_blank">C4062</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -597,7 +637,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler processes only the first character of a wide-character constant.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4066?view=msvc-160" target="_blank">C4066</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4066?view=msvc-170" target="_blank">C4066</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -608,7 +648,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler found and ignored extra characters following a preprocessor directive. This can be caused by any unexpected characters, though a common cause is a stray semicolon after the directive. Comments do not cause this warning. The <strong>/Za</strong> compiler option enables this warning for more preprocessor directives than the default setting.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4067?view=msvc-160" target="_blank">C4067</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4067?view=msvc-170" target="_blank">C4067</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -617,9 +657,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4068: unknown pragma</name>
     <description>
       <![CDATA[
-<p>The compiler ignored an unrecognized <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/pragma-directives-and-the-pragma-keyword?view=msvc-160">pragma</a>. Be sure the <strong>pragma</strong> is allowed by the compiler you are using. The following sample generates C4068:</p>
+<p>The compiler ignored an unrecognized <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/pragma-directives-and-the-pragma-keyword?view=msvc-170">pragma</a>. Be sure the <strong>pragma</strong> is allowed by the compiler you are using.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4068?view=msvc-160" target="_blank">C4068</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4068?view=msvc-170" target="_blank">C4068</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -628,9 +668,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4073: initializers put in library initialization area</name>
     <description>
       <![CDATA[
-<p>Only third-party library developers should use the library initialization area, which is specified by <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/init-seg?view=msvc-160">#pragma init_seg</a>. The following sample generates C4073:</p>
+<p>Only third-party library developers should use the library initialization area, which is specified by <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/init-seg?view=msvc-170">#pragma init_seg</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4073?view=msvc-160" target="_blank">C4073</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4073?view=msvc-170" target="_blank">C4073</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -639,9 +679,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4074: initializers put in compiler reserved initialization area</name>
     <description>
       <![CDATA[
-<p>The compiler initialization area, which is specified by <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/init-seg?view=msvc-160">#pragma init_seg</a>, is reserved by Microsoft. Code in this area may be executed before initialization of the C run-time library.</p>
+<p>The compiler initialization area, which is specified by <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/init-seg?view=msvc-170">#pragma init_seg</a>, is reserved by Microsoft. Code in this area may be executed before initialization of the C run-time library.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4074?view=msvc-160" target="_blank">C4074</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4074?view=msvc-170" target="_blank">C4074</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -650,9 +690,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4075: initializers put in unrecognized initialization area</name>
     <description>
       <![CDATA[
-<p>A <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/init-seg?view=msvc-160">#pragma init_seg</a> uses an unrecognized section name. The compiler ignores the <strong>pragma</strong> command.</p>
+<p>A <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/init-seg?view=msvc-170">#pragma init_seg</a> uses an unrecognized section name. The compiler ignores the <strong>pragma</strong> command.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4075?view=msvc-160" target="_blank">C4075</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4075?view=msvc-170" target="_blank">C4075</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -663,7 +703,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A type modifier, whether it is <strong><code>signed</code></strong> or <strong><code>unsigned</code></strong>, cannot be used with a non-integer type. <em>type modifier</em> is ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4076?view=msvc-160" target="_blank">C4076</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4076?view=msvc-170" target="_blank">C4076</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -674,7 +714,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The old form of the <strong>check_stack</strong> pragma is used with an unknown argument. The argument must be <code>+</code>, <code>-</code>, <code>(on)</code>, <code>(off)</code>, or empty.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4077?view=msvc-160" target="_blank">C4077</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4077?view=msvc-170" target="_blank">C4077</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -685,7 +725,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An unexpected separator token occurs in a pragma argument list. The remainder of the pragma was ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4079?view=msvc-160" target="_blank">C4079</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4079?view=msvc-170" target="_blank">C4079</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -694,9 +734,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4080: expected identifier for segment name; found 'symbol'</name>
     <description>
       <![CDATA[
-<p>The name of the segment in <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/alloc-text?view=msvc-160">#pragma alloc_text</a> must be a string or an identifier. The compiler ignores the pragma if a valid identifier is not found.</p>
+<p>The name of the segment in <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/alloc-text?view=msvc-170">#pragma alloc_text</a> must be a string or an identifier. The compiler ignores the pragma if a valid identifier is not found.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4080?view=msvc-160" target="_blank">C4080</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4080?view=msvc-170" target="_blank">C4080</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -707,7 +747,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler expected a different token in this context.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4081?view=msvc-160" target="_blank">C4081</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4081?view=msvc-170" target="_blank">C4081</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -718,7 +758,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An identifier occurs in the wrong place in a <strong>#pragma</strong> statement.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4083?view=msvc-160" target="_blank">C4083</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4083?view=msvc-170" target="_blank">C4083</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -729,7 +769,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The pragma requires an <strong>on</strong> or <strong>off</strong> parameter. The pragma is ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4085?view=msvc-160" target="_blank">C4085</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4085?view=msvc-170" target="_blank">C4085</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -740,7 +780,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The pragma parameter does not have the required value (1, 2, 4, 8, or 16).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4086?view=msvc-160" target="_blank">C4086</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4086?view=msvc-170" target="_blank">C4086</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -751,7 +791,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The function declaration has no formal parameters, but the function call has actual parameters. Extra parameters are passed according to the calling convention of the function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4087?view=msvc-160" target="_blank">C4087</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4087?view=msvc-170" target="_blank">C4087</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -762,7 +802,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The corresponding formal and actual parameters have a different level of indirection. The actual parameter is passed without change. The called function interprets its value as a pointer.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4088?view=msvc-160" target="_blank">C4088</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4088?view=msvc-170" target="_blank">C4088</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -773,7 +813,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The corresponding formal and actual parameters have different types. The actual parameter is passed without change. The function casts the actual parameter to the type specified in the function definition.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4089?view=msvc-160" target="_blank">C4089</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4089?view=msvc-170" target="_blank">C4089</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -784,7 +824,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A variable used in an operation is defined with a specified modifier that prevents it from being modified without detection by the compiler. The expression is compiled without modification.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4090?view=msvc-160" target="_blank">C4090</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4090?view=msvc-170" target="_blank">C4090</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -795,7 +835,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected a situation where the user probably intended a variable to be declared, but the compiler was not able to declare the variable.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4091?view=msvc-160" target="_blank">C4091</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4091?view=msvc-170" target="_blank">C4091</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -804,9 +844,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4092: sizeof returns 'unsigned long'</name>
     <description>
       <![CDATA[
-<p>The operand of the <strong><code>sizeof</code></strong> operator was very large, so <strong><code>sizeof</code></strong> returned an <strong><code>unsigned long</code></strong>. This warning occurs under the Microsoft extensions (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160"><code>/Ze</code></a>). Under ANSI compatibility (<strong><code>/Za</code></strong>), the result is truncated instead.</p>
+<p>The operand of the <strong><code>sizeof</code></strong> operator was very large, so <strong><code>sizeof</code></strong> returned an <strong><code>unsigned long</code></strong>. This warning occurs under the Microsoft extensions (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170"><code>/Ze</code></a>). Under ANSI compatibility (<strong><code>/Za</code></strong>), the result is truncated instead.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4092?view=msvc-160" target="_blank">C4092</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4092?view=msvc-170" target="_blank">C4092</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -817,7 +857,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected an empty declaration using an untagged structure, union, or class. The declaration is ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4094?view=msvc-160" target="_blank">C4094</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4094?view=msvc-170" target="_blank">C4094</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -828,7 +868,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An interface definition that you may have intended as a COM interface was not defined as a COM interface and therefore will not be emitted to the IDL file.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4096?view=msvc-160" target="_blank">C4096</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4096?view=msvc-170" target="_blank">C4096</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -839,7 +879,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A pragma was passed an invalid value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4097?view=msvc-160" target="_blank">C4097</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4097?view=msvc-170" target="_blank">C4097</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -848,9 +888,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4098: 'function' : void function returning a value</name>
     <description>
       <![CDATA[
-<p>A function declared with return type <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/void-cpp?view=msvc-160">void</a> has a <strong><code>return</code></strong> statement that returns a value. The compiler assumes the function returns a value of type <strong><code>int</code></strong>.</p>
+<p>A function declared with return type <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/void-cpp?view=msvc-170">void</a> has a <strong><code>return</code></strong> statement that returns a value. The compiler assumes the function returns a value of type <strong><code>int</code></strong>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4098?view=msvc-160" target="_blank">C4098</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4098?view=msvc-170" target="_blank">C4098</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -861,7 +901,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An object declared as a structure is defined as a class, or an object declared as a class is defined as a structure. The compiler uses the type given in the definition.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4099?view=msvc-160" target="_blank">C4099</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4099?view=msvc-170" target="_blank">C4099</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -872,7 +912,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The formal parameter is not referenced in the body of the function. The unreferenced parameter is ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4100?view=msvc-160" target="_blank">C4100</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4100?view=msvc-170" target="_blank">C4100</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -881,9 +921,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4101: 'identifier' : unreferenced local variable</name>
     <description>
       <![CDATA[
-<p>The local variable is never used. This warning will occur in the obvious situation:</p>
+<p>The local variable is never used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4101?view=msvc-160" target="_blank">C4101</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4101?view=msvc-170" target="_blank">C4101</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -894,7 +934,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The label is defined but never referenced. The compiler ignores the label.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4102?view=msvc-160" target="_blank">C4102</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4102?view=msvc-170" target="_blank">C4102</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -905,7 +945,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Packing affects the layout of classes, and commonly, if packing changes across header files, there can be problems.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4103?view=msvc-160" target="_blank">C4103</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4103?view=msvc-170" target="_blank">C4103</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -916,7 +956,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The pragma containing the unexpected identifier is ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4109?view=msvc-160" target="_blank">C4109</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4109?view=msvc-170" target="_blank">C4109</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -925,9 +965,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4112: #line requires an integer between 1 and number</name>
     <description>
       <![CDATA[
-<p>The <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/hash-line-directive-c-cpp?view=msvc-160">#line</a> directive specifies an integer parameter that is outside the allowable range.</p>
+<p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-line-directive-c-cpp?view=msvc-170">#line</a> directive specifies an integer parameter that is outside the allowable range.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-1-and-4-c4112?view=msvc-160" target="_blank">C4112</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-1-and-4-c4112?view=msvc-170" target="_blank">C4112</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -938,7 +978,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function pointer is assigned to another function pointer, but the formal parameter lists of the functions do not agree. The assignment is compiled without modification.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4113?view=msvc-160" target="_blank">C4113</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4113?view=msvc-170" target="_blank">C4113</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -949,7 +989,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A type declaration or definition uses a type qualifier (<strong><code>const</code></strong>, <strong><code>volatile</code></strong>, <strong><code>signed</code></strong>, or <strong><code>unsigned</code></strong>) more than once. This causes a warning with Microsoft extensions (/Ze) and an error under ANSI compatibility (/Za).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4114?view=msvc-160" target="_blank">C4114</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4114?view=msvc-170" target="_blank">C4114</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -960,7 +1000,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The given symbol is used to define a structure, union, or enumerated type inside a parenthetical expression. The scope of the definition may be unexpected.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-1-and-4-c4115?view=msvc-160" target="_blank">C4115</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-1-and-4-c4115?view=msvc-170" target="_blank">C4115</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -971,7 +1011,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A structure, union, or enumerated type with no name is defined in a parenthetical expression. The type definition is meaningless.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4116?view=msvc-160" target="_blank">C4116</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4116?view=msvc-170" target="_blank">C4116</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -980,9 +1020,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4117: macro name 'name' is reserved; 'Command' ignored</name>
     <description>
       <![CDATA[
-<p>The following sample generates C4117:</p>
+<p>macro name 'name' is reserved; 'Command' ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4117?view=msvc-160" target="_blank">C4117</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4117?view=msvc-170" target="_blank">C4117</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -993,7 +1033,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Two based pointers are incompatible because they have different bases. The compiler cannot convert between them.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4119?view=msvc-160" target="_blank">C4119</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4119?view=msvc-170" target="_blank">C4119</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1004,7 +1044,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler cannot convert between the two pointers because one is based and the other is not.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4120?view=msvc-160" target="_blank">C4120</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4120?view=msvc-170" target="_blank">C4120</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1013,9 +1053,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4121: 'symbol' : alignment of a member was sensitive to packing</name>
     <description>
       <![CDATA[
-<p>The compiler added padding to align a structure member on the packing boundary but the packing value is less than the member's size. For example, the following code snippet produces C4121:</p>
+<p>The compiler added padding to align a structure member on the packing boundary but the packing value is less than the member's size.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4121?view=msvc-160" target="_blank">C4121</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4121?view=msvc-170" target="_blank">C4121</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1026,7 +1066,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <strong>alloc_text</strong> pragma applies only to functions declared with <strong>extern c</strong>. It cannot be used with external C++ functions.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4122?view=msvc-160" target="_blank">C4122</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4122?view=msvc-170" target="_blank">C4122</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1037,7 +1077,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <strong><code>__fastcall</code></strong> keyword was used with stack checking enabled.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4124?view=msvc-160" target="_blank">C4124</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4124?view=msvc-170" target="_blank">C4124</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1048,7 +1088,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler evaluates the octal number without the decimal digit and assumes the decimal digit is a character.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4125?view=msvc-160" target="_blank">C4125</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4125?view=msvc-170" target="_blank">C4125</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1059,7 +1099,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The controlling expression of an <strong><code>if</code></strong> statement or <strong><code>while</code></strong> loop evaluates to a constant. Because of their common idiomatic usage, beginning in Visual Studio 2015 update 3, trivial constants such as 1 or <strong><code>true</code></strong> do not trigger the warning, unless they are the result of an operation in an expression.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4127?view=msvc-160" target="_blank">C4127</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4127?view=msvc-170" target="_blank">C4127</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1070,7 +1110,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <code>character</code> following a backslash (\) in a character or string constant is not recognized as a valid escape sequence. The backslash is ignored and not printed. The character following the backslash is printed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4129?view=msvc-160" target="_blank">C4129</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4129?view=msvc-170" target="_blank">C4129</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1081,7 +1121,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Using the operator with the address of a string literal produces unexpected code.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4130?view=msvc-160" target="_blank">C4130</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4130?view=msvc-170" target="_blank">C4130</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -1094,7 +1134,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The specified function declaration is not in prototype form.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4131?view=msvc-160" target="_blank">C4131</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4131?view=msvc-170" target="_blank">C4131</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1105,7 +1145,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The constant is not initialized. The value of a symbol with the <strong><code>const</code></strong> attribute cannot be changed after its definition, it should be given an initialization value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4132?view=msvc-160" target="_blank">C4132</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4132?view=msvc-170" target="_blank">C4132</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1116,7 +1156,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning can be caused by trying to subtract two pointers of different types.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4133?view=msvc-160" target="_blank">C4133</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4133?view=msvc-170" target="_blank">C4133</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -1129,7 +1169,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The closing-comment delimiter is not preceded by an opening-comment delimiter. The compiler assumes a space between the asterisk (<strong>*</strong>) and the forward slash (/).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4138?view=msvc-160" target="_blank">C4138</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4138?view=msvc-170" target="_blank">C4138</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -1140,9 +1180,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4141: 'modifier' : used more than once</name>
     <description>
       <![CDATA[
-<p>C4141: 'modifier' : used more than once</p>
+<p>'modifier' : used more than once.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4141?view=msvc-160" target="_blank">C4141</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4141?view=msvc-170" target="_blank">C4141</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1153,18 +1193,18 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A type is redefined in a manner that has no effect on the generated code.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4142?view=msvc-160" target="_blank">C4142</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4142?view=msvc-170" target="_blank">C4142</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4143</key>
-    <name>C4143: pragma 'same_seg' not supported; use __based allocation</name>
+    <name>C4143: pragma 'same_seg' not supported</name>
     <description>
       <![CDATA[
-<p>The <strong>#pragma same_seg</strong> is no longer supported. Use the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/based-pointers-cpp?view=msvc-160">__based</a> keyword instead.</p>
+<p>The <strong>#pragma same_seg</strong> is no longer supported. Use the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/based-pointers-cpp?view=msvc-170">__based</a> keyword instead.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4143?view=msvc-160" target="_blank">C4143</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4143?view=msvc-170" target="_blank">C4143</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1173,9 +1213,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4144: 'expression' : relational expression as switch expression</name>
     <description>
       <![CDATA[
-<p>The specified relational expression was used as the control expression of a <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/switch-statement-cpp?view=msvc-160">switch</a> statement. The associated case statements will be offered Boolean values. The following sample generates C4144:</p>
+<p>The specified relational expression was used as the control expression of a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/switch-statement-cpp?view=msvc-170">switch</a> statement. The associated case statements will be offered Boolean values.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4144?view=msvc-160" target="_blank">C4144</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4144?view=msvc-170" target="_blank">C4144</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1186,7 +1226,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A <strong><code>switch</code></strong> statement uses a relational expression as its control expression, which results in a Boolean value for the <strong><code>case</code></strong> statements. Did you mean <em>expression2</em>?</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4145?view=msvc-160" target="_blank">C4145</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4145?view=msvc-170" target="_blank">C4145</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1195,9 +1235,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4146: unary minus operator applied to unsigned type, result still unsigned</name>
     <description>
       <![CDATA[
-<p>Unsigned types can hold only non-negative values, so unary minus (negation) does not usually make sense when applied to an unsigned type. Both the operand and the result are non-negative.</p>
+<p>Unsigned types can hold only non-negative values, so unary minus (negation) usually doesn't make sense when applied to an unsigned type. Both the operand and the result are non-negative.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146?view=msvc-160" target="_blank">C4146</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146?view=msvc-170" target="_blank">C4146</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1208,7 +1248,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <strong><code>delete</code></strong> operator is called to delete a type that was declared but not defined, so the compiler cannot find a destructor.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4150?view=msvc-160" target="_blank">C4150</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4150?view=msvc-170" target="_blank">C4150</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1219,7 +1259,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function pointer is converted to or from a data pointer. This conversion is allowed under Microsoft extensions (/Ze) but not under ANSI C.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4152?view=msvc-160" target="_blank">C4152</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4152?view=msvc-170" target="_blank">C4152</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1230,7 +1270,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function pointer is converted to or from a data pointer. This conversion is allowed under Microsoft extensions (/Ze) but not under ANSI C.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4153?view=msvc-160" target="_blank">C4153</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4153?view=msvc-170" target="_blank">C4153</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1241,7 +1281,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>You cannot use <strong><code>delete</code></strong> on an array, so the compiler converts the array to a pointer.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4154?view=msvc-160" target="_blank">C4154</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4154?view=msvc-170" target="_blank">C4154</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1252,7 +1292,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The array form of <strong><code>delete</code></strong> should be used to delete an array. This warning occurs only under ANSI-compatibility (/Za).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4155?view=msvc-160" target="_blank">C4155</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4155?view=msvc-170" target="_blank">C4155</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1263,7 +1303,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The non-array form of <strong><code>delete</code></strong> cannot delete an array. The compiler translated <strong><code>delete</code></strong> to the array form.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4156?view=msvc-160" target="_blank">C4156</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4156?view=msvc-170" target="_blank">C4156</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1274,7 +1314,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Only the C++ compiler recognizes <strong>init_seg()</strong>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4157?view=msvc-160" target="_blank">C4157</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4157?view=msvc-170" target="_blank">C4157</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1283,9 +1323,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4158: assuming #pragma pointers_to_members(full_generality, inheritance)</name>
     <description>
       <![CDATA[
-<p>A <strong>#pragma pointers_to_members(</strong> <em>single</em> | <em>multiple</em> | <em>virtual</em> <strong>)</strong> was issued without an accompanying <strong>#pragma pointers_to_members(full_generality)</strong>.</p>
+<p>A <code>#pragma pointers_to_members( single | multiple | virtual )</code> was issued without an accompanying <code>#pragma pointers_to_members(full_generality)</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4158?view=msvc-160" target="_blank">C4158</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4158?view=msvc-170" target="_blank">C4158</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1296,7 +1336,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Your source code contains a <strong>push</strong> instruction with an identifier for a pragma followed by a <strong>pop</strong> instruction without an identifier. As a result, <em>identifier</em> is popped, and subsequent uses of <em>identifier</em> may cause unexpected behavior.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4159?view=msvc-160" target="_blank">C4159</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4159?view=msvc-170" target="_blank">C4159</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1307,7 +1347,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A pragma statement in your source code tries to pop an identifier that has not been pushed. To avoid this warning, be sure that the identifier being popped has been properly pushed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4160?view=msvc-160" target="_blank">C4160</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4160?view=msvc-170" target="_blank">C4160</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1318,7 +1358,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Because your source code contains one more pop than pushes for pragma <em>pragma</em>, the stack may not behave as you expect. To avoid the warning, be sure that the number of pops does not exceed the number of pushes.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4161?view=msvc-160" target="_blank">C4161</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4161?view=msvc-170" target="_blank">C4161</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1329,7 +1369,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function with C linkage is declared but cannot be found.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4162?view=msvc-160" target="_blank">C4162</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4162?view=msvc-170" target="_blank">C4162</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1338,9 +1378,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4163: 'identifier' : not available as an intrinsic function</name>
     <description>
       <![CDATA[
-<p>The specified function cannot be used as an <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/intrinsic?view=msvc-160">intrinsic</a> function. The compiler ignores the invalid function name.</p>
+<p>The specified function cannot be used as an <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/intrinsic?view=msvc-170">intrinsic</a> function. The compiler ignores the invalid function name.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4163?view=msvc-160" target="_blank">C4163</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4163?view=msvc-170" target="_blank">C4163</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1351,7 +1391,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The specified intrinsic function is not declared; you may need to #include the appropriate header file.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4164?view=msvc-160" target="_blank">C4164</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4164?view=msvc-170" target="_blank">C4164</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1360,9 +1400,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4165: 'HRESULT' is being converted to 'bool'</name>
     <description>
       <![CDATA[
-<p>When using an HRESULT in an <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/if-else-statement-cpp?view=msvc-160">if</a> statement, the HRESULT will be converted to a <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/bool-cpp?view=msvc-160">bool</a> unless you explicitly test for the variable as an HRESULT. This warning is off by default.</p>
+<p>When using an HRESULT in an <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/if-else-statement-cpp?view=msvc-170">if</a> statement, the HRESULT will be converted to a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/bool-cpp?view=msvc-170">bool</a> unless you explicitly test for the variable as an HRESULT. This warning is off by default.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4165?view=msvc-160" target="_blank">C4165</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4165?view=msvc-170" target="_blank">C4165</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1373,7 +1413,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Constructors and destructors cannot have calling conventions other than the default for the platform (except when you explicitly specify <strong>__clrcall</strong>).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4166?view=msvc-160" target="_blank">C4166</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4166?view=msvc-170" target="_blank">C4166</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1384,7 +1424,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <strong>#pragma function</strong> tries to force the compiler to use a conventional call to a function that must be used in intrinsic form. The pragma is ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4167?view=msvc-160" target="_blank">C4167</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4167?view=msvc-170" target="_blank">C4167</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1395,7 +1435,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The program database file must be rebuilt to accommodate all types in the program.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4168?view=msvc-160" target="_blank">C4168</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4168?view=msvc-170" target="_blank">C4168</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1406,7 +1446,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function returns the address of a local variable or temporary object. Local variables and temporary objects are destroyed when a function returns, so the address returned is not valid.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4172?view=msvc-160" target="_blank">C4172</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4172?view=msvc-170" target="_blank">C4172</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -1417,9 +1457,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4174: 'name' : not available as a #pragma component</name>
     <description>
       <![CDATA[
-<p>C4174: 'name' : not available as a #pragma component</p>
+<p>'name' : not available as a #pragma component.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4174?view=msvc-160" target="_blank">C4174</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4174?view=msvc-170" target="_blank">C4174</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1428,9 +1468,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4175: #pragma component(browser, on) : browser info must initially be specified on the command line</name>
     <description>
       <![CDATA[
-<p>To use <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/component?view=msvc-160">component</a> pragma, you must generate browse information during compilation (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/fr-fr-create-dot-sbr-file?view=msvc-160">/FR</a>).</p>
+<p>To use <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/component?view=msvc-170">component</a> pragma, you must generate browse information during compilation (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/fr-fr-create-dot-sbr-file?view=msvc-170">/FR</a>).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4175?view=msvc-160" target="_blank">C4175</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4175?view=msvc-170" target="_blank">C4175</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1441,7 +1481,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <strong>component</strong> pragma contains an invalid subcomponent. To exclude references to a particular name, you must use the <strong>references</strong> option before the name.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4176?view=msvc-160" target="_blank">C4176</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4176?view=msvc-170" target="_blank">C4176</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1450,9 +1490,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4177: #pragma pragma should be at global scope</name>
     <description>
       <![CDATA[
-<p>The <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/pragma-directives-and-the-pragma-keyword?view=msvc-160">pragma</a> pragma should not be used within a local scope. The <strong>pragma</strong> will not be valid until global scope is encountered after the current scope.</p>
+<p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/pragma-directives-and-the-pragma-keyword?view=msvc-170">pragma</a> pragma should not be used within a local scope. The <strong>pragma</strong> will not be valid until global scope is encountered after the current scope.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4177?view=msvc-160" target="_blank">C4177</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4177?view=msvc-170" target="_blank">C4177</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1463,7 +1503,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A case constant in a <strong><code>switch</code></strong> expression does not fit in the type to which it is assigned.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4178?view=msvc-160" target="_blank">C4178</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4178?view=msvc-170" target="_blank">C4178</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1472,9 +1512,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4179: '//*' : parsed as '/' and '/*': confusion with standard '//' comments</name>
     <description>
       <![CDATA[
-<p><strong>//*</strong> is an incorrect comment delimiter. Use <strong>//</strong> or <strong>/*</strong> instead.</p>
+<p>In standard C89, <strong><code>//*</code></strong> is an incorrect comment delimiter. Use <strong><code>/*</code></strong> under <strong><code>/Za</code></strong> instead.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4179?view=msvc-160" target="_blank">C4179</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4179?view=msvc-170" target="_blank">C4179</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1485,7 +1525,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A qualifier, such as <strong><code>const</code></strong>, is applied to a function type defined by <strong><code>typedef</code></strong>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4180?view=msvc-160" target="_blank">C4180</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4180?view=msvc-170" target="_blank">C4180</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1496,7 +1536,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler ran out of space on the heap because of the number of nested include files. An include file is nested when it is included from another include file.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4182?view=msvc-160" target="_blank">C4182</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4182?view=msvc-170" target="_blank">C4182</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1507,7 +1547,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The inline definition of a member function in a class or a structure does not have a return type. This member function is assumed to have a default return type of <strong><code>int</code></strong>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4183?view=msvc-160" target="_blank">C4183</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4183?view=msvc-170" target="_blank">C4183</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1518,7 +1558,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The attribute is not a valid attribute of <code>#import</code>. It is ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4185?view=msvc-160" target="_blank">C4185</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4185?view=msvc-170" target="_blank">C4185</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1529,7 +1569,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A <code>#import</code> attribute has the wrong number of arguments.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4186?view=msvc-160" target="_blank">C4186</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4186?view=msvc-170" target="_blank">C4186</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1538,9 +1578,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4187: #import attributes 'attribute1' and 'attribute2' are incompatible; both ignored</name>
     <description>
       <![CDATA[
-<p>A <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-160">#import</a> statement specified <code>no_implementation</code> and <code>implementation_only</code> attributes. Both are ignored.</p>
+<p>A <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170">#import</a> statement specified <code>no_implementation</code> and <code>implementation_only</code> attributes. Both are ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4187?view=msvc-160" target="_blank">C4187</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4187?view=msvc-170" target="_blank">C4187</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1551,7 +1591,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A variable is declared and initialized but not used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4189?view=msvc-160" target="_blank">C4189</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4189?view=msvc-170" target="_blank">C4189</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1560,9 +1600,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4190: 'identifier1' has C-linkage specified, but returns UDT 'identifier2' which is incompatible with C</name>
     <description>
       <![CDATA[
-<p>A function or pointer to function has a UDT (user-defined type, which is a class, structure, enum, or union) as return type and <code>extern "C"</code> linkage. This is legal if:</p>
+<p>A function or pointer to function has a UDT (user-defined type, which is a class, structure, enum, or union) as return type and <code>extern "C"</code> linkage.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4190?view=msvc-160" target="_blank">C4190</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4190?view=msvc-170" target="_blank">C4190</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1571,9 +1611,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4191: 'operator/operation' : unsafe conversion from 'type of expression' to 'type required'</name>
     <description>
       <![CDATA[
-<p>Several operations involving function pointers are considered unsafe:</p>
+<p>Several operations involving function pointers are considered unsafe.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4191?view=msvc-160" target="_blank">C4191</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4191?view=msvc-170" target="_blank">C4191</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1584,7 +1624,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A <code>#import</code> library contains an item, <em>name</em>, that is also defined in the Win32 system headers. Due to limitations of type libraries, names such as <strong>IUnknown</strong> or GUID are often defined in a type library, duplicating the definition from the system headers. <code>#import</code> will detect these items and refuse to incorporate them in the .tlh and .tli header files.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4192?view=msvc-160" target="_blank">C4192</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4192?view=msvc-170" target="_blank">C4192</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1593,9 +1633,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4197: 'type' : top-level volatile in cast is ignored</name>
     <description>
       <![CDATA[
-<p>The compiler detected a cast to an r-value type which is qualified with <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/volatile-cpp?view=msvc-160">volatile</a>, or a cast of an r-value type to some type that is qualified with volatile. According to the C standard (6.5.3), properties associated with qualified types are meaningful only for l-value expressions.</p>
+<p>The compiler detected a cast to an r-value type which is qualified with <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/volatile-cpp?view=msvc-170">volatile</a>, or a cast of an r-value type to some type that is qualified with volatile. According to the C standard (6.5.3), properties associated with qualified types are meaningful only for l-value expressions.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4197?view=msvc-160" target="_blank">C4197</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4197?view=msvc-170" target="_blank">C4197</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1606,7 +1646,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Indicates that a structure or union contains an array that has zero size.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-2-and-4-c4200?view=msvc-160" target="_blank">C4200</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-2-and-4-c4200?view=msvc-170" target="_blank">C4200</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1615,9 +1655,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4201: nonstandard extension used : nameless struct/union</name>
     <description>
       <![CDATA[
-<p>Under Microsoft extensions (/Ze), you can specify a structure without a declarator as members of another structure or union. These structures generate an error under ANSI compatibility (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Za</a>).</p>
+<p>Under Microsoft extensions (/Ze), you can specify a structure without a declarator as members of another structure or union. These structures generate an error under ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4201?view=msvc-160" target="_blank">C4201</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4201?view=msvc-170" target="_blank">C4201</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1626,9 +1666,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4202: nonstandard extension used : '...': prototype parameter in name list illegal</name>
     <description>
       <![CDATA[
-<p>An old-style function definition contains variable arguments. These definitions generate an error under ANSI compatibility (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Za</a>).</p>
+<p>An old-style function definition contains variable arguments. These definitions generate an error under ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4202?view=msvc-160" target="_blank">C4202</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4202?view=msvc-170" target="_blank">C4202</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1639,7 +1679,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>With Microsoft extensions (/Ze), you can initialize aggregate types (arrays, structures, unions, and classes) with values that are not constants.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4204?view=msvc-160" target="_blank">C4204</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4204?view=msvc-170" target="_blank">C4204</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1650,7 +1690,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>With Microsoft extensions (/Ze), <strong><code>static</code></strong> functions can be declared inside another function. The function is given global scope.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4205?view=msvc-160" target="_blank">C4205</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4205?view=msvc-170" target="_blank">C4205</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1661,7 +1701,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The file was empty after preprocessing.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4206?view=msvc-160" target="_blank">C4206</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4206?view=msvc-170" target="_blank">C4206</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1672,7 +1712,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>With Microsoft extensions (/Ze), you can initialize an unsized array of <strong><code>char</code></strong> using a string within braces.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4207?view=msvc-160" target="_blank">C4207</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4207?view=msvc-170" target="_blank">C4207</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1681,9 +1721,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4208: nonstandard extension used : delete [exp] - exp evaluated but ignored</name>
     <description>
       <![CDATA[
-<p>With Microsoft extensions (/Ze), you can delete an array using a value within brackets with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/delete-operator-cpp?view=msvc-160">delete operator</a>. The value is ignored.</p>
+<p>With Microsoft extensions (/Ze), you can delete an array using a value within brackets with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/delete-operator-cpp?view=msvc-170">delete operator</a>. The value is ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4208?view=msvc-160" target="_blank">C4208</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4208?view=msvc-170" target="_blank">C4208</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1692,9 +1732,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4210: nonstandard extension used : function given file scope</name>
     <description>
       <![CDATA[
-<p>With the default Microsoft extensions (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Ze</a>), function declarations have file scope.</p>
+<p>With the default Microsoft extensions (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Ze</a>), function declarations have file scope.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4210?view=msvc-160" target="_blank">C4210</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4210?view=msvc-170" target="_blank">C4210</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1705,7 +1745,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>With the default Microsoft extensions (/Ze), you can redefine an <strong><code>extern</code></strong> identifier as <strong><code>static</code></strong>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4211?view=msvc-160" target="_blank">C4211</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4211?view=msvc-170" target="_blank">C4211</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1716,7 +1756,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The function prototype has a variable number of arguments. The function definition does not.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4212?view=msvc-160" target="_blank">C4212</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4212?view=msvc-170" target="_blank">C4212</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1727,7 +1767,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>With the default Microsoft extensions (/Ze), you can use casts on the left side of an assignment statement.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4213?view=msvc-160" target="_blank">C4213</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4213?view=msvc-170" target="_blank">C4213</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1738,7 +1778,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>With the default Microsoft extensions (/Ze), bitfield structure members can be of any integer type.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4214?view=msvc-160" target="_blank">C4214</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4214?view=msvc-170" target="_blank">C4214</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1747,9 +1787,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4215: nonstandard extension used : long float</name>
     <description>
       <![CDATA[
-<p>The default Microsoft extensions (/Ze) treat <strong>long float</strong> as <strong><code>double</code></strong>. ANSI compatibility (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Za</a>) does not. Use <strong><code>double</code></strong> to maintain compatibility.</p>
+<p>The default Microsoft extensions (/Ze) treat <strong>long float</strong> as <strong><code>double</code></strong>. ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>) does not. Use <strong><code>double</code></strong> to maintain compatibility.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4215?view=msvc-160" target="_blank">C4215</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4215?view=msvc-170" target="_blank">C4215</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1758,9 +1798,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4216: nonstandard extension used : float long</name>
     <description>
       <![CDATA[
-<p>The default Microsoft extensions (/Ze) treat <strong>float long</strong> as <strong><code>double</code></strong>. ANSI compatibility (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Za</a>) does not. Use <strong><code>double</code></strong> to maintain compatibility. The following sample generates C4216:</p>
+<p>The default Microsoft extensions (/Ze) treat <strong>float long</strong> as <strong><code>double</code></strong>. ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>) does not. Use <strong><code>double</code></strong> to maintain compatibility.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4216?view=msvc-160" target="_blank">C4216</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4216?view=msvc-170" target="_blank">C4216</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1771,7 +1811,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>With the default Microsoft extensions (/Ze), you can declare a variable without specifying a type or storage class. The default type is <strong><code>int</code></strong>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4218?view=msvc-160" target="_blank">C4218</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4218?view=msvc-170" target="_blank">C4218</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1782,7 +1822,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Under the default Microsoft extensions (/Ze), a pointer to a function matches a pointer to a function with similar, but variable, arguments.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4220?view=msvc-160" target="_blank">C4220</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4220?view=msvc-170" target="_blank">C4220</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1793,7 +1833,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>With the default Microsoft extensions (/Ze), you can initialize an aggregate type (<strong>array</strong>, <strong><code>struct</code></strong>, or <strong><code>union</code></strong>) with the address of a local (automatic) variable.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4221?view=msvc-160" target="_blank">C4221</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4221?view=msvc-170" target="_blank">C4221</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1802,9 +1842,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4223: nonstandard extension used : non-lvalue array converted to pointer</name>
     <description>
       <![CDATA[
-<p>In standard C, you cannot convert a non-lvalue array to a pointer. With the default Microsoft extensions (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Ze</a>), you can.</p>
+<p>In standard C, you cannot convert a non-lvalue array to a pointer. With the default Microsoft extensions (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Ze</a>), you can.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-1-and-4-c4223?view=msvc-160" target="_blank">C4223</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-1-and-4-c4223?view=msvc-170" target="_blank">C4223</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1813,9 +1853,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4224: nonstandard extension used : formal parameter 'identifier' was previously defined as a type</name>
     <description>
       <![CDATA[
-<p>The identifier was previously used as a <strong><code>typedef</code></strong>. This causes a warning under ANSI compatibility (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Za</a>).</p>
+<p>The identifier was previously used as a <strong><code>typedef</code></strong>. This causes a warning under ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4224?view=msvc-160" target="_blank">C4224</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4224?view=msvc-170" target="_blank">C4224</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1826,7 +1866,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The current version of Visual C++ does not use this keyword.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4226?view=msvc-160" target="_blank">C4226</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4226?view=msvc-170" target="_blank">C4226</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1837,7 +1877,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Using qualifiers like <strong><code>const</code></strong> or <strong><code>volatile</code></strong> with C++ references is an outdated practice.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4227?view=msvc-160" target="_blank">C4227</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4227?view=msvc-170" target="_blank">C4227</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1846,9 +1886,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4228: nonstandard extension used : qualifiers after comma in declarator list are ignored</name>
     <description>
       <![CDATA[
-<p>Use of qualifiers like <strong><code>const</code></strong> or <strong><code>volatile</code></strong> after a comma when declaring variables is a Microsoft extension (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Ze</a>).</p>
+<p>Use of qualifiers like <strong><code>const</code></strong> or <strong><code>volatile</code></strong> after a comma when declaring variables is a Microsoft extension (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Ze</a>).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4228?view=msvc-160" target="_blank">C4228</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4228?view=msvc-170" target="_blank">C4228</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1859,7 +1899,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Using a Microsoft modifier such as <strong><code>__cdecl</code></strong> on a data declaration is an outdated practice.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4229?view=msvc-160" target="_blank">C4229</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4229?view=msvc-170" target="_blank">C4229</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1870,7 +1910,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Using a qualifier before a Microsoft modifier such as <strong><code>__cdecl</code></strong> is an outdated practice.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4230?view=msvc-160" target="_blank">C4230</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4230?view=msvc-170" target="_blank">C4230</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1879,9 +1919,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4232: nonstandard extension used : 'identifier' : address of dllimport 'dllimport' is not static, identity not guaranteed</name>
     <description>
       <![CDATA[
-<p>Under Microsoft extensions (/Ze), you can give a nonstatic value as the address of a function declared with the <strong><code>dllimport</code></strong> modifier. Under ANSI compatibility (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Za</a>), this causes an error.</p>
+<p>Under Microsoft extensions (/Ze), you can give a nonstatic value as the address of a function declared with the <strong><code>dllimport</code></strong> modifier. Under ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>), this causes an error.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4232?view=msvc-160" target="_blank">C4232</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4232?view=msvc-170" target="_blank">C4232</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1890,9 +1930,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4233: nonstandard extension used : 'keyword' keyword only supported in C++, not C</name>
     <description>
       <![CDATA[
-<p>The compiler compiled your source code as C rather than C++, and you used a keyword that is only valid in C++. The compiler compiles your source file as C if the extension of the source file is .c or you use <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/tc-tp-tc-tp-specify-source-file-type?view=msvc-160">/Tc</a>.</p>
+<p>The compiler compiled your source code as C rather than C++, and you used a keyword that is only valid in C++. The compiler compiles your source file as C if the extension of the source file is .c or you use <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/tc-tp-tc-tp-specify-source-file-type?view=msvc-170">/Tc</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4233?view=msvc-160" target="_blank">C4233</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4233?view=msvc-170" target="_blank">C4233</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1903,7 +1943,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler does not yet implement the keyword you used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4234?view=msvc-160" target="_blank">C4234</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4234?view=msvc-170" target="_blank">C4234</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1914,7 +1954,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler does not support the keyword you used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4235?view=msvc-160" target="_blank">C4235</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4235?view=msvc-170" target="_blank">C4235</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1925,7 +1965,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A keyword in the C++ specification is not implemented in the Microsoft C++ compiler, but the keyword is not available as a user-defined symbol.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4237?view=msvc-160" target="_blank">C4237</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4237?view=msvc-170" target="_blank">C4237</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1936,7 +1976,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>For compatibility with previous versions of Visual C++, Microsoft extensions (<strong>/Ze</strong>) allow you to use a class type as an rvalue in a context that implicitly or explicitly takes its address. In some cases, such as the example below, this can be dangerous.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4238?view=msvc-160" target="_blank">C4238</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4238?view=msvc-170" target="_blank">C4238</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1947,7 +1987,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This type conversion is not allowed by the C++ standard, but it is permitted here as an extension. This warning is always followed by at least one line of explanation describing the language rule being violated.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4239?view=msvc-160" target="_blank">C4239</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4239?view=msvc-170" target="_blank">C4239</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1956,9 +1996,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4240: nonstandard extension used : access to 'classname' now defined to be 'access specifier', previously it was defined to be 'access specifier'</name>
     <description>
       <![CDATA[
-<p>Under ANSI compatibility (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Za</a>), you cannot change the access to a nested class. Under the default Microsoft extensions (/Ze), you can, with this warning.</p>
+<p>Under ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>), you cannot change the access to a nested class. Under the default Microsoft extensions (/Ze), you can, with this warning.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4240?view=msvc-160" target="_blank">C4240</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4240?view=msvc-170" target="_blank">C4240</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1969,7 +2009,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The types are different. Type conversion may result in loss of data. The compiler makes the type conversion.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4242?view=msvc-160" target="_blank">C4242</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4242?view=msvc-170" target="_blank">C4242</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -1980,7 +2020,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A pointer to a derived class is converted to a pointer to a base class, but the derived class inherits the base class with private or protected access.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4243?view=msvc-160" target="_blank">C4243</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4243?view=msvc-170" target="_blank">C4243</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -1991,9 +2031,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4244: 'conversion' conversion from 'type1' to 'type2', possible loss of data</name>
     <description>
       <![CDATA[
-<p>An integer type is converted to a smaller integer type. This is a level-4 warning if <em>type1</em> is <strong><code>int</code></strong> and <em>type2</em> is smaller than <strong><code>int</code></strong>. Otherwise, it is a level 3 (assigned a value of type <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/int8-int16-int32-int64?view=msvc-160">__int64</a> to a variable of type <strong><code>unsigned int</code></strong>). A possible loss of data may have occurred.</p>
+<p>An integer type is converted to a smaller integer type. This is a level-4 warning if <em>type1</em> is <strong><code>int</code></strong> and <em>type2</em> is smaller than <strong><code>int</code></strong>. Otherwise, it is a level 3 (assigned a value of type <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/int8-int16-int32-int64?view=msvc-170">__int64</a> to a variable of type <strong><code>unsigned int</code></strong>). A possible loss of data may have occurred.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244?view=msvc-160" target="_blank">C4244</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244?view=msvc-170" target="_blank">C4244</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2004,7 +2044,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>You tried to convert a <strong><code>signed const</code></strong> type that has a negative value to an <strong><code>unsigned</code></strong> type.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4245?view=msvc-160" target="_blank">C4245</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4245?view=msvc-170" target="_blank">C4245</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2017,7 +2057,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Two or more members have the same name. The one in <code>class2</code> is inherited because it is a base class for the other classes that contained this member.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4250?view=msvc-160" target="_blank">C4250</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4250?view=msvc-170" target="_blank">C4250</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2026,9 +2066,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4251: 'type' : class 'type1' needs to have dll-interface to be used by clients of class 'type2'</name>
     <description>
       <![CDATA[
-<p>To minimize the possibility of data corruption when exporting a class declared as <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=msvc-160">__declspec(dllexport)</a>, ensure that:</p>
+<p>To minimize the possibility of data corruption when exporting a class declared as <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=msvc-170"><code>__declspec(dllexport)</code></a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251?view=msvc-160" target="_blank">C4251</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251?view=msvc-170" target="_blank">C4251</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2039,7 +2079,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A larger bit field was assigned to a smaller bit field. There could be a loss of data.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4254?view=msvc-160" target="_blank">C4254</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4254?view=msvc-170" target="_blank">C4254</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2050,18 +2090,18 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler did not find an explicit list of arguments to a function. This warning is for the C compiler only.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4255?view=msvc-160" target="_blank">C4255</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4255?view=msvc-170" target="_blank">C4255</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4256</key>
-    <name>C4256: 'function' : constructor for class with virtual bases has '...'; calls may not be compatible with older versions of Visual C++</name>
+    <name>C4256: Calls may not be compatible with older versions of Visual C++</name>
     <description>
       <![CDATA[
-<p>Possible incompatibility.</p>
+<p>Constructor for class with virtual bases has '...'; calls may not be compatible with older versions of Visual C++.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4256?view=msvc-160" target="_blank">C4256</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4256?view=msvc-170" target="_blank">C4256</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2070,9 +2110,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4258: 'variable' : definition from the for loop is ignored; the definition from the enclosing scope is used"</name>
     <description>
       <![CDATA[
-<p>Under <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Ze</a> and <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/zc-forscope-force-conformance-in-for-loop-scope?view=msvc-160">/Zc:forScope</a>, variables defined in a <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/for-statement-cpp?view=msvc-160">for</a> loop go out of scope after the <strong><code>for</code></strong> loop ends. This warning occurs if a variable with the same name as the loop variable, but defined in the enclosing loop, is used again in the scope containing the <strong><code>for</code></strong> loop. For example:</p>
+<p>Under <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Ze</a> and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/zc-forscope-force-conformance-in-for-loop-scope?view=msvc-170">/Zc:forScope</a>, variables defined in a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/for-statement-cpp?view=msvc-170">for</a> loop go out of scope after the <strong><code>for</code></strong> loop ends. This warning occurs if a variable with the same name as the loop variable, but defined in the enclosing loop, is used again in the scope containing the <strong><code>for</code></strong> loop.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4258?view=msvc-160" target="_blank">C4258</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4258?view=msvc-170" target="_blank">C4258</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2083,7 +2123,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A class function definition has the same name as a virtual function in a base class but not the same number or type of arguments. This effectively hides the virtual function in the base class.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4263?view=msvc-160" target="_blank">C4263</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4263?view=msvc-170" target="_blank">C4263</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2092,9 +2132,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4264: 'virtual_function' : no override available for virtual member function from base 'class'; function is hidden</name>
     <description>
       <![CDATA[
-<p>C4264 is always generated after <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4263?view=msvc-160">C4263</a>.</p>
+<p>C4264 is always generated after <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4263?view=msvc-170">C4263</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4264?view=msvc-160" target="_blank">C4264</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4264?view=msvc-170" target="_blank">C4264</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2105,7 +2145,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>When a class has virtual functions but a nonvirtual destructor, objects of the type might not be destroyed properly when the class is destroyed through a base class pointer.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4265?view=msvc-160" target="_blank">C4265</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4265?view=msvc-170" target="_blank">C4265</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2116,7 +2156,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A derived class did not override all overloads of a virtual function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4266?view=msvc-160" target="_blank">C4266</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4266?view=msvc-170" target="_blank">C4266</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2127,7 +2167,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected a conversion from <code>size_t</code> to a smaller type.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267?view=msvc-160" target="_blank">C4267</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267?view=msvc-170" target="_blank">C4267</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2138,7 +2178,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A <strong><code>const</code></strong> global or static instance of a non-trivial class is initialized with a compiler-generated default constructor.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4268?view=msvc-160" target="_blank">C4268</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4268?view=msvc-170" target="_blank">C4268</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2149,7 +2189,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A <strong><code>const</code></strong> automatic instance of a non-trivial class is initialized with a compiler-generated default constructor.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4269?view=msvc-160" target="_blank">C4269</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4269?view=msvc-170" target="_blank">C4269</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2158,9 +2198,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4272: 'function' : is marked __declspec(dllimport); must specify native calling convention when importing a function</name>
     <description>
       <![CDATA[
-<p>It is an error to export a function marked with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/clrcall?view=msvc-160">__clrcall</a> calling convention, and the compiler issues this warning if you attempt to import a function marked <code>__clrcall</code>.</p>
+<p>It is an error to export a function marked with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/clrcall?view=msvc-170">__clrcall</a> calling convention, and the compiler issues this warning if you attempt to import a function marked <code>__clrcall</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4272?view=msvc-160" target="_blank">C4272</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4272?view=msvc-170" target="_blank">C4272</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2169,9 +2209,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4273: 'function' : inconsistent DLL linkage</name>
     <description>
       <![CDATA[
-<p>Two definitions in a file differ in their use of <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=msvc-160">dllimport</a>.</p>
+<p>Two definitions in a file differ in their use of <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=msvc-170"><code>dllimport</code></a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4273?view=msvc-160" target="_blank">C4273</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4273?view=msvc-170" target="_blank">C4273</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2182,7 +2222,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <code>#ident</code> directive, which inserts a user-specified string in the object or executable file, is deprecated. Consequently, the compiler ignores the directive.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4274?view=msvc-160" target="_blank">C4274</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4274?view=msvc-170" target="_blank">C4274</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2193,7 +2233,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An exported class was derived from a class that wasn't exported.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275?view=msvc-160" target="_blank">C4275</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275?view=msvc-170" target="_blank">C4275</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2202,20 +2242,21 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4276: 'function' : no prototype provided; assumed no parameters</name>
     <description>
       <![CDATA[
-<p>When you take the address of a function with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/stdcall?view=msvc-160">__stdcall</a> calling convention, you must give a prototype so the compiler can create the function's decorated name. Since <em>function</em> has no prototype, the compiler, when creating the decorated name, assumes the function has no parameters.</p>
+<p>When you take the address of a function with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/stdcall?view=msvc-170">__stdcall</a> calling convention, you must give a prototype so the compiler can create the function's decorated name. Since <em>function</em> has no prototype, the compiler, when creating the decorated name, assumes the function has no parameters.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4276?view=msvc-160" target="_blank">C4276</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4276?view=msvc-170" target="_blank">C4276</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4278</key>
-    <name>C4278: 'identifier': identifier in type library 'tlb' is already a macro; use the 'rename' qualifier</name>
+    <name>C4278: 'identifier': identifier in type library 'tlb' is already a macro</name>
     <description>
       <![CDATA[
-<p>When using <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-160">#import</a>, an identifier in the typelib you are importing is attempting to declare an identifier <em>identifier</em>. However, this is already a valid symbol.</p>
+<p>Identifier in type library 'tlb' is already a macro; use the 'rename' qualifier.</p>
+<p>When using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170">#import</a>, an identifier in the typelib you are importing is attempting to declare an identifier <em>identifier</em>. However, this is already a valid symbol.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4278?view=msvc-160" target="_blank">C4278</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4278?view=msvc-170" target="_blank">C4278</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2226,7 +2267,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Your code incorrectly allows <strong>operator-&gt;</strong> to call itself.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4280?view=msvc-160" target="_blank">C4280</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4280?view=msvc-170" target="_blank">C4280</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2237,7 +2278,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Your code allows <strong>operator-&gt;</strong> to call itself.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4281?view=msvc-160" target="_blank">C4281</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4281?view=msvc-170" target="_blank">C4281</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2248,7 +2289,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This continuation of warning C4281shows that <strong>operator-&gt;</strong> calls itself through <code>type</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4282?view=msvc-160" target="_blank">C4282</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4282?view=msvc-170" target="_blank">C4282</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2257,9 +2298,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4283: and through type 'type'</name>
     <description>
       <![CDATA[
-<p>This continuation of warning <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4281?view=msvc-160">C4281</a> shows that <strong>operator-&gt;</strong> calls itself through <code>type</code>.</p>
+<p>This continuation of warning <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4281?view=msvc-170">C4281</a> shows that <strong>operator-&gt;</strong> calls itself through <code>type</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4283?view=msvc-160" target="_blank">C4283</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4283?view=msvc-170" target="_blank">C4283</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2270,7 +2311,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The specified <strong>operator-&gt;()</strong> function cannot return the type for which it is defined or a reference to the type for which it is defined.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4285?view=msvc-160" target="_blank">C4285</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4285?view=msvc-170" target="_blank">C4285</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2281,7 +2322,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The specified exception type is handled by a previous handler. The type for the second catch is derived from the type of the first. Exceptions for a base class catch exceptions for a derived class.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4286?view=msvc-160" target="_blank">C4286</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4286?view=msvc-170" target="_blank">C4286</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2292,7 +2333,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An unsigned variable was used in an operation with a negative number.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4287?view=msvc-160" target="_blank">C4287</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4287?view=msvc-170" target="_blank">C4287</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2301,9 +2342,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4288: nonstandard extension used</name>
     <description>
       <![CDATA[
-<p>When compiling with <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160"><code>/Ze</code></a> and <strong>/Zc:forscope-</strong>, a variable declared in a <strong><code>for</code></strong> loop was used after the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/for-statement-cpp?view=msvc-160">for</a>-loop scope. A Microsoft extension to the C++ language allows this variable to remain in scope, and C4288 reminds you that the first declaration of the variable is not used.</p>
+<p>When compiling with <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170"><code>/Ze</code></a> and <strong>/Zc:forscope-</strong>, a variable declared in a <strong><code>for</code></strong> loop was used after the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/for-statement-cpp?view=msvc-170">for</a>-loop scope. A Microsoft extension to the C++ language allows this variable to remain in scope, and C4288 reminds you that the first declaration of the variable is not used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4288?view=msvc-160" target="_blank">C4288</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4288?view=msvc-170" target="_blank">C4288</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2312,9 +2353,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4289: nonstandard extension used : 'var' : loop control variable declared in the for-loop is used outside the for-loop scope</name>
     <description>
       <![CDATA[
-<p>When compiling with <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Ze</a> and <strong>/Zc:forScope-</strong>, a variable declared in a <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/for-statement-cpp?view=msvc-160">for</a> loop was used after the <strong><code>for</code></strong>-loop scope.</p>
+<p>When compiling with <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Ze</a> and <strong>/Zc:forScope-</strong>, a variable declared in a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/for-statement-cpp?view=msvc-170">for</a> loop was used after the <strong><code>for</code></strong>-loop scope.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4289?view=msvc-160" target="_blank">C4289</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4289?view=msvc-170" target="_blank">C4289</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2325,7 +2366,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function is declared using exception specification, which Visual C++ accepts but does not implement. Code with exception specifications that are ignored during compilation may need to be recompiled and linked to be reused in future versions supporting exception specifications.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4290?view=msvc-160" target="_blank">C4290</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4290?view=msvc-170" target="_blank">C4290</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2334,9 +2375,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4291: 'declaration' : no matching operator delete found; memory will not be freed if initialization throws an exception</name>
     <description>
       <![CDATA[
-<p>A placement <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/new-operator-cpp?view=msvc-160">new</a> is used for which there is no placement <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/delete-operator-cpp?view=msvc-160">delete</a>.</p>
+<p>A placement <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/new-operator-cpp?view=msvc-170">new</a> is used for which there is no placement <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/delete-operator-cpp?view=msvc-170">delete</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4291?view=msvc-160" target="_blank">C4291</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4291?view=msvc-170" target="_blank">C4291</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2349,7 +2390,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>If a shift count is negative or too large, the behavior of the resulting image is undefined.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4293?view=msvc-160" target="_blank">C4293</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4293?view=msvc-170" target="_blank">C4293</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2362,7 +2403,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An array was initialized but the last character in the array is not a null; accessing the array as a string may produce unexpected results.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4295?view=msvc-160" target="_blank">C4295</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4295?view=msvc-170" target="_blank">C4295</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2375,7 +2416,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An unsigned variable was used in a comparison operation with zero.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4296?view=msvc-160" target="_blank">C4296</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4296?view=msvc-170" target="_blank">C4296</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2386,9 +2427,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4297: 'function' : function assumed not to throw an exception but does</name>
     <description>
       <![CDATA[
-<p>A function declaration contains a (possibly implicit) <strong><code>noexcept</code></strong> specifier, an empty <strong><code>throw</code></strong> exception specifier, or a <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/nothrow-cpp?view=msvc-160">__declspec(nothrow)</a> attribute, and the definition contains one or more <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/try-throw-and-catch-statements-cpp?view=msvc-160">throw</a> statements. To resolve C4297, do not attempt to throw exceptions in functions that are declared <code>__declspec(nothrow)</code>, <code>noexcept(true)</code> or <code>throw()</code>. Alternatively, remove the <strong><code>noexcept</code></strong>, <code>throw()</code>, or <code>__declspec(nothrow)</code> specification.</p>
+<p>A function declaration contains a (possibly implicit) <strong><code>noexcept</code></strong> specifier, an empty <strong><code>throw</code></strong> exception specifier, or a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/nothrow-cpp?view=msvc-170">__declspec(nothrow)</a> attribute, and the definition contains one or more <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/try-throw-and-catch-statements-cpp?view=msvc-170">throw</a> statements. To resolve C4297, do not attempt to throw exceptions in functions that are declared <code>__declspec(nothrow)</code>, <code>noexcept(true)</code> or <code>throw()</code>. Alternatively, remove the <strong><code>noexcept</code></strong>, <code>throw()</code>, or <code>__declspec(nothrow)</code> specification.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4297?view=msvc-160" target="_blank">C4297</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4297?view=msvc-170" target="_blank">C4297</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2399,7 +2440,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected a conversion from a larger type to a smaller type. Information may be lost.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4302?view=msvc-160" target="_blank">C4302</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4302?view=msvc-170" target="_blank">C4302</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2410,7 +2451,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning is issued when a value is converted to a smaller type in an initialization or as a constructor argument, resulting in a loss of information.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4305?view=msvc-160" target="_blank">C4305</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4305?view=msvc-170" target="_blank">C4305</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2421,7 +2462,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The identifier is type cast to a larger pointer. The unfilled high bits of the new type will be zero-filled.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4306?view=msvc-160" target="_blank">C4306</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4306?view=msvc-170" target="_blank">C4306</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2432,7 +2473,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The operator is used in an expression that results in an integer constant overflowing the space allocated for it. You may need to use a larger type for the constant. A <strong><code>signed int</code></strong> holds a smaller value than an <strong><code>unsigned int</code></strong> because the <strong><code>signed int</code></strong> uses one bit to represent the sign.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4307?view=msvc-160" target="_blank">C4307</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4307?view=msvc-170" target="_blank">C4307</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2443,7 +2484,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An expression converts a negative integer constant to an unsigned type. The result of the expression is probably meaningless.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4308?view=msvc-160" target="_blank">C4308</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4308?view=msvc-170" target="_blank">C4308</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2454,7 +2495,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The type conversion causes a constant to exceed the space allocated for it. You may need to use a larger type for the constant.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4309?view=msvc-160" target="_blank">C4309</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4309?view=msvc-170" target="_blank">C4309</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2465,9 +2506,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4310: cast truncates constant value</name>
     <description>
       <![CDATA[
-<p>A constant value is cast to a smaller type. The compiler performs the cast, which truncates data. The following sample generates C4310:</p>
+<p>A constant value is cast to a smaller type. The compiler performs the cast, which truncates data.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4310?view=msvc-160" target="_blank">C4310</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4310?view=msvc-170" target="_blank">C4310</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2478,7 +2519,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning detects 64-bit pointer truncation issues. For example, if code is compiled for a 64-bit architecture, the value of a pointer (64 bits) will be truncated if it is assigned to an <strong><code>int</code></strong> (32 bits). For more information, see <a data-linktype="absolute-path" href="/en-us/windows/win32/WinProg64/rules-for-using-pointers">Rules for Using Pointers</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4311?view=msvc-160" target="_blank">C4311</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4311?view=msvc-170" target="_blank">C4311</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2489,7 +2530,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning detects an attempt to assign a 32-bit value to a 64-bit pointer type, for example, casting a 32-bit <strong><code>int</code></strong> or <strong><code>long</code></strong> to a 64-bit pointer.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4312?view=msvc-160" target="_blank">C4312</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4312?view=msvc-170" target="_blank">C4312</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2500,7 +2541,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>There is a conflict between the format specified and the value that you are passing. For example, you passed a 64-bit parameter to an unqualified %d format specifier, which expects a 32-bit integer parameter. This warning is only in effect when the code is compiled for 64-bit targets.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4313?view=msvc-160" target="_blank">C4313</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4313?view=msvc-170" target="_blank">C4313</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2511,9 +2552,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4316: Object allocated on the heap may not be aligned for this type</name>
     <description>
       <![CDATA[
-<p>An over-aligned object allocated by using <code>operator new</code> may not have the specified alignment. Override <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/c-runtime-library/new-operator-crt?view=msvc-160">operator new</a> and <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/c-runtime-library/delete-operator-crt?view=msvc-160">operator delete</a> for over-aligned types so that they use the aligned allocation routines—for example, <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-malloc?view=msvc-160">_aligned_malloc</a> and <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-free?view=msvc-160">_aligned_free</a>. The following sample generates C4316:</p>
+<p>An over-aligned object allocated by using <code>operator new</code> may not have the specified alignment. Override <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/new-operator-crt?view=msvc-170">operator new</a> and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/delete-operator-crt?view=msvc-170">operator delete</a> for over-aligned types so that they use the aligned allocation routines—for example, <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-malloc?view=msvc-170">_aligned_malloc</a> and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-free?view=msvc-170">_aligned_free</a>.
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4316?view=msvc-160" target="_blank">C4316</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4316?view=msvc-170" target="_blank">C4316</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2524,7 +2565,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The result of the <strong>~</strong> (bitwise complement) operator is unsigned and then zero-extended when it is converted to a larger type.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4319?view=msvc-160" target="_blank">C4319</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4319?view=msvc-170" target="_blank">C4319</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2533,9 +2574,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4324: 'struct_name' : structure was padded due to __declspec(align())</name>
     <description>
       <![CDATA[
-<p>Padding was added at the end of a structure because you specified a <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-160">__declspec(align)</a> value.</p>
+<p>Padding was added at the end of a structure because you specified a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-170">__declspec(align)</a> value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4324?view=msvc-160" target="_blank">C4324</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4324?view=msvc-170" target="_blank">C4324</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2544,9 +2585,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4325: attributes for standard section 'section' ignored</name>
     <description>
       <![CDATA[
-<p>You may not change the attributes of a standard section. For example:</p>
+<p>You may not change the attributes of a standard section.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4325?view=msvc-160" target="_blank">C4325</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4325?view=msvc-170" target="_blank">C4325</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2555,9 +2596,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4326: return type of 'function' should be 'type1' instead of 'type2'</name>
     <description>
       <![CDATA[
-<p>A function returned a type other than <em>type1</em>. For example, using <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Za</a>, <strong>main</strong> did not return an <strong><code>int</code></strong>.</p>
+<p>A function returned a type other than <em>type1</em>. For example, using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>, <strong>main</strong> did not return an <strong><code>int</code></strong>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4326?view=msvc-160" target="_blank">C4326</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4326?view=msvc-170" target="_blank">C4326</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2566,9 +2607,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4329: __declspec(align()) is ignored on enum</name>
     <description>
       <![CDATA[
-<p>Use of the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-160">align</a> keyword of the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/declspec?view=msvc-160">__declspec</a> modifier is not allowed on an <strong><code>enum</code></strong>. The following sample generates C4329:</p>
+<p>Use of the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-170">align</a> keyword of the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/declspec?view=msvc-170">__declspec</a> modifier is not allowed on an <strong><code>enum</code></strong>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4329?view=msvc-160" target="_blank">C4329</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4329?view=msvc-170" target="_blank">C4329</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2579,7 +2620,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A right shift operation was too large an amount.  All significant bits are shifted out and the result will always be zero.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4333?view=msvc-160" target="_blank">C4333</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4333?view=msvc-170" target="_blank">C4333</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2592,7 +2633,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The result of 32-bit shift was implicitly converted to 64-bits, and the compiler suspects that a 64-bit shift was intended.  To resolve this warning, either use 64-bit shift, or explicitly cast the shift result to 64-bit.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4334?view=msvc-160" target="_blank">C4334</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4334?view=msvc-170" target="_blank">C4334</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2603,7 +2644,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The line termination character of the first line of a source file is Macintosh style ('\r') as opposed to UNIX ('\n') or DOS ('\r\n').</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4335?view=msvc-160" target="_blank">C4335</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4335?view=msvc-170" target="_blank">C4335</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2612,9 +2653,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4336: import cross-referenced type library 'type_lib1' before importing 'type_lib2'</name>
     <description>
       <![CDATA[
-<p>A type library was referenced with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-160">#import</a> directive. However, the type library contained a reference to another type library that was not referenced with <code>#import</code>. This other .tlb file was found by the compiler.</p>
+<p>A type library was referenced with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170">#import</a> directive. However, the type library contained a reference to another type library that was not referenced with <code>#import</code>. This other .tlb file was found by the compiler.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4336?view=msvc-160" target="_blank">C4336</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4336?view=msvc-170" target="_blank">C4336</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2623,20 +2664,20 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4337: cross-referenced type library 'typelib1' in 'typelib2' is being automatically imported</name>
     <description>
       <![CDATA[
-<p>The auto_search attribute of <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-160">the #import directive</a> caused a type library to be implicitly imported.</p>
+<p>The auto_search attribute of <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170">the #import directive</a> caused a type library to be implicitly imported.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4337?view=msvc-160" target="_blank">C4337</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4337?view=msvc-170" target="_blank">C4337</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4339</key>
-    <name>C4339: 'type' : use of undefined type detected in WinRT or CLR meta-data - use of this type may lead to a runtime exception</name>
+    <name>C4339: 'type' : use of undefined type detected in WinRT or CLR meta-data</name>
     <description>
       <![CDATA[
 <p>A type was not defined in code that was compiled for Windows Runtime or the common language runtime. Define the type to avoid a possible runtime exception.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4339?view=msvc-160" target="_blank">C4339</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4339?view=msvc-170" target="_blank">C4339</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2649,7 +2690,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <strong><code>enum</code></strong> value is greater than the largest <strong><code>enum</code></strong> positive value wrapped around to a negative value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4340?view=msvc-160" target="_blank">C4340</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4340?view=msvc-170" target="_blank">C4340</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2662,7 +2703,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>In versions of Visual C++ before Visual Studio 2002, a member was called, but this behavior has been changed and the compiler now finds the best match in namespace scope.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4342?view=msvc-160" target="_blank">C4342</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4342?view=msvc-170" target="_blank">C4342</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2671,9 +2712,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4343: #pragma optimize("g",off) overrides /Og option</name>
     <description>
       <![CDATA[
-<p>This warning, only valid in the Itanium Processor Family (IPF) compiler, reports that a pragma <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/optimize?view=msvc-160">optimize</a> overrode a <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/og-global-optimizations?view=msvc-160">/Og</a> compiler option.</p>
+<p>This warning, only valid in the Itanium Processor Family (IPF) compiler, reports that a pragma <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/optimize?view=msvc-170">optimize</a> overrode a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/og-global-optimizations?view=msvc-170">/Og</a> compiler option.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4343?view=msvc-160" target="_blank">C4343</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4343?view=msvc-170" target="_blank">C4343</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2682,9 +2723,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4344: behavior change: use of explicit template arguments results in call to 'function'</name>
     <description>
       <![CDATA[
-<p>A call to a function using explicit template arguments calls a different function than it would if explicit arguments had not been specified</p>
+<p>A call to a function using explicit template arguments calls a different function than it would if explicit arguments had not been specified.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4344?view=msvc-160" target="_blank">C4344</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4344?view=msvc-170" target="_blank">C4344</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2693,9 +2734,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4346: 'name' : dependent name is not a type</name>
     <description>
       <![CDATA[
-<p>The <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/typename?view=msvc-160">typename</a> keyword is required if a dependent name is to be treated as a type. For code that works the same in all versions of Visual C++, add <strong><code>typename</code></strong> to the declaration.</p>
+<p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/typename?view=msvc-170">typename</a> keyword is required if a dependent name is to be treated as a type. For code that works the same in all versions of Visual C++, add <strong><code>typename</code></strong> to the declaration.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4346?view=msvc-160" target="_blank">C4346</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4346?view=msvc-170" target="_blank">C4346</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2706,7 +2747,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A template parameter was redefined.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4348?view=msvc-160" target="_blank">C4348</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4348?view=msvc-170" target="_blank">C4348</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2717,7 +2758,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An rvalue cannot be bound to a non-const reference. In versions of Visual C++ before Visual Studio 2003, it was possible to bind an rvalue to a non-const reference in a direct initialization. This code now gives a warning.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4350?view=msvc-160" target="_blank">C4350</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4350?view=msvc-170" target="_blank">C4350</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2726,9 +2767,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4353: nonstandard extension used: constant 0 as function expression</name>
     <description>
       <![CDATA[
-<p>You cannot use the constant zero (0) as a function expression. For more information, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/intrinsics/noop?view=msvc-160">__noop</a>.</p>
+<p>You cannot use the constant zero (0) as a function expression. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/intrinsics/noop?view=msvc-170">__noop</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4353?view=msvc-160" target="_blank">C4353</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4353?view=msvc-170" target="_blank">C4353</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2739,7 +2780,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <strong><code>this</code></strong> pointer is valid only within nonstatic member functions. It cannot be used in the initializer list for a base class.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4355?view=msvc-160" target="_blank">C4355</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4355?view=msvc-170" target="_blank">C4355</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2752,7 +2793,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The initialization of a static data member was ill formed. The compiler accepted the initialization. To avoid the warning, initialize the member through the base class.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4356?view=msvc-160" target="_blank">C4356</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4356?view=msvc-170" target="_blank">C4356</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2765,7 +2806,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <code>ParamArray</code> attribute was ignored, and <code>function</code> cannot be called with variable arguments.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4357?view=msvc-160" target="_blank">C4357</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4357?view=msvc-170" target="_blank">C4357</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2776,7 +2817,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Two delegates were combined and the return value is not void. If two delegates with non-void return values are combined, the compiler will not be able to do a proper assignment if the return value of the delegate is used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4358?view=msvc-160" target="_blank">C4358</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4358?view=msvc-170" target="_blank">C4358</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2787,9 +2828,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4359: 'type': actual alignment (8) is greater than the value specified in __declspec(align())</name>
     <description>
       <![CDATA[
-<p>The alignment specified for a type is less than the alignment of the type of one of its data members.  For more information, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-160">align</a>.</p>
+<p>The alignment specified for a type is less than the alignment of the type of one of its data members.  For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-170">align</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4359?view=msvc-160" target="_blank">C4359</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4359?view=msvc-170" target="_blank">C4359</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2802,7 +2843,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A <code>#using</code> directive was repeated for a given metadata file, but the <strong><code>as_friend</code></strong> qualifier was not used in the first occurrence; the compiler will ignore the second <strong><code>as_friend</code></strong>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4364?view=msvc-160" target="_blank">C4364</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4364?view=msvc-170" target="_blank">C4364</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2813,7 +2854,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>For example, you tried to convert an unsigned value to a signed value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4365?view=msvc-160" target="_blank">C4365</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4365?view=msvc-170" target="_blank">C4365</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2824,7 +2865,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>If a structure member could ever be unaligned because of packing, the compiler will warn when that member's address is assigned to an aligned pointer. By default, all pointers are aligned.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4366?view=msvc-160" target="_blank">C4366</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4366?view=msvc-170" target="_blank">C4366</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2835,7 +2876,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>You cannot embed a native data member in a CLR type.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4368?view=msvc-160" target="_blank">C4368</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4368?view=msvc-170" target="_blank">C4368</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -2848,7 +2889,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An enumerator was calculated to be greater than the greatest value for the specified underlying type.  This caused an overflow and the compiler wrapped the enumerator value to the lowest possible value for the type.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4369?view=msvc-160" target="_blank">C4369</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4369?view=msvc-170" target="_blank">C4369</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2859,7 +2900,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>If your code relies on a particular memory layout for a class, warning C4371 tells you that the layout created by the current compiler may be different from the layout generated by previous versions of the compiler. This may be significant for serialization operations or operating system interfaces that rely on a particular memory layout. In most other cases, this warning is safe to ignore.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4371?view=msvc-160" target="_blank">C4371</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4371?view=msvc-170" target="_blank">C4371</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2868,9 +2909,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4373: 'function': virtual function overrides 'base_function', previous versions of the compiler did not override when parameters only differed by const/volatile qualifiers</name>
     <description>
       <![CDATA[
-<p>Your application contains a method in a derived class that overrides a virtual method in a base class, and the parameters in the overriding method differ by only a <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/const-cpp?view=msvc-160">const</a> or <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/volatile-cpp?view=msvc-160">volatile</a> qualifier from the parameters of the virtual method. This means the compiler must bind a function reference to the method in either the base or derived class.</p>
+<p>Your application contains a method in a derived class that overrides a virtual method in a base class, and the parameters in the overriding method differ by only a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/const-cpp?view=msvc-170">const</a> or <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/volatile-cpp?view=msvc-170">volatile</a> qualifier from the parameters of the virtual method. This means the compiler must bind a function reference to the method in either the base or derived class.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4373?view=msvc-160" target="_blank">C4373</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4373?view=msvc-170" target="_blank">C4373</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2879,9 +2920,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4374: 'function1': interface method will not be implemented by non-virtual method 'function2'</name>
     <description>
       <![CDATA[
-<p>The compiler expected to find the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/virtual-specifier?view=msvc-160">virtual</a> keyword on a method definition.</p>
+<p>The compiler expected to find the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/virtual-specifier?view=msvc-170">virtual</a> keyword on a method definition.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4374?view=msvc-160" target="_blank">C4374</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4374?view=msvc-170" target="_blank">C4374</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2892,18 +2933,19 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A type that implements another type defined an override method, but the override was not public. Therefore, the method does not override the base type method.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4375?view=msvc-160" target="_blank">C4375</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4375?view=msvc-170" target="_blank">C4375</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4376</key>
-    <name>C4376: access specifier 'old_specifier:' is no longer supported: please use 'new_specifier:' instead</name>
+    <name>C4376: access specifier 'old_specifier:' is no longer supported</name>
     <description>
       <![CDATA[
-<p>For more information on specifying type and member accessibility in metadata, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli?view=msvc-160#BKMK_Type_visibility">Type visibility</a> and <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli?view=msvc-160#BKMK_Member_visibility">Member visibility</a> in <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli?view=msvc-160">How to: Define and Consume Classes and Structs (C++/CLI)</a>.</p>
+<p>Access specifier 'old_specifier:' is no longer supported: please use 'new_specifier:' instead.</p>
+<p>For more information on specifying type and member accessibility in metadata, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli?view=msvc-170#BKMK_Type_visibility">Type visibility</a> and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli?view=msvc-170#BKMK_Member_visibility">Member visibility</a> in <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli?view=msvc-170">How to: Define and Consume Classes and Structs (C++/CLI)</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4376?view=msvc-160" target="_blank">C4376</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4376?view=msvc-170" target="_blank">C4376</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2914,18 +2956,18 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>In previous releases, native types in assemblies were public by default, and an internal, undocumented compiler option (<strong>/d1PrivateNativeTypes</strong>) was used to make them private.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4377?view=msvc-160" target="_blank">C4377</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4377?view=msvc-170" target="_blank">C4377</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4378</key>
-    <name>C4378: Must obtain function pointers to run initializers; consider System::ModuleHandle::ResolveMethodHandle</name>
+    <name>C4378: Must obtain function pointers to run initializers</name>
     <description>
       <![CDATA[
-<p>Under <strong>/clr</strong>, initializer symbols contain function tokens, not functions pointers.  You need to convert tokens to pointers using <a data-linktype="absolute-path" href="/en-us/dotnet/api/system.modulehandle.resolvemethodhandle">ResolveMethodHandle</a>.</p>
+<p>Under <strong>/clr</strong>, initializer symbols contain function tokens, not functions pointers.  You need to convert tokens to pointers using <a class="no-loc" data-linktype="absolute-path" href="/en-us/dotnet/api/system.modulehandle.resolvemethodhandle">ResolveMethodHandle</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4378?view=msvc-160" target="_blank">C4378</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4378?view=msvc-170" target="_blank">C4378</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2936,7 +2978,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>You have a previous version of the common language runtime on your machine, but not the current version. To resolve C4379, install the version of the common language runtime that shipped with your compiler.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4379?view=msvc-160" target="_blank">C4379</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4379?view=msvc-170" target="_blank">C4379</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2947,7 +2989,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A class must implement all function in an interface. A class can satisfy this condition if one of its base classes implements the function. However, the function must be implemented as a public function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4381?view=msvc-160" target="_blank">C4381</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4381?view=msvc-170" target="_blank">C4381</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2958,7 +3000,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <strong>/clr:pure</strong> compiler option is deprecated in Visual Studio 2015 and unsupported in Visual Studio 2017.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4382?view=msvc-160" target="_blank">C4382</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4382?view=msvc-170" target="_blank">C4382</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2967,9 +3009,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4383: 'instance_dereference_operator' : the meaning of dereferencing a handle can change, when a user-defined 'operator' operator exists</name>
     <description>
       <![CDATA[
-<p>'instance_dereference_operator' : the meaning of dereferencing a handle can change, when a user-defined 'operator' operator exists; write the operator as a static function to be explicit about the operand</p>
+<p>'instance_dereference_operator' : the meaning of dereferencing a handle can change, when a user-defined 'operator' operator exists; write the operator as a static function to be explicit about the operand.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4383?view=msvc-160" target="_blank">C4383</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4383?view=msvc-170" target="_blank">C4383</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2978,9 +3020,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4384: #pragma 'make_public' should only be used at global scope</name>
     <description>
       <![CDATA[
-<p>The <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/make-public?view=msvc-160">make_public</a> pragma was applied incorrectly.</p>
+<p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/make-public?view=msvc-170">make_public</a> pragma was applied incorrectly.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4384?view=msvc-160" target="_blank">C4384</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4384?view=msvc-170" target="_blank">C4384</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -2991,7 +3033,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Using the <em>token</em> operator to compare a <strong><code>signed</code></strong> and a larger <strong><code>unsigned</code></strong> number required the compiler to convert the <strong><code>signed</code></strong> value to the larger <strong><code>unsigned</code></strong> type.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4388?view=msvc-160" target="_blank">C4388</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4388?view=msvc-170" target="_blank">C4388</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3002,7 +3044,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An <strong><code>==</code></strong> or <strong><code>!=</code></strong> operation involved <strong><code>signed</code></strong> and <strong><code>unsigned</code></strong> variables. This could result in a loss of data.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4389?view=msvc-160" target="_blank">C4389</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4389?view=msvc-170" target="_blank">C4389</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3013,7 +3055,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A semicolon was found after a control statement that contains no instructions.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4390?view=msvc-160" target="_blank">C4390</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4390?view=msvc-170" target="_blank">C4390</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3024,7 +3066,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function declaration for a compiler intrinsic had the wrong return type. The resulting image may not run correctly.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4391?view=msvc-160" target="_blank">C4391</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4391?view=msvc-170" target="_blank">C4391</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3035,7 +3077,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function declaration for a compiler intrinsic had the wrong number of arguments. The resulting image may not run correctly.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4392?view=msvc-160" target="_blank">C4392</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4392?view=msvc-170" target="_blank">C4392</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3044,9 +3086,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4393: 'var' : const has no effect on literal data member; ignored</name>
     <description>
       <![CDATA[
-<p>A <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/extensions/literal-cpp-component-extensions?view=msvc-160">literal</a> data member was also specified as const.  Since a literal data member implies const, you do not need to add const to the declaration.</p>
+<p>A <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/extensions/literal-cpp-component-extensions?view=msvc-170">literal</a> data member was also specified as const.  Since a literal data member implies const, you do not need to add const to the declaration.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4393?view=msvc-160" target="_blank">C4393</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4393?view=msvc-170" target="_blank">C4393</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3055,9 +3097,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4394: 'function' : per-appdomain symbol should not be marked with __declspec(dllexport)</name>
     <description>
       <![CDATA[
-<p>A function marked with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/appdomain?view=msvc-160">appdomain</a> <strong><code>__declspec</code></strong> modifier is compiled to MSIL (not to native), and export tables (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/windows/attributes/export?view=msvc-160">export</a> <strong><code>__declspec</code></strong> modifier) are not supported for managed functions.</p>
+<p>A function marked with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/appdomain?view=msvc-170">appdomain</a> <strong><code>__declspec</code></strong> modifier is compiled to MSIL (not to native), and export tables (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/export?view=msvc-170">export</a> <strong><code>__declspec</code></strong> modifier) are not supported for managed functions.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4394?view=msvc-160" target="_blank">C4394</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4394?view=msvc-170" target="_blank">C4394</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3066,9 +3108,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4395: 'function' : member function will be invoked on a copy of the initonly data member 'member'</name>
     <description>
       <![CDATA[
-<p>A member function was called on an <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/dotnet/initonly-cpp-cli?view=msvc-160">initonly (C++/CLI)</a> data member.  C4395 warns that the <strong>initonly</strong> data member cannot be modified by the function.</p>
+<p>A member function was called on an <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/dotnet/initonly-cpp-cli?view=msvc-170">initonly (C++/CLI)</a> data member.  C4395 warns that the <strong>initonly</strong> data member cannot be modified by the function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4395?view=msvc-160" target="_blank">C4395</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4395?view=msvc-170" target="_blank">C4395</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3077,9 +3119,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4396: "name" : the inline specifier cannot be used when a friend declaration refers to a specialization of a function template</name>
     <description>
       <![CDATA[
-<p>A specialization of a function template cannot specify any of the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/inline-functions-cpp?view=msvc-160">inline</a> specifiers. The compiler issues warning C4396 and ignores the inline specifier.</p>
+<p>A specialization of a function template cannot specify any of the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/inline-functions-cpp?view=msvc-170">inline</a> specifiers. The compiler issues warning C4396 and ignores the inline specifier.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4396?view=msvc-160" target="_blank">C4396</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4396?view=msvc-170" target="_blank">C4396</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3088,20 +3130,21 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4397: DefaultCharSetAttribute is ignored</name>
     <description>
       <![CDATA[
-<p><a data-linktype="absolute-path" href="/en-us/dotnet/api/system.runtime.interopservices.defaultcharsetattribute">DefaultCharSetAttribute</a> is ignored by the Microsoft C++ compiler. To specify a character set for the DLL, use the CharSet option of DllImport. For more information, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/dotnet/using-cpp-interop-implicit-pinvoke?view=msvc-160">Using C++ Interop (Implicit PInvoke)</a>.</p>
+<p><a class="no-loc" data-linktype="absolute-path" href="/en-us/dotnet/api/system.runtime.interopservices.defaultcharsetattribute">DefaultCharSetAttribute</a> is ignored by the Microsoft C++ compiler. To specify a character set for the DLL, use the CharSet option of DllImport. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/dotnet/using-cpp-interop-implicit-pinvoke?view=msvc-170">Using C++ Interop (Implicit PInvoke)</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4397?view=msvc-160" target="_blank">C4397</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4397?view=msvc-170" target="_blank">C4397</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4398</key>
-    <name>C4398: 'variable' : per-process global object might not work correctly with multiple appdomains; consider using __declspec(appdomain)</name>
+    <name>C4398: 'variable' : per-process global object might not work correctly with multiple appdomains</name>
     <description>
       <![CDATA[
-<p>A virtual function with <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/clrcall?view=msvc-160">__clrcall</a> calling convention in a native type causes the creation of a per application domain vtable. Such a variable may not correct correctly when used in multiple application domains.</p>
+<p>Per-process global object might not work correctly with multiple appdomains; consider using __declspec(appdomain).</p>
+<p>A virtual function with <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/clrcall?view=msvc-170">__clrcall</a> calling convention in a native type causes the creation of a per application domain vtable. Such a variable may not correct correctly when used in multiple application domains.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4398?view=msvc-160" target="_blank">C4398</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4398?view=msvc-170" target="_blank">C4398</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3112,7 +3155,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <strong>/clr:pure</strong> compiler option is deprecated in Visual Studio 2015 and unsupported in Visual Studio 2017.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4399?view=msvc-160" target="_blank">C4399</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4399?view=msvc-170" target="_blank">C4399</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3121,9 +3164,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4400: 'type' : const/volatile qualifiers on this type are not supported</name>
     <description>
       <![CDATA[
-<p>The <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/const-cpp?view=msvc-160">const</a>and <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/volatile-cpp?view=msvc-160">volatile</a>qualifiers will not work with variables of common language runtime types.</p>
+<p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/const-cpp?view=msvc-170">const</a>and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/volatile-cpp?view=msvc-170">volatile</a>qualifiers will not work with variables of common language runtime types.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4400?view=msvc-160" target="_blank">C4400</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4400?view=msvc-170" target="_blank">C4400</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3134,7 +3177,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Inline assembly code tries to access a bit-field member. Inline assembly cannot access bit-field members, so the last packing boundary before the bit-field member is used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4401?view=msvc-160" target="_blank">C4401</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4401?view=msvc-170" target="_blank">C4401</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3145,7 +3188,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A type is used on an operand without a PTR operator when referring to or casting to a type in inline assembly code.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4402?view=msvc-160" target="_blank">C4402</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4402?view=msvc-170" target="_blank">C4402</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3156,7 +3199,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A PTR operator is used inappropriately in inline assembler code.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4403?view=msvc-160" target="_blank">C4403</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4403?view=msvc-170" target="_blank">C4403</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3167,7 +3210,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The optional period preceding the directive is ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4404?view=msvc-160" target="_blank">C4404</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4404?view=msvc-170" target="_blank">C4404</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3176,9 +3219,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4405: 'identifier' : identifier is reserved word</name>
     <description>
       <![CDATA[
-<p>A word reserved for inline assembly is used as a variable name. This may cause unpredictable results. To fix this warning, avoid naming variables with words reserved for inline assembly. The following sample generates C4405:</p>
+<p>A word reserved for inline assembly is used as a variable name. This may cause unpredictable results. To fix this warning, avoid naming variables with words reserved for inline assembly.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4405?view=msvc-160" target="_blank">C4405</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4405?view=msvc-170" target="_blank">C4405</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -3191,7 +3234,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The directive does not take any operands, but an operand was specified.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4406?view=msvc-160" target="_blank">C4406</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4406?view=msvc-170" target="_blank">C4406</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3202,7 +3245,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An incorrect cast between pointer-to-member types was detected.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4407?view=msvc-160" target="_blank">C4407</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4407?view=msvc-170" target="_blank">C4407</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -3215,7 +3258,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An anonymous struct or union must have at least one data member.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4408?view=msvc-160" target="_blank">C4408</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4408?view=msvc-170" target="_blank">C4408</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3226,7 +3269,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The instruction did not have a form with the specified size. The smallest legal size was used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4409?view=msvc-160" target="_blank">C4409</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4409?view=msvc-170" target="_blank">C4409</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3237,7 +3280,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>One of the operands on the instruction had an incorrect size. The smallest legal size for the operand was used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4410?view=msvc-160" target="_blank">C4410</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4410?view=msvc-170" target="_blank">C4410</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3248,7 +3291,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The identifier is a local symbol that resolves to a displacement register and therefore may be used on an operand with another symbol.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4411?view=msvc-160" target="_blank">C4411</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4411?view=msvc-170" target="_blank">C4411</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3259,7 +3302,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <strong>/clr:pure</strong> compiler option is deprecated in Visual Studio 2015 and unsupported in Visual Studio 2017. If you have code that needs to be pure, we recommend that you port it to C#.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4412?view=msvc-160" target="_blank">C4412</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4412?view=msvc-170" target="_blank">C4412</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3270,7 +3313,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Short jumps generate compact instruction which branches to an address within a limited range from the instruction. The instruction includes a short offset that represents the distance between the jump and the target address, the function definition. During linking a function may be moved or subject to link-time optimizations that cause the function to be moved out of the range reachable from a short offset. The compiler must generate a special record for the jump, which requires the jmp instruction to be either NEAR or FAR. The compiler made the conversion.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4414?view=msvc-160" target="_blank">C4414</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4414?view=msvc-170" target="_blank">C4414</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3279,9 +3322,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4420: 'operator' : operator not available, using 'operator' instead; run-time checking may be compromised</name>
     <description>
       <![CDATA[
-<p>This warning is generated when you use the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/rtc-run-time-error-checks?view=msvc-160">/RTCv</a> (vector new/delete checking) and when no vector form is found. In this case, the non-vector form is used.</p>
+<p>This warning is generated when you use the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/rtc-run-time-error-checks?view=msvc-170">/RTCv</a> (vector new/delete checking) and when no vector form is found. In this case, the non-vector form is used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4420?view=msvc-160" target="_blank">C4420</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4420?view=msvc-170" target="_blank">C4420</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3292,7 +3335,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected a character sequence that may be a badly formed universal character name. A universal character name is <code>\u</code> followed by four hex digits, or <code>\U</code> followed by eight hex digits.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4429?view=msvc-160" target="_blank">C4429</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4429?view=msvc-170" target="_blank">C4429</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3303,7 +3346,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This error can be generated as a result of compiler conformance work that was done for Visual Studio 2005: all declarations must explicitly specify the type; int is no longer assumed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4430?view=msvc-160" target="_blank">C4430</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4430?view=msvc-170" target="_blank">C4430</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3314,7 +3357,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This error can be generated as a result of compiler conformance work that was done for Visual Studio 2005: Visual C++ no longer creates untyped identifiers as int by default. The type of an identifier must be specified explicitly.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4431?view=msvc-160" target="_blank">C4431</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4431?view=msvc-170" target="_blank">C4431</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3323,9 +3366,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4434: a class constructor must have private accessibility; changing to private access</name>
     <description>
       <![CDATA[
-<p>C4434 indicates that the compiler changed the accessibility of a static constructor. Static constructors must have private accessibility, as they are only meant to be called by the common language runtime. For more information, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli?view=msvc-160#BKMK_Static_constructors">Static constructors</a>.</p>
+<p>C4434 indicates that the compiler changed the accessibility of a static constructor. Static constructors must have private accessibility, as they are only meant to be called by the common language runtime. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli?view=msvc-170#BKMK_Static_constructors">Static constructors</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4434?view=msvc-160" target="_blank">C4434</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4434?view=msvc-170" target="_blank">C4434</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3334,9 +3377,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4435: 'class1' : Object layout under /vd2 will change due to virtual base 'class2'</name>
     <description>
       <![CDATA[
-<p>This warning is off by default. See <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/compiler-warnings-that-are-off-by-default?view=msvc-160">Compiler Warnings That Are Off by Default</a> for more information.</p>
+<p>This warning is off by default. See <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/compiler-warnings-that-are-off-by-default?view=msvc-170">Compiler Warnings That Are Off by Default</a> for more information.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4435?view=msvc-160" target="_blank">C4435</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4435?view=msvc-170" target="_blank">C4435</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3345,9 +3388,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4436: dynamic_cast from virtual base 'class1' to 'class2' in constructor or destructor could fail with partially-constructed object</name>
     <description>
       <![CDATA[
-<p>dynamic_cast from virtual base 'class1' to 'class2' in constructor or destructor could fail with partially-constructed object. Compile with /vd2 or define 'class2' with #pragma vtordisp(2) in effect</p>
+<p>dynamic_cast from virtual base 'class1' to 'class2' in constructor or destructor could fail with partially-constructed object. Compile with /vd2 or define 'class2' with #pragma vtordisp(2) in effect.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4436?view=msvc-160" target="_blank">C4436</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4436?view=msvc-170" target="_blank">C4436</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3356,9 +3399,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4437: dynamic_cast from virtual base 'class1' to 'class2' could fail in some contexts</name>
     <description>
       <![CDATA[
-<p>This warning is off by default. See <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/compiler-warnings-that-are-off-by-default?view=msvc-160">Compiler Warnings That Are Off by Default</a> for more information.</p>
+<p>This warning is off by default. See <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/compiler-warnings-that-are-off-by-default?view=msvc-170">Compiler Warnings That Are Off by Default</a> for more information.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4437?view=msvc-160" target="_blank">C4437</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4437?view=msvc-170" target="_blank">C4437</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3367,9 +3410,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4439: 'function' : function definition with a managed type in the signature must have a __clrcall calling convention</name>
     <description>
       <![CDATA[
-<p>The compiler implicitly replaced a calling convention with <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/clrcall?view=msvc-160"><code>__clrcall</code></a>. To resolve this warning, remove the <strong><code>__cdecl</code></strong> or <strong><code>__stdcall</code></strong> calling convention.</p>
+<p>The compiler implicitly replaced a calling convention with <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/clrcall?view=msvc-170"><code>__clrcall</code></a>. To resolve this warning, remove the <strong><code>__cdecl</code></strong> or <strong><code>__stdcall</code></strong> calling convention.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4439?view=msvc-160" target="_blank">C4439</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4439?view=msvc-170" target="_blank">C4439</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3380,7 +3423,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An attempt to change the calling convention was ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4440?view=msvc-160" target="_blank">C4440</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4440?view=msvc-170" target="_blank">C4440</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3389,9 +3432,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4441: calling convention of 'cc1' ignored; 'cc2' used instead</name>
     <description>
       <![CDATA[
-<p>Member functions in managed user-defined types and global function generics must use the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/clrcall?view=msvc-160">__clrcall</a> calling convention.  The compiler used <code>__clrcall</code>.</p>
+<p>Member functions in managed user-defined types and global function generics must use the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/clrcall?view=msvc-170">__clrcall</a> calling convention.  The compiler used <code>__clrcall</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4441?view=msvc-160" target="_blank">C4441</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4441?view=msvc-170" target="_blank">C4441</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3402,7 +3445,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>If a virtual function is private, it cannot be accessed by a derived type. To fix this error, change the accessibility of the virtual member function to protected or public.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4445?view=msvc-160" target="_blank">C4445</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4445?view=msvc-170" target="_blank">C4445</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3413,7 +3456,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The declaration of <em>identifier</em> in the local scope hides the declaration of the previous local declaration of the same name. This warning lets you know that references to <em>identifier</em> in the local scope resolve to the locally declared version, not the previous local, which may or may not be your intent. To fix this issue, we recommend you give local variables names that do not conflict with other local names.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4456?view=msvc-160" target="_blank">C4456</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4456?view=msvc-170" target="_blank">C4456</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3424,7 +3467,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The declaration of <em>identifier</em> in the local scope hides the declaration of the identically-named function parameter. This warning lets you know that references to <em>identifier</em> in the local scope resolve to the locally declared version, not the parameter, which may or may not be your intent. To fix this issue, we recommend you give local variables names that do not conflict with parameter names.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4457?view=msvc-160" target="_blank">C4457</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4457?view=msvc-170" target="_blank">C4457</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3435,7 +3478,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The declaration of <em>identifier</em> in the local scope hides the declaration of the identically-named <em>identifier</em> at class scope. This warning lets you know that references to <em>identifier</em> in this scope resolve to the locally declared version, not the class member version, which may or may not be your intent. To fix this issue, we recommend you give local variables names that do not conflict with class member names.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4458?view=msvc-160" target="_blank">C4458</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4458?view=msvc-170" target="_blank">C4458</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3446,7 +3489,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The declaration of <em>identifier</em> in the local scope hides the declaration of the identically-named <em>identifier</em> in global scope. This warning lets you know that references to <em>identifier</em> in this scope resolve to the locally declared version, not the global version, which may or may not be your intent. Generally, we recommend you minimize the use of global variables as a good engineering practice. To minimize pollution of the global namespace, we recommend use of a named namespace for global variables.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4459?view=msvc-160" target="_blank">C4459</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4459?view=msvc-170" target="_blank">C4459</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3457,7 +3500,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>You passed a value by reference to a user-defined Windows Runtime or CLR operator. If the value is changed inside the function, note that the value returned after the function call will be assigned the return value of the function. In standard C++, the changed value is reflected after the function call.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4460?view=msvc-160" target="_blank">C4460</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4460?view=msvc-170" target="_blank">C4460</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3468,7 +3511,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The presence of a finalizer in a type implies resources to delete. Unless a finalizer is explicitly called from the type's destructor, the common language runtime determines when to run the finalizer, after your object goes out of scope.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4461?view=msvc-160" target="_blank">C4461</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4461?view=msvc-170" target="_blank">C4461</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3479,7 +3522,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Warning C4462 occurs in a Windows Runtime app or component when a public <code>TypedEventHandler</code> has as one of its type parameters a reference to the enclosing class.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4462?view=msvc-160" target="_blank">C4462</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4462?view=msvc-170" target="_blank">C4462</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3490,7 +3533,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The assigned <em>value</em> is outside the range of values that the bit-field can hold. Signed bit-field types use the high-order bit for the sign, so if <em>n</em> is the bit-field size, the range for signed bit-fields is -2<sup>n-1</sup> to 2<sup>n-1</sup>-1, while unsigned bit-fields have a range from 0 to 2<sup>n</sup>-1.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4463?view=msvc-160" target="_blank">C4463</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4463?view=msvc-170" target="_blank">C4463</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3499,9 +3542,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4464: relative include path contains '..'</name>
     <description>
       <![CDATA[
-<p>A <code>#include</code> directive has a path that includes a '..' parent directory specifier.</p>
+<p>A <code>#include</code> directive has a path that includes a parent directory specifier (a <code>..</code> path segment).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4464?view=msvc-160" target="_blank">C4464</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4464?view=msvc-170" target="_blank">C4464</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3510,9 +3553,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4470: floating-point control pragmas ignored under /clr</name>
     <description>
       <![CDATA[
-<p>The float-control pragmas:</p>
+<p>floating-point control pragmas ignored under /clr.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4470?view=msvc-160" target="_blank">C4470</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4470?view=msvc-170" target="_blank">C4470</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3523,7 +3566,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A forward declaration of an unscoped enumeration was found without a specifier for the underlying type. By default, Visual C++ assumes <strong><code>int</code></strong> is the underlying type for an enumeration. This can cause issues if a different type is used in the enumeration definition, for example, if a different explicit type is specified, or if a different type is implicitly set by an initializer. You may also have portability issues; other compilers do not assume <strong><code>int</code></strong> is the underlying type of an enumeration.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4471?view=msvc-160" target="_blank">C4471</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4471?view=msvc-170" target="_blank">C4471</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3534,7 +3577,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected a mismatch between the number of arguments required to satisfy the placeholders in a format string, and the number of arguments supplied. Correct use of the printf and scanf families of variadic functions requires that you supply as many arguments as specified by the format string. Certain placeholders require additional arguments, to specify the width, precision, or buffer size, as well as an argument for the content. A mismatch generally means there is a bug in your code.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4473?view=msvc-160" target="_blank">C4473</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4473?view=msvc-170" target="_blank">C4473</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -3547,7 +3590,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected a mismatch between the type of argument required to satisfy the placeholder in a format string, and the type of argument supplied. Correct use of the printf and scanf families of variadic functions requires that you supply arguments of the types specified by the format string. A mismatch generally means there is a bug in your code.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4477?view=msvc-160" target="_blank">C4477</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4477?view=msvc-170" target="_blank">C4477</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -3558,9 +3601,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4481: nonstandard extension used: override specifier 'keyword'</name>
     <description>
       <![CDATA[
-<p>A keyword was used that is not in the C++ standard, for example, one of the override specifiers that also works under /clr.  For more information, see,</p>
+<p>A keyword was used that is not in the C++ standard, for example, one of the override specifiers that also works under /clr.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4481?view=msvc-160" target="_blank">C4481</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4481?view=msvc-170" target="_blank">C4481</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3571,7 +3614,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>When compiling with <strong>/clr</strong>, the compiler will not implicitly override a base class function, which means the function will get a new slot in the vtable. To resolve, explicitly specify whether a function is an override.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4484?view=msvc-160" target="_blank">C4484</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4484?view=msvc-170" target="_blank">C4484</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3582,7 +3625,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An accessor overrides, with or without the <strong><code>virtual</code></strong> keyword, a base class accessor function, but the <code>override</code> or <strong><code>new</code></strong> specifier was not part of the overriding function signature. Add the <strong><code>new</code></strong> or <code>override</code> specifier to resolve this warning.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4485?view=msvc-160" target="_blank">C4485</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4485?view=msvc-170" target="_blank">C4485</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3591,9 +3634,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4486: 'function' : a private virtual method of a ref class or value class should be marked 'sealed'</name>
     <description>
       <![CDATA[
-<p>Since a private virtual member function of a managed class or struct cannot be accessed or overridden, it should be marked <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/extensions/sealed-cpp-component-extensions?view=msvc-160">sealed</a>.</p>
+<p>Since a private virtual member function of a managed class or struct cannot be accessed or overridden, it should be marked <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/extensions/sealed-cpp-component-extensions?view=msvc-170">sealed</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4486?view=msvc-160" target="_blank">C4486</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4486?view=msvc-170" target="_blank">C4486</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3604,7 +3647,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function in a derived class has the same signature as a non-virtual base class function. C4487 reminds you that the derived class function does not override the base class function. Explicitly mark the derived class function as <strong><code>new</code></strong> to resolve this warning.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4487?view=msvc-160" target="_blank">C4487</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4487?view=msvc-170" target="_blank">C4487</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3615,7 +3658,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A class must implement all members of an interface from which it directly inherits. An implemented member must have public accessibility, and must be marked virtual.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4488?view=msvc-160" target="_blank">C4488</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4488?view=msvc-170" target="_blank">C4488</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3626,7 +3669,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A specifier keyword was incorrectly used on an interface method.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4489?view=msvc-160" target="_blank">C4489</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4489?view=msvc-170" target="_blank">C4489</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3637,7 +3680,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An override specifier was used incorrectly. For example, you do not override an interface function, you implement it.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4490?view=msvc-160" target="_blank">C4490</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4490?view=msvc-170" target="_blank">C4490</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3648,7 +3691,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A linkage was specified without the <strong><code>extern</code></strong> keyword. Linkage is not relevant to non-extern types.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4502?view=msvc-160" target="_blank">C4502</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4502?view=msvc-170" target="_blank">C4502</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3659,7 +3702,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This compiler warning is obsolete and is not generated in Visual Studio 2017 and later compilers.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4503?view=msvc-160" target="_blank">C4503</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4503?view=msvc-170" target="_blank">C4503</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3670,7 +3713,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The given function is local and not referenced in the body of the module; therefore, the function is dead code.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4505?view=msvc-160" target="_blank">C4505</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4505?view=msvc-170" target="_blank">C4505</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3681,7 +3724,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The given function was declared and marked for inlining but was not defined.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4506?view=msvc-160" target="_blank">C4506</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4506?view=msvc-170" target="_blank">C4506</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3692,7 +3735,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The function has no return type specified. In this case, C4430 should also fire and the compiler implements the fix reported by C4430 (default value is int).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4508?view=msvc-160" target="_blank">C4508</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4508?view=msvc-170" target="_blank">C4508</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3703,7 +3746,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler can't generate a default constructor for the specified class, which has no user-defined constructors. Objects of this type can't be created.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4510?view=msvc-160" target="_blank">C4510</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4510?view=msvc-170" target="_blank">C4510</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3714,7 +3757,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler could not generate a default copy-constructor for a class; a base class may have a private copy-constructor.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4511?view=msvc-160" target="_blank">C4511</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4511?view=msvc-170" target="_blank">C4511</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3725,7 +3768,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler cannot generate an assignment operator for the given class. No assignment operator was created.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4512?view=msvc-160" target="_blank">C4512</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4512?view=msvc-170" target="_blank">C4512</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3736,7 +3779,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler cannot generate a default destructor for the given class; no destructor was created. The destructor is in a base class that is not accessible to the derived class. If the base class has a private destructor, make it public or protected.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4513?view=msvc-160" target="_blank">C4513</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4513?view=msvc-170" target="_blank">C4513</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3747,7 +3790,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The optimizer removed an inline function that is not called.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4514?view=msvc-160" target="_blank">C4514</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4514?view=msvc-170" target="_blank">C4514</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3758,7 +3801,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A namespace is used recursively.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4515?view=msvc-160" target="_blank">C4515</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4515?view=msvc-170" target="_blank">C4515</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3767,9 +3810,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4516: 'class::symbol' : access-declarations are deprecated; member using-declarations provide a better alternative</name>
     <description>
       <![CDATA[
-<p>The ANSI C++ committee has declared access declarations (changing the access of a member in a derived class without the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/using-declaration?view=msvc-160">using</a> keyword) to be outdated. Access declarations may not be supported by future versions of C++.</p>
+<p>The ANSI C++ committee has declared access declarations (changing the access of a member in a derived class without the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/using-declaration?view=msvc-170">using</a> keyword) to be outdated. Access declarations may not be supported by future versions of C++.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4516?view=msvc-160" target="_blank">C4516</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4516?view=msvc-170" target="_blank">C4516</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3778,9 +3821,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4517: access-declarations are deprecated; member using-declarations provide a better alternative</name>
     <description>
       <![CDATA[
-<p>The ANSI C++ committee has declared access declarations (changing the access of a member in a derived class without the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/using-declaration?view=msvc-160">using</a> keyword) to be outdated. Access declarations may not be supported by future versions of C++.</p>
+<p>The ANSI C++ committee has declared access declarations (changing the access of a member in a derived class without the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/using-declaration?view=msvc-170">using</a> keyword) to be outdated. Access declarations may not be supported by future versions of C++.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4517?view=msvc-160" target="_blank">C4517</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4517?view=msvc-170" target="_blank">C4517</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3789,9 +3832,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4518: 'specifier' : storage-class or type specifier(s) unexpected here; ignored</name>
     <description>
       <![CDATA[
-<p>The following sample generates C4518:</p>
+<p>storage-class or type specifier(s) unexpected here; ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4518?view=msvc-160" target="_blank">C4518</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4518?view=msvc-170" target="_blank">C4518</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3802,7 +3845,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The class has multiple copy constructors of a single type. This warning is informational; the constructors are callable in your program.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4521?view=msvc-160" target="_blank">C4521</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4521?view=msvc-170" target="_blank">C4521</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3813,7 +3856,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The class has multiple assignment operators of a single type. This warning is informational; the constructors are callable in your program.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4522?view=msvc-160" target="_blank">C4522</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4522?view=msvc-170" target="_blank">C4522</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3824,7 +3867,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The class has multiple destructors.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4523?view=msvc-160" target="_blank">C4523</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4523?view=msvc-170" target="_blank">C4523</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3835,7 +3878,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The static member function meets the criteria to override the virtual function, which makes the member function both virtual and static.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4526?view=msvc-160" target="_blank">C4526</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4526?view=msvc-170" target="_blank">C4526</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -3846,9 +3889,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4530: C++ exception handler used, but unwind semantics are not enabled</name>
     <description>
       <![CDATA[
-<p>The code uses C++ exception handling, but <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-160">/EHsc</a> wasn't included in the compiler options.</p>
+<p>The code uses C++ exception handling, but <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170">/EHsc</a> wasn't included in the compiler options.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4530?view=msvc-160" target="_blank">C4530</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4530?view=msvc-170" target="_blank">C4530</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3857,9 +3900,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4532: 'continue' : jump out of __finally/finally block has undefined behavior during termination handling</name>
     <description>
       <![CDATA[
-<p>The compiler encountered one of the following keywords:</p>
+<p>jump out of __finally/finally block has undefined behavior during termination handling,</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4532?view=msvc-160" target="_blank">C4532</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4532?view=msvc-170" target="_blank">C4532</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3868,9 +3911,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4533: initialization of 'variable' is skipped by 'instruction'</name>
     <description>
       <![CDATA[
-<p>An instruction in your program changed the flow of control, such that, an instruction that initialized a variable was not executed. The following sample generates C4533:</p>
+<p>An instruction in your program changed the flow of control, so an instruction that initialized a variable wasn't executed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4533?view=msvc-160" target="_blank">C4533</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4533?view=msvc-170" target="_blank">C4533</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3881,7 +3924,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An unmanaged class can have a constructor with parameters that have default values and the compiler will use this as the default constructor. A class marked with the <code>value</code> keyword will not use a constructor with default values for its parameters as a default constructor.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4534?view=msvc-160" target="_blank">C4534</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4534?view=msvc-170" target="_blank">C4534</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3890,9 +3933,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4535: calling _set_se_translator() requires /EHa</name>
     <description>
       <![CDATA[
-<p>The use of <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/set-se-translator?view=msvc-160">_set_se_translator</a> requires the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-160">/EHa</a> compiler option and not <strong>/EHs</strong>.</p>
+<p>The use of <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/set-se-translator?view=msvc-170">_set_se_translator</a> requires the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170">/EHa</a> compiler option and not <strong>/EHs</strong>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4535?view=msvc-160" target="_blank">C4535</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4535?view=msvc-170" target="_blank">C4535</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3901,9 +3944,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4536: 'type name' : type-name exceeds meta-data limit of 'limit' characters</name>
     <description>
       <![CDATA[
-<p>A type name would be truncated in metadata if it was a managed type. See <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c3180?view=msvc-160">C3180</a> for more information.</p>
+<p>A type name would be truncated in metadata if it was a managed type. See <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c3180?view=msvc-170">C3180</a> for more information.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4536?view=msvc-160" target="_blank">C4536</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4536?view=msvc-170" target="_blank">C4536</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3914,7 +3957,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A reference was passed where an object (user-defined type) was expected. A reference is not an object, but inline assembler code is not able to make the distinction. The compiler generates code as though <em>object</em> were an instance.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4537?view=msvc-160" target="_blank">C4537</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4537?view=msvc-170" target="_blank">C4537</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3923,9 +3966,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4538: 'type' : const/volatile qualifiers on this type are not supported</name>
     <description>
       <![CDATA[
-<p>A qualifier keyword was applied to an array incorrectly. For more information, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/extensions/arrays-cpp-component-extensions?view=msvc-160">array</a>.</p>
+<p>A qualifier keyword was applied to an array incorrectly. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/extensions/arrays-cpp-component-extensions?view=msvc-170">array</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4538?view=msvc-160" target="_blank">C4538</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4538?view=msvc-170" target="_blank">C4538</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3936,7 +3979,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>You used <strong><code>dynamic_cast</code></strong> to convert from one type to another. The compiler determined that the cast would always fail (return <strong>NULL</strong>) because a base class is inaccessible (<strong><code>private</code></strong>, for instance) or ambiguous (appears more than once in the class hierarchy, for instance).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4540?view=msvc-160" target="_blank">C4540</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4540?view=msvc-170" target="_blank">C4540</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3945,9 +3988,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4541: 'identifier' used on polymorphic type 'type' with /GR-; unpredictable behavior may result</name>
     <description>
       <![CDATA[
-<p>You tried to use a feature that requires run-time type information without enabling run-time type information. Recompile with <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/gr-enable-run-time-type-information?view=msvc-160">/GR</a>.</p>
+<p>You tried to use a feature that requires run-time type information without enabling run-time type information. Recompile with <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/gr-enable-run-time-type-information?view=msvc-170">/GR</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4541?view=msvc-160" target="_blank">C4541</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4541?view=msvc-170" target="_blank">C4541</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -3958,9 +4001,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4543: Injected text suppressed by attribute 'no_injected_text'</name>
     <description>
       <![CDATA[
-<p>The <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/windows/attributes/no-injected-text?view=msvc-160">no_injected_text</a> attribute appeared in source code, which means the compiler will prevent attributes from injecting code.</p>
+<p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/no-injected-text?view=msvc-170">no_injected_text</a> attribute appeared in source code, which means the compiler will prevent attributes from injecting code.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4543?view=msvc-160" target="_blank">C4543</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4543?view=msvc-170" target="_blank">C4543</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3971,7 +4014,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A default template argument was specified in an incorrect location and was ignored. A default template argument for a class template can only be specified in the declaration or definition of the class template and not on a member of the class template.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4544?view=msvc-160" target="_blank">C4544</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4544?view=msvc-170" target="_blank">C4544</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3982,7 +4025,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected an ill-formed comma expression.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4545?view=msvc-160" target="_blank">C4545</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4545?view=msvc-170" target="_blank">C4545</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -3993,7 +4036,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected an ill-formed comma expression.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4546?view=msvc-160" target="_blank">C4546</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4546?view=msvc-170" target="_blank">C4546</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4004,7 +4047,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected an ill-formed comma expression.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4547?view=msvc-160" target="_blank">C4547</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4547?view=msvc-170" target="_blank">C4547</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4015,7 +4058,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected an ill-formed comma expression.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4548?view=msvc-160" target="_blank">C4548</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4548?view=msvc-170" target="_blank">C4548</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4026,7 +4069,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected an ill-formed comma expression.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4549?view=msvc-160" target="_blank">C4549</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4549?view=msvc-170" target="_blank">C4549</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4037,7 +4080,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A dereferenced pointer to a function is missing an argument list.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4550?view=msvc-160" target="_blank">C4550</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4550?view=msvc-170" target="_blank">C4550</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4048,7 +4091,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function call must include the open and close parentheses after the function name even if the function takes no parameters.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4551?view=msvc-160" target="_blank">C4551</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4551?view=msvc-170" target="_blank">C4551</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4059,7 +4102,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>If an expression statement has an operator with no side effect as the top of the expression, it's probably a mistake.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4552?view=msvc-160" target="_blank">C4552</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4552?view=msvc-170" target="_blank">C4552</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4070,18 +4113,18 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>If an expression statement has an operator with no side effect as the top of the expression, it's probably a mistake.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4553?view=msvc-160" target="_blank">C4553</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4553?view=msvc-170" target="_blank">C4553</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4554</key>
-    <name>C4554: 'operator' : check operator precedence for possible error; use parentheses to clarify precedence</name>
+    <name>C4554: 'operator' : check operator precedence for possible error</name>
     <description>
       <![CDATA[
-<p>The following sample generates C4554:</p>
+<p>Check operator precedence for possible error; use parentheses to clarify precedence.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4554?view=msvc-160" target="_blank">C4554</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4554?view=msvc-170" target="_blank">C4554</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4092,7 +4135,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning informs you when an expression has no effect.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4555?view=msvc-160" target="_blank">C4555</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4555?view=msvc-170" target="_blank">C4555</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4103,7 +4146,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An intrinsic matches a hardware instruction. The hardware instruction has a fixed number of bits to encode the constant. If <em>value</em> is out of range, it will not encode properly. The compiler truncates the extra bits.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4556?view=msvc-160" target="_blank">C4556</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4556?view=msvc-170" target="_blank">C4556</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4112,9 +4155,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4557: '__assume' contains effect 'effect'</name>
     <description>
       <![CDATA[
-<p>The value passed to an <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/intrinsics/assume?view=msvc-160">__assume</a> statement2 was modified.</p>
+<p>The value passed to an <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/intrinsics/assume?view=msvc-170">__assume</a> statement2 was modified.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4557?view=msvc-160" target="_blank">C4557</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4557?view=msvc-170" target="_blank">C4557</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4125,7 +4168,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The value passed to an assembly language instruction is out of the range specified for the parameter. The value will be truncated.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4558?view=msvc-160" target="_blank">C4558</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4558?view=msvc-170" target="_blank">C4558</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4136,7 +4179,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function was redefined or redeclared and the second definition or declaration added a <strong><code>__declspec</code></strong> modifier (<em>modifier</em>). This warning is informational. To fix this warning, delete one of the definitions.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4559?view=msvc-160" target="_blank">C4559</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4559?view=msvc-170" target="_blank">C4559</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4145,9 +4188,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4561: '__fastcall' incompatible with the '/clr' option: converting to '__stdcall'</name>
     <description>
       <![CDATA[
-<p>The <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/fastcall?view=msvc-160">__fastcall</a> function-calling convention cannot be used with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/clr-common-language-runtime-compilation?view=msvc-160">/clr</a> compiler option. The compiler ignores the calls to <strong><code>__fastcall</code></strong>. To fix this warning, either remove the calls to <strong><code>__fastcall</code></strong> or compile without <strong>/clr</strong>.</p>
+<p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/fastcall?view=msvc-170">__fastcall</a> function-calling convention cannot be used with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/clr-common-language-runtime-compilation?view=msvc-170">/clr</a> compiler option. The compiler ignores the calls to <strong><code>__fastcall</code></strong>. To fix this warning, either remove the calls to <strong><code>__fastcall</code></strong> or compile without <strong>/clr</strong>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4561?view=msvc-160" target="_blank">C4561</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4561?view=msvc-170" target="_blank">C4561</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4158,7 +4201,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected a method with one or more parameters with default values. The default value(s) for the parameters will be ignored when the method is invoked; explicitly specify values for those parameters. If you do not explicitly specify values for those parameters, the C++ compiler will generate an error.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4564?view=msvc-160" target="_blank">C4564</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4564?view=msvc-170" target="_blank">C4564</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4169,7 +4212,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A symbol was redefined or redeclared and the second definition or declaration, unlike the first definition or declaration, did not have a <strong><code>__declspec</code></strong> modifier (<em>modifier</em>). This warning is informational. To fix this warning, delete one of the definitions.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4565?view=msvc-160" target="_blank">C4565</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4565?view=msvc-170" target="_blank">C4565</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4180,7 +4223,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Not every Unicode character can be represented in your current ANSI code page.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4566?view=msvc-160" target="_blank">C4566</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4566?view=msvc-170" target="_blank">C4566</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4189,31 +4232,33 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4570: 'type' : is not explicitly declared as abstract but has abstract functions</name>
     <description>
       <![CDATA[
-<p>A type that contains <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/extensions/abstract-cpp-component-extensions?view=msvc-160">abstract</a> functions should itself be marked as abstract.</p>
+<p>A type that contains <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/extensions/abstract-cpp-component-extensions?view=msvc-170">abstract</a> functions should itself be marked as abstract.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4570?view=msvc-160" target="_blank">C4570</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4570?view=msvc-170" target="_blank">C4570</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4571</key>
-    <name>C4571: Informational: catch(...) semantics changed since Visual C++ 7.1; structured exceptions (SEH) are no longer caught</name>
+    <name>C4571: Structured exceptions (SEH) are no longer caught</name>
     <description>
       <![CDATA[
+<p>Informational: catch(...) semantics changed since Visual C++ 7.1; structured exceptions (SEH) are no longer caught.</p>
 <p>C4571 is generated for every <code>catch(...)</code> block when you specify the <strong><code>/EHs</code></strong> compiler option.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4571?view=msvc-160" target="_blank">C4571</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4571?view=msvc-170" target="_blank">C4571</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4572</key>
-    <name>C4572: [ParamArray] attribute is deprecated under /clr, use '...' instead</name>
+    <name>C4572: [ParamArray] attribute is deprecated under /clr</name>
     <description>
       <![CDATA[
-<p>An obsolete style for specifying a variable argument list was used. When compiling for the CLR, use ellipsis syntax instead of <a data-linktype="absolute-path" href="/en-us/dotnet/api/system.paramarrayattribute">ParamArrayAttribute</a>. For more information, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/extensions/variable-argument-lists-dot-dot-dot-cpp-cli?view=msvc-160">Variable Argument Lists (...) (C++/CLI)</a>.</p>
+<p>[ParamArray] attribute is deprecated under /clr, use '...' instead.</p>
+<p>An obsolete style for specifying a variable argument list was used. When compiling for the CLR, use ellipsis syntax instead of <a class="no-loc" data-linktype="absolute-path" href="/en-us/dotnet/api/system.paramarrayattribute">ParamArrayAttribute</a>. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/extensions/variable-argument-lists-dot-dot-dot-cpp-cli?view=msvc-170">Variable Argument Lists (...) (C++/CLI)</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4572?view=msvc-160" target="_blank">C4572</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4572?view=msvc-170" target="_blank">C4572</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4222,20 +4267,21 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4577: 'noexcept' used with no exception handling mode specified; termination on exception is not guaranteed</name>
     <description>
       <![CDATA[
-<p>The compiler detected a <strong><code>noexcept</code></strong> specification, but standard C++ exception handling wasn't specified. The compiler doesn't fully support exception handling according to the C++ standard unless the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-160">/EHsc</a> compiler option is specified. To resolve this issue, set the <strong>/EHsc</strong> compiler option.</p>
+<p>The compiler detected a <strong><code>noexcept</code></strong> specification, but standard C++ exception handling wasn't specified. The compiler doesn't fully support exception handling according to the C++ standard unless the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170">/EHsc</a> compiler option is specified. To resolve this issue, set the <strong>/EHsc</strong> compiler option.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4577?view=msvc-160" target="_blank">C4577</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4577?view=msvc-170" target="_blank">C4577</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4580</key>
-    <name>C4580: [attribute] is deprecated; instead specify System::Attribute or Platform::Metadata as a base class</name>
+    <name>C4580: [attribute] is deprecated</name>
     <description>
       <![CDATA[
-<p>[<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/windows/attributes/attribute?view=msvc-160">attribute</a>] is no longer the preferred syntax for creating user-defined attributes. For more information, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/extensions/user-defined-attributes-cpp-component-extensions?view=msvc-160">User-Defined Attributes</a>. For CLR code, derive attributes from <code>System::Attribute</code>. For Windows Runtime code, derive attributes from <code>Platform::Metadata</code>.</p>
+<p>[attribute] is deprecated; instead specify System::Attribute or Platform::Metadata as a base class.</p>
+<p>[<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/attribute?view=msvc-170">attribute</a>] is no longer the preferred syntax for creating user-defined attributes. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/extensions/user-defined-attributes-cpp-component-extensions?view=msvc-170">User-Defined Attributes</a>. For CLR code, derive attributes from <code>System::Attribute</code>. For Windows Runtime code, derive attributes from <code>Platform::Metadata</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4580?view=msvc-160" target="_blank">C4580</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4580?view=msvc-170" target="_blank">C4580</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4246,7 +4292,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This error can be generated as a result of compiler conformance work that was done for Visual Studio 2005: parameter checking for Visual C++ attributes.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4581?view=msvc-160" target="_blank">C4581</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4581?view=msvc-170" target="_blank">C4581</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4255,9 +4301,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4584: 'class1' : base-class 'class2' is already a base-class of 'class3'</name>
     <description>
       <![CDATA[
-<p>The class you defined inherits from two classes, one of which inherits from the other. For example:</p>
+<p>The class you defined inherits from two classes, one of which inherits from the other.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4584?view=msvc-160" target="_blank">C4584</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4584?view=msvc-170" target="_blank">C4584</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4268,7 +4314,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A member declaration has an unexpected qualification. To resolve this warning, remove the qualification from the identifier.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4596?view=msvc-160" target="_blank">C4596</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4596?view=msvc-170" target="_blank">C4596</a></p>]]>
     </description>
     <severity>INFO</severity>
     </rule>
@@ -4279,7 +4325,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Using <code>offsetof(T, m)</code> where <em><code>m</code></em> refers to a static data member or a member function results in C4597.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4597?view=msvc-160" target="_blank">C4597</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4597?view=msvc-170" target="_blank">C4597</a></p>]]>
       </description>
     <severity>INFO</severity>
   </rule>
@@ -4288,9 +4334,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4600: #pragma 'macro name' : expected a valid non-empty string</name>
     <description>
       <![CDATA[
-<p>You cannot specify an empty string when you push or pop a macro name with either the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/pop-macro?view=msvc-160">pop_macro</a> or <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/push-macro?view=msvc-160">push_macro</a>.</p>
+<p>You cannot specify an empty string when you push or pop a macro name with either the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/pop-macro?view=msvc-170">pop_macro</a> or <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/push-macro?view=msvc-170">push_macro</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4600?view=msvc-160" target="_blank">C4600</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4600?view=msvc-170" target="_blank">C4600</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4299,9 +4345,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4602: #pragma pop_macro : 'macro name' no previous #pragma push_macro for this identifier</name>
     <description>
       <![CDATA[
-<p>If you use <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/pop-macro?view=msvc-160">pop_macro</a> for a particular macro, you must first have passed that macro name to <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/push-macro?view=msvc-160">push_macro</a>. For example, the following sample generates C4602:</p>
+<p>If you use <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/pop-macro?view=msvc-170">pop_macro</a> for a particular macro, you must first have passed that macro name to <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/push-macro?view=msvc-170">push_macro</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4602?view=msvc-160" target="_blank">C4602</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4602?view=msvc-170" target="_blank">C4602</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4312,7 +4358,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The macro specified by the <em>identifier</em> placeholder is either different or no longer defined after the precompiler header is used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4603?view=msvc-160" target="_blank">C4603</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4603?view=msvc-170" target="_blank">C4603</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4321,9 +4367,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4606: #pragma warning : 'warning_number' ignored; Code Analysis warnings are not associated with warning levels</name>
     <description>
       <![CDATA[
-<p>For Code Analysis warnings, only <code>error</code>, <code>once</code>, and <code>default</code> are supported with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-160">warning</a> pragma.</p>
+<p>For Code Analysis warnings, only <code>error</code>, <code>once</code>, and <code>default</code> are supported with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170">warning</a> pragma.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4606?view=msvc-160" target="_blank">C4606</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4606?view=msvc-170" target="_blank">C4606</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4334,18 +4380,18 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Two members of the same union were initialized in an initialization list. You can only access one member of the union.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4608?view=msvc-160" target="_blank">C4608</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4608?view=msvc-170" target="_blank">C4608</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4610</key>
-    <name>C4610: object 'class' can never be instantiated - user-defined constructor required</name>
+    <name>C4610: object 'class' can never be instantiated</name>
     <description>
       <![CDATA[
-<p>The class has no user-defined or default constructors. No instantiation is performed. The following sample generates C4610:</p>
+<p>The class has no user-defined or default constructors. No instantiation is performed - user-defined constructor required.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4610?view=msvc-160" target="_blank">C4610</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4610?view=msvc-170" target="_blank">C4610</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4356,7 +4402,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>On some platforms, functions that include <strong><code>catch</code></strong> may not support C++ object semantics of destruction when out of scope.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4611?view=msvc-160" target="_blank">C4611</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4611?view=msvc-170" target="_blank">C4611</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4367,7 +4413,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning occurs with <strong>#pragma include_alias</strong> when a filename is incorrect or missing.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4612?view=msvc-160" target="_blank">C4612</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4612?view=msvc-170" target="_blank">C4612</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4378,7 +4424,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>You tried to create a segment with the same class name as a segment used by the compiler. No new segment class was created.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4613?view=msvc-160" target="_blank">C4613</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4613?view=msvc-170" target="_blank">C4613</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4387,9 +4433,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4615: #pragma warning : unknown user warning type</name>
     <description>
       <![CDATA[
-<p>An invalid warning specifier was used with <strong>pragma</strong> <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-160">warning</a>. To resolve the error, use a valid warning specifier.</p>
+<p>An invalid warning specifier was used with <strong>pragma</strong> <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170">warning</a>. To resolve the error, use a valid warning specifier.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4615?view=msvc-160" target="_blank">C4615</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4615?view=msvc-170" target="_blank">C4615</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4398,9 +4444,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4616: #pragma warning : warning number 'number' not a valid compiler warning</name>
     <description>
       <![CDATA[
-<p>The warning number specified in the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-160">warning</a> pragma cannot be reassigned. The pragma was ignored.</p>
+<p>The warning number specified in the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170">warning</a> pragma cannot be reassigned. The pragma was ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4616?view=msvc-160" target="_blank">C4616</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4616?view=msvc-170" target="_blank">C4616</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4411,7 +4457,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A null string was given as an argument to a <strong>#pragma</strong>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4618?view=msvc-160" target="_blank">C4618</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4618?view=msvc-170" target="_blank">C4618</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4422,7 +4468,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An attempt was made to disable a warning that does not exist.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4619?view=msvc-160" target="_blank">C4619</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4619?view=msvc-170" target="_blank">C4619</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4433,7 +4479,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>There is no postfix increment operator defined for the given type. The compiler used the overloaded prefix operator.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4620?view=msvc-160" target="_blank">C4620</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4620?view=msvc-170" target="_blank">C4620</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4444,7 +4490,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>There was no postfix decrement operator defined for the given type. The compiler used the overloaded prefix operator.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4621?view=msvc-160" target="_blank">C4621</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4621?view=msvc-170" target="_blank">C4621</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4453,20 +4499,20 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4622: Overwriting debug information formed during creation of the precompiled header in object file: 'file'</name>
     <description>
       <![CDATA[
-<p>CodeView information in the specified file was lost when it was compiled with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/yu-use-precompiled-header-file?view=msvc-160">/Yu</a> (Use Precompiled Headers) option.</p>
+<p>CodeView information in the specified file was lost when it was compiled with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/yu-use-precompiled-header-file?view=msvc-170">/Yu</a> (Use Precompiled Headers) option.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4622?view=msvc-160" target="_blank">C4622</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4622?view=msvc-170" target="_blank">C4622</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4623</key>
-    <name>C4623: 'derived class' : default constructor was implicitly defined as deleted because a base class default constructor is inaccessible or deleted</name>
+    <name>C4623: 'derived class' : default constructor was implicitly defined as deleted</name>
     <description>
       <![CDATA[
-<p>A constructor was not accessible in a base class and was not generated for the derived class. Any attempt to create an object of this type on the stack will cause a compiler error.</p>
+<p>Because the default constructor is deleted or inaccessible in a base class, the compiler can't generate a default constructor for the derived class. Attempts to create an object of this type by using the default constructor (for example, in an array) cause a compiler error.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4623?view=msvc-160" target="_blank">C4623</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4623?view=msvc-170" target="_blank">C4623</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4477,7 +4523,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A destructor was not accessible or deleted in a base class and was therefore not generated for a derived class. Any attempt to create an object of this type on the stack will cause a compiler error.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4624?view=msvc-160" target="_blank">C4624</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4624?view=msvc-170" target="_blank">C4624</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4488,7 +4534,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A copy constructor was deleted or not accessible in a base class and was therefore not generated for a derived class. Any attempt to copy an object of this type will cause a compiler error.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4625?view=msvc-160" target="_blank">C4625</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4625?view=msvc-170" target="_blank">C4625</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4499,7 +4545,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An assignment operator was deleted or not accessible in a base class and was therefore not generated for a derived class. Any attempt to assign objects of this type will cause a compiler error.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4626?view=msvc-160" target="_blank">C4626</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4626?view=msvc-170" target="_blank">C4626</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4508,9 +4554,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4627: 'header_file': skipped when looking for precompiled header use</name>
     <description>
       <![CDATA[
-<p>If the current source file has the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/yu-use-precompiled-header-file?view=msvc-160">/Yu (Use precompiled header file)</a> option set, then the compiler ignores everything in the file before the precompiled header is included. Warning <strong>C4627</strong> is generated in Visual Studio 2015 and earlier versions if <em>header_file</em> is included before the precompiled header file, and if the precompiled header does not also include <em>header_file</em>.</p>
+<p>If the current source file has the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/yu-use-precompiled-header-file?view=msvc-170">/Yu (Use precompiled header file)</a> option set, then the compiler ignores everything in the file before the precompiled header is included. Warning <strong>C4627</strong> is generated in Visual Studio 2015 and earlier versions if <em>header_file</em> is included before the precompiled header file, and if the precompiled header does not also include <em>header_file</em>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4627?view=msvc-160" target="_blank">C4627</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4627?view=msvc-170" target="_blank">C4627</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4519,9 +4565,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4628: digraphs not supported with -Ze</name>
     <description>
       <![CDATA[
-<p>Digraphs are not supported under <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Ze</a>. This warning will be followed by an error.</p>
+<p>Digraphs are not supported under <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Ze</a>. This warning will be followed by an error.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4628?view=msvc-160" target="_blank">C4628</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4628?view=msvc-170" target="_blank">C4628</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4530,9 +4576,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4629: digraph used, character sequence 'digraph' interpreted as token 'char'</name>
     <description>
       <![CDATA[
-<p>Under <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-160">/Za</a>, the compiler warns when it detects a digraph.</p>
+<p>Under <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>, the compiler warns when it detects a digraph.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4629?view=msvc-160" target="_blank">C4629</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4629?view=msvc-170" target="_blank">C4629</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4541,9 +4587,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4630: 'symbol' : 'extern' storage class specifier illegal on member definition</name>
     <description>
       <![CDATA[
-<p>A data member or member function is defined as <strong><code>extern</code></strong>. Members cannot be external, although entire objects can. The compiler ignores the <strong><code>extern</code></strong> keyword. The following sample generates C4630:</p>
+<p>A data member or member function is defined as <strong><code>extern</code></strong>. Members cannot be external, although entire objects can. The compiler ignores the <strong><code>extern</code></strong> keyword.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4630?view=msvc-160" target="_blank">C4630</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4630?view=msvc-170" target="_blank">C4630</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4554,7 +4600,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Your common language runtime installation did not have the necessary files to support processing doc comment. Reinstall the common language runtime.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4631?view=msvc-160" target="_blank">C4631</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4631?view=msvc-170" target="_blank">C4631</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4565,7 +4611,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The path to .xdc file (<code>file</code>) was not valid, and no .xdc file created.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4632?view=msvc-160" target="_blank">C4632</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4632?view=msvc-170" target="_blank">C4632</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4574,9 +4620,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4633: XML document comment target: error:  reason</name>
     <description>
       <![CDATA[
-<p>A name passed to the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/param-visual-cpp?view=msvc-160">&lt;param&gt;</a> tag was not found by the compiler.</p>
+<p>A name passed to the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/param-visual-cpp?view=msvc-170">&lt;param&gt;</a> tag was not found by the compiler.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4633?view=msvc-160" target="_blank">C4633</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4633?view=msvc-170" target="_blank">C4633</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4587,7 +4633,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>XML documentation tags can not be applied to all C++ constructs.  For example, you cannot add a documentation comment to a namespace or template.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4634?view=msvc-160" target="_blank">C4634</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4634?view=msvc-170" target="_blank">C4634</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4596,9 +4642,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4635: XML document comment target: badly-formed XML: reason</name>
     <description>
       <![CDATA[
-<p>The compiler found some problem with the XML tags.  Fix the problem and recompile</p>
+<p>The compiler found some problem with the XML tags. Fix the problem and recompile.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4635?view=msvc-160" target="_blank">C4635</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4635?view=msvc-170" target="_blank">C4635</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4609,7 +4655,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A tag, such as <code>cref</code>, did not have a value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4636?view=msvc-160" target="_blank">C4636</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4636?view=msvc-170" target="_blank">C4636</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4618,9 +4664,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4637: XML document comment target: &lt;include&gt; tag discarded</name>
     <description>
       <![CDATA[
-<p>The syntax of an <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/include-visual-cpp?view=msvc-160">&lt;include&gt;</a> tag was not correct.</p>
+<p>The syntax of an <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/include-visual-cpp?view=msvc-170">&lt;include&gt;</a> tag was not correct.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4637?view=msvc-160" target="_blank">C4637</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4637?view=msvc-170" target="_blank">C4637</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4631,7 +4677,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler was unable to resolve a symbol (<em>symbol</em>). The symbol must be valid in the compilation.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4638?view=msvc-160" target="_blank">C4638</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4638?view=msvc-170" target="_blank">C4638</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4642,7 +4688,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning can occur for any number of reasons.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4639?view=msvc-160" target="_blank">C4639</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4639?view=msvc-170" target="_blank">C4639</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4653,7 +4699,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A static instance of an object is not thread safe.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4640?view=msvc-160" target="_blank">C4640</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4640?view=msvc-170" target="_blank">C4640</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4664,7 +4710,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler was unable to unambiguously resolve a reference. To resolve this warning, specify the parameter information necessary to make the reference unambiguous.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4641?view=msvc-160" target="_blank">C4641</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4641?view=msvc-170" target="_blank">C4641</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4673,9 +4719,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4645: function declared with __declspec(noreturn) has a return statement</name>
     <description>
       <![CDATA[
-<p>A <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/program-termination?view=msvc-160">return</a> statement was found in a function that is marked with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/noreturn?view=msvc-160">noreturn</a> <strong><code>__declspec</code></strong> modifier. The <strong><code>return</code></strong> statement was ignored.</p>
+<p>A <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/program-termination?view=msvc-170">return</a> statement was found in a function that is marked with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/noreturn?view=msvc-170">noreturn</a> <strong><code>__declspec</code></strong> modifier. The <strong><code>return</code></strong> statement was ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4645?view=msvc-160" target="_blank">C4645</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4645?view=msvc-170" target="_blank">C4645</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4684,9 +4730,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4646: function declared with __declspec(noreturn) has non-void return type</name>
     <description>
       <![CDATA[
-<p>A function marked with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/noreturn?view=msvc-160">noreturn</a> <strong><code>__declspec</code></strong> modifier should have a <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/void-cpp?view=msvc-160">void</a> return type.</p>
+<p>A function marked with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/noreturn?view=msvc-170">noreturn</a> <strong><code>__declspec</code></strong> modifier should have a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/void-cpp?view=msvc-170">void</a> return type.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4646?view=msvc-160" target="_blank">C4646</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4646?view=msvc-170" target="_blank">C4646</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4697,7 +4743,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The precompiled header file was not compiled with Microsoft symbolic debugging information.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4650?view=msvc-160" target="_blank">C4650</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4650?view=msvc-170" target="_blank">C4650</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4708,7 +4754,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The definition was specified when the precompiled header was generated, but not in this compilation.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4651?view=msvc-160" target="_blank">C4651</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4651?view=msvc-170" target="_blank">C4651</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4719,7 +4765,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The given command-line option differed from that given when the precompiled header (.pch) was created. The option specified in the current command line was used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4652?view=msvc-160" target="_blank">C4652</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4652?view=msvc-170" target="_blank">C4652</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4728,9 +4774,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4653: compiler option 'option' inconsistent with precompiled header; current command-line option ignored</name>
     <description>
       <![CDATA[
-<p>An option specified with the Use Precompiled Headers (<a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/yu-use-precompiled-header-file?view=msvc-160">/Yu</a>) option was inconsistent with the options specified when the precompiled header was created. This compilation used the option specified when the precompiled header was created.</p>
+<p>An option specified with the Use Precompiled Headers (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/yu-use-precompiled-header-file?view=msvc-170">/Yu</a>) option was inconsistent with the options specified when the precompiled header was created. This compilation used the option specified when the precompiled header was created.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4653?view=msvc-160" target="_blank">C4653</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4653?view=msvc-170" target="_blank">C4653</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4741,7 +4787,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>You changed or added a new data type since the last successful build. Edit and Continue does not support changes to existing data types.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4655?view=msvc-160" target="_blank">C4655</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4655?view=msvc-170" target="_blank">C4655</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4752,7 +4798,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>You added or changed a data type, making it new to your source code since the last successful build. Edit and Continue does not support changes to existing data types.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4656?view=msvc-160" target="_blank">C4656</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4656?view=msvc-170" target="_blank">C4656</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4763,18 +4809,18 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>You added or changed a data type, making it new to your source code since the last successful build. Edit and Continue does not support changes to existing data types.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4657?view=msvc-160" target="_blank">C4657</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4657?view=msvc-170" target="_blank">C4657</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4659</key>
-    <name>C4659: #pragma 'pragma' : use of reserved segment 'segment' has undefined behavior, use #pragma comment(linker, ...)</name>
+    <name>C4659: #pragma 'pragma' : use of reserved segment 'segment' has undefined behavior</name>
     <description>
       <![CDATA[
-<p>The .drectve option was used to pass an option to the linker. Instead use pragma <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/comment-c-cpp?view=msvc-160">comment</a> for passing a linker option.</p>
+<p>The .drectve option was used to pass an option to the linker. Instead use pragma <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/comment-c-cpp?view=msvc-170">comment</a> for passing a linker option.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4659?view=msvc-160" target="_blank">C4659</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4659?view=msvc-170" target="_blank">C4659</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4785,7 +4831,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A member of the template class is not defined.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4661?view=msvc-160" target="_blank">C4661</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4661?view=msvc-170" target="_blank">C4661</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4796,7 +4842,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The specified template-class was declared, but not defined.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4662?view=msvc-160" target="_blank">C4662</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4662?view=msvc-170" target="_blank">C4662</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4807,7 +4853,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>You cannot instantiate a function template that has not been declared.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4667?view=msvc-160" target="_blank">C4667</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4667?view=msvc-170" target="_blank">C4667</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4816,9 +4862,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4668: 'symbol' is not defined as a preprocessor macro, replacing with '0' for 'directives'</name>
     <description>
       <![CDATA[
-<p>A symbol that was not defined was used with a preprocessor directive. The symbol will evaluate to false. To define a symbol, you can use either the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/hash-define-directive-c-cpp?view=msvc-160">#define directive</a> or <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/d-preprocessor-definitions?view=msvc-160">/D</a> compiler option.</p>
+<p>A symbol that was not defined was used with a preprocessor directive. The symbol will evaluate to false. To define a symbol, you can use either the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-define-directive-c-cpp?view=msvc-170">#define directive</a> or <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/d-preprocessor-definitions?view=msvc-170">/D</a> compiler option.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4668?view=msvc-160" target="_blank">C4668</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4668?view=msvc-170" target="_blank">C4668</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4829,7 +4875,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A cast contains a Windows Runtime or managed type. The compiler completes the cast by performing a bit-wise copy of one pointer to the other, but provides no other checking. To resolve this warning, do not cast classes containing managed members or Windows Runtime types.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4669?view=msvc-160" target="_blank">C4669</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4669?view=msvc-170" target="_blank">C4669</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4840,18 +4886,19 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The specified base class of an object to be thrown in a <strong><code>try</code></strong> block is not accessible. The object cannot be instantiated if it is thrown. Check that the base class is inherited with the correct access specifier.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4670?view=msvc-160" target="_blank">C4670</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4670?view=msvc-170" target="_blank">C4670</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4672</key>
-    <name>C4672: 'identifier1' : ambiguous. First seen as 'identifier2'</name>
+    <name>C4672: 'identifier1' : ambiguous</name>
     <description>
       <![CDATA[
+<p>'identifier1' : ambiguous. First seen as 'identifier2'.</p>
 <p>The specified object to be thrown in a <strong><code>try</code></strong> block is ambiguous. The object cannot be disambiguated if it is thrown.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4672?view=msvc-160" target="_blank">C4672</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4672?view=msvc-170" target="_blank">C4672</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4862,7 +4909,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A throw object cannot be handled in the <strong><code>catch</code></strong> block. Each type that cannot be handled is listed in the error output immediately following the line containing this warning. Each unhandled type has its own warning. Read the warning for each specific type for more information.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4673?view=msvc-160" target="_blank">C4673</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4673?view=msvc-170" target="_blank">C4673</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4871,9 +4918,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4674: 'method' should be declared 'static' and have exactly one parameter</name>
     <description>
       <![CDATA[
-<p>The signature of a conversion operator was not correct. The method is not considered a user-defined conversion. For more information on defining operators, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/dotnet/user-defined-operators-cpp-cli?view=msvc-160">User-Defined Operators (C++/CLI)</a> and <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/dotnet/user-defined-conversions-cpp-cli?view=msvc-160">User-Defined Conversions (C++/CLI)</a>.</p>
+<p>The signature of a conversion operator was not correct. The method is not considered a user-defined conversion. For more information on defining operators, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/dotnet/user-defined-operators-cpp-cli?view=msvc-170">User-Defined Operators (C++/CLI)</a> and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/dotnet/user-defined-conversions-cpp-cli?view=msvc-170">User-Defined Conversions (C++/CLI)</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4674?view=msvc-160" target="_blank">C4674</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4674?view=msvc-170" target="_blank">C4674</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4884,7 +4931,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A type that has public accessibility outside the assembly uses a type that has private access outside the assembly. A component that references the public assembly type will not be able to use the type member or members that reference the assembly private type.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4677?view=msvc-160" target="_blank">C4677</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4677?view=msvc-170" target="_blank">C4677</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4895,7 +4942,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A public type derives from a private type. If the public type is instantiated in a referenced assembly, members of the private base type will not be accessible.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4678?view=msvc-160" target="_blank">C4678</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4678?view=msvc-170" target="_blank">C4678</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4906,7 +4953,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler encountered a construct that it cannot support, that cannot be imported from metadata.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4679?view=msvc-160" target="_blank">C4679</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4679?view=msvc-170" target="_blank">C4679</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4915,9 +4962,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4680: 'class' : coclass does not specify a default interface</name>
     <description>
       <![CDATA[
-<p>A <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/windows/attributes/default-cpp?view=msvc-160">default</a> interface was not specified for a class that was marked with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/windows/attributes/coclass?view=msvc-160">coclass</a> attribute. In order for an object to be useful, it must implement an interface.</p>
+<p>A <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/default-cpp?view=msvc-170">default</a> interface was not specified for a class that was marked with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/coclass?view=msvc-170">coclass</a> attribute. In order for an object to be useful, it must implement an interface.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4680?view=msvc-160" target="_blank">C4680</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4680?view=msvc-170" target="_blank">C4680</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4926,9 +4973,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4681: 'class' : coclass does not specify a default interface that is an event source</name>
     <description>
       <![CDATA[
-<p>A <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/windows/attributes/source-cpp?view=msvc-160">source</a> interface was not specified for a class.</p>
+<p>A <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/source-cpp?view=msvc-170">source</a> interface was not specified for a class.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4681?view=msvc-160" target="_blank">C4681</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4681?view=msvc-170" target="_blank">C4681</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4937,9 +4984,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4682: 'parameter' : no directional parameter attribute specified, defaulting to [in]</name>
     <description>
       <![CDATA[
-<p>A method on a parameter in an attributed interface does not have one of the directional attributes: <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/windows/attributes/in-cpp?view=msvc-160">in</a> or <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/windows/attributes/out-cpp?view=msvc-160">out</a>. The parameter defaults to in.</p>
+<p>A method on a parameter in an attributed interface does not have one of the directional attributes: <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/in-cpp?view=msvc-170">in</a> or <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/out-cpp?view=msvc-170">out</a>. The parameter defaults to in.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4682?view=msvc-160" target="_blank">C4682</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4682?view=msvc-170" target="_blank">C4682</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4950,18 +4997,18 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>If more than one event sink is listening to a COM event source, the value of an out parameter may be ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4683?view=msvc-160" target="_blank">C4683</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4683?view=msvc-170" target="_blank">C4683</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4684</key>
-    <name>C4684: 'attribute' : WARNING!! attribute may cause invalid code generation: use with caution</name>
+    <name>C4684: 'attribute' : WARNING!! attribute may cause invalid code generation</name>
     <description>
       <![CDATA[
 <p>You used an attribute that should not commonly be used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4684?view=msvc-160" target="_blank">C4684</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4684?view=msvc-170" target="_blank">C4684</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4972,7 +5019,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A template definition was not terminated correctly.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4685?view=msvc-160" target="_blank">C4685</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4685?view=msvc-170" target="_blank">C4685</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4983,7 +5030,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A class template specialization wasn't defined before it was used in a return type. Anything that instantiates the class resolves C4686; declaring an instance or accessing a member (for example, <code>C&lt;int&gt;::some_member</code>) are also options.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4686?view=msvc-160" target="_blank">C4686</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4686?view=msvc-170" target="_blank">C4686</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -4994,7 +5041,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A sealed, abstract type is typically only useful to hold static member functions.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4687?view=msvc-160" target="_blank">C4687</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4687?view=msvc-170" target="_blank">C4687</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5003,9 +5050,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4688: 'constraint': constraint list contains assembly private type 'type'</name>
     <description>
       <![CDATA[
-<p>A constraint list has an assembly private type, meaning it will not be available when the type is accessed from outside the assembly. For more information, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/extensions/generics-cpp-component-extensions?view=msvc-160">Generics</a>.</p>
+<p>A constraint list has an assembly private type, meaning it will not be available when the type is accessed from outside the assembly. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/extensions/generics-cpp-component-extensions?view=msvc-170">Generics</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4688?view=msvc-160" target="_blank">C4688</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4688?view=msvc-170" target="_blank">C4688</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5014,9 +5061,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4690: [ emitidl( pop ) ] : more pops than pushes</name>
     <description>
       <![CDATA[
-<p>The <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/windows/attributes/emitidl?view=msvc-160">emitidl</a> attribute was popped one more time that it was pushed.</p>
+<p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/emitidl?view=msvc-170">emitidl</a> attribute was popped one more time that it was pushed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4690?view=msvc-160" target="_blank">C4690</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4690?view=msvc-170" target="_blank">C4690</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5027,7 +5074,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The metadata file containing the original type definition is not referenced, and the compiler is using a local type definition.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4691?view=msvc-160" target="_blank">C4691</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4691?view=msvc-170" target="_blank">C4691</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5038,7 +5085,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A type that is visible outside the assembly contains a member function whose signature contains a native type that is not visible outside the assembly. Therefore, the member function should not be called if its containing type is instantiated outside the assembly.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4692?view=msvc-160" target="_blank">C4692</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4692?view=msvc-170" target="_blank">C4692</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5047,9 +5094,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4693: 'class': a sealed abstract class cannot have any instance members 'Test'</name>
     <description>
       <![CDATA[
-<p>If a type is marked <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/extensions/sealed-cpp-component-extensions?view=msvc-160">sealed</a> and <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/extensions/abstract-cpp-component-extensions?view=msvc-160">abstract</a>, it can only have static members.</p>
+<p>If a type is marked <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/extensions/sealed-cpp-component-extensions?view=msvc-170">sealed</a> and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/extensions/abstract-cpp-component-extensions?view=msvc-170">abstract</a>, it can only have static members.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4693?view=msvc-160" target="_blank">C4693</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4693?view=msvc-170" target="_blank">C4693</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5060,7 +5107,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An abstract and sealed class cannot inherit from a reference type; a sealed and abstract class can neither implement the base class functions nor allow itself to be used as a base class.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4694?view=msvc-160" target="_blank">C4694</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4694?view=msvc-170" target="_blank">C4694</a></p>]]>
     </description>
     <severity>INFO</severity>
     </rule>
@@ -5071,7 +5118,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>WinRT APIs that are released for experimentation and feedback are decorated with the <code>Windows.Foundation.Metadata.ExperimentalAttribute</code> attribute. In Visual Studio 2017 version 15.3, the compiler produces warning C4698 for this attribute. A few APIs in previous versions of the Windows SDK have already been decorated with the attribute, and calls to these APIs now trigger this compiler warning. Newer Windows SDKs have the attribute removed from all shipped types. If you're using an older SDK, you'll need to suppress these warnings for all calls to shipped types.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4698?view=msvc-160" target="_blank">C4698</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4698?view=msvc-170" target="_blank">C4698</a></p>]]>
       </description>
     <severity>INFO</severity>
   </rule>
@@ -5080,9 +5127,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4700: uninitialized local variable 'name' used</name>
     <description>
       <![CDATA[
-<p>The local variable <em>name</em> has been <em>used</em>, that is, read from, before it has been assigned a value. In C and C++, local variables are not initialized by default. Uninitialized variables can contain any value, and their use leads to undefined behavior. Warning C4700 almost always indicates a bug that can cause unpredictable results or crashes in your program.</p>
+<p>The local variable <em>name</em> has been <em>used</em>, that is, read from, before it has been assigned a value. In C and C++, local variables aren't initialized by default. Uninitialized variables can contain any value, and their use leads to undefined behavior. Warning C4700 almost always indicates a bug that can cause unpredictable results or crashes in your program.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-and-level-4-c4700?view=msvc-160" target="_blank">C4700</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-and-level-4-c4700?view=msvc-170" target="_blank">C4700</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5093,7 +5140,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The local variable <em>name</em> might have been used without being assigned a value. This could lead to unpredictable results.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4701?view=msvc-160" target="_blank">C4701</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4701?view=msvc-170" target="_blank">C4701</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5102,9 +5149,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4702: unreachable code</name>
     <description>
       <![CDATA[
-<p>This warning is the result of compiler conformance work that was done for Visual Studio .NET 2003: unreachable code. When the compiler (back end) detects unreachable code, it will generate C4702, a level 4 warning.</p>
+<p>When the compiler back end detects unreachable code, it generates C4702 as a level 4 warning.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4702?view=msvc-160" target="_blank">C4702</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4702?view=msvc-170" target="_blank">C4702</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5113,9 +5160,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4703: Potentially uninitialized local pointer variable 'name' used</name>
     <description>
       <![CDATA[
-<p>The local pointer variable <em>name</em> might have been used without being assigned a value. This could lead to unpredictable results.</p>
+<p>The local pointer variable <em>name</em> might have been used without being assigned a value. This access could lead to unpredictable results.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4703?view=msvc-160" target="_blank">C4703</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4703?view=msvc-170" target="_blank">C4703</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5126,7 +5173,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The test value in a conditional expression was the result of an assignment.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4706?view=msvc-160" target="_blank">C4706</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4706?view=msvc-170" target="_blank">C4706</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5137,7 +5184,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>When a comma occurs in an array index expression, the compiler uses the value after the last comma.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4709?view=msvc-160" target="_blank">C4709</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4709?view=msvc-170" target="_blank">C4709</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5146,9 +5193,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4710: 'function' : function not inlined</name>
     <description>
       <![CDATA[
-<p>The given function was selected for inline expansion, but the compiler did not perform the inlining.</p>
+<p>The specified function was marked for inline expansion, but the compiler didn't inline the function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4710?view=msvc-160" target="_blank">C4710</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4710?view=msvc-170" target="_blank">C4710</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5159,7 +5206,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler performed inlining on the given function, although it was not marked for inlining.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4711?view=msvc-160" target="_blank">C4711</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4711?view=msvc-170" target="_blank">C4711</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5170,7 +5217,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The given function was selected for inline expansion, but the compiler did not perform the inlining.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4714?view=msvc-160" target="_blank">C4714</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4714?view=msvc-170" target="_blank">C4714</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5181,7 +5228,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The specified function can potentially not return a value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4715?view=msvc-160" target="_blank">C4715</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4715?view=msvc-170" target="_blank">C4715</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -5194,7 +5241,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The given function did not return a value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4716?view=msvc-160" target="_blank">C4716</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4716?view=msvc-170" target="_blank">C4716</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -5207,7 +5254,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Every path through a function contains a call to the function. Since there is no way to exit the function without first calling itself recursively, the function will never exit.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4717?view=msvc-160" target="_blank">C4717</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4717?view=msvc-170" target="_blank">C4717</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -5220,7 +5267,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function contains a recursive call, but otherwise has no side effects. A call to this function is being deleted. The correctness of the program is not affected, but the behavior is. Whereas leaving the call in could result in a runtime stack overflow exception, deleting the call removes that possibility.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4718?view=msvc-160" target="_blank">C4718</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4718?view=msvc-170" target="_blank">C4718</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5231,7 +5278,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The flow of control terminates in a destructor. The thread or the entire program will terminate and allocated resources may not be released.  Furthermore, if a destructor will be called for stack unwinding during exception processing, the behavior of executable is undefined.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4722?view=msvc-160" target="_blank">C4722</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4722?view=msvc-170" target="_blank">C4722</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5242,7 +5289,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The second operand in a divide operation evaluated to zero at compile time, giving undefined results.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4723?view=msvc-160" target="_blank">C4723</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4723?view=msvc-170" target="_blank">C4723</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5253,7 +5300,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The second operand in a remainder operation evaluated to zero at compile time, giving undefined results.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4724?view=msvc-160" target="_blank">C4724</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4724?view=msvc-170" target="_blank">C4724</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5264,7 +5311,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Your code contains an inline assembly instruction that may not produce accurate results on some Pentium microprocessors.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4725?view=msvc-160" target="_blank">C4725</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4725?view=msvc-170" target="_blank">C4725</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5275,7 +5322,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>C4727 occurs when compiling multiple compilands with <strong>/Yc</strong>, and where the compiler was able to mark all .obj files with the same .pch timestamp.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4727?view=msvc-160" target="_blank">C4727</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4727?view=msvc-170" target="_blank">C4727</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5284,9 +5331,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4729: function too big for flow graph based warnings</name>
     <description>
       <![CDATA[
-<p>This warning is generated when a function is too big to be compiled with reliable checking for situations that would generate a warning. This warning is only generated when the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/od-disable-debug?view=msvc-160">/Od</a> compiler option used.</p>
+<p>This warning is generated when a function is too big to be compiled with reliable checking for situations that would generate a warning. This warning is only generated when the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/od-disable-debug?view=msvc-170">/Od</a> compiler option used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4729?view=msvc-160" target="_blank">C4729</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4729?view=msvc-170" target="_blank">C4729</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5295,9 +5342,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4730: 'main' : mixing _m64 and floating point expressions may result in incorrect code</name>
     <description>
       <![CDATA[
-<p>A function uses <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/m64?view=msvc-160">__m64</a> and <strong><code>float</code></strong>/<strong><code>double</code></strong> types. Because the MMX and floating-point registers share the same physical register space (cannot be used simultaneously), using <strong><code>__m64</code></strong> and <strong><code>float</code></strong>/<strong><code>double</code></strong> types in the same function can result in data corruption, possibly causing an exception.</p>
+<p>A function uses <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/m64?view=msvc-170">__m64</a> and <strong><code>float</code></strong>/<strong><code>double</code></strong> types. Because the MMX and floating-point registers share the same physical register space (cannot be used simultaneously), using <strong><code>__m64</code></strong> and <strong><code>float</code></strong>/<strong><code>double</code></strong> types in the same function can result in data corruption, possibly causing an exception.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4730?view=msvc-160" target="_blank">C4730</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4730?view=msvc-170" target="_blank">C4730</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5308,7 +5355,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A frame pointer register was modified. You must save and restore the register in your inline assembly block or frame variable (local or parameter, depending on the register modified), or your code may not work properly.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4731?view=msvc-160" target="_blank">C4731</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4731?view=msvc-170" target="_blank">C4731</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5317,9 +5364,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4733: Inline asm assigning to 'FS:0' : handler not registered as safe handler</name>
     <description>
       <![CDATA[
-<p>A function modifying the value at FS:0 to add a new exception handler may not work with Safe Exceptions, because the handler may not be registered as a valid exception handler (see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/safeseh-image-has-safe-exception-handlers?view=msvc-160">/SAFESEH</a>).</p>
+<p>A function modifying the value at FS:0 to add a new exception handler may not work with Safe Exceptions, because the handler may not be registered as a valid exception handler (see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/safeseh-image-has-safe-exception-handlers?view=msvc-170">/SAFESEH</a>).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4733?view=msvc-160" target="_blank">C4733</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4733?view=msvc-170" target="_blank">C4733</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5330,7 +5377,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>C4738 warns that the result of an assignment, cast, passed argument, or other operation may need to be rounded or that the operation ran out of registers and needed to use memory (spilling). This can result in performance loss.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4738?view=msvc-160" target="_blank">C4738</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4738?view=msvc-170" target="_blank">C4738</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5341,7 +5388,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A value was assigned to a variable, but the value is greater than the size of the variable. Memory will be written beyond the variable's memory location, and data loss is possible.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4739?view=msvc-160" target="_blank">C4739</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4739?view=msvc-170" target="_blank">C4739</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5352,7 +5399,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>When there is a jump in to or out of an <strong><code>asm</code></strong> block, global optimizations are disabled for that function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4740?view=msvc-160" target="_blank">C4740</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4740?view=msvc-170" target="_blank">C4740</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5363,18 +5410,18 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An external variable that was referenced or defined in two files has different alignment in those files.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4742?view=msvc-160" target="_blank">C4742</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4742?view=msvc-170" target="_blank">C4742</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4743</key>
-    <name>C4743: 'type' has different size in 'file1' and 'file2': number and number bytes</name>
+    <name>C4743: 'type' has different size in 'file1' and 'file2': size_1 and size_2 bytes</name>
     <description>
       <![CDATA[
 <p>An external variable referenced or defined in two files has different types in those files, and the compiler determined that the size of the variable in <em>file1</em> differs from the size of the variable in <em>file2</em>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4743?view=msvc-160" target="_blank">C4743</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4743?view=msvc-170" target="_blank">C4743</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5385,7 +5432,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An external variable referenced or defined in two files has different types in those files.  To resolve, either make the type definitions the same, or change variable name in one of the files.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4744?view=msvc-160" target="_blank">C4744</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4744?view=msvc-170" target="_blank">C4744</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5394,9 +5441,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4746: volatile access of '&lt;expression&gt;' is subject to /volatile:[iso|ms] setting</name>
     <description>
       <![CDATA[
-<p>C4746 is emitted whenever a volatile variable is accessed directly. It is intended to help developers identify code locations that are affected by the specific volatile model currently specified (which can be controlled with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/volatile-volatile-keyword-interpretation?view=msvc-160">/volatile</a> compiler option). In particular, it can be useful in locating compiler-generated hardware memory barriers when /volatile:ms is used.</p>
+<p>C4746 is emitted whenever a volatile variable is accessed directly. It's intended to help developers identify code locations that are affected by the specific volatile model currently specified (which can be controlled with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/volatile-volatile-keyword-interpretation?view=msvc-170"><code>/volatile</code></a> compiler option). In particular, it can be useful in locating compiler-generated hardware memory barriers when <code>/volatile:ms</code> is used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4746?view=msvc-160" target="_blank">C4746</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4746?view=msvc-170" target="_blank">C4746</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5407,7 +5454,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler found a (probable) DLL entry point compiled to MSIL.  Because of potential problems with loading a DLL whose entry point has been compiled to MSIL, you are strongly discouraged from compiling a DLL entry point function to MSIL.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4747?view=msvc-160" target="_blank">C4747</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4747?view=msvc-170" target="_blank">C4747</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5416,9 +5463,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4750: 'identifier': function with _alloca() inlined into a loop</name>
     <description>
       <![CDATA[
-<p>The '<em>identifier</em>' function forces inline expansion of the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/alloca?view=msvc-160"><code>_alloca</code></a> function within a loop, which might cause a stack overflow when the loop is executed.</p>
+<p>The '<em>identifier</em>' function forces inline expansion of the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/alloca?view=msvc-170"><code>_alloca</code></a> function within a loop, which might cause a stack overflow when the loop is executed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4750?view=msvc-160" target="_blank">C4750</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4750?view=msvc-170" target="_blank">C4750</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5429,7 +5476,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The C4754 warning is issued because the result of the comparison is always the same. This indicates that one of the branches of the condition is never executed, most likely because the associated integer expression is incorrect. This code defect often occurs in incorrect integer overflow checks on 64-bit architectures.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4754?view=msvc-160" target="_blank">C4754</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4754?view=msvc-170" target="_blank">C4754</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5440,7 +5487,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler generated an exception while doing constant arithmetic during compilation.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4756?view=msvc-160" target="_blank">C4756</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4756?view=msvc-170" target="_blank">C4756</a></p>]]>
     </description>
     <type>BUG</type>
     <remediationFunction>LINEAR</remediationFunction>
@@ -5453,7 +5500,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An alignment greater than 16 was specified, but on some platforms, if the function throws an exception, the stack will force an alignment of not greater than 16.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4764?view=msvc-160" target="_blank">C4764</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4764?view=msvc-170" target="_blank">C4764</a></p>]]>
     </description>
     <severity>INFO</severity>
     </rule>
@@ -5464,18 +5511,29 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler warns if <code>__declspec(...)</code> is applied before the <code>extern "C"</code> linkage specification. Previously, the compiler would ignore the attribute, which could have runtime implications.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4768?view=msvc-160" target="_blank">C4768</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4768?view=msvc-170" target="_blank">C4768</a></p>]]>
       </description>
     <severity>INFO</severity>
   </rule>
+  <rule>
+    <key>C4770</key>
+    <name>C4770: partially validated enum 'symbol' used as index</name>
+    <description>
+      <![CDATA[
+<p>The compiler warns if an enum value is cast or aliased to an integer type, but the result isn't checked for non-negative or excessive values.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4770?view=msvc-170" target="_blank">C4770</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
   <rule>
     <key>C4772</key>
     <name>C4772: #import referenced a type from a missing type library; 'missing-type' used as a placeholder</name>
     <description>
       <![CDATA[
-<p>A type library was referenced with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-160">#import</a> directive. However, the type library contained a reference to another type library that was not referenced with <code>#import</code>. This other .tlb file was not found by the compiler.</p>
+<p>A type library was referenced with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170">#import</a> directive. However, the type library contained a reference to another type library that was not referenced with <code>#import</code>. This other .tlb file was not found by the compiler.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4772?view=msvc-160" target="_blank">C4772</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4772?view=msvc-170" target="_blank">C4772</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5486,7 +5544,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler limits the maximum length allowed for a function name. When the compiler generates funclets for EH/SEH code, it forms the funclet name by prepending the function name with some text, for example "__catch", "__unwind", or another string.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4788?view=msvc-160" target="_blank">C4788</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4788?view=msvc-170" target="_blank">C4788</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5497,7 +5555,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p><strong>C4789</strong> warns about buffer overruns when specific C run-time (CRT) functions are used. It can also report size mismatches when parameters are passed or assignments are made. The warning is possible if the data sizes are known at compile time. This warning is for situations that might elude typical data-size mismatch detection.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4789?view=msvc-160" target="_blank">C4789</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4789?view=msvc-170" target="_blank">C4789</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5508,7 +5566,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A native function that was imported into the program with DllImport was called from an unmanaged function. Therefore, you must link to the import library for the DLL.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4792?view=msvc-160" target="_blank">C4792</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4792?view=msvc-170" target="_blank">C4792</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5517,9 +5575,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4793: 'function' : function is compiled as native code: 'reason'</name>
     <description>
       <![CDATA[
-<p>The compiler cannot compile <em>function</em> into managed code, even though the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/clr-common-language-runtime-compilation?view=msvc-160">/clr</a> compiler option is specified. Instead, the compiler emits warning C4793 and an explanatory continuation message, and then compiles <em>function</em> into native code. The continuation message contains the <em>reason</em> text that explains why <em>function</em> cannot be compiled to <code>MSIL</code>.</p>
+<p>The compiler cannot compile <em>function</em> into managed code, even though the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/clr-common-language-runtime-compilation?view=msvc-170">/clr</a> compiler option is specified. Instead, the compiler emits warning C4793 and an explanatory continuation message, and then compiles <em>function</em> into native code. The continuation message contains the <em>reason</em> text that explains why <em>function</em> cannot be compiled to <code>MSIL</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-and-3-c4793?view=msvc-160" target="_blank">C4793</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-and-3-c4793?view=msvc-170" target="_blank">C4793</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5528,9 +5586,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4794: segment of thread local storage variable 'variable' changed from 'section name' to '.tls$'</name>
     <description>
       <![CDATA[
-<p>You used <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/data-seg?view=msvc-160">#pragma data_seg</a> to put a tls variable in a section not starting with .tls$.</p>
+<p>You used <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/data-seg?view=msvc-170">#pragma data_seg</a> to put a tls variable in a section not starting with .tls$.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4794?view=msvc-160" target="_blank">C4794</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4794?view=msvc-170" target="_blank">C4794</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5541,7 +5599,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The function has at least one MMX instruction, but does not have an <code>EMMS</code> instruction. When a multimedia instruction is used, an <code>EMMS</code> instruction or <code>_mm_empty</code> intrinsic should also be used to clear the multimedia tag word at the end of the MMX code.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4799?view=msvc-160" target="_blank">C4799</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4799?view=msvc-170" target="_blank">C4799</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5550,9 +5608,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4800: Implicit conversion from 'type' to bool</name>
     <description>
       <![CDATA[
-<p>C4800 is a level 3 warning in Visual Studio 2015 and earlier:</p>
+<p>This warning is generated when a value is implicitly converted into type bool.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4800?view=msvc-160" target="_blank">C4800</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4800?view=msvc-170" target="_blank">C4800</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5563,7 +5621,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Event methods must have the same storage class as the event declaration. The compiler adjusts the event's methods so that the storage classes are the same.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4803?view=msvc-160" target="_blank">C4803</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4803?view=msvc-170" target="_blank">C4803</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5574,7 +5632,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning is for when you used a <strong><code>bool</code></strong> variable or value in an unexpected way. For example, C4804 is generated if you use operators such as the negative unary operator (<strong>-</strong>) or the complement operator (<code>~</code>). The compiler evaluates the expression.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4804?view=msvc-160" target="_blank">C4804</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4804?view=msvc-170" target="_blank">C4804</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5583,9 +5641,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4805: 'operation' : unsafe mix of type 'type' and type 'type' in operation</name>
     <description>
       <![CDATA[
-<p>This warning is generated for comparison operations between <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/bool-cpp?view=msvc-160">bool</a> and <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/c-language/integer-types?view=msvc-160">int</a>. The following sample generates C4805:</p>
+<p>This warning is generated for comparison operations between <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/bool-cpp?view=msvc-170">bool</a> and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/c-language/integer-types?view=msvc-170">int</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4805?view=msvc-160" target="_blank">C4805</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4805?view=msvc-170" target="_blank">C4805</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5594,9 +5652,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4806: 'operation' : unsafe operation: no value of type 'type' promoted to type 'type' can equal the given constant</name>
     <description>
       <![CDATA[
-<p>This message warns against code such as <code>b == 3</code>, where <code>b</code> has type <strong><code>bool</code></strong>. The promotion rules cause <strong><code>bool</code></strong> to be promoted to <strong><code>int</code></strong>. This is legal, but it can never be <strong><code>true</code></strong>. The following sample generates C4806:</p>
+<p>This message warns against code such as <code>b == 3</code>, where <code>b</code> has type <strong><code>bool</code></strong>. The promotion rules cause <strong><code>bool</code></strong> to be promoted to <strong><code>int</code></strong>. This is legal, but it can never be <strong><code>true</code></strong>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4806?view=msvc-160" target="_blank">C4806</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4806?view=msvc-170" target="_blank">C4806</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5607,7 +5665,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning is generated when comparing a one-bit signed bit field to a <strong><code>bool</code></strong> variable. Because a one-bit, signed bit field can only contain the values -1 or 0, it is dangerous to compare it to <strong><code>bool</code></strong>. No warnings are generated about mixing <strong><code>bool</code></strong> and one-bit, unsigned bitfields since they are identical to <strong><code>bool</code></strong> and can only hold 0 or 1.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4807?view=msvc-160" target="_blank">C4807</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4807?view=msvc-170" target="_blank">C4807</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5616,9 +5674,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4810: value of pragma pack(show) == n</name>
     <description>
       <![CDATA[
-<p>This warning is issued when you use the <strong>show</strong> option of the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/pack?view=msvc-160">pack</a> pragma. <em>n</em> is the current pack value.</p>
+<p>This warning is issued when you use the <strong>show</strong> option of the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/pack?view=msvc-170">pack</a> pragma. <em>n</em> is the current pack value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4810?view=msvc-160" target="_blank">C4810</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4810?view=msvc-170" target="_blank">C4810</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5627,20 +5685,20 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4811: value of pragma conform(forScope, show) == value</name>
     <description>
       <![CDATA[
-<p>This warning is issued when you use the <strong>show</strong> option of the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/conform?view=msvc-160">conform</a> pragma. <em>value</em> is the current conform value.</p>
+<p>This warning is issued when you use the <strong>show</strong> option of the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/conform?view=msvc-170">conform</a> pragma. <em>value</em> is the current conform value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4811?view=msvc-160" target="_blank">C4811</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4811?view=msvc-170" target="_blank">C4811</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4812</key>
-    <name>C4812: obsolete declaration style: please use 'new_syntax' instead</name>
+    <name>C4812: obsolete declaration style</name>
     <description>
       <![CDATA[
 <p>In the current release of Visual C++, the explicit constructor specialization is still supported, but it may not be supported in a future release.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4812?view=msvc-160" target="_blank">C4812</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4812?view=msvc-170" target="_blank">C4812</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5651,7 +5709,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A friend function in an inner class was not declared in the outer class.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4813?view=msvc-160" target="_blank">C4813</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4813?view=msvc-170" target="_blank">C4813</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5662,7 +5720,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A parameter to an object with a zero-size array was not passed by reference. The array will not get copied when the object is passed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4816?view=msvc-160" target="_blank">C4816</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4816?view=msvc-170" target="_blank">C4816</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5673,7 +5731,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The wrong member access operator was used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4817?view=msvc-160" target="_blank">C4817</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4817?view=msvc-170" target="_blank">C4817</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5684,7 +5742,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>C4819 occurs when you compile an ANSI source file on a system using a codepage that can't represent all characters in the file.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4819?view=msvc-160" target="_blank">C4819</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4819?view=msvc-170" target="_blank">C4819</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5693,9 +5751,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4820: 'bytes' bytes padding added after construct 'member_name'</name>
     <description>
       <![CDATA[
-<p>The type and order of elements caused the compiler to add padding to the end of a struct. See <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-160">align</a> for more information on padding in a struct.</p>
+<p>The type and order of elements caused the compiler to add padding to the end of a struct. See <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-170">align</a> for more information on padding in a struct.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4820?view=msvc-160" target="_blank">C4820</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4820?view=msvc-170" target="_blank">C4820</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5706,7 +5764,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler could not determine the encoding type for a file. To resolve this warning, save the file with a byte order marker. See <a data-linktype="absolute-path" href="/en-us/sql/ssms/solution/manage-files-with-encoding">Manage Files with Encoding</a> for more information.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4821?view=msvc-160" target="_blank">C4821</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4821?view=msvc-170" target="_blank">C4821</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5715,9 +5773,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4822: 'member' : local class member function does not have a body</name>
     <description>
       <![CDATA[
-<p>A local class member function was declared but not defined in class. To use a local class member function, you must define it in the class. You cannot declare it in class and define it out of class.</p>
+<p>A local class member function was declared but not defined in the class. To use a local class member function, you must define it in the class. You can't declare it in class and define it out of class.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4822?view=msvc-160" target="_blank">C4822</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4822?view=msvc-170" target="_blank">C4822</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5726,9 +5784,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4823: 'function' : uses pinning pointers but unwind semantics are not enabled</name>
     <description>
       <![CDATA[
-<p>To unpin an object on the managed heap pointed to by a pinning pointer declared in a block scope, the compiler simulates the behavior of destructors of local classes, "pretending" the pinning pointer has a destructor that nullifies the pointer. To enable a call to a destructor after throwing an exception, you must enable object unwinding, which you can do by using <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-160">/EHsc</a>.</p>
+<p>To unpin an object on the managed heap pointed to by a pinning pointer declared in a block scope, the compiler simulates the behavior of destructors of local classes, "pretending" the pinning pointer has a destructor that nullifies the pointer. To enable a call to a destructor after throwing an exception, you must enable object unwinding, which you can do by using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170">/EHsc</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4823?view=msvc-160" target="_blank">C4823</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4823?view=msvc-170" target="_blank">C4823</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5739,7 +5797,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Certain functions, such as main, cannot take reference type parameters. While compilation will succeed, the resulting image will probably not run.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4829?view=msvc-160" target="_blank">C4829</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4829?view=msvc-170" target="_blank">C4829</a></p>]]>
     </description>
     <severity>INFO</severity>
     </rule>
@@ -5750,7 +5808,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Starting in the C++17 Standard, the <code>[[nodiscard]]</code> attribute specifies that a function's return value isn't intended to be discarded. If a caller discards the return value, the compiler generates warning C4834.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4834?view=msvc-160" target="_blank">C4834</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4834?view=msvc-170" target="_blank">C4834</a></p>]]>
       </description>
     <severity>INFO</severity>
   </rule>
@@ -5759,9 +5817,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4835: 'variable' : the initializer for exported data will not be run until managed code is first executed in the host assembly</name>
     <description>
       <![CDATA[
-<p>When accessing data between managed components, it is recommended that you not use native C++ import and export mechanisms. Instead, declare your data members inside a managed type and reference the metadata with <code>#using</code> in the client. For more information, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/hash-using-directive-cpp?view=msvc-160">#using Directive</a>.</p>
+<p>When accessing data between managed components, it is recommended that you not use native C++ import and export mechanisms. Instead, declare your data members inside a managed type and reference the metadata with <code>#using</code> in the client. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-using-directive-cpp?view=msvc-170">#using Directive</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4835?view=msvc-160" target="_blank">C4835</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4835?view=msvc-170" target="_blank">C4835</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5772,7 +5830,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>An implicit narrowing conversion was found when using aggregate or list initialization.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4838?view=msvc-160" target="_blank">C4838</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4838?view=msvc-170" target="_blank">C4838</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5783,7 +5841,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Classes or structs that are passed to a variadic function such as <code>printf</code> must be trivially copyable. When passing such objects, the compiler simply makes a bitwise copy and does not call the constructor or destructor.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4839?view=msvc-160" target="_blank">C4839</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4839?view=msvc-170" target="_blank">C4839</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5794,7 +5852,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Classes or structs that are passed to a variadic function must be trivially copyable. When passing such objects, the compiler simply makes a bitwise copy and does not call the constructor or destructor.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4840?view=msvc-160" target="_blank">C4840</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4840?view=msvc-170" target="_blank">C4840</a></p>]]>
     </description>
     <severity>INFO</severity>
     </rule>
@@ -5805,18 +5863,18 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>If you use <code>offsetof(T, m)</code>, where <em><code>m</code></em> is a compound member designator, the compiler generates a warning when you compile with the <strong><code>/Wall</code></strong> option.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4841?view=msvc-160" target="_blank">C4841</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4841?view=msvc-170" target="_blank">C4841</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
     <key>C4843</key>
-    <name>C4843: 'type1': An exception handler of reference to array or function type is unreachable, use 'type2' instead</name>
+    <name>C4843: 'type1': An exception handler of reference to array or function type is unreachable</name>
     <description>
       <![CDATA[
 <p>Handlers of reference to array or function type are never a match for any exception object. Starting in Visual Studio 2017 version 15.5, the compiler honors this rule and raises a level 4 warning. It also no longer matches a handler of <code>char*</code> or <code>wchar_t*</code> to a string literal when <strong><code>/Zc:strictStrings</code></strong> is used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4843?view=msvc-160" target="_blank">C4843</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4843?view=msvc-170" target="_blank">C4843</a></p>]]>
       </description>
     <severity>INFO</severity>
   </rule>
@@ -5825,20 +5883,20 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4866: 'file(line_number)' compiler may not enforce left-to-right evaluation order for call to operator_name</name>
     <description>
       <![CDATA[
-<p>Starting in C++17, the operands of the operators <strong>-&gt;*</strong>, <strong>[]</strong>, <strong>&gt;&gt;</strong>, and <strong>&lt;&lt;</strong> must be evaluated in left-to-right order. There are two cases in which the compiler is unable to guarantee this order:</p>
+<p>Starting in C++17, the operands of the operators <strong>-&gt;*</strong>, <strong>[]</strong>, <strong>&gt;&gt;</strong>, and <strong>&lt;&lt;</strong> must be evaluated in left-to-right order.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4866?view=msvc-160" target="_blank">C4866</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4866?view=msvc-170" target="_blank">C4866</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4867</key>
-    <name>C4867: 'function': function call missing argument list; use 'call' to create a pointer to member</name>
+    <name>C4867: 'function': function call missing argument list</name>
     <description>
       <![CDATA[
-<p>A pointer to member function was initialized incorrectly.</p>
+<p>Function call missing argument list; use 'call' to create a pointer to member.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4867?view=msvc-160" target="_blank">C4867</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4867?view=msvc-170" target="_blank">C4867</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5849,7 +5907,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The elements of a braced initializer list are to be evaluated in left-to-right order. There are two cases in which the compiler is unable to guarantee this order: the first is when some of the elements are objects passed by value; the second is  when compiling with <code>/clr</code> and some of the elements are fields of objects or are array elements. When the compiler can't guarantee left-to-right evaluation it emits warning C4868.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4868?view=msvc-160" target="_blank">C4868</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4868?view=msvc-170" target="_blank">C4868</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5860,7 +5918,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The intermediate language used in <em>tool1</em> and <em>tool2</em> did not match. Check that the most current version of each tool has been installed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4900?view=msvc-160" target="_blank">C4900</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4900?view=msvc-170" target="_blank">C4900</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5871,7 +5929,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected an unsafe cast. The cast did succeed, but you should use a conversion routine.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4905?view=msvc-160" target="_blank">C4905</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4905?view=msvc-170" target="_blank">C4905</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5882,7 +5940,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected an unsafe cast. The cast did succeed, but you should use a conversion routine.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4906?view=msvc-160" target="_blank">C4906</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4906?view=msvc-170" target="_blank">C4906</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5893,7 +5951,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The explicit template instantiation named <em>&lt;identifier&gt;</em> is modified by both the <code>__declspec(dllexport)</code> and <strong><code>extern</code></strong> keywords. However, these keywords are mutually exclusive. The <code>__declspec(dllexport)</code> keyword means instantiate the template class, while the <strong><code>extern</code></strong> keyword means do not automatically instantiate the template class.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4910?view=msvc-160" target="_blank">C4910</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4910?view=msvc-170" target="_blank">C4910</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5904,7 +5962,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Attributes that apply to nested UDTs (user-defined type, which could be a typedef, union, or struct) may be ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4912?view=msvc-160" target="_blank">C4912</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4912?view=msvc-170" target="_blank">C4912</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5915,7 +5973,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A call to the built-in comma operator occurred in a program that also had an overloaded comma operator; a conversion that you thought may have occurred did not.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4913?view=msvc-160" target="_blank">C4913</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4913?view=msvc-170" target="_blank">C4913</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5924,9 +5982,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4917: 'declarator' : a GUID can only be associated with a class, interface or namespace</name>
     <description>
       <![CDATA[
-<p>A user-defined structure other than <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/class-cpp?view=msvc-160">class</a>, <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/interface?view=msvc-160">interface</a>, or <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/namespaces-cpp?view=msvc-160">namespace</a> cannot have a GUID.</p>
+<p>A user-defined structure other than <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/class-cpp?view=msvc-170">class</a>, <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/interface?view=msvc-170">interface</a>, or <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/namespaces-cpp?view=msvc-170">namespace</a> cannot have a GUID.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4917?view=msvc-160" target="_blank">C4917</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4917?view=msvc-170" target="_blank">C4917</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5935,9 +5993,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4918: 'character' : invalid character in pragma optimization list</name>
     <description>
       <![CDATA[
-<p>An unknown character was found in the optimization list of an <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/optimize?view=msvc-160">optimize</a> pragma statement.</p>
+<p>An unknown character was found in the optimization list of an <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/optimize?view=msvc-170">optimize</a> pragma statement.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4918?view=msvc-160" target="_blank">C4918</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4918?view=msvc-170" target="_blank">C4918</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5948,7 +6006,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>If a .tlb that you pass to #import has the same symbol defined in two or more enums, this warning indicates that subsequent identical symbols are ignored and will be commented out in the .tlh file.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4920?view=msvc-160" target="_blank">C4920</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4920?view=msvc-170" target="_blank">C4920</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5959,7 +6017,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Scripting languages cannot create a VT_BYREF 'in' parameter, it can only create VT_BYREF 'out' parameters.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4925?view=msvc-160" target="_blank">C4925</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4925?view=msvc-170" target="_blank">C4925</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5970,7 +6028,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A forward declaration was found but an attributed construct with the same name already exists. The attributes for the forward declaration are ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4926?view=msvc-160" target="_blank">C4926</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4926?view=msvc-170" target="_blank">C4926</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5981,7 +6039,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>More than one user-defined conversion is implicitly applied to a single value -- the compiler did not find an explicit conversion but did find a conversion, which it used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4927?view=msvc-160" target="_blank">C4927</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4927?view=msvc-170" target="_blank">C4927</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -5992,7 +6050,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>More than one user-defined conversion routine was found. The compiler executed the code in all such routines.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4928?view=msvc-160" target="_blank">C4928</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4928?view=msvc-170" target="_blank">C4928</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6001,9 +6059,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4929: 'file': typelibrary contains a union; ignoring the 'embedded_idl' qualifier</name>
     <description>
       <![CDATA[
-<p>The embedded_idl attribute of <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-160">#import</a> could not be applied to the type library because a union is present in the type library. To resolve this warning, don't use embedded_idl.</p>
+<p>The embedded_idl attribute of <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170">#import</a> could not be applied to the type library because a union is present in the type library. To resolve this warning, don't use embedded_idl.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4929?view=msvc-160" target="_blank">C4929</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4929?view=msvc-170" target="_blank">C4929</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6014,7 +6072,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler detected an unused function prototype. If the prototype was intended as a variable declaration, remove the open/close parentheses.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4930?view=msvc-160" target="_blank">C4930</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4930?view=msvc-170" target="_blank">C4930</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6023,9 +6081,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4931: we are assuming the type library was built for number-bit pointers</name>
     <description>
       <![CDATA[
-<p>Explicit information was not supplied with the <strong>ptrsize</strong> attribute of the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-160">#import</a> directive; the compiler concluded that pointer size of the type library is <em>number</em>.</p>
+<p>Explicit information was not supplied with the <strong>ptrsize</strong> attribute of the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170">#import</a> directive; the compiler concluded that pointer size of the type library is <em>number</em>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4931?view=msvc-160" target="_blank">C4931</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4931?view=msvc-170" target="_blank">C4931</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6034,9 +6092,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4932: __identifier(identifier_1) and __identifier(identifier_2) are indistinguishable</name>
     <description>
       <![CDATA[
-<p>The compiler is unable to distinguish between <strong><code>_finally</code></strong> and <strong><code>__finally</code></strong> or <strong><code>__try</code></strong> and <strong><code>_try</code></strong> as a parameter passed to <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/extensions/identifier-cpp-cli?view=msvc-160"><code>__identifier</code></a>. You should not attempt to use them both as identifiers in the same program, as it will result in a <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2374?view=msvc-160">C2374</a> error.</p>
+<p>The compiler is unable to distinguish between <strong><code>_finally</code></strong> and <strong><code>__finally</code></strong> or <strong><code>__try</code></strong> and <strong><code>_try</code></strong> as a parameter passed to <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/extensions/identifier-cpp-cli?view=msvc-170"><code>__identifier</code></a>. You should not attempt to use them both as identifiers in the same program, as it will result in a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2374?view=msvc-170">C2374</a> error.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4932?view=msvc-160" target="_blank">C4932</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4932?view=msvc-170" target="_blank">C4932</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6047,7 +6105,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The assembly visibility of a type was modified. The compiler uses the last specifier that it encounters. For example, the assembly visibility of a forward declaration may be different from the assembly visibility of the class definition.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4935?view=msvc-160" target="_blank">C4935</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4935?view=msvc-170" target="_blank">C4935</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6058,7 +6116,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <strong>/clr:pure</strong> compiler option is deprecated in Visual Studio 2015 and unsupported in Visual Studio 2017.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4936?view=msvc-160" target="_blank">C4936</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4936?view=msvc-170" target="_blank">C4936</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6069,7 +6127,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Because of the way the compiler processes arguments to directives, names that have meaning to the compiler, such as keywords with multiple text representations (single and double underscore forms), cannot be distinguished.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4937?view=msvc-160" target="_blank">C4937</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4937?view=msvc-170" target="_blank">C4937</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6078,9 +6136,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4938: 'var' : Floating point reduction variable may cause inconsistent results under /fp:strict or #pragma fenv_access</name>
     <description>
       <![CDATA[
-<p>You should not use <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/fp-specify-floating-point-behavior?view=msvc-160">/fp:strict</a> or <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/fenv-access?view=msvc-160">fenv_access</a> with OpenMP floating-point reductions, because the sum is computed in a different order. Thus, results can differ from the results without /openmp.</p>
+<p>You should not use <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/fp-specify-floating-point-behavior?view=msvc-170">/fp:strict</a> or <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/fenv-access?view=msvc-170">fenv_access</a> with OpenMP floating-point reductions, because the sum is computed in a different order. Thus, results can differ from the results without /openmp.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4938?view=msvc-160" target="_blank">C4938</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4938?view=msvc-170" target="_blank">C4938</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6089,9 +6147,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4939: #pragma vtordisp is deprecated and will be removed in a future release of Visual C++</name>
     <description>
       <![CDATA[
-<p>The <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/vtordisp?view=msvc-160">vtordisp</a> pragma will be removed in a future release of Visual C++.</p>
+<p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/vtordisp?view=msvc-170">vtordisp</a> pragma will be removed in a future release of Visual C++.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4939?view=msvc-160" target="_blank">C4939</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4939?view=msvc-170" target="_blank">C4939</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6102,7 +6160,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A symbol was defined in a source code file and then a #using statement referenced an assembly that also defined the symbol. The symbol in the assembly is ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4944?view=msvc-160" target="_blank">C4944</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4944?view=msvc-170" target="_blank">C4944</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6113,7 +6171,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A symbol was imported from a referenced assembly but that symbol was already imported from another referenced assembly. Either do not reference one of the assemblies or get the symbol name changed in one of the assemblies.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4945?view=msvc-160" target="_blank">C4945</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4945?view=msvc-170" target="_blank">C4945</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6122,9 +6180,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4946: reinterpret_cast used between related classes: 'class1' and 'class2'</name>
     <description>
       <![CDATA[
-<p>Do not use <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/reinterpret-cast-operator?view=msvc-160">reinterpret_cast</a> to cast between related types. Use <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/static-cast-operator?view=msvc-160">static_cast</a> instead, or for polymorphic types, use <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/dynamic-cast-operator?view=msvc-160">dynamic_cast</a>.</p>
+<p>Do not use <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/reinterpret-cast-operator?view=msvc-170">reinterpret_cast</a> to cast between related types. Use <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/static-cast-operator?view=msvc-170">static_cast</a> instead, or for polymorphic types, use <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/dynamic-cast-operator?view=msvc-170">dynamic_cast</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4946?view=msvc-160" target="_blank">C4946</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4946?view=msvc-170" target="_blank">C4946</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6133,9 +6191,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4947: 'type_or_member' : marked as obsolete</name>
     <description>
       <![CDATA[
-<p>A member or type was marked as obsolete with the <a data-linktype="absolute-path" href="/en-us/dotnet/api/system.obsoleteattribute">ObsoleteAttribute</a> class.</p>
+<p>A member or type was marked as obsolete with the <a class="no-loc" data-linktype="absolute-path" href="/en-us/dotnet/api/system.obsoleteattribute">ObsoleteAttribute</a> class.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4947?view=msvc-160" target="_blank">C4947</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4947?view=msvc-170" target="_blank">C4947</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6146,7 +6204,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler found a mismatch between what data type is being get and set for an indexed property.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4948?view=msvc-160" target="_blank">C4948</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4948?view=msvc-170" target="_blank">C4948</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6155,9 +6213,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4949: pragmas 'managed' and 'unmanaged' are meaningful only when compiled with '/clr[:option]'</name>
     <description>
       <![CDATA[
-<p>The compiler ignores the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/managed-unmanaged?view=msvc-160">managed</a> and unmanaged pragmas if the source code is not compiled with <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/clr-common-language-runtime-compilation?view=msvc-160">/clr</a>. This warning is informational.</p>
+<p>The compiler ignores the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/managed-unmanaged?view=msvc-170">managed</a> and unmanaged pragmas if the source code is not compiled with <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/clr-common-language-runtime-compilation?view=msvc-170">/clr</a>. This warning is informational.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-and-level-4-c4949?view=msvc-160" target="_blank">C4949</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-and-level-4-c4949?view=msvc-170" target="_blank">C4949</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6166,9 +6224,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4950: 'type_or_member' : marked as obsolete</name>
     <description>
       <![CDATA[
-<p>A member or type was marked as obsolete with the <a data-linktype="absolute-path" href="/en-us/dotnet/api/system.obsoleteattribute">ObsoleteAttribute</a> attribute.</p>
+<p>A member or type was marked as obsolete with the <a class="no-loc" data-linktype="absolute-path" href="/en-us/dotnet/api/system.obsoleteattribute">ObsoleteAttribute</a> attribute.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4950?view=msvc-160" target="_blank">C4950</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4950?view=msvc-170" target="_blank">C4950</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6177,9 +6235,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4951: 'function' has been edited since profile data was collected, function profile data not used</name>
     <description>
       <![CDATA[
-<p>A function has been edited in an input module to <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=msvc-160">/LTCG:PGUPDATE</a>, so that the profile data is now not valid. The input module was recompiled after <strong>/LTCG:PGINSTRUMENT</strong> and has a function (<em>function</em>) with a different flow of control than was in the module at the time of the <strong>/LTCG:PGINSTRUMENT</strong> operation.</p>
+<p>A function has been edited in an input module to <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=msvc-170">/LTCG:PGUPDATE</a>, so that the profile data is now not valid. The input module was recompiled after <strong>/LTCG:PGINSTRUMENT</strong> and has a function (<em>function</em>) with a different flow of control than was in the module at the time of the <strong>/LTCG:PGINSTRUMENT</strong> operation.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4951?view=msvc-160" target="_blank">C4951</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4951?view=msvc-170" target="_blank">C4951</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6188,9 +6246,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4952: 'function' : no profile data found in program database 'pgd_file'</name>
     <description>
       <![CDATA[
-<p>When using <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=msvc-160">/LTCG:PGUPDATE</a>, the compiler detected an input module that was recompiled after <code>/LTCG:PGINSTRUMENT</code> and has a new function (<em>function</em>) present.</p>
+<p>When using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=msvc-170">/LTCG:PGUPDATE</a>, the compiler detected an input module that was recompiled after <code>/LTCG:PGINSTRUMENT</code> and has a new function (<em>function</em>) present.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4952?view=msvc-160" target="_blank">C4952</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4952?view=msvc-170" target="_blank">C4952</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6199,9 +6257,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4953: Inlinee 'function' has been edited since profile data was collected, profile data not used</name>
     <description>
       <![CDATA[
-<p>When using <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=msvc-160">/LTCG:PGUPDATE</a>, the compiler detected an input module that was recompiled after <code>/LTCG:PGINSTRUMENT</code> and has a function (<em>function</em>) that was edited and where existing test runs identified the function as a candidate for inlining. However, as a result of recompiling the module, the function will no longer be a candidate for inlining.</p>
+<p>When using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=msvc-170">/LTCG:PGUPDATE</a>, the compiler detected an input module that was recompiled after <code>/LTCG:PGINSTRUMENT</code> and has a function (<em>function</em>) that was edited and where existing test runs identified the function as a candidate for inlining. However, as a result of recompiling the module, the function will no longer be a candidate for inlining.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4953?view=msvc-160" target="_blank">C4953</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4953?view=msvc-170" target="_blank">C4953</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6210,9 +6268,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4956: 'type' : this type is not verifiable</name>
     <description>
       <![CDATA[
-<p>This warning is generated when <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/clr-common-language-runtime-compilation?view=msvc-160">/clr:safe</a> is specified and your code contains a type that is not verifiable. The <strong>/clr:safe</strong> compiler option is deprecated in Visual Studio 2015 and unsupported in Visual Studio 2017.</p>
+<p>This warning is generated when <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/clr-common-language-runtime-compilation?view=msvc-170">/clr:safe</a> is specified and your code contains a type that is not verifiable. The <strong>/clr:safe</strong> compiler option is deprecated in Visual Studio 2015 and unsupported in Visual Studio 2017.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4956?view=msvc-160" target="_blank">C4956</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4956?view=msvc-170" target="_blank">C4956</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6223,7 +6281,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A cast will result in an unverifiable image.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4957?view=msvc-160" target="_blank">C4957</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4957?view=msvc-170" target="_blank">C4957</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6234,7 +6292,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Using pointer arithmetic will produce an unverifiable image.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4958?view=msvc-160" target="_blank">C4958</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4958?view=msvc-170" target="_blank">C4958</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6245,7 +6303,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Accessing a member of an unmanaged type will produce an unverifiable (peverify.exe) image.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4959?view=msvc-160" target="_blank">C4959</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4959?view=msvc-170" target="_blank">C4959</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6254,9 +6312,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4960: 'function' is too big to be profiled</name>
     <description>
       <![CDATA[
-<p>When using <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=msvc-160">/LTCG:PGOPTIMIZE</a>, the compiler detected an input module with a function larger than 65,535 instructions. Such a large function is not available for profile-guided optimizations.</p>
+<p>When using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=msvc-170">/LTCG:PGOPTIMIZE</a>, the compiler detected an input module with a function larger than 65,535 instructions. Such a large function is not available for profile-guided optimizations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4960?view=msvc-160" target="_blank">C4960</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4960?view=msvc-170" target="_blank">C4960</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6267,7 +6325,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>No profile data (.pgc files) were available, so profile-guided optimizations cannot take place.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4961?view=msvc-160" target="_blank">C4961</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4961?view=msvc-170" target="_blank">C4961</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6278,7 +6336,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A function was not compiled with /LTCG:PGO, because count (profile) data for the function was unreliable. Redo profiling to regenerate the .pgc file that contains the unreliable profile data for that function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4962?view=msvc-160" target="_blank">C4962</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4962?view=msvc-170" target="_blank">C4962</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6287,20 +6345,21 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4964: No optimization options were specified; profile info will not be collected</name>
     <description>
       <![CDATA[
-<p><a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/gl-whole-program-optimization?view=msvc-160">/GL</a> and <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=msvc-160">/LTCG</a> were specified, but no optimizations were requested, so no .pgc files will be generated and, therefore, no profile-guided optimizations will be possible.</p>
+<p><a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/gl-whole-program-optimization?view=msvc-170">/GL</a> and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=msvc-170">/LTCG</a> were specified, but no optimizations were requested, so no .pgc files will be generated and, therefore, no profile-guided optimizations will be possible.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4964?view=msvc-160" target="_blank">C4964</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4964?view=msvc-170" target="_blank">C4964</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4965</key>
-    <name>C4965: implicit box of integer 0; use nullptr or explicit cast</name>
+    <name>C4965: implicit box of integer 0</name>
     <description>
       <![CDATA[
+<p>Implicit box of integer 0; use nullptr or explicit cast.</p>
 <p>Visual C++ features implicit boxing of value types. An instruction that resulted in a null assignment using Managed Extensions for C++ now becomes an assignment to a boxed int.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4965?view=msvc-160" target="_blank">C4965</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4965?view=msvc-170" target="_blank">C4965</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6311,7 +6370,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Dereferencing a handle to a value type, also known as unboxing, and then assigning to it is not verifiable.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4972?view=msvc-160" target="_blank">C4972</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4972?view=msvc-170" target="_blank">C4972</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6322,7 +6381,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler found an <code>if constexpr</code> expression in code compiled by using the default C++14 standard. This expression is specified starting in the C++17 standard. If you require C++11 or C++14 compatibility, this expression isn't portable.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4984?view=msvc-160" target="_blank">C4984</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4984?view=msvc-170" target="_blank">C4984</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6333,7 +6392,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The Microsoft source code annotation language (SAL) annotations on the current method declaration or definition differ from the annotations on an earlier declaration. The same SAL annotations must be used in the definition and declarations of a method.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4985?view=msvc-160" target="_blank">C4985</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4985?view=msvc-170" target="_blank">C4985</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6344,7 +6403,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning can be generated when there is an exception specification in one declaration and not the other.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4986?view=msvc-160" target="_blank">C4986</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4986?view=msvc-170" target="_blank">C4986</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6353,9 +6412,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4995: 'function': name was marked as #pragma deprecated</name>
     <description>
       <![CDATA[
-<p>The compiler encountered a function that was marked with pragma <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/deprecated-c-cpp?view=msvc-160">deprecated</a>. The function may no longer be supported in a future release. You can turn this warning off with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-160">warning</a> pragma (example below).</p>
+<p>The compiler encountered a function that was marked with <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/deprecated-c-cpp?view=msvc-170"><code>#pragma deprecated</code></a>. The function may no longer be supported in a future release. You can turn off this warning by using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170"><code>#pragma warning</code></a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4995?view=msvc-160" target="_blank">C4995</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4995?view=msvc-170" target="_blank">C4995</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6364,9 +6423,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4996: Your code uses a function, class member, variable, or typedef that's marked deprecated</name>
     <description>
       <![CDATA[
-<p>Your code uses a function, class member, variable, or typedef that's marked <em>deprecated</em>. Symbols are deprecated by using a <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/deprecated-cpp?view=msvc-160"><code>__declspec(deprecated)</code></a> modifier, or the C++14 <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/attributes?view=msvc-160"><code>[[deprecated]]</code></a> attribute. The actual C4996 warning message is specified by the <code>deprecated</code> modifier or attribute of the declaration.</p>
+<p>Your code uses a function, class member, variable, or typedef that's marked <em>deprecated</em>. Symbols are deprecated by using a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/deprecated-cpp?view=msvc-170"><code>__declspec(deprecated)</code></a> modifier, or the C++14 <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/attributes?view=msvc-170"><code>[[deprecated]]</code></a> attribute. The actual C4996 warning message is specified by the <code>deprecated</code> modifier or attribute of the declaration.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=msvc-160" target="_blank">C4996</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=msvc-170" target="_blank">C4996</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6375,9 +6434,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4997: 'class': coclass does not implement a COM interface or pseudo-interface</name>
     <description>
       <![CDATA[
-<p>A class marked with the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/windows/attributes/coclass?view=msvc-160">coclass</a> attribute did not implement an interface.</p>
+<p>A class marked with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/coclass?view=msvc-170">coclass</a> attribute did not implement an interface.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4997?view=msvc-160" target="_blank">C4997</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4997?view=msvc-170" target="_blank">C4997</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6388,7 +6447,18 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Note the circumstances of the error, try to isolate the problem and create a reproducible test case, then contact <a data-linktype="absolute-path" href="/en-us/visualstudio/ide/talk-to-us">Microsoft Product Support Services</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4999?view=msvc-160" target="_blank">C4999</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4999?view=msvc-170" target="_blank">C4999</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>C5033</key>
+    <name>C5033: 'storage-class-keyword' is no longer a supported storage class</name>
+    <description>
+      <![CDATA[
+<p>The  <strong><code>auto</code></strong> and <strong><code>register</code></strong> storage class keywords have been deprecated or removed from the C++ language.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5033?view=msvc-170" target="_blank">C5033</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6397,9 +6467,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C5037: 'member-function': an out-of-line definition of a member of a class template cannot have default arguments</name>
     <description>
       <![CDATA[
-<p>Default arguments aren't allowed on out-of-line definitions of member functions in template classes. The compiler issues a level 3 warning under <strong><code>/permissive</code></strong>, and an error under <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-160"><code>/permissive-</code></a>.</p>
+<p>Default arguments aren't allowed on out-of-line definitions of member functions in template classes. The compiler issues a level 3 warning under <strong><code>/permissive</code></strong>, and an error under <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170"><code>/permissive-</code></a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5037?view=msvc-160" target="_blank">C5037</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5037?view=msvc-170" target="_blank">C5037</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -6410,7 +6480,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Class members get initialized in the order they're declared, not the order they appear in initializer lists. The compiler warns when the initialization order isn't the same as the declaration order of data members or base classes. The order can lead to undefined runtime behavior: for example, if the initialization of one member in the list depends on the initialization of a member that's declared later.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5038?view=msvc-160" target="_blank">C5038</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5038?view=msvc-170" target="_blank">C5038</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6419,9 +6489,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C5045: Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified</name>
     <description>
       <![CDATA[
-<p>Warning C5045 lets you see what patterns in your code cause a Spectre mitigation, such as an LFENCE, to be inserted when the <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/build/reference/qspectre?view=msvc-160">/Qspectre</a> compiler option is specified. This lets you identify which code files are affected by the security issue. This warning is purely informational: the mitigation is not inserted until you recompile using the <strong>/Qspectre</strong> switch. The functionality of C5045 is independent of the <strong>/Qspectre</strong> switch, so you can use them both in the same compilation.</p>
+<p>Warning C5045 lets you see what patterns in your code cause a Spectre mitigation, such as an LFENCE, to be inserted when the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/qspectre?view=msvc-170">/Qspectre</a> compiler option is specified. This lets you identify which code files are affected by the security issue. This warning is purely informational: the mitigation is not inserted until you recompile using the <strong>/Qspectre</strong> switch. The functionality of C5045 is independent of the <strong>/Qspectre</strong> switch, so you can use them both in the same compilation.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5045?view=msvc-160" target="_blank">C5045</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5045?view=msvc-170" target="_blank">C5045</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6432,7 +6502,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler has detected a use of a function that doesn't have a definition, but the signature of this function involves types that aren't visible outside this translation unit. Because these types aren't externally visible, no other translation unit can provide a definition for this function, so the program can't be successfully linked.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5046?view=msvc-160" target="_blank">C5046</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5046?view=msvc-170" target="_blank">C5046</a></p>]]>
     </description>
     <severity>INFO</severity>
     </rule>
@@ -6443,18 +6513,51 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The compiler raises C5050 whenever the command-line options for modules aren't consistent between the module creation and module consumption sides.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5050?view=msvc-160" target="_blank">C5050</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5050?view=msvc-170" target="_blank">C5050</a></p>]]>
       </description>
     <severity>INFO</severity>
   </rule>
+  <rule>
+    <key>C5054</key>
+    <name>C5054: operator 'operator-name': deprecated between enumerations of different types</name>
+    <description>
+      <![CDATA[
+<p>C++20 has deprecated the usual arithmetic conversions on operands, where one operand is of enumeration type and the other is of a different enumeration type. For more information, see C++ Standard proposal <a data-linktype="external" href="https://wg21.link/p1120r0">P1120R0</a>.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5054?view=msvc-170" target="_blank">C5054</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>C5055</key>
+    <name>C5055: operator 'operator-name': deprecated between enumerations and floating-point types</name>
+    <description>
+      <![CDATA[
+<p>C++20 has deprecated the usual arithmetic conversions on operands, where one operand is of enumeration type and the other is of floating-point type. For more information, see C++ Standard proposal <a data-linktype="external" href="https://wg21.link/p1120r0">P1120R0</a>.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5055?view=msvc-170" target="_blank">C5055</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>C5056</key>
+    <name>C5056: operator 'operator-name': deprecated for array types</name>
+    <description>
+      <![CDATA[
+<p>Equality and relational comparisons between two operands of array type are deprecated in C++20. For more information, see C++ Standard proposal <a data-linktype="external" href="https://wg21.link/p1120r0">P1120R0</a>.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5056?view=msvc-170" target="_blank">C5056</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
   <rule>
     <key>C5105</key>
     <name>C5105: macro expansion producing 'defined' has undefined behavior</name>
     <description>
       <![CDATA[
-<p>The preprocessor detected a <code>defined</code> operator in the output of a macro expansion. If a <code>defined</code> operator appears as the result of a macro expansion, the C standard specifies the behavior as undefined. The C5105 warning is a portability and standards compliance warning, issued because other compliant compilers may have different behavior. To resolve this issue, move the <code>defined</code> operator out of the macro, or suppress warning C5105.</p>
+<p>The preprocessor detected a <code>defined</code> operator in the output of a macro expansion. If a <code>defined</code> operator appears as the result of a macro expansion, the C standard specifies the behavior as undefined. The C5105 warning is a portability and standards conformance warning, issued because other conformant compilers may have different behavior. To resolve this issue, move the <code>defined</code> operator out of the macro, or suppress warning C5105.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5105?view=msvc-160" target="_blank">C5105</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5105?view=msvc-170" target="_blank">C5105</a></p>]]>
     </description>
     <severity>INFO</severity>
   </rule>
@@ -6463,10 +6566,21 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C5208: unnamed class used in typedef name cannot declare members other than non-static data members, member enumerations, or member classes</name>
     <description>
       <![CDATA[
-<p>Unnamed classes within a <strong><code>typedef</code></strong> declaration can't have any members other than:</p>
+<p>Unnamed classes within a <strong><code>typedef</code></strong> declaration can't have any members other than: non-static data members with no default member initializers, member classes, or member enumerations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5208?view=msvc-160" target="_blank">C5208</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5208?view=msvc-170" target="_blank">C5208</a></p>]]>
     </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>C5240</key>
+    <name>C5240: 'attribute-string': attribute is ignored in this syntactic position</name>
+    <description>
+      <![CDATA[
+<p>Warning C5240 occurs when a <code>[[nodiscard]]</code> or <code>[[maybe_unused]]</code> attribute is found in the wrong syntactic position. For example, the <code>[[nodiscard]]</code> attribute in this syntactic position applies to the <em><code>decl-specifier-seq</code></em>, not to the function <code>f</code>.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5240?view=msvc-170" target="_blank">C5240</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -6476,7 +6590,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The Microsoft C++ ABI in Visual Studio 2019 and earlier versions uses more than one kind of pointer-to-member type. These types have different sizes that depend on the inheritance model used by the class. The C++ standard allows you to declare a pointer-to-member of an incomplete class type. If you declare a variable of pointer-to-member type for an incomplete class, the compiler must use the most general representation. It can lead to a <em>one definition rule</em>, or ODR violation, since the compiler may use a smaller, more specific representation for this pointer-to-member type in other translation units where the complete class type is available.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5243?view=msvc-160" target="_blank">C5243</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5243?view=msvc-170" target="_blank">C5243</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -6487,7 +6601,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The Microsoft C++ compiler uses reserved section names for internal implementation of features such as C++ dynamic initialization. If your code creates a section with the same name as a reserved section, such as <code>.CRT$XCU</code>, it interferes with the compiler. It may prevent other dynamic initialization and cause undefined behavior.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5247?view=msvc-160" target="_blank">C5247</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5247?view=msvc-170" target="_blank">C5247</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -6498,18 +6612,18 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The Microsoft C++ compiler uses reserved section names for internal implementation of features such as C++ dynamic initialization. If your code inserts a variable in a reserved section, such as <code>.CRT$XCU</code>, it interferes with the compiler. Your variable isn't considered a C++ dynamic initializer. Also, its relative initialization order compared to compiler generated dynamic initializers isn't specified.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5248?view=msvc-160" target="_blank">C5248</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5248?view=msvc-170" target="_blank">C5248</a></p>]]>
       </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C6001</key>
-    <name>C6001: using uninitialized memory &lt;variable&gt;</name>
+    <name>C6001: Using uninitialized memory 'variable'</name>
     <description>
       <![CDATA[
-<p>This warning is reported when an uninitialized local variable is used before it is assigned a value. This could lead to unpredictable results. You should always initialize variables before use.</p>
+<p>This warning is reported when an uninitialized local variable is used before it's assigned a value. This usage could lead to unpredictable results. You should always initialize variables before use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6001?view=msvc-160" target="_blank">C6001</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6001?view=msvc-170" target="_blank">C6001</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6518,12 +6632,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6011</key>
-    <name>C6011: dereferencing NULL pointer &lt;name&gt;</name>
+    <name>C6011: Dereferencing NULL pointer 'pointer-name'</name>
     <description>
       <![CDATA[
 <p>This warning indicates that your code dereferences a potentially null pointer. If the pointer value is invalid, the result is undefined. To resolve the issue, validate the pointer before use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6011?view=msvc-160" target="_blank">C6011</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6011?view=msvc-170" target="_blank">C6011</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6532,12 +6646,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6014</key>
-    <name>C6014: Leaking memory</name>
+    <name>C6014: Leaking memory 'pointer-name'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the specified pointer points to allocated memory or some other allocated resource that has not been freed. The analyzer checks for this condition only when the <code>_Analysis_mode_(_Analysis_local_leak_checks_)</code> SAL annotation is specified. By default, this annotation is specified for Windows kernel mode (driver) code. For more information about SAL annotations, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-160">Using SAL Annotations to Reduce C/C++ Code Defects</a>.</p>
+<p>This warning indicates that the specified pointer points to allocated memory or some other allocated resource that has not been freed. The analyzer checks for this condition only when the <code>_Analysis_mode_(_Analysis_local_leak_checks_)</code> SAL annotation is specified. By default, this annotation is specified for Windows kernel mode (driver) code. For more information about SAL annotations, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">Using SAL Annotations to Reduce C/C++ Code Defects</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6014?view=msvc-160" target="_blank">C6014</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6014?view=msvc-170" target="_blank">C6014</a></p>]]>
     </description>
     <severity>BLOCKER</severity>
     <type>BUG</type>
@@ -6546,12 +6660,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6029</key>
-    <name>C6029: possible buffer overrun in call to &lt;function&gt;: use of unchecked value</name>
+    <name>C6029: Possible buffer overrun in call to 'function': use of unchecked value</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a function that takes a buffer and a size is being passed a unchecked size. The data read-in from some external source has not been verified to see whether it is smaller than the buffer size. An attacker might intentionally specify a much larger than expected value for the size, which will lead to a buffer overrun.</p>
+<p>This warning indicates that a function that takes a buffer and a size is being passed an unchecked size. The data read-in from some external source hasn't been verified to see whether it's smaller than the buffer size. An attacker might intentionally specify a much larger than expected value for the size, which will lead to a buffer overrun.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6029?view=msvc-160" target="_blank">C6029</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6029?view=msvc-170" target="_blank">C6029</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6559,12 +6673,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6031</key>
-    <name>C6031: return value ignored: called-function could return unexpected value</name>
+    <name>C6031: Return value ignored: 'called-function' could return unexpected value</name>
     <description>
       <![CDATA[
-<p>This warning indicates the caller doesn't check a function's return value for failure. Depending on which function is being called, this defect can lead to seemingly random program misbehavior. That includes crashes and data corruptions in error conditions or low-resource situations.</p>
+<p>Warning C6031 indicates the caller doesn't check a function's return value for failure. Depending on which function is being called, this defect can lead to seemingly random program misbehavior. That includes crashes and data corruptions in error conditions or low-resource situations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6031?view=msvc-160" target="_blank">C6031</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6031?view=msvc-170" target="_blank">C6031</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6572,12 +6686,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6053</key>
-    <name>C6053: call to &lt;function&gt; may not zero-terminate string &lt;variable&gt;</name>
+    <name>C6053: Call to 'function' may not zero-terminate string 'variable'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the specified function has been called in such a way that the resulting string might not be zero-terminated. This defect might cause an exploitable buffer overrun or crash. This warning is also generated if an annotated function expects a null terminated string is passed a string that is not null terminated.</p>
+<p>This warning indicates that the specified function has been called in such a way that the resulting string might not be zero-terminated. This defect might cause an exploitable buffer overrun or crash. This warning is also generated if an annotated function expects a null-terminated string, but you pass a non-null-terminated string.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6053?view=msvc-160" target="_blank">C6053</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6053?view=msvc-170" target="_blank">C6053</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6585,12 +6699,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6054</key>
-    <name>C6054: string &lt;variable&gt; may not be zero-terminated</name>
+    <name>C6054: String 'variable' may not be zero-terminated</name>
     <description>
       <![CDATA[
 <p>This warning indicates that a function that requires a zero-terminated string was passed a non-zero terminated string. A function that expects a zero-terminated string could look for the zero beyond the end of the buffer. This defect might cause an exploitable buffer overrun error or crash. The program should make sure the string passed in ends with a zero.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6054?view=msvc-160" target="_blank">C6054</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6054?view=msvc-170" target="_blank">C6054</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6598,12 +6712,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6059</key>
-    <name>C6059: Incorrect length parameter in call to &lt;function&gt;</name>
+    <name>C6059: Incorrect length parameter in call to 'function'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a call to a string concatenation function is probably passing an incorrect value for the number of characters to concatenate. This defect might cause an exploitable buffer overrun or crash. A common cause of this defect is passing the buffer size, instead of the remaining number of characters in the buffer, to the string manipulation function.</p>
+<p>This warning indicates that a call to a string concatenation function is probably passing an incorrect value for the number of characters to concatenate. This defect might cause an exploitable buffer overrun or crash. A common cause of this defect is passing the buffer size (instead of the remaining number of characters in the buffer) to the string manipulation function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6059?view=msvc-160" target="_blank">C6059</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6059?view=msvc-170" target="_blank">C6059</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6611,12 +6725,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6063</key>
-    <name>C6063: missing string argument to &lt;function&gt; corresponding to conversion specifier &lt;number&gt;</name>
+    <name>C6063: Missing string argument to 'function' that corresponds to conversion specifier 'number'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that not enough arguments are being provided to match a format string; at least one of the missing arguments is a string. This defect can cause crashes and buffer overflows (if the called function is of the <code>sprintf</code> family), as well as potentially incorrect output.</p>
+<p>This warning indicates that not enough arguments are being provided to match a format string. At least one of the missing arguments is a string. This defect can cause crashes and buffer overflows (if the called function is of the <code>sprintf</code> family), and also potentially incorrect output.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6063?view=msvc-160" target="_blank">C6063</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6063?view=msvc-170" target="_blank">C6063</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6625,12 +6739,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6064</key>
-    <name>C6064: missing integer argument to &lt;function&gt; corresponding to conversion specifier &lt;number&gt;</name>
+    <name>C6064: Missing integer argument to 'function-name' corresponding to conversion specifier 'number'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that not enough arguments are being provided to match a format string and one of the missing arguments is an integer. This defect can cause incorrect output.</p>
+<p>This warning indicates that not enough arguments are provided to match a format string and one of the missing arguments is an integer.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6064?view=msvc-160" target="_blank">C6064</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6064?view=msvc-170" target="_blank">C6064</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6639,12 +6753,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6066</key>
-    <name>C6066: non-pointer passed as parameter &lt;number&gt; when pointer is required in call to &lt;function&gt;</name>
+    <name>C6066: Non-pointer passed as parameter(number) when pointer is required in call to 'function'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the format string specifies that a pointer is required, for example, a <code>%n</code> or <code>%p</code> specification for printf or a <code>%d</code> for <code>scanf</code>, but a non-pointer is being passed. This defect is likely to cause a crash or corruption of some form.</p>
+<p>This warning indicates that the format string specifies that a pointer is required, but a non-pointer is being passed. A pointer is required, for example, when you use a <code>%n</code> or <code>%p</code> specification for <code>printf</code>, or a <code>%d</code> for <code>scanf</code>. This defect is likely to cause a crash or corruption of some form.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6066?view=msvc-160" target="_blank">C6066</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6066?view=msvc-170" target="_blank">C6066</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6653,12 +6767,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6067</key>
-    <name>C6067: parameter &lt;number&gt; in call to &lt;function&gt; must be the address of the string</name>
+    <name>C6067: Parameter 'number' in call to 'function' must be the address of the string</name>
     <description>
       <![CDATA[
 <p>This warning indicates a mismatch between the format specifier and the function parameter. Even though the warning suggests using the address of the string, you must check the type of parameter a function expects before correcting the problem. For example, a <code>%s</code> specification for <code>printf</code> requires a string argument, but a <code>%s</code> specification in <code>scanf</code> requires an address of the string.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6067?view=msvc-160" target="_blank">C6067</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6067?view=msvc-170" target="_blank">C6067</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6669,9 +6783,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6101: Returning uninitialized memory</name>
     <description>
       <![CDATA[
-<p>A successful path through the function does not set the named <code>_Out_</code> parameter. This message is generated based on SAL annotations that indicate that the function in question always succeeds. A function that doesn't return a success/failure indication should set all of its <code>_Out_</code> parameters because the analyzer assumes that the <code>_Out_</code> parameter is uninitialized data before the function is called, and that the function will set the parameter so that it's no longer uninitialized. If the function does indicate success/failure, then the <code>_Out_</code> parameter doesn't have to be set in the case of failure, and you can detect and avoid the uninitialized location. In either case, the objective is to avoid the reading of an uninitialized location. If the function sometimes doesn't touch an <code>_Out_</code> parameter that's subsequently used, then the parameter should be initialized before the function call and be marked with the <code>_Inout_</code> annotation, or the more explicit <code>_Pre_null_</code> or <code>_Pre_satisfies_()</code> when appropriate. "Partial success" can be handled with the <code>_When_</code> annotation. For more information, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-160">Using SAL Annotations to Reduce C/C++ Code Defects</a>.</p>
+<p>This message is generated based on SAL annotations that indicate that the function in question always succeeds. A function that doesn't return a success/failure indication should set all of its <code>_Out_</code> parameters because the analyzer assumes that the <code>_Out_</code> parameter is uninitialized data before the function is called, and that the function will set the parameter so that it's no longer uninitialized. If, however, the function does indicate success/failure and failure occurs, then the <code>_Out_</code> parameter doesn't have to be set. You can then detect and avoid the uninitialized location. In either case, the objective is to avoid the reading of an uninitialized location. If the function sometimes doesn't touch an <code>_Out_</code> parameter that's later used, then the parameter should be initialized before the function call and be marked with the <code>_Inout_</code> annotation, or the more explicit <code>_Pre_null_</code> or <code>_Pre_satisfies_()</code> when appropriate. "Partial success" can be handled with the <code>_When_</code> annotation. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">Using SAL Annotations to Reduce C/C++ Code Defects</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6101?view=msvc-160" target="_blank">C6101</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6101?view=msvc-170" target="_blank">C6101</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6680,12 +6794,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6102</key>
-    <name>C6102: Using &lt;variable&gt; from failed function call at line &lt;location&gt;</name>
+    <name>C6102: Using 'variable' from failed function call at line 'location'</name>
     <description>
       <![CDATA[
-<p>This warning is reported instead of <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/c6001?view=msvc-160">C6001</a> when a variable is not set because it was marked as an <code>_Out_</code> parameter on a prior function call that failed.</p>
+<p>This warning is reported instead of <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c6001?view=msvc-170">C6001</a> when a variable isn't set because it was marked as an <code>_Out_</code> parameter on a prior function call that failed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6102?view=msvc-160" target="_blank">C6102</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6102?view=msvc-170" target="_blank">C6102</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6694,12 +6808,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6103</key>
-    <name>C6103: Returning &lt;variable&gt; from failed function call at line &lt;location&gt;</name>
+    <name>C6103: Returning 'variable' from failed function call at line 'location'</name>
     <description>
       <![CDATA[
 <p>A successful path through the function is returning a variable that was used as an <code>_Out_</code> parameter to an internal function call that failed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6103?view=msvc-160" target="_blank">C6103</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6103?view=msvc-170" target="_blank">C6103</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6708,12 +6822,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6200</key>
-    <name>C6200: index &lt;name&gt; is out of valid index range &lt;min&gt; to &lt;max&gt; for non-stack buffer &lt;variable&gt;</name>
+    <name>C6200: Index 'index' is out of valid index range 'min' to 'max' for non-stack buffer 'parameter-name'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an integer offset into the specified array exceeds the maximum bounds of that array. This defect might cause random behavior or crashes.</p>
+<p>This warning indicates that an integer offset into the specified non-stack array exceeds the maximum bounds of that array, potentially causing random behavior and/or crashes.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6200?view=msvc-160" target="_blank">C6200</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6200?view=msvc-170" target="_blank">C6200</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6722,12 +6836,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6201</key>
-    <name>C6201: buffer overrun for &lt;variable&gt;, which is possibly stack allocated: index &lt;name&gt; is out of valid index range &lt;min&gt; to &lt;max&gt;</name>
+    <name>C6201: Index 'index-name' is out of valid index range 'minimum' to 'maximum' for possibly stack allocated buffer 'variable'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an integer offset into the specified stack array exceeds the maximum bounds of that array. This defect might cause random behavior or crashes.</p>
+<p>This warning indicates that an integer offset into the specified stack array exceeds the maximum bounds of that array. It may potentially cause stack overflow errors, random behavior, or crashes.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6201?view=msvc-160" target="_blank">C6201</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6201?view=msvc-170" target="_blank">C6201</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6736,12 +6850,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6211</key>
-    <name>C6211: Leaking memory &lt;pointer&gt; due to an exception</name>
+    <name>C6211: Leaking memory 'pointer' due to an exception</name>
     <description>
       <![CDATA[
-<p>This warning indicates that allocated memory is not being freed when an exception is thrown. The statement at the end of the path could throw an exception. The analyzer checks for this condition only when the <code>_Analysis_mode_(_Analysis_local_leak_checks_)</code> SAL annotation is specified. By default, this annotation is specified for Windows kernel mode (driver) code. For more information about SAL annotations, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-160">Using SAL Annotations to Reduce C/C++ Code Defects</a>.</p>
+<p>This warning indicates that allocated memory is not being freed when an exception is thrown. The statement at the end of the path could throw an exception. The analyzer checks for this condition only when the <code>_Analysis_mode_(_Analysis_local_leak_checks_)</code> SAL annotation is specified. By default, this annotation is specified for Windows kernel mode (driver) code. For more information about SAL annotations, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">Using SAL Annotations to Reduce C/C++ Code Defects</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6211?view=msvc-160" target="_blank">C6211</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6211?view=msvc-170" target="_blank">C6211</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6754,7 +6868,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that an <code>HRESULT</code> is being cast to a Boolean type. The success value (<code>S_OK</code>) of an <code>HRESULT</code> equals 0. However, 0 indicates failure for a Boolean type. Casting an <code>HRESULT</code> to a Boolean type and then using it in a test expression will yield an incorrect result. Sometimes, this warning occurs if an <code>HRESULT</code> is being stored in a Boolean variable. Any comparison that uses the Boolean variable to test for <code>HRESULT</code> success or failure could lead to incorrect results.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6214?view=msvc-160" target="_blank">C6214</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6214?view=msvc-170" target="_blank">C6214</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6767,7 +6881,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that a Boolean is being cast to an <code>HRESULT</code>. Boolean types indicate success by a non-zero value, whereas success (<code>S_OK</code>) in <code>HRESULT</code> is indicated by a value of 0. Casting a Boolean type to an <code>HRESULT</code> and then using it in a test expression will yield an incorrect result.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6215?view=msvc-160" target="_blank">C6215</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6215?view=msvc-170" target="_blank">C6215</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6780,7 +6894,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>A Boolean type is being used as an <code>HRESULT</code> without being explicitly cast. Boolean types indicate success by a non-zero value; success (<code>S_OK</code>) in <code>HRESULT</code> is indicated by a value of 0.  This means a Boolean false value used as an <code>HRESULT</code> would indicate <code>S_OK</code>, which is frequently a mistake.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6216?view=msvc-160" target="_blank">C6216</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6216?view=msvc-170" target="_blank">C6216</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6791,9 +6905,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6217: Implicit cast between semantically different integer types: testing HRESULT with 'not'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an <code>HRESULT</code> is being tested with the not (<code>!</code>) operator. A success (<code>S_OK</code>) in <code>HRESULT</code> is indicated by a value of 0. However, 0 indicates failure for a Boolean type. Testing <code>HRESULT</code> with the not operator (<code>!</code>) to determine which code block to run can cause following the wrong code path. This will lead to unwanted results.</p>
+<p>This warning indicates that an <code>HRESULT</code> is being tested with the logical-not (<code>!</code>) operator. A success (<code>S_OK</code>) in <code>HRESULT</code> is indicated by a value of 0. However, 0 indicates failure for a Boolean type. Testing <code>HRESULT</code> with the logical-not operator (<code>!</code>) to determine which code block to run can cause following the wrong code path. This test will lead to unwanted results.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6217?view=msvc-160" target="_blank">C6217</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6217?view=msvc-170" target="_blank">C6217</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6804,9 +6918,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6219: Implicit cast between semantically different integer types: comparing HRESULT to 1 or TRUE</name>
     <description>
       <![CDATA[
-<p>This warning indicates an <code>HRESULT</code> is being compared with an explicit, non-<code>HRESULT</code> value of one (1). This comparison is likely to lead to incorrect results, because the typical success value of <code>HRESULT</code> (<code>S_OK</code>) is 0. If you compare this value to a Boolean type it's implicitly converted to false.</p>
+<p>This warning indicates an <code>HRESULT</code> is being compared with an explicit, non-<code>HRESULT</code> value of one (1). This comparison is likely to lead to incorrect results, because the typical success value of <code>HRESULT</code> (<code>S_OK</code>) is 0. If you compare this value to a Boolean type, it's implicitly converted to <code>false</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6219?view=msvc-160" target="_blank">C6219</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6219?view=msvc-170" target="_blank">C6219</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6819,7 +6933,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that an <code>HRESULT</code> is being compared with an explicit, non-<code>HRESULT</code> value of -1, which is not a well-formed <code>HRESULT</code>. A failure in <code>HRESULT</code> (<code>E_FAIL</code>) is not represented by a -1. Therefore, an implicit cast of an <code>HRESULT</code> to an integer will generate an incorrect value and is likely to lead to the wrong result.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6220?view=msvc-160" target="_blank">C6220</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6220?view=msvc-170" target="_blank">C6220</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6832,7 +6946,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that an <code>HRESULT</code> is being compared to an integer other than zero. A success in <code>HRESULT</code> (<code>S_OK</code>) is represented by a 0. Therefore, an implicit cast of an <code>HRESULT</code> to an integer will generate an incorrect value and is likely to lead to the wrong result. It is often caused by mistakenly expecting a function to return an integer when it actually returns an <code>HRESULT</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6221?view=msvc-160" target="_blank">C6221</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6221?view=msvc-170" target="_blank">C6221</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6845,7 +6959,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that an <code>HRESULT</code> is being assigned or initialized with a value of an explicit 1. Boolean types indicate success by a non-zero value; success (<code>S_OK</code>) in <code>HRESULT</code> is indicated by a value of 0. This warning is frequently caused by accidental confusion of Boolean and <code>HRESULT</code> types. To indicate success, the symbolic constant <code>S_OK</code> should be used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6225?view=msvc-160" target="_blank">C6225</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6225?view=msvc-170" target="_blank">C6225</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6858,7 +6972,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that an <code>HRESULT</code> is assigned or initialized to an explicit value of -1. This warning is frequently caused by accidental confusion of integer and <code>HRESULT</code> types. To indicate success, use the symbolic constant <code>S_OK</code> instead. To indicate failure, use the symbolic constants that start with E_<em>constant</em>, such as <code>E_FAIL</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6226?view=msvc-160" target="_blank">C6226</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6226?view=msvc-170" target="_blank">C6226</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6871,7 +6985,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that a bare <code>HRESULT</code> is used in a context where a Boolean result is expected, such as an <strong><code>if</code></strong> statement. This test is likely to yield incorrect results. For example, the typical success value for <code>HRESULT</code> (<code>S_OK</code>) is false when it's tested as a Boolean.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6230?view=msvc-160" target="_blank">C6230</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6230?view=msvc-170" target="_blank">C6230</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6879,12 +6993,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6235</key>
-    <name>C6235: (&lt;non-zero constant&gt; || &lt;expression&gt;) is always a non-zero constant</name>
+    <name>C6235: ('non-zero constant' || 'expression') is always a non-zero constant</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a non-zero constant value, other than one, was detected on the left side of a logical-or operation that occurs in a test context. The right side of the logical-or operation is not evaluated because the resulting expression always evaluates to true. This is referred to as "short-circuit evaluation."</p>
+<p>This warning indicates that a non-zero constant value, other than one, was detected on the left side of a logical-or operation that occurs in a test context. The right side of the logical-or operation isn't evaluated because the resulting expression always evaluates to true. This language feature is referred to as "short-circuit evaluation."</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6235?view=msvc-160" target="_blank">C6235</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6235?view=msvc-170" target="_blank">C6235</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6893,12 +7007,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6236</key>
-    <name>C6236: (&lt;expression&gt; || &lt;non-zero constant&gt;) is always a non-zero constant</name>
+    <name>C6236: ('expression' || 'non-zero constant') is always a non-zero constant</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a non-zero constant value, other than one, was detected on the right side of a logical OR operation that occurs in a test context. Logically, this implies that the test is redundant and can be removed safely. Alternatively, it suggests that the programmer may have intended to use a different operator, for example, the equality (<code>==</code>), bitwise-AND (<code>&amp;</code>) or bitwise-XOR (<code>^</code>) operator, to test for a specific value or flag.</p>
+<p>This warning indicates that a non-zero constant value, other than one, was detected on the right side of a logical OR operation that occurs in a test context. Logically, it implies that the test is redundant and can be removed safely. Alternatively, it suggests that the programmer may have intended to use a different operator, for example, the equality (<code>==</code>), bitwise-AND (<code>&amp;</code>) or bitwise-XOR (<code>^</code>) operator, to test for a specific value or flag.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6236?view=msvc-160" target="_blank">C6236</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6236?view=msvc-170" target="_blank">C6236</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6907,12 +7021,13 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6237</key>
-    <name>C6237: (&lt;zero&gt; &amp;&amp; &lt;expression&gt;) is always zero. &lt;expression&gt; is never evaluated and may have side effects</name>
+    <name>C6237: ('zero' &amp;&amp; 'expression') is always zero</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a constant value of zero was detected on the left side of a logical-and operation that occurs in a test context. The resulting expression always evaluates to false. Therefore, the right side of the logical-AND operation is not evaluated. This is referred to as "short-circuit evaluation."</p>
+<p>('zero' &amp;&amp; 'expression') is always zero. 'expression' is never evaluated and may have side effects.</p>
+<p>This warning indicates that a constant value of zero was detected on the left side of a logical-and operation that occurs in a test context. The resulting expression always evaluates to false. Therefore, the right side of the logical-AND operation isn't evaluated. This language feature is referred to as "short-circuit evaluation."</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6237?view=msvc-160" target="_blank">C6237</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6237?view=msvc-170" target="_blank">C6237</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6921,12 +7036,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6239</key>
-    <name>C6239: (&lt;non-zero constant&gt; &amp;&amp; &lt;expression&gt;) always evaluates to the result of &lt;expression&gt;</name>
+    <name>C6239: ('non-zero constant' &amp;&amp; 'expression') always evaluates to the result of 'expression'</name>
     <description>
       <![CDATA[
 <p>This warning indicates that a non-zero constant value, other than one, was detected on the left side of a logical-AND operation that occurs in a test context. For example, the expression <code>( 2 &amp;&amp; n )</code> is reduced to <code>(!!n)</code>, which is the Boolean value of <code>n</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6239?view=msvc-160" target="_blank">C6239</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6239?view=msvc-170" target="_blank">C6239</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6935,12 +7050,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6240</key>
-    <name>C6240: (&lt;expression&gt; &amp;&amp; &lt;non-zero constant&gt;) always evaluates to the result of &lt;expression&gt;</name>
+    <name>C6240: ('expression' &amp;&amp; 'non-zero constant') always evaluates to the result of 'expression'?</name>
     <description>
       <![CDATA[
 <p>This warning indicates that a non-zero constant value, other than one, was detected on the right side of a logical-and operation that occurs in a test context. For example, the  expression <code>(n &amp;&amp; 3)</code> reduces to <code>(!!n)</code>, which is the Boolean value of <code>n</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6240?view=msvc-160" target="_blank">C6240</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6240?view=msvc-170" target="_blank">C6240</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -6954,7 +7069,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that a jump statement causes control-flow to leave the protected block of a <code>try-finally</code> other than by fall-through.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6242?view=msvc-160" target="_blank">C6242</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6242?view=msvc-170" target="_blank">C6242</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6962,12 +7077,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6244</key>
-    <name>C6244: local declaration of &lt;variable&gt; hides previous declaration at &lt;line&gt; of &lt;file&gt;</name>
+    <name>C6244: Local declaration of 'variable' hides previous declaration at 'line' of 'file'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a declaration has the same name as a declaration at an outer scope and hides the previous declaration. You will not be able to refer to the previous declaration from inside the local scope. Any intended use of the previous declaration will end up using the local declaration This warning only identifies a scope overlap and not lifetime overlap.</p>
+<p>This warning indicates that a declaration has the same name as a declaration at an outer scope and hides the previous declaration. You won't be able to refer to the previous declaration from inside the local scope. Any intended use of the previous declaration will end up using the local declaration. This warning only identifies a scope overlap and not lifetime overlap.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6244?view=msvc-160" target="_blank">C6244</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6244?view=msvc-170" target="_blank">C6244</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6975,12 +7090,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6246</key>
-    <name>C6246: Local declaration of &lt;variable&gt; hides declaration of same name in outer scope</name>
+    <name>C6246: Local declaration of 'variable' hides declaration of same name in outer scope'</name>
     <description>
       <![CDATA[
 <p>This warning indicates that two declarations have the same name at local scope. The name at outer scope is hidden by the declaration at the inner scope. Any intended use of the outer scope declaration will result in the use of local declaration.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6246?view=msvc-160" target="_blank">C6246</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6246?view=msvc-170" target="_blank">C6246</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -6991,9 +7106,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6248: setting a SECURITY_DESCRIPTOR's DACL to NULL will result in an unprotected object</name>
     <description>
       <![CDATA[
-<p>This warning identifies a call that sets a SECURITY_DESCRIPTOR's DACL field to null. If the DACL that belongs to the security descriptor of an object is set to NULL, a null DACL is created. A null DACL grants full access to any user who requests it; normal security checking is not performed with respect to the object. A null DACL should not be confused with an empty DACL. An empty DACL is a properly allocated and initialized DACL that contains no ACEs. An empty DACL grants no access to the object it is assigned to.</p>
+<p>If the DACL that belongs to the security descriptor of an object is set to NULL, a null DACL is created. A null DACL grants full access to any user who requests it; normal security checking isn't performed with respect to the object. A null DACL shouldn't be confused with an empty DACL. An empty DACL is a properly allocated and initialized DACL that contains no ACEs. An empty DACL grants no access to the object it's assigned to. Objects that have null DACLs can have their security descriptors altered by malicious users, making it so that no one has access to the object. Even in a situation where everyone needs access to an object, only administrators should be able to alter that object's security. If only the creator needs access to an object, a DACL shouldn't be set on the object; the system will choose an appropriate default.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6248?view=msvc-160" target="_blank">C6248</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6248?view=msvc-170" target="_blank">C6248</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7001,12 +7116,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6250</key>
-    <name>C6250: Calling &lt;function&gt; VirtualFree without the MEM_RELEASE flag may free memory but not address descriptors (VADs); results in address space leaks</name>
+    <name>C6250: Calling 'VirtualFree' without the MEM_RELEASE flag may free memory but not address descriptors (VADs); results in address space leaks</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a call to <code>VirtualFree</code> without the <code>MEM_RELEASE</code> flag only decommits the pages, and does not release them. To decommit and release pages, use <code>MEM_RELEASE</code> flag in call to <code>VirtualFree</code>. If any pages in the region are committed, the function first decommits and then releases them. After this operation, the pages are in the free state. If you specify this flag, <code>dwSize</code> must be zero, and <code>lpAddress</code> must point to the base address returned by the <code>VirtualAlloc</code> function when the region was reserved. The function fails if either of these conditions is not met.</p>
+<p>This warning indicates that a call to <code>VirtualFree</code> without the <code>MEM_RELEASE</code> flag only decommits the pages, and doesn't release them. To both decommit and release pages, use the <code>MEM_RELEASE</code> flag in the call to <code>VirtualFree</code>. If any pages in the region are committed, the function first decommits and then releases them. After this operation, the pages are in the free state. If you specify this flag, <code>dwSize</code> must be zero, and <code>lpAddress</code> must point to the base address returned by the <code>VirtualAlloc</code> function when the region was reserved. The function fails if either of these conditions isn't met.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6250?view=msvc-160" target="_blank">C6250</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6250?view=msvc-170" target="_blank">C6250</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7019,7 +7134,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that a call to <code>_alloca</code> has been detected outside of local exception handling. <code>_alloca</code> should always be called from within the protected range of an exception handler because it can raise a stack overflow exception on failure. If possible, instead of using <code>_alloca</code>, consider using <code>_malloca</code> which is a more secure version of <code>_alloca</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6255?view=msvc-160" target="_blank">C6255</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6255?view=msvc-170" target="_blank">C6255</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7030,9 +7145,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6258: using TerminateThread does not allow proper thread clean up</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a call to TerminateThread has been detected.</p>
+<p>This warning indicates that a call to <code>TerminateThread</code> has been detected.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6258?view=msvc-160" target="_blank">C6258</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6258?view=msvc-170" target="_blank">C6258</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7040,12 +7155,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6259</key>
-    <name>C6259: labeled code is unreachable: (&lt;expression&gt; &amp; &lt;constant&gt;) in switch-expr cannot evaluate to &lt;case-label&gt;</name>
+    <name>C6259: Labeled code is unreachable: ('expression' &amp; 'constant') in switch-expr cannot evaluate to 'case-label'</name>
     <description>
       <![CDATA[
-<p>This warning indicates unreachable code caused by the result of a bitwise-AND (<code>&amp;</code>) comparison in a switch expression. The case statement that matches the constant in the switch expression is only reachable; all other case statements are not reachable.</p>
+<p>This warning indicates unreachable code caused by the result of a bitwise-AND (<code>&amp;</code>) comparison in a switch expression. Only the case statement that matches the constant in the switch expression is reachable; all other case statements aren't reachable.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6259?view=msvc-160" target="_blank">C6259</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6259?view=msvc-170" target="_blank">C6259</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7058,7 +7173,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that the results of two <strong><code>sizeof</code></strong> operations have been multiplied together. The C/C++ <strong><code>sizeof</code></strong> operator returns the number of bytes of storage an object uses. It is typically incorrect to multiply it by another <strong><code>sizeof</code></strong> operation; usually one is interested in the number of bytes in an object or the number of elements in an array (for example the number of wide-characters in an array).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6260?view=msvc-160" target="_blank">C6260</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6260?view=msvc-170" target="_blank">C6260</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7072,7 +7187,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that stack usage that exceeds a preset threshold (<em>constant_2</em>) has been detected in a function. The default stack frame size for this warning is 16 KB for user mode, 1 KB for kernel mode. Stack—even in user mode—is limited, and failure to commit a page of stack causes a stack overflow exception. Kernel mode has a 12 KB stack size limit, which can't be increased. Try to aggressively limit stack use in kernel-mode code.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6262?view=msvc-160" target="_blank">C6262</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6262?view=msvc-170" target="_blank">C6262</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7083,9 +7198,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6263: using _alloca in a loop; this can quickly overflow stack</name>
     <description>
       <![CDATA[
-<p>This warning indicates that calling _alloca inside a loop to allocate memory can cause stack overflow. _alloca allocates memory from the stack, but that memory is only freed when the calling function exits. Stack, even in user-mode, is limited, and failure to commit a page of stack causes a stack overflow exception. The <code>_resetstkoflw</code> function recovers from a stack overflow condition, allowing a program to continue instead of failing with a fatal exception error. If the <code>_resetstkoflw</code> function is not called, there is no guard page after the previous exception. The next time that there is a stack overflow, there are no exceptions at all and the process terminates without warning.</p>
+<p>This warning indicates that calling <code>_alloca</code> inside a loop to allocate memory can cause stack overflow. <code>_alloca</code> allocates memory from the stack, but that memory is only freed when the calling function exits. Stack, even in user-mode, is limited, and failure to commit a page of stack causes a stack overflow exception. The <code>_resetstkoflw</code> function recovers from a stack overflow condition, allowing a program to continue instead of failing with a fatal exception error. If the <code>_resetstkoflw</code> function isn't called, there's no guard page after the previous exception. The next time that there's a stack overflow, there are no exceptions at all and the process terminates without warning.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6263?view=msvc-160" target="_blank">C6263</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6263?view=msvc-170" target="_blank">C6263</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7093,12 +7208,13 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6268</key>
-    <name>C6268: Incorrect order of operations: (&lt;TYPE1&gt;)(&lt;TYPE2&gt;)x + y</name>
+    <name>C6268: Incorrect order of operations: ('TYPE1')('TYPE2')x + y</name>
     <description>
       <![CDATA[
+<p>Incorrect order of operations: ('TYPE1')('TYPE2')x + y. Possible missing parentheses in ('TYPE1')(('TYPE2')x + y).</p>
 <p>This warning indicates that a complex cast expression might involve a precedence problem when performing pointer arithmetic. Because casts group more closely than binary operators, the result might not be what the programmer intended. In some cases, this defect causes incorrect behavior or a program crash.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6268?view=msvc-160" target="_blank">C6268</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6268?view=msvc-170" target="_blank">C6268</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7111,7 +7227,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that the result of a pointer dereference is being ignored, which raises the question of why the pointer is being dereferenced in the first place.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6269?view=msvc-160" target="_blank">C6269</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6269?view=msvc-170" target="_blank">C6269</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7119,12 +7235,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6270</key>
-    <name>C6270: missing float argument to &lt;function&gt;: add a float argument corresponding to conversion specifier &lt;number&gt;</name>
+    <name>C6270: Missing float argument to 'function-name': add a float argument corresponding to conversion specifier 'number'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that not enough arguments are being provided to match a format string; at least one of the missing arguments is a floating-point number. This defect can lead to crashes, in addition to potentially incorrect output.</p>
+<p>This warning indicates that not enough arguments are provided to match a format string; at least one of the missing arguments is a floating-point number.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6270?view=msvc-160" target="_blank">C6270</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6270?view=msvc-170" target="_blank">C6270</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7132,12 +7248,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6271</key>
-    <name>C6271: extra argument passed to &lt;function&gt;: parameter &lt;number&gt; is not used by the format string</name>
+    <name>C6271: Extra argument passed to 'function': parameter 'number' is not used by the format string</name>
     <description>
       <![CDATA[
-<p>This warning indicates that additional arguments are being provided beyond those specified by the format string. By itself, this defect will not have any visible effect although it indicates that the programmer's intent is not reflected in the code.</p>
+<p>This warning indicates that additional arguments are being provided beyond the ones specified by the format string. By itself, this defect won't have any visible effect although it indicates that the programmer's intent isn't reflected in the code.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6271?view=msvc-160" target="_blank">C6271</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6271?view=msvc-170" target="_blank">C6271</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7145,12 +7261,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6272</key>
-    <name>C6272: non-float passed as argument &lt;number&gt; when float is required in call to &lt;function&gt;</name>
+    <name>C6272: Non-float passed as argument 'number' when float is required in call to 'function-name'</name>
     <description>
       <![CDATA[
 <p>This warning indicates that the format string specifies that a float is required, for example, a <code>%f</code> or <code>%g</code> specification for <code>printf,</code> but a non-float such as an integer or string is being passed. This defect is likely to result in incorrect output; however, in certain circumstances it could result in a crash.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6272?view=msvc-160" target="_blank">C6272</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6272?view=msvc-170" target="_blank">C6272</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7159,12 +7275,13 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6273</key>
-    <name>C6273: non-integer passed as parameter &lt;number&gt; when integer is required in call to &lt;function&gt;: if a pointer value is being passed, %p should be used</name>
+    <name>C6273: Non-integer passed as parameter 'number' when integer is required in call to 'function'</name>
     <description>
       <![CDATA[
+<p>Non-integer passed as parameter 'number' when integer is required in call to 'function': if a pointer value is being passed, %p should be used.</p>
 <p>This warning indicates that the format string specifies an integer, for example, a <code>%d</code>, length or precedence specification for <code>printf</code> but a non-integer such as a <strong><code>float</code></strong>, string, or <strong><code>struct</code></strong> is being passed as a parameter. This defect is likely to result in incorrect output.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6273?view=msvc-160" target="_blank">C6273</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6273?view=msvc-170" target="_blank">C6273</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7172,12 +7289,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6274</key>
-    <name>C6274: non-character passed as parameter &lt;number&gt; when character is required in call to &lt;function&gt;</name>
+    <name>C6274: Non-character passed as parameter 'number' when character is required in call to 'function'</name>
     <description>
       <![CDATA[
 <p>This warning indicates that the format string specifies that a character is required (for example, a <code>%c</code> or <code>%C</code> specification) but a non-integer such as a float, string, or struct is being passed. This defect is likely to cause incorrect output.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6274?view=msvc-160" target="_blank">C6274</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6274?view=msvc-170" target="_blank">C6274</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7185,12 +7302,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6276</key>
-    <name>C6276: Cast between semantically different string types: char* to wchar_t*</name>
+    <name>C6276: Cast between semantically different string types</name>
     <description>
       <![CDATA[
-<p>This warning indicates a potentially incorrect cast from an ANSI string (<code>char_t*</code>) to a UNICODE string (<code>wchar_t *</code>). Because UNICODE strings have a character size of 2 bytes, this cast might yield strings that are not correctly terminated. Using such strings with the wcs* library of functions could cause buffer overruns and access violations.</p>
+<p>This warning indicates a potentially incorrect cast from a narrow character string (<code>char*</code>) to a wide character string (<code>wchar_t*</code>).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6276?view=msvc-160" target="_blank">C6276</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6276?view=msvc-170" target="_blank">C6276</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7198,12 +7315,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6277</key>
-    <name>C6277: NULL application name with an unquoted path in call to &lt;function&gt;: results in a security vulnerability if the path contains spaces</name>
+    <name>C6277: NULL application name with an unquoted path in call to 'function-name': results in a security vulnerability if the path contains spaces</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the application name parameter is null and there might be spaces in the executable path name. In this case, unless the executable name is "fully qualified," there is likely to be a security problem. A malicious user might insert a rogue executable with the same name earlier in the path. To correct this warning, you can specify the application name instead of passing null or if you do pass null for the application name, use quotation marks around the executable path.</p>
+<p>This warning indicates that the application name parameter is null and that there might be spaces in the executable path name.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6277?view=msvc-160" target="_blank">C6277</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6277?view=msvc-170" target="_blank">C6277</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>VULNERABILITY</type>
@@ -7212,12 +7329,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6278</key>
-    <name>C6278: &lt;variable&gt; is allocated with array new [], but deleted with scalar delete</name>
+    <name>C6278: 'variable' is allocated with array new [], but deleted with scalar delete</name>
     <description>
       <![CDATA[
-<p>This warning appears only in C++ code and indicates that the calling function has inconsistently allocated memory with the array <strong>new []</strong> operator, but freed it with the scalar <strong><code>delete</code></strong> operator. This is undefined behavior according to the C++ standard and the Microsoft C++ implementation. There are at least three reasons that this is likely to cause problems:</p>
+<p>This warning appears only in C++ code and indicates that the calling function has inconsistently allocated memory with the array <strong><code>new []</code></strong> operator, but freed it with the scalar <strong><code>delete</code></strong> operator. This usage is undefined behavior according to the C++ standard and the Microsoft C++ implementation.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6278?view=msvc-160" target="_blank">C6278</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6278?view=msvc-170" target="_blank">C6278</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7226,12 +7343,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6279</key>
-    <name>C6279: &lt;variable&gt; is allocated with scalar new, deleted with array delete []</name>
+    <name>C6279: 'variable-name' is allocated with scalar new, deleted with array delete []</name>
     <description>
       <![CDATA[
-<p>This warning appears only in C++ code and indicates that the calling function has inconsistently allocated memory with the scalar <strong><code>new</code></strong> operator, but freed it with the array <strong>delete []</strong> operator. If memory is allocated with scalar <strong><code>new</code></strong>, it should typically be freed with scalar <strong><code>delete</code></strong>.</p>
+<p>This warning appears only in C++ code and indicates that the calling function has inconsistently allocated memory with the scalar <code>new</code> operator, but freed it with the array <code>delete[]</code> operator. If memory is allocated with scalar <code>new</code>, it should typically be freed with scalar <code>delete</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6279?view=msvc-160" target="_blank">C6279</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6279?view=msvc-170" target="_blank">C6279</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7240,12 +7357,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6280</key>
-    <name>C6280: &lt;variable&gt; is allocated with &lt;function&gt;, but deleted with &lt;function&gt;</name>
+    <name>C6280: 'variable-name' is allocated with 'function-name-1', but deleted with 'function-name-2'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the calling function has inconsistently allocated memory by using a function from one memory allocation family and freed it by using a function from another memory allocation family. The analyzer checks for this condition only when the <code>_Analysis_mode_(_Analysis_local_leak_checks_)</code> SAL annotation is specified. By default, this annotation is specified for Windows kernel mode (driver) code. For more information about SAL annotations, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-160">Using SAL Annotations to Reduce C/C++ Code Defects</a>.</p>
+<p>This warning indicates that the calling function has inconsistently allocated memory by using a function from one memory allocation family and freed it by using a function from another memory allocation family. The analyzer checks for this condition only when the <code>_Analysis_mode_(_Analysis_local_leak_checks_)</code> SAL annotation is specified. By default, this annotation is specified for Windows kernel mode (driver) code. For more information about SAL annotations, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">Using SAL Annotations to Reduce C/C++ Code Defects</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6280?view=msvc-160" target="_blank">C6280</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6280?view=msvc-170" target="_blank">C6280</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7256,9 +7373,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6281: incorrect order of operations: relational operators have higher precedence than bitwise operators</name>
     <description>
       <![CDATA[
-<p>This warning indicates a possible error in the operator precedence. This might produce incorrect results. You should check the precedence and use parentheses to clarify the intent. Relational operators (&lt;, &gt;, &lt;=, &gt;=, ==, != ) have higher precedence than bitwise operators (&amp; | ^).</p>
+<p>This warning indicates a possible error in the operator precedence, which might produce incorrect results. You should check the precedence and use parentheses to clarify the intent. Relational operators (<code>&lt;</code>, <code>&gt;</code>, <code>&lt;=</code>, <code>&gt;=</code>, <code>==</code>, <code>!=</code>) have higher precedence than bitwise operators (<code>&amp;</code>, <code>|</code>, <code>^</code>).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6281?view=msvc-160" target="_blank">C6281</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6281?view=msvc-170" target="_blank">C6281</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7271,7 +7388,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that an assignment of a constant to a variable was detected in a test context. Assignment of a constant to a variable in a test context is almost always incorrect. Replace the <code>=</code> with <code>==</code>, or remove the assignment from the test context to resolve this warning.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6282?view=msvc-160" target="_blank">C6282</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6282?view=msvc-170" target="_blank">C6282</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7279,12 +7396,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6283</key>
-    <name>C6283: &lt;variable&gt; is allocated with array new [], but deleted with scalar delete</name>
+    <name>C6283: 'variable-name' is allocated with array new [], but deleted with scalar delete</name>
     <description>
       <![CDATA[
 <p>This warning appears only in C++ code and indicates that the calling function has inconsistently allocated memory with the array <code>new []</code> operator, but freed it with the scalar <strong><code>delete</code></strong> operator. This defect might cause leaks, memory corruptions, and, in situations where operators have been overridden, crashes. If memory is allocated with array <code>new []</code>, it should typically be freed with array <code>delete[]</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6283?view=msvc-160" target="_blank">C6283</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6283?view=msvc-170" target="_blank">C6283</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7293,12 +7410,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6284</key>
-    <name>C6284: object passed as parameter when string is required in call to &lt;function&gt;</name>
+    <name>C6284: Object passed as parameter when string is required in call to '*function*'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that there is a mismatch between the format specifier and the type being used in a <code>printf</code>-style function.  The format specifier is a C style String type such as <code>%s</code> or <code>%ws</code>, and the argument matched with it is an object type.</p>
+<p>This warning indicates that there's a mismatch between the format specifier and the type being used in a <code>printf</code>-style function.  The format specifier is a C style String type such as <code>%s</code> or <code>%ws</code>, and the argument matched with it's an object type.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6284?view=msvc-160" target="_blank">C6284</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6284?view=msvc-170" target="_blank">C6284</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7306,12 +7423,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6285</key>
-    <name>C6285: (&lt;non-zero constant&gt; || &lt;non-zero constant&gt;) is always a non-zero constant</name>
+    <name>C6285: ('non-zero constant' || 'non-zero constant') is always a non-zero constant</name>
     <description>
       <![CDATA[
 <p>This warning indicates that two constant values, both greater than one, were detected as arguments to a logical-or operation that occurs in a test context. This expression is always TRUE.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6285?view=msvc-160" target="_blank">C6285</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6285?view=msvc-170" target="_blank">C6285</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7319,12 +7436,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6286</key>
-    <name>C6286: (&lt;non-zero constant&gt; || &lt;expression&gt;) is always a non-zero constant</name>
+    <name>C6286: ('non-zero constant' || 'expression') is always a non-zero constant</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a non-zero constant was detected on the left side of a logical-or operation that occurs in a test context. The resulting expression always evaluates to TRUE. In addition, the right side of the expression appears to have side effects, and they will be lost.</p>
+<p>This warning indicates that a non-zero constant was detected on the left side of a logical-or operation that occurs in a test context. The resulting expression always evaluates to TRUE. In addition, the right side of the expression appears to have side effects, and they'll be lost.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6286?view=msvc-160" target="_blank">C6286</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6286?view=msvc-170" target="_blank">C6286</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7335,9 +7452,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6287: redundant code: the left and right subexpressions are identical</name>
     <description>
       <![CDATA[
-<p>This warning is emitted when an expression contains redundant logic. The warning can indicate a logic error. For example, accidentally using the wrong variable. It might also be a redundant test that can be removed. Inspect the code to verify that there is no logic error.</p>
+<p>This warning is emitted when an expression contains redundant logic. The warning can indicate a logic error. For example, accidentally using the wrong variable. It might also be a redundant test that can be removed. Inspect the code to verify that there's no logic error.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6287?view=msvc-160" target="_blank">C6287</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6287?view=msvc-170" target="_blank">C6287</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7349,9 +7466,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6288: Incorrect operator: mutual inclusion over &amp;&amp; is always zero</name>
     <description>
       <![CDATA[
-<p>This warning indicates that in a test expression, a variable is being tested against two different constants and the result depends on both conditions being true. The code in these cases indicates that the programmer's intent is not captured correctly. It is important to examine the code and correct the problem; otherwise your code will not behave the way you expected it to.</p>
+<p>This warning indicates that in a test expression, a variable is being tested against two different constants. The result depends on both conditions being true, which is impossible. The code in these cases indicates that the programmer's intent isn't captured correctly. It's important to examine the code and correct the problem. Otherwise, your code won't behave the way you expected it to.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6288?view=msvc-160" target="_blank">C6288</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6288?view=msvc-170" target="_blank">C6288</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7362,9 +7479,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6289: Incorrect operator: mutual exclusion over || is always a non-zero constant</name>
     <description>
       <![CDATA[
-<p>This warning indicates that in a test expression a variable is being tested against two different constants and the result depends on either condition being true. This always evaluates to true.</p>
+<p>This warning indicates that in a test expression a variable is being tested as unequal to two different constants. The result depends on either condition being true, but it always evaluates to true.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6289?view=msvc-160" target="_blank">C6289</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6289?view=msvc-170" target="_blank">C6289</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7377,7 +7494,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates possible confusion in the use of an operator or an operator precedence.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6290?view=msvc-160" target="_blank">C6290</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6290?view=msvc-170" target="_blank">C6290</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7390,7 +7507,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <code>!</code> operator yields a Boolean result, and the <code>|</code> (bitwise-or) operator takes two arithmetic arguments. The <code>!</code> operator also has higher precedence than <code>|</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6291?view=msvc-160" target="_blank">C6291</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6291?view=msvc-170" target="_blank">C6291</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7403,7 +7520,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that a for-loop might not function as intended.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6292?view=msvc-160" target="_blank">C6292</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6292?view=msvc-170" target="_blank">C6292</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7416,7 +7533,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that a for-loop might not function as intended. It occurs when a loop counts down from a minimum, but has a higher termination condition.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6293?view=msvc-160" target="_blank">C6293</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6293?view=msvc-170" target="_blank">C6293</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7427,9 +7544,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6294: Ill-defined for-loop: initial condition does not satisfy test</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a for-loop cannot be executed  because the terminating condition is true. This warning suggests that the programmer's intent is not correctly captured.</p>
+<p>This warning indicates that a for-loop can't be executed because the terminating condition is true. This warning suggests that the programmer's intent isn't correctly captured.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6294?view=msvc-160" target="_blank">C6294</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6294?view=msvc-170" target="_blank">C6294</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7438,12 +7555,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6295</key>
-    <name>C6295: Ill-defined for-loop: &lt;variable&gt; values are of the range "min" to "max"</name>
+    <name>C6295: Ill-defined for-loop: 'variable' values are of the range "min" to "max"</name>
     <description>
       <![CDATA[
 <p>This warning indicates that a for-loop might not function as intended. The for-loop tests an unsigned value against zero (0) with &gt;=. The result is always true, therefore the loop is infinite.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6295?view=msvc-160" target="_blank">C6295</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6295?view=msvc-170" target="_blank">C6295</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7457,7 +7574,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that a for-loop might not function as intended. When the index is unsigned and a loop counts down from zero, its body is run only once.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6296?view=msvc-160" target="_blank">C6296</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6296?view=msvc-170" target="_blank">C6296</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7471,7 +7588,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates incorrect behavior that results from integral promotion rules and types larger than the ones in which arithmetic is typically performed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6297?view=msvc-160" target="_blank">C6297</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6297?view=msvc-170" target="_blank">C6297</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7479,12 +7596,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6298</key>
-    <name>C6298: using a read-only string &lt;pointer&gt; as a writable string argument: this will attempt to write into static read-only memory and cause random crashes</name>
+    <name>C6298: Using a read-only string 'pointer' as a writable string argument</name>
     <description>
       <![CDATA[
 <p>This warning indicates the use of a constant string as an argument to a function that might modify the contents of that string. Because the compiler allocates constant strings in a static read-only memory, any attempts to modify it cause access violations and random crashes.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6298?view=msvc-160" target="_blank">C6298</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6298?view=msvc-170" target="_blank">C6298</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7497,7 +7614,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates an incorrect assumption that Booleans and bit fields are equivalent. Assigning 1 to bit fields will place 1 in its single bit; however, any comparison of this bit field to 1 includes an implicit cast of the bit field to a signed int. This cast will convert the stored 1 to a -1 and the comparison can yield unexpected results.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6299?view=msvc-160" target="_blank">C6299</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6299?view=msvc-170" target="_blank">C6299</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7506,12 +7623,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6302</key>
-    <name>C6302: format string mismatch: character string passed as parameter &lt;number&gt; when wide character string is required in call to &lt;function&gt;</name>
+    <name>C6302: Format string mismatch: character string passed as parameter 'number' when wide character string is required in call to 'function'</name>
     <description>
       <![CDATA[
 <p>This warning indicates that the format string specifies a wide character string is expected. However, a character string is being passed. This will likely cause the output to be malformed or for the program to crash at runtime.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6302?view=msvc-160" target="_blank">C6302</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6302?view=msvc-170" target="_blank">C6302</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7519,12 +7636,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6303</key>
-    <name>C6303: format string mismatch: wide character string passed as parameter &lt;number&gt; when character string is required in call to &lt;function&gt;</name>
+    <name>C6303: Format string mismatch: wide character string passed as parameter 'number' when character string is required in call to 'function-name'</name>
     <description>
       <![CDATA[
 <p>This warning indicates that the format string specifies that a character string is required. However, a wide character string is being passed. This defect is likely to cause a crash or corruption of some form.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6303?view=msvc-160" target="_blank">C6303</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6303?view=msvc-170" target="_blank">C6303</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7535,9 +7652,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6305: potential mismatch between sizeof and countof quantities</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a variable holding a <strong><code>sizeof</code></strong> result is being added to or subtracted from a pointer or <code>countof</code> expression. This will cause unexpected scaling in pointer arithmetic.</p>
+<p>This warning indicates that a variable holding a <strong><code>sizeof</code></strong> result is being added to or subtracted from a pointer or <code>countof</code> expression. This operation will cause unexpected scaling in pointer arithmetic.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6305?view=msvc-160" target="_blank">C6305</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6305?view=msvc-170" target="_blank">C6305</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7545,12 +7662,13 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6306</key>
-    <name>C6306: incorrect call to &lt;function&gt;: consider using &lt;function&gt; which accepts a va_list as an argument</name>
+    <name>C6306: Incorrect call to 'function'</name>
     <description>
       <![CDATA[
-<p>This warning indicates an incorrect function call. The <code>printf</code> family includes several functions that take a variable list of arguments; however, these functions cannot be called with a <code>va_list</code> argument. There is a corresponding <code>vprintf</code> family of functions that can be used for such calls. Calling the wrong print function will cause incorrect output.</p>
+<p>Incorrect call to 'function': consider using 'function' which accepts a va_list as an argument.</p>
+<p>This warning indicates an incorrect function call. The <code>printf</code> family includes several functions that take a variable list of arguments; however, these functions can't be called with a <code>va_list</code> argument. There's a corresponding <code>vprintf</code> family of functions that can be used for such calls. Calling the wrong print function will cause incorrect output.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6306?view=msvc-160" target="_blank">C6306</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6306?view=msvc-170" target="_blank">C6306</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7558,12 +7676,13 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6308</key>
-    <name>C6308: 'realloc' may return null pointer: assigning a null pointer to &lt;variable&gt;, which is passed as an argument to 'realloc', will cause the original memory block to be leaked</name>
+    <name>C6308: 'realloc' may return null pointer</name>
     <description>
       <![CDATA[
-<p>This warning indicates a memory leak that is the result of the incorrect use of a reallocation function. Heap reallocation functions do not free the passed buffer if reallocation is unsuccessful. To correct the defect, assign the result of the reallocation function to a temporary, and then replace the original pointer after successful reallocation.</p>
+<p>'realloc' may return null pointer: assigning a null pointer to 'parameter-name', which is passed as an argument to 'realloc', will cause the original memory block to be leaked.</p>
+<p>Heap reallocation functions don't free the passed buffer if reallocation is unsuccessful, potentially resulting in a memory leak if not handled properly. To correct the issue, assign the result of the reallocation function to a temporary variable, and then replace the original pointer after successful reallocation.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6308?view=msvc-160" target="_blank">C6308</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6308?view=msvc-170" target="_blank">C6308</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7575,9 +7694,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6310: illegal constant in exception filter can cause unexpected behavior</name>
     <description>
       <![CDATA[
-<p>This message indicates that an illegal constant was detected in the filter expression of a structured exception handler. The constants defined for use in the filter expression of a structured exception handler are:</p>
+<p>This message indicates that an illegal constant was detected in the filter expression of a structured exception handler.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6310?view=msvc-160" target="_blank">C6310</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6310?view=msvc-170" target="_blank">C6310</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7585,12 +7704,13 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6312</key>
-    <name>C6312: Possible infinite loop: use of the constant EXCEPTION_CONTINUE_EXECUTION in the exception-filter expression of a try-except</name>
+    <name>C6312: Possible infinite loop</name>
     <description>
       <![CDATA[
-<p>This warning indicates the use of the constant <code>EXCEPTION_CONTINUE_EXECUTION</code> (or another constant that evaluates to -1) in the filter expression of a structured exception handler. Use of the constant value <code>EXCEPTION_CONTINUE_EXECUTION</code> could lead to an infinite loop. For example, if an exception was raised by hardware, the instruction that caused the exception will be restarted. If the address that caused the exception is still bad, another exception will occur and be handled in the same way. This causes an infinite loop.</p>
+<p>Possible infinite loop: use of the constant EXCEPTION_CONTINUE_EXECUTION in the exception-filter expression of a try-except.</p>
+<p>This warning indicates the use of the constant <code>EXCEPTION_CONTINUE_EXECUTION</code> (or another constant that evaluates to -1) in the filter expression of a structured exception handler. Use of the constant value <code>EXCEPTION_CONTINUE_EXECUTION</code> could lead to an infinite loop. For example, if an exception was raised by hardware, the instruction that caused the exception will be restarted. If the address that caused the exception is still bad, another exception will occur and be handled in the same way. The result is an infinite loop.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6312?view=msvc-160" target="_blank">C6312</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6312?view=msvc-170" target="_blank">C6312</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7598,12 +7718,13 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6313</key>
-    <name>C6313: Incorrect operator: Zero-valued flag cannot be tested with bitwise-and</name>
+    <name>C6313: Incorrect operator</name>
     <description>
       <![CDATA[
+<p>Incorrect operator: Zero-valued flag cannot be tested with bitwise-and.</p>
 <p>This warning indicates that a constant value of zero was provided as an argument to the bitwise-and (<code>&amp;</code>) operator in a test context. The resulting expression is constant and evaluates to false; the result is different than intended.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6313?view=msvc-160" target="_blank">C6313</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6313?view=msvc-170" target="_blank">C6313</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7616,7 +7737,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This message indicates that an expression that contains a bitwise-or operator (<code>|</code>) was detected in the tested expression of a conditional operation (<code>?:</code>).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6314?view=msvc-160" target="_blank">C6314</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6314?view=msvc-170" target="_blank">C6314</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7629,7 +7750,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that an expression in a test context contains both bitwise-and (<code>&amp;</code>) and bitwise-or (<code>|</code>) operations, but causes a constant because the bitwise-or operation happens last. Parentheses should be added to clarify intent.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6315?view=msvc-160" target="_blank">C6315</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6315?view=msvc-170" target="_blank">C6315</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7642,7 +7763,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates the use of bitwise-or (<code>|</code>) when bitwise-and (<code>&amp;</code>) should have been used. Bitwise-or adds bits to the resulting expression, whereas bitwise-and selects only those bits in common between its two operators. Tests for flags must be performed with bitwise-and or a test of equality.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6316?view=msvc-160" target="_blank">C6316</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6316?view=msvc-170" target="_blank">C6316</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7653,9 +7774,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6317: incorrect operator: logical-not (!) is not interchangeable with ones-complement (~)</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a logical-not (<code>!</code>) is being applied to a constant that is likely to be a bit-flag. The result of logical-not is Boolean; it is incorrect to apply the bitwise-and (<code>&amp;</code>) operator to a Boolean value. Use the ones-complement (<code>~</code>) operator to flip flags.</p>
+<p>This warning indicates that a logical-not (<code>!</code>) is being applied to a constant that is likely to be a bit-flag. The result of logical-not is Boolean; it's incorrect to apply the bitwise-and (<code>&amp;</code>) operator to a Boolean value. Use the ones-complement (<code>~</code>) operator to flip flags.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6317?view=msvc-160" target="_blank">C6317</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6317?view=msvc-170" target="_blank">C6317</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7666,9 +7787,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6318: Ill-defined __try/__except: use of the constant EXCEPTION_CONTINUE_SEARCH or another constant that evaluates to zero in the exception-filter expression</name>
     <description>
       <![CDATA[
-<p>This warning indicates that if an exception occurs in the protected block of this structured exception handler, the exception will not be handled because the constant <code>EXCECPTION_CONTINUE_SEARCH</code> is used in the exception filter expression.</p>
+<p>This warning indicates that if an exception occurs in the protected block of this structured exception handler, the exception won't be handled because the constant <code>EXCECPTION_CONTINUE_SEARCH</code> is used in the exception filter expression.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6318?view=msvc-160" target="_blank">C6318</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6318?view=msvc-170" target="_blank">C6318</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7680,9 +7801,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6319: use of the comma-operator in a tested expression causes the left argument to be ignored when it has no side-effects</name>
     <description>
       <![CDATA[
-<p>This warning indicates an ignored sub-expression in test context because of the comma-operator (,). The comma operator has left-to-right associativity. The result of the comma-operator is the last expression evaluated. If the left expression to comma-operator has no side effects, the compiler might omit code generation for the expression.</p>
+<p>This warning indicates an ignored sub-expression in test context because of the comma-operator (<strong><code>,</code></strong>). The comma operator has left-to-right associativity. The result of the comma-operator is the last expression evaluated. If the left expression to comma-operator has no side effects, the compiler might omit code generation for the expression.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6319?view=msvc-160" target="_blank">C6319</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6319?view=msvc-170" target="_blank">C6319</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7693,9 +7814,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6320: exception-filter expression is the constant EXCEPTION_EXECUTE_HANDLER</name>
     <description>
       <![CDATA[
-<p>This warning indicates the side effect of using EXCEPTION_EXECUTE_HANDLER constant in __except block. In this case, the statement in the __except block will always execute to handle the exception, including exceptions you did not want to handle in a particular function. It is recommended that you check the exception before handling it.</p>
+<p>This warning indicates the side effect of using <code>EXCEPTION_EXECUTE_HANDLER</code> constant in an <code>__except</code> block. In this case, the statement in the <code>__except</code> block will always execute to handle the exception, including exceptions you didn't want to handle in a particular function. It's recommended that you check the exception before handling it.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6320?view=msvc-160" target="_blank">C6320</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6320?view=msvc-170" target="_blank">C6320</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7703,12 +7824,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6322</key>
-    <name>C6322: empty _except block</name>
+    <name>C6322: Empty __except block</name>
     <description>
       <![CDATA[
-<p>This message indicates that there is no code in the _except block. As a result, exceptions might go unhandled.</p>
+<p>This message indicates that there's no code in the <code>__except</code> block. As a result, exceptions might go unhandled.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6322?view=msvc-160" target="_blank">C6322</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6322?view=msvc-170" target="_blank">C6322</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7717,12 +7838,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6323</key>
-    <name>C6323: - use of arithmetic operator on Boolean type(s)</name>
+    <name>C6323: Use of arithmetic operator on Boolean type(s)</name>
     <description>
       <![CDATA[
-<p>This warning occurs if arithmetic operators are used on Boolean data types. Use of incorrect operator might yield incorrect results. It also indicates that the programmer's intent is not reflected in the code.</p>
+<p>This warning occurs if arithmetic operators are used on Boolean data types. Use of incorrect operator might yield incorrect results. It also indicates that the programmer's intent isn't reflected in the code.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6323?view=msvc-160" target="_blank">C6323</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6323?view=msvc-170" target="_blank">C6323</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7730,12 +7851,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6324</key>
-    <name>C6324: potential incorrect use of &lt;function1&gt;</name>
+    <name>C6324: Potential incorrect use of 'function1'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a string copy function was used where a string comparison function should have been used. Incorrect use of function can cause an unexpected logic error.</p>
+<p>This warning indicates that a string copy function was used where a string comparison function should have been used. Incorrect use of the function can cause an unexpected logic error.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6324?view=msvc-160" target="_blank">C6324</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6324?view=msvc-170" target="_blank">C6324</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7748,7 +7869,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates a potential comparison of a constant with another constant, which is redundant code. You must check to make sure that your intent is properly captured in the code. In some cases, you can simplify the test condition to achieve the same result.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6326?view=msvc-160" target="_blank">C6326</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6326?view=msvc-170" target="_blank">C6326</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7756,12 +7877,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6328</key>
-    <name>C6328: Size mismatch: &lt;type&gt; passed as parameter &lt;number&gt; when &lt;type&gt; is required in call to &lt;function&gt;</name>
+    <name>C6328: Size mismatch: 'type' passed as parameter 'number' when 'type' is required in call to 'function-name'</name>
     <description>
       <![CDATA[
-<p>Passing an argument of type <strong><code>char</code></strong> to C runtime, character-based routines named <code>is&lt;xxx&gt;()</code>, for example, <code>isspace()</code>, can have unpredictable results. For example, an SBCS or MBCS single-byte character of type <strong><code>char</code></strong> with a value greater than <code>0x7F</code> is a negative value. If a <strong><code>char</code></strong> is passed, the compiler might convert the value to a signed <strong><code>int</code></strong> or a signed <strong><code>long</code></strong>. This value could be sign-extended by the compiler, with unexpected results. For example, <code>isspace</code> accepts an argument of type <strong><code>int</code></strong>; however, the valid range of values for its input argument is:</p>
+<p>An argument of type <code>char</code> passed to C runtime, character-based routines named <code>is&lt;xxx&gt;</code> (for example, <code>isspace</code>) can have unpredictable results. For example, an SBCS or MBCS single-byte character of type <code>char</code> with a value greater than <code>0x7F</code> is a negative value. If a <code>char</code> is passed, the compiler might convert the value to a signed <code>int</code> or a signed <code>long</code>. This value could be sign-extended by the compiler, with unexpected results. This issue could result in a function like <code>isspace</code>, which only expects values from 0-255 or <code>EOF</code>, being sent a negative value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6328?view=msvc-160" target="_blank">C6328</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6328?view=msvc-170" target="_blank">C6328</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7769,12 +7890,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6329</key>
-    <name>C6329: Return value for a call to &lt;function&gt; should not be checked against &lt;number&gt;</name>
+    <name>C6329: Return value for a call to 'function' should not be checked against 'number'</name>
     <description>
       <![CDATA[
 <p>The program is comparing a number against the return value from a call to <code>CreateFile</code>. If <code>CreateFile</code> succeeds, it returns an open handle to the object. If it fails, it returns <code>INVALID_HANDLE_VALUE</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6329?view=msvc-160" target="_blank">C6329</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6329?view=msvc-170" target="_blank">C6329</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7782,12 +7903,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6330</key>
-    <name>C6330: Incorrect type passed as parameter in call to function</name>
+    <name>C6330: 'type1' passed as Parameter('number') when 'type2' is required in call to 'function'</name>
     <description>
       <![CDATA[
-<p>C6330: Incorrect type passed as parameter in call to function</p>
+<p>Incorrect type passed as parameter in call to function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6330?view=msvc-160" target="_blank">C6330</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6330?view=msvc-170" target="_blank">C6330</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7795,12 +7916,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6331</key>
-    <name>C6331: Invalid parameter: passing MEM_RELEASE and MEM_DECOMMIT in conjunction to &lt;function&gt; is not allowed</name>
+    <name>C6331: Invalid parameter: passing MEM_RELEASE and MEM_DECOMMIT in conjunction to *function* is not allowedl</name>
     <description>
       <![CDATA[
-<p>This message indicates that an invalid parameter being passed to VirtualFree or VirtualFreeEx. VirtualFree and VirtualFreeEx both reject the flags (MEM_RELEASE | MEM_DECOMMIT) in combination. Therefore, the values MEM_DECOMMIT and MEM_RELEASE may not be used together in the same call.</p>
+<p>This message indicates that an invalid parameter is passed to <code>VirtualFree</code> or <code>VirtualFreeEx</code>. <code>VirtualFree</code> and <code>VirtualFreeEx</code> both reject the flags (<code>MEM_RELEASE | MEM_DECOMMIT</code>) in combination. Therefore, the values <code>MEM_DECOMMIT</code> and <code>MEM_RELEASE</code> may not be used together in the same call.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6331?view=msvc-160" target="_blank">C6331</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6331?view=msvc-170" target="_blank">C6331</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7808,12 +7929,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6332</key>
-    <name>C6332: Invalid parameter: passing zero as the dwFreeType parameter to &lt;function&gt; is not allowed</name>
+    <name>C6332: Invalid parameter: passing zero as the dwFreeType parameter to 'function' is not allowed</name>
     <description>
       <![CDATA[
 <p>This warning indicates that an invalid parameter is being passed to VirtualFree or VirtualFreeEx. VirtualFree and VirtualFreeEx both reject a dwFreeType parameter of zero. The dwFreeType parameter can be either MEM_DECOMMIT or MEM_RELEASE. However, the values MEM_DECOMMIT and MEM_RELEASE may not be used together in the same call. Also, make sure that the return value of the VirtualFree function is not ignored.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6332?view=msvc-160" target="_blank">C6332</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6332?view=msvc-170" target="_blank">C6332</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7821,12 +7942,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6333</key>
-    <name>C6333: Invalid parameter: passing MEM_RELEASE and a non-zero dwSize parameter to &lt;function&gt; is not allowed</name>
+    <name>C6333: Invalid parameter: passing MEM_RELEASE and a non-zero dwSize parameter to 'function_name' is not allowedl</name>
     <description>
       <![CDATA[
-<p>This warning indicates an invalid parameter is being passed to VirtualFree or VirtualFreeEx. Both of these functions reject a dwFreeType of MEM_RELEASE with a non-zero value of dwSize. When passing MEM_RELEASE, the dwSize parameter must be zero. Also, make sure that the return value of this function is not ignored.</p>
+<p>Both <code>VirtualFree</code> and <code>VirtualFreeEx</code> reject a <code>dwFreeType</code> of <code>MEM_RELEASE</code> with a non-zero value of <code>dwSize</code>. When <code>MEM_RELEASE</code> is passed, the <code>dwSize</code> parameter must be zero.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6333?view=msvc-160" target="_blank">C6333</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6333?view=msvc-170" target="_blank">C6333</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7837,9 +7958,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6334: sizeof operator applied to an expression with an operator may yield unexpected results</name>
     <description>
       <![CDATA[
-<p>This warning indicates a misuse of the <strong><code>sizeof</code></strong> operator. The <strong><code>sizeof</code></strong> operator, when applied to an expression, yields the size of the type of the resulting expression.</p>
+<p>The <code>sizeof</code> operator, when applied to an expression, yields the size of the type of the resulting expression.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6334?view=msvc-160" target="_blank">C6334</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6334?view=msvc-170" target="_blank">C6334</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7848,12 +7969,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6335</key>
-    <name>C6335: leaking process information handle &lt;handlename&gt;</name>
+    <name>C6335: Leaking process information handle 'handlename'</name>
     <description>
       <![CDATA[
 <p>This warning indicates that the process information handles returned by the CreateProcess family of functions need to be closed using CloseHandle. Failure to do so will cause handle leaks.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6335?view=msvc-160" target="_blank">C6335</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6335?view=msvc-170" target="_blank">C6335</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7862,12 +7983,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6336</key>
-    <name>C6336: arithmetic operator has precedence over question operator, use parentheses to clarify intent</name>
+    <name>C6336: arithmetic operator has precedence over question operator</name>
     <description>
       <![CDATA[
-<p>This warning indicates a possible operator precedence problem. The '+','-','*' and '/' operators have precedence over the '?' operator. If the precedence in the expression is not correct, use parentheses to change the operator precedence.</p>
+<p>This warning indicates a possible operator precedence problem. The '<code>+</code>','<code>-</code>','<code>*</code>' and '<code>/</code>' operators have precedence over the '<code>?</code>' operator. If the precedence in the expression isn't correct, use parentheses to change the operator precedence.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6336?view=msvc-160" target="_blank">C6336</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6336?view=msvc-170" target="_blank">C6336</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7878,9 +7999,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6340: Mismatch on sign: Incorrect type passed as parameter in call to function</name>
     <description>
       <![CDATA[
-<p>C6340: Mismatch on sign: Incorrect type passed as parameter in call to function</p>
+<p>Mismatch on sign: Incorrect type passed as parameter in call to function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6340?view=msvc-160" target="_blank">C6340</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6340?view=msvc-170" target="_blank">C6340</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7888,12 +8009,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6381</key>
-    <name>C6381: Shutdown API &lt;function&gt; requires a valid dwReason or lpMessage</name>
+    <name>C6381: Shutdown API 'function' requires a valid dwReason or lpMessage</name>
     <description>
       <![CDATA[
-<p>This warning is issued if InitiateSystemShutdownEx is called:</p>
+<p>This warning is issued if <code>InitiateSystemShutdownEx</code> is called.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6381?view=msvc-160" target="_blank">C6381</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6381?view=msvc-170" target="_blank">C6381</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7901,12 +8022,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6383</key>
-    <name>C6383: buffer overrun due to conversion of an element count into a byte count: an element count is expected for parameter &lt;number&gt; in call to &lt;function&gt;</name>
+    <name>C6383: Buffer overrun due to conversion of an element count into a byte count: an element count is expected for parameter *parameter_name* in call to *function_name*</name>
     <description>
       <![CDATA[
 <p>This warning indicates that a non-constant byte count is being passed when an element count is required. Typically, this occurs when a variable is multiplied by the <strong><code>sizeof</code></strong> a type, but code analysis suggests that an element count is required.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6383?view=msvc-160" target="_blank">C6383</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6383?view=msvc-170" target="_blank">C6383</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
@@ -7918,9 +8039,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6384: dividing sizeof a pointer by another value</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a size calculation might be incorrect. To calculate the number of elements in an array, one sometimes divides the size of the array by the size of the first element; however, when the array is actually a pointer, the result is typically different than intended.</p>
+<p>This warning indicates that a size calculation might be incorrect. To calculate the number of elements in an array, you sometimes divide the size of the array by the size of the first element. However, when the array is actually a pointer, the result is typically different than intended.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6384?view=msvc-160" target="_blank">C6384</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6384?view=msvc-170" target="_blank">C6384</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7933,7 +8054,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The readable extent of the buffer might be smaller than the index used to read from it. Attempts to read data outside the valid range leads to buffer overrun.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6385?view=msvc-160" target="_blank">C6385</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6385?view=msvc-170" target="_blank">C6385</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7941,12 +8062,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6386</key>
-    <name>C6386: buffer overrun: accessing &lt;buffer name&gt;, the writable size is &lt;size1&gt; bytes, but &lt;size2&gt; bytes may be written: Lines: x, y</name>
+    <name>C6386: Buffer overrun: accessing 'buffer name', the writable size is 'size1' bytes, but 'size2' bytes may be written: Lines: x, y</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the writable extent of the specified buffer might be smaller than the index used to write to it. This can cause buffer overrun.</p>
+<p>This warning indicates that the writable extent of the specified buffer might be smaller than the index used to write to it. This defect can cause buffer overrun.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6386?view=msvc-160" target="_blank">C6386</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6386?view=msvc-170" target="_blank">C6386</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7954,12 +8075,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6387</key>
-    <name>C6387: &lt;argument&gt; may be &lt;value&gt;: this does not adhere to the specification for the function &lt;function name&gt;: Lines: x, y</name>
+    <name>C6387: 'argument' may be 'value': this does not adhere to the specification for the function 'function name': Lines: x, y</name>
     <description>
       <![CDATA[
 <p>This warning is raised if an annotated function parameter is being passed an unexpected value. For example, passing a potentially null value to a parameter that is marked with <code>_In_</code> annotation generates this warning.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6387?view=msvc-160" target="_blank">C6387</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6387?view=msvc-170" target="_blank">C6387</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7967,12 +8088,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6388</key>
-    <name>C6388: &lt;argument&gt; may not be &lt;value&gt;: this does not adhere to the specification for the function &lt;function name&gt;: Lines: x, y</name>
+    <name>C6388: 'argument' may not be 'value': this does not adhere to the specification for the function 'function-name': Lines: x, y</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an unexpected value is being used in the specified context. This is typically reported for values passed as arguments to a function that does not expect it.</p>
+<p>This warning indicates that an unexpected value is being used in the specified context. This warning is typically reported for values passed as arguments to a function that doesn't expect it.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6388?view=msvc-160" target="_blank">C6388</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6388?view=msvc-170" target="_blank">C6388</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7980,12 +8101,25 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6389</key>
-    <name>C6389: MARK_INTERNAL_OR_MISSING_COMMON_DECL</name>
+    <name>C6389: Move 'declaration' to anonymous namespace or put a forward declaration in a common header included in this file</name>
     <description>
       <![CDATA[
 <p>This check is intended to help reduce the visibility of certain symbols and to modularize the code. In multi-file C++ projects, each declaration should be either local to a C++ file (part of the anonymous namespace) or declared in a common header file that's included by multiple C++ files.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6389?view=msvc-160" target="_blank">C6389</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6389?view=msvc-170" target="_blank">C6389</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C6390</key>
+    <name>C6390: According to the C++ standard, the value of 'this' is never null</name>
+    <description>
+      <![CDATA[
+<p>While MSVC doesn't do such optimizations, some compilers optimize null checks for <code>this</code> out. Code that relies on null-valued <code>this</code> can trigger unexpected behavior when compiled with other compilers. This warning helps detect these portability problems.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6390?view=msvc-170" target="_blank">C6390</a></p>]]>
       </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -7993,12 +8127,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     </rule>
   <rule>
     <key>C6400</key>
-    <name>C6400: Using &lt;function name&gt; to perform a case-insensitive compare to constant string &lt;string name&gt;</name>
+    <name>C6400: Using 'function name' to perform a case-insensitive compare to constant string 'string name'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a case-insensitive comparison to a constant string is being performed in a locale-dependent way, when, apparently, a locale-independent comparison was intended.</p>
+<p>This warning indicates that a case-insensitive comparison to a constant string is being done in a locale-dependent way. It appears that a locale-independent comparison was intended.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6400?view=msvc-160" target="_blank">C6400</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6400?view=msvc-170" target="_blank">C6400</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8006,12 +8140,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6401</key>
-    <name>C6401: Using &lt;function name&gt; in a default locale to perform a case-insensitive compare to constant string &lt; string name&gt;</name>
+    <name>C6401: Using 'function name' in a default locale to perform a case-insensitive compare to constant string 'string name'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a case-insensitive comparison to a constant string is being performed when specifying the default locale; usually, a locale-independent comparison was intended.</p>
+<p>This warning indicates that a case-insensitive comparison to a constant string is being done when specifying the default locale. Usually, a locale-independent comparison was intended.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6401?view=msvc-160" target="_blank">C6401</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6401?view=msvc-170" target="_blank">C6401</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8019,12 +8153,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6411</key>
-    <name>C6411: Potentially reading invalid data from the buffer</name>
+    <name>C6411: Potentially reading invalid data from 'buffer'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the value of the index that is used to read from the buffer can exceed the readable size of the buffer. Because the code analysis tool reports this warning when it cannot reduce a complex expression that represents the buffer size, or the index used to access the buffer, this warning might be reported in error.</p>
+<p>This warning indicates that the value of the index that is used to read from the buffer can exceed the readable size of the buffer. The code analysis tool may report this warning in error. The error may occur when it can't reduce a complex expression that represents the buffer size, or the index used to access the buffer.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6411?view=msvc-160" target="_blank">C6411</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6411?view=msvc-170" target="_blank">C6411</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8035,9 +8169,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6412: Potential buffer overrun while writing to buffer</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the value of the index that is used to write to the buffer can exceed the writeable size of the buffer.</p>
+<p>This warning indicates that the value of the index that's used to write to the buffer can exceed the writeable size of the buffer.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6412?view=msvc-160" target="_blank">C6412</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6412?view=msvc-170" target="_blank">C6412</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8045,12 +8179,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6500</key>
-    <name>C6500: invalid annotation: value for &lt;name&gt; property is invalid</name>
+    <name>C6500: Invalid annotation: value for 'name' property is invalid</name>
     <description>
       <![CDATA[
 <p>This warning indicates that a property value used in the annotation is not valid. For example, it can occur if an incorrect level of dereference is used in the Deref property, or if you use a constant value that is larger than size_t for properties like ElementSize.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6500?view=msvc-160" target="_blank">C6500</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6500?view=msvc-170" target="_blank">C6500</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8058,12 +8192,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6501</key>
-    <name>C6501: annotation conflict: &lt;name&gt; property conflicts with previously specified property</name>
+    <name>C6501: Annotation conflict: 'name' property conflicts with previously specified property</name>
     <description>
       <![CDATA[
 <p>This warning indicates the presence of conflicting properties in the annotation. This typically occurs when multiple properties that serve similar purpose are used to annotate a parameter or return value. To correct the warning, you must choose the property that best addresses your need.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6501?view=msvc-160" target="_blank">C6501</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6501?view=msvc-170" target="_blank">C6501</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8076,7 +8210,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that Null property is incorrectly used on a reference or array type. A reference or array type holds the address of an object and must point to a valid object. Because reference and array types cannot be null, you must correct the error by either removing the Null property or by setting the Null property value to No.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6503?view=msvc-160" target="_blank">C6503</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6503?view=msvc-170" target="_blank">C6503</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8087,9 +8221,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6504: invalid annotation: property may only be used on values of pointer, pointer-to-member, or array type</name>
     <description>
       <![CDATA[
-<p>This warning indicates the use of a pointer-specific SAL annotation on a non-pointer data type. For more information about what data types are supported by properties, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-160">Annotation Properties</a>.</p>
+<p>This warning indicates the use of a pointer-specific SAL annotation on a non-pointer data type. For more information about what data types are supported by properties, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">Annotation Properties</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6504?view=msvc-160" target="_blank">C6504</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6504?view=msvc-170" target="_blank">C6504</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8100,9 +8234,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6505: invalid annotation: MustCheck property may not be used on values of void type</name>
     <description>
       <![CDATA[
-<p>This warning indicated that MustCheck property was used on a void data type. You cannot use MustCheck property on void type. Either remove the MustCheck property or use another data type.</p>
+<p>This warning indicated that MustCheck property was used on a void data type. You can't use <code>MustCheck</code> property on <code>void</code> type. Either remove the <code>MustCheck</code> property or use another data type.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6505?view=msvc-160" target="_blank">C6505</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6505?view=msvc-170" target="_blank">C6505</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8110,12 +8244,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6506</key>
-    <name>C6506: invalid annotation: &lt;name&gt; property may only be used on values of pointer or array types</name>
+    <name>C6506: Invalid annotation: 'name' property may only be used on values of pointer or array types</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a property is used on a type other than pointer or array types. The Access, Tainted, and Valid properties can be used on all data types. Other properties, such as ValidBytesConst, ValidElementsConst, ElementSize, and NullTerminted support pointer, pointer to members, or array types. For a complete list of properties and the supported data types, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-160">Using SAL Annotations to reduce code defects</a>.</p>
+<p>This warning indicates that a property is used on a type other than pointer or array types. The Access, Tainted, and Valid properties can be used on all data types. Other properties, such as ValidBytesConst, ValidElementsConst, ElementSize, and NullTerminted support pointer, pointer to members, or array types. For a complete list of properties and the supported data types, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">Using SAL Annotations to reduce code defects</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6506?view=msvc-160" target="_blank">C6506</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6506?view=msvc-170" target="_blank">C6506</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8128,7 +8262,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that the Access property specified on a const parameter implies that it can be written to. For constant values, Access=Read is the only valid setting.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6508?view=msvc-160" target="_blank">C6508</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6508?view=msvc-170" target="_blank">C6508</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8139,9 +8273,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6509: invalid annotation: 'return' cannot be referenced from a precondition</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the <strong><code>return</code></strong>  keyword cannot be used in a precondition. The <strong><code>return</code></strong> keyword is used to terminate the execution of a function and return control to the calling function.</p>
+<p>This warning indicates that the <strong><code>return</code></strong>  keyword can't be used in a precondition. The <strong><code>return</code></strong> keyword is used to terminate the execution of a function and return control to the calling function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6509?view=msvc-160" target="_blank">C6509</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6509?view=msvc-170" target="_blank">C6509</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8149,12 +8283,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6510</key>
-    <name>C6510: Invalid annotation: 'NullTerminated' property may only be used on buffers whose elements are of integral or pointer type: Function '&lt;function&gt;' &lt;parameter&gt;</name>
+    <name>C6510: Invalid annotation: 'NullTerminated' property may only be used on buffers whose elements are of integral or pointer type: Function ''function'' 'parameter'</name>
     <description>
       <![CDATA[
-<p>This warning indicates an incorrect use of the <strong>NullTerminated</strong> property (those ending in '<code>_z</code>'). You can only use this type of property on pointer or array types.</p>
+<p>This warning indicates an incorrect use of the <strong>NullTerminated</strong> property (the ones ending in '<code>_z</code>'). You can only use this type of property on pointer or array types.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6510?view=msvc-160" target="_blank">C6510</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6510?view=msvc-170" target="_blank">C6510</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8167,7 +8301,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates an invalid value for MustCheck property was specified. The only valid values for this property are: Yes and No.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6511?view=msvc-160" target="_blank">C6511</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6511?view=msvc-170" target="_blank">C6511</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8180,7 +8314,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that ElementSizeConst requires other properties that are missing from the annotation. Specifying ElementSizeConst alone does not provide any benefit to the analysis process. In addition to specifying ElementSize, other properties such as ValidElementsConst or WritableElementsConst must also be specified.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6513?view=msvc-160" target="_blank">C6513</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6513?view=msvc-170" target="_blank">C6513</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8188,12 +8322,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6514</key>
-    <name>C6514: invalid annotation: value of the &lt;name&gt; property exceeds the size of the array</name>
+    <name>C6514: Invalid annotation: value of the 'name' property exceeds the size of the array</name>
     <description>
       <![CDATA[
 <p>This warning indicates that a property value exceeds the size of the array specified in the parameter being annotated. This warning occurs when the value specified for the annotation property is greater than the actual length of the array being passed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6514?view=msvc-160" target="_blank">C6514</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6514?view=msvc-170" target="_blank">C6514</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8201,12 +8335,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6515</key>
-    <name>C6515: invalid annotation: &lt;name&gt; property may only be used on values of pointer type</name>
+    <name>C6515: Invalid annotation: 'name' property may only be used on values of pointer type</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a property for use on pointers was applied to a non-pointer type. For a list of annotation properties, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-160">Using SAL Annotations to reduce code defects</a>.</p>
+<p>This warning indicates that a property for use on pointers was applied to a non-pointer type. For a list of annotation properties, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">Using SAL Annotations to reduce code defects</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6515?view=msvc-160" target="_blank">C6515</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6515?view=msvc-170" target="_blank">C6515</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8214,12 +8348,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6516</key>
-    <name>C6516: invalid annotation: no properties specified for &lt;name&gt; attribute</name>
+    <name>C6516: Invalid annotation: no properties specified for 'name' attribute</name>
     <description>
       <![CDATA[
 <p>This warning indicates that either no property was specified in the attribute or the property that was specified is invalid; therefore, the attribute cannot be considered complete.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6516?view=msvc-160" target="_blank">C6516</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6516?view=msvc-170" target="_blank">C6516</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8227,12 +8361,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6517</key>
-    <name>C6517: Invalid annotation: 'SAL_readableTo' property may not be specified on buffers that are not readable: '_Param_(1)'</name>
+    <name>C6517: Invalid annotation: 'SAL_readableTo' property may not be specified on buffers that are not readable: 'Parameter'</name>
     <description>
       <![CDATA[
 <p>This warning indicates that <code>SAL_readableTo</code> property does not have the required read access. You cannot use this property to annotate a parameter without providing read access.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6517?view=msvc-160" target="_blank">C6517</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6517?view=msvc-170" target="_blank">C6517</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8240,12 +8374,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6518</key>
-    <name>C6518: Invalid annotation: 'SAL_writableTo' property may not be specified as a precondition on buffers that are not writable: '_Param_(1)'</name>
+    <name>C6518: Invalid annotation: 'SAL_writableTo' property may not be specified as a precondition on buffers that are not writable: 'Parameter'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a conflict exists between a <code>SAL_writableTo</code> property value and a writable property. This ordinarily indicates that a writable property does not have write access to the parameter being annotated.</p>
+<p>This warning indicates that a conflict exists between a <code>SAL_writableTo</code> property value and a writable property. The warning ordinarily indicates that a writable property doesn't have write access to the parameter being annotated.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6518?view=msvc-160" target="_blank">C6518</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6518?view=msvc-170" target="_blank">C6518</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8256,9 +8390,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6522: invalid size specification: expression must be of integral type</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an integral type was expected, but an incorrect data type was used. You can use annotation properties that accept the size of a parameter in terms of another parameter, but you must use correct data type. For a list of annotation properties, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-160">Using SAL Annotations to reduce code defects</a>.</p>
+<p>This warning indicates that an integral type was expected, but an incorrect data type was used. You can use annotation properties that accept the size of a parameter in terms of another parameter, but you must use correct data type. For a list of annotation properties, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">Using SAL Annotations to reduce code defects</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6522?view=msvc-160" target="_blank">C6522</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6522?view=msvc-170" target="_blank">C6522</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8271,7 +8405,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>This warning indicates that the property value used to specify the size is not valid. This occurs if the size parameter is annotated using Valid=No.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6525?view=msvc-160" target="_blank">C6525</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6525?view=msvc-170" target="_blank">C6525</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8282,9 +8416,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6527: Invalid annotation: NeedsRelease property may not be used on values of void type</name>
     <description>
       <![CDATA[
-<p>C6527: Invalid annotation: NeedsRelease property may not be used on values of void type</p>
+<p>Invalid annotation: NeedsRelease property may not be used on values of void type.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6527?view=msvc-160" target="_blank">C6527</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6527?view=msvc-170" target="_blank">C6527</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8292,12 +8426,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6530</key>
-    <name>C6530: unrecognized format string style &lt;name&gt;</name>
+    <name>C6530: Unrecognized format string style 'name'</name>
     <description>
       <![CDATA[
 <p>This warning indicates that the FormatString property is using a value other than scanf or printf. To correct this warning, review your code and use a valid value for the Style property.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6530?view=msvc-160" target="_blank">C6530</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6530?view=msvc-170" target="_blank">C6530</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8308,9 +8442,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6540: The use of attribute annotations on this function will invalidate all of its existing __declspec annotations</name>
     <description>
       <![CDATA[
-<p>C6540: The use of attribute annotations on this function will invalidate all of its existing __declspec annotations</p>
+<p>The use of attribute annotations on this function will invalidate all of its existing __declspec annotations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6540?view=msvc-160" target="_blank">C6540</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6540?view=msvc-170" target="_blank">C6540</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8321,9 +8455,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6551: Invalid size specification: expression not parsable</name>
     <description>
       <![CDATA[
-<p>C6551: Invalid size specification: expression not parsable</p>
+<p>Invalid size specification: expression not parsable.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6551?view=msvc-160" target="_blank">C6551</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6551?view=msvc-170" target="_blank">C6551</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8334,9 +8468,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6552: Invalid Deref= or Notref=: expression not parsable</name>
     <description>
       <![CDATA[
-<p>C6552: Invalid Deref= or Notref=: expression not parsable</p>
+<p>Invalid Deref= or Notref=: expression not parsable.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6552?view=msvc-160" target="_blank">C6552</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6552?view=msvc-170" target="_blank">C6552</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8344,12 +8478,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6701</key>
-    <name>C6701: The value is not a valid Yes/No/Maybe value: &lt;string&gt;</name>
+    <name>C6701: The value is not a valid Yes/No/Maybe value: 'string'</name>
     <description>
       <![CDATA[
-<p>This warning is reported when there is an error in the annotations.</p>
+<p>This warning is reported when there's an error in the annotations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6701?view=msvc-160" target="_blank">C6701</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6701?view=msvc-170" target="_blank">C6701</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8357,12 +8491,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6702</key>
-    <name>C6702: The value is not a string value: &lt;string&gt;</name>
+    <name>C6702: The value is not a string value: 'string'</name>
     <description>
       <![CDATA[
-<p>This warning is reported when there is an error in the annotations.</p>
+<p>This warning is reported when there's an error in the annotations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6702?view=msvc-160" target="_blank">C6702</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6702?view=msvc-170" target="_blank">C6702</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8370,12 +8504,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6703</key>
-    <name>C6703: The value is not a number: &lt;string&gt;</name>
+    <name>C6703: The value is not a number: 'string'</name>
     <description>
       <![CDATA[
-<p>This warning is reported when there is an error in the annotations.</p>
+<p>This warning is reported when there's an error in the annotations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6703?view=msvc-160" target="_blank">C6703</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6703?view=msvc-170" target="_blank">C6703</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8383,12 +8517,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6704</key>
-    <name>C6704: Unexpected Annotation Expression Error: &lt;annotation&gt; [&lt;why&gt;]</name>
+    <name>C6704: Unexpected Annotation Expression Error: 'annotation' ['why']</name>
     <description>
       <![CDATA[
-<p>This warning is reported when there is an error in the annotations.</p>
+<p>This warning is reported when there's an error in the annotations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6704?view=msvc-160" target="_blank">C6704</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6704?view=msvc-170" target="_blank">C6704</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8396,12 +8530,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6705</key>
-    <name>C6705: Annotation error expected &lt;expected_number&gt; arguments for annotation &lt;parameter&gt; found &lt;actual_number&gt;</name>
+    <name>C6705: Annotation error expected &lt;expected_number&gt; arguments for annotation 'parameter' found &lt;actual_number&gt;</name>
     <description>
       <![CDATA[
-<p>This warning is reported when there is an error in the annotations.</p>
+<p>This warning is reported when there's an error in the annotations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6705?view=msvc-160" target="_blank">C6705</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6705?view=msvc-170" target="_blank">C6705</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8409,12 +8543,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6706</key>
-    <name>C6706: Unexpected Annotation Error for annotation &lt;annotation&gt;: &lt;why&gt;</name>
+    <name>C6706: Unexpected Annotation Error for annotation 'annotation': 'why'</name>
     <description>
       <![CDATA[
-<p>This warning is reported when there is an error in the annotations.</p>
+<p>This warning is reported when there's an error in the annotations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6706?view=msvc-160" target="_blank">C6706</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6706?view=msvc-170" target="_blank">C6706</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8422,12 +8556,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6707</key>
-    <name>C6707: Unexpected Model Error: &lt;why&gt;</name>
+    <name>C6707: Unexpected Model Error: 'why'</name>
     <description>
       <![CDATA[
-<p>C6707: Unexpected Model Error: &lt;why&gt;</p>
+<p>Unexpected Model Error: 'why'.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6707?view=msvc-160" target="_blank">C6707</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6707?view=msvc-170" target="_blank">C6707</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8438,9 +8572,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6993: Code analysis ignores OpenMP constructs; analyzing single-threaded code</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the Code Analyzer has encountered Open MP pragmas that it cannot analyze.</p>
+<p>This warning indicates that the Code Analyzer has encountered Open MP pragmas that it can't analyze.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6993?view=msvc-160" target="_blank">C6993</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6993?view=msvc-170" target="_blank">C6993</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8451,9 +8585,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6995: Failed to save XML Log file</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the Code Analysis tool cannot create the defect log, which is the output of the code analysis.</p>
+<p>This warning indicates that the Code Analysis tool can't create the defect log, which is the output of the code analysis.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6995?view=msvc-160" target="_blank">C6995</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6995?view=msvc-170" target="_blank">C6995</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8464,9 +8598,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6997: Annotations at this location are meaningless and will be ignored</name>
     <description>
       <![CDATA[
-<p>Annotations cannot be applied to <code>extern "C" {...}</code>. Apply the annotations to a specific object.</p>
+<p>Annotations can't be applied to <code>extern "C" {...}</code>. Apply the annotations to a specific object.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c6997?view=msvc-160" target="_blank">C6997</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6997?view=msvc-170" target="_blank">C6997</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8479,7 +8613,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>The <code>_Guarded_by_</code> annotation in the code specifies the lock to use to guard a shared variable. Warning C26100 is generated when the guard contract is violated.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26100?view=msvc-160" target="_blank">C26100</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26100?view=msvc-170" target="_blank">C26100</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8487,12 +8621,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26101</key>
-    <name>C26101: Failing to use interlocked operation properly for variable &lt;var&gt;</name>
+    <name>C26101: Failing to use interlocked operation properly for variable 'var'</name>
     <description>
       <![CDATA[
-<p>Windows APIs offer a variety of interlocked operations. Annotation <code>_Interlocked_</code> specifies that a variable should only be accessed through an interlocked operation. Warning C26101 is issued when an access is not consistent with the <code>_Interlocked_</code> annotation.</p>
+<p>Windows APIs offer various interlocked operations. Annotation <code>_Interlocked_</code> specifies that a variable should only be accessed through an interlocked operation. Warning C26101 is issued when a variable access isn't consistent with the <code>_Interlocked_</code> annotation.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26101?view=msvc-160" target="_blank">C26101</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26101?view=msvc-170" target="_blank">C26101</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8505,7 +8639,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Concurrency SAL supports <em>lock levels</em>. To declare a lock level, which is denoted by a string literal without double quotes, use <code>_Create_lock_level_</code>. You can impose an order of acquisition between two lock levels by using the annotation <code>_Set_lock_level_order_(A,B)</code>, which states that locks that have level <code>A</code> must be acquired before locks that have level <code>B</code>. To establish a lock order hierarchy (a partial order among lock levels), use multiple <code>_Set_lock_level_order_</code> annotations. To associate a lock with a lock level, use the <code>_Set_lock_level_</code> annotation when you declare the lock. Warning C26105 is issued when a lock ordering violation is detected.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26105?view=msvc-160" target="_blank">C26105</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26105?view=msvc-170" target="_blank">C26105</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8513,12 +8647,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26110</key>
-    <name>C26110: Caller failing to hold lock &lt;lock&gt; before calling function &lt;func&gt;</name>
+    <name>C26110: Caller failing to hold lock 'lock' before calling function 'func'</name>
     <description>
       <![CDATA[
-<p>When a lock is required, make sure to clarify whether the function itself or its caller should acquire the lock. Warning C26110 is issued when there is a violation of the <code>_Requires_lock_held_</code> annotation, or other lock-related annotations. For more information, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/annotating-locking-behavior?view=msvc-160">Annotating Locking Behavior</a></p>
+<p>When a lock is required, make sure to clarify whether the function itself, or its caller, should acquire the lock. Warning C26110 is issued when there's a violation of the <code>_Requires_lock_held_</code> annotation, or other lock-related annotations. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/annotating-locking-behavior?view=msvc-170">Annotating Locking Behavior</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26110?view=msvc-160" target="_blank">C26110</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26110?view=msvc-170" target="_blank">C26110</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8526,12 +8660,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26111</key>
-    <name>C26111: Caller failing to release lock &lt;lock&gt; before calling function &lt;func&gt;</name>
+    <name>C26111: Caller failing to release lock 'lock' before calling function 'func'</name>
     <description>
       <![CDATA[
-<p>The annotation <code>_Requires_lock_not_held_</code> imposes a precondition that the lock count for the specified lock cannot be greater than zero when the function is called. Warning C26111 is issued when a function fails to release the lock before it calls another function.</p>
+<p>The annotation <code>_Requires_lock_not_held_</code> imposes a precondition that the lock count for the specified lock can't be greater than zero when the function is called. Warning C26111 is issued when a function fails to release the lock before it calls another function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26111?view=msvc-160" target="_blank">C26111</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26111?view=msvc-170" target="_blank">C26111</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8539,12 +8673,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26112</key>
-    <name>C26112: Caller cannot hold any lock before calling &lt;func&gt;</name>
+    <name>C26112: Caller cannot hold any lock before calling 'func'</name>
     <description>
       <![CDATA[
 <p>The annotation <code>_Requires_no_locks_held_</code> imposes a precondition that the caller must not hold any lock while it calls the function. Warning C26112 is issued when a function fails to release all locks before it calls another function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26112?view=msvc-160" target="_blank">C26112</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26112?view=msvc-170" target="_blank">C26112</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8552,12 +8686,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26115</key>
-    <name>C26115: Failing to release lock &lt;lock&gt; in function &lt;func&gt;</name>
+    <name>C26115: Failing to release lock 'lock' in function 'func'</name>
     <description>
       <![CDATA[
-<p>Enforcement of syntactically scoped lock <em>acquire</em> and lock <em>release</em> pairs in C/C++ programs is not performed by the language. A function may introduce a locking side effect by making an observable modification to the concurrency state. For example, a lock wrapper function increments the number of lock acquisitions, or lock count, for a given lock.</p>
+<p>Enforcement of syntactically scoped lock <em>acquire</em> and lock <em>release</em> pairs in C/C++ programs isn't performed by the language. A function may introduce a locking side effect by making an observable modification to the concurrency state. For example, a lock wrapper function increments the number of lock acquisitions, or lock count, for a given lock.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26115?view=msvc-160" target="_blank">C26115</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26115?view=msvc-170" target="_blank">C26115</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8565,12 +8699,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26116</key>
-    <name>C26116: Failing to acquire or to hold lock &lt;lock&gt; in &lt;func&gt;</name>
+    <name>C26116: Failing to acquire or to hold lock 'lock' in 'func'</name>
     <description>
       <![CDATA[
-<p>Enforcement of syntactically scoped lock <em>acquire</em> and lock <em>release</em> pairs in C/C++ programs is not performed by the language. A function may introduce a locking side effect by making an observable modification to the concurrency state. For example, a lock wrapper function increments the number of lock acquisitions, or lock count, for a given lock.You can annotate a function that has a side effect from a lock acquire or lock release by using <code>_Acquires_lock_</code> or <code>_Requires_lock_held</code>, respectively. Without such annotations, a function is expected not to change any lock count after it returns. If acquires and releases are not balanced, they are considered to be <em>orphaned</em>. Warning C26116 is issued when a function has been annotated with <code>_Acquires_lock_</code>, but it does not acquire a lock, or when a function is annotated with <code>_Requires_lock_held</code> and releases the lock.</p>
+<p>Enforcement of syntactically scoped lock <em>acquire</em> and lock <em>release</em> pairs in C/C++ programs isn't performed by the language. A function may introduce a locking side effect by making an observable modification to the concurrency state. For example, a lock wrapper function increments the number of lock acquisitions, or lock count, for a given lock. You can annotate a function that has a side effect from a lock acquire or lock release by using <code>_Acquires_lock_</code> or <code>_Requires_lock_held</code>, respectively. Without such annotations, a function is expected not to change any lock count after it returns. If acquires and releases aren't balanced, they're considered to be <em>orphaned</em>. Warning C26116 is issued when a function has been annotated with <code>_Acquires_lock_</code>, but it doesn't acquire a lock, or when a function is annotated with <code>_Requires_lock_held</code> and releases the lock.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26116?view=msvc-160" target="_blank">C26116</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26116?view=msvc-170" target="_blank">C26116</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8578,12 +8712,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26117</key>
-    <name>C26117: Releasing unheld lock &lt;lock&gt; in function &lt;func&gt;</name>
+    <name>C26117: Releasing unheld lock 'lock' in function 'func'</name>
     <description>
       <![CDATA[
-<p>Enforcement of syntactically scoped lock <em>acquire</em> and lock <em>release</em> pairs in C/C++ programs is not performed by the language. A function may introduce a locking side effect by making an observable modification to the concurrency state. For example, a lock wrapper function increments the number of lock acquisitions, or lock count, for a given lock.You can annotate a function that has a side effect from a lock acquire or lock release by using <code>_Acquires_lock_</code> or <code>_Releases_lock_</code>, respectively. Without such annotations, a function is expected not to change any lock count after it returns. If acquires and releases are not balanced, they are considered to be <em>orphaned</em>. Warning C26117 is issued when a function that has not been annotated with <code>_Releases_lock_</code> releases a lock that it doesn't hold, because the function must own the lock before it releases it.</p>
+<p>Enforcement of syntactically scoped lock <em>acquire</em> and lock <em>release</em> pairs in C/C++ programs isn't performed by the language. A function may introduce a locking side effect by making an observable modification to the concurrency state. For example, a lock wrapper function increments the number of lock acquisitions, or lock count, for a given lock. You can annotate a function that has a side effect from a lock acquire or lock release by using <code>_Acquires_lock_</code> or <code>_Releases_lock_</code>, respectively. Without such annotations, a function is expected not to change any lock count after it returns. If acquires and releases aren't balanced, they're considered to be <em>orphaned</em>. Warning C26117 is issued when a function that hasn't been annotated with <code>_Releases_lock_</code> releases a lock that it doesn't hold, because the function must own the lock before it releases it.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26117?view=msvc-160" target="_blank">C26117</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26117?view=msvc-170" target="_blank">C26117</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8591,12 +8725,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26130</key>
-    <name>C26130: Missing annotation _Requires_lock_held_(&lt;lock&gt;) or _No_competing_thread_ at function &lt;func&gt;</name>
+    <name>C26130: Missing annotation _Requires_lock_held_('lock') or _No_competing_thread_ at function 'func'</name>
     <description>
       <![CDATA[
-<p>Warning C26130 is issued when the analyzer detects a potential race condition but infers that the function is likely to be run in a single threaded mode, for example, when the function is in the initialization stage based on certain heuristics.</p>
+<p>Warning C26130 is issued when the analyzer detects a potential race condition but infers that the function is likely to be run in a single threaded mode. For example, when the function is in the initialization stage, based on certain heuristics.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26130?view=msvc-160" target="_blank">C26130</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26130?view=msvc-170" target="_blank">C26130</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8604,12 +8738,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26135</key>
-    <name>C26135: Missing annotation &lt;annotation&gt; at function &lt;func&gt;</name>
+    <name>C26135: Missing annotation 'annotation' at function 'func'</name>
     <description>
       <![CDATA[
-<p>Warning C26135 is issued when the analyzer infers that a function is a lock wrapper function that has a lock acquire or lock release side effect. If the code is not intended to be a wrapper function, then either the lock is leaking (if the lock is being acquired) or it is being released incorrectly (if the lock is being released).</p>
+<p>Warning C26135 is issued when the analyzer infers that a function is a lock wrapper function that has a "lock acquire" or "lock release" side effect. If the code isn't intended to be a wrapper function, then either the lock is leaking (if it's being acquired), or it's being released incorrectly (if the lock is being released).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26135?view=msvc-160" target="_blank">C26135</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26135?view=msvc-170" target="_blank">C26135</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8617,12 +8751,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26138</key>
-    <name>C26138: Suspending a coroutine while holding lock &lt;lock&gt;</name>
+    <name>C26138: Suspending a coroutine while holding lock 'lock'</name>
     <description>
       <![CDATA[
 <p>Warning C26138 warns when a coroutine is suspended while holding a lock. In general, we can't know how long will a coroutine remain in the suspended state so this pattern may result in longer critical sections than expected.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26138?view=msvc-160" target="_blank">C26138</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26138?view=msvc-170" target="_blank">C26138</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8630,12 +8764,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26140</key>
-    <name>C26140: Undefined lock kind &lt;lock&gt; in annotation &lt;annotation&gt; on lock &lt;lock&gt;</name>
+    <name>C26140: Undefined lock kind 'lock' in annotation 'annotation' on lock 'lock'</name>
     <description>
       <![CDATA[
-<p>C26140: Undefined lock kind &lt;lock&gt; in annotation &lt;annotation&gt; on lock &lt;lock&gt;</p>
+<p>Undefined lock kind 'lock' in annotation 'annotation' on lock 'lock'.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26140?view=msvc-160" target="_blank">C26140</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26140?view=msvc-170" target="_blank">C26140</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8643,12 +8777,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26160</key>
-    <name>C26160: Caller possibly failing to hold lock &lt;lock&gt; before calling function &lt;func&gt;</name>
+    <name>C26160: Caller possibly failing to hold lock 'lock' before calling function 'func'</name>
     <description>
       <![CDATA[
-<p>Warning C26160 resembles warning <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/c26110?view=msvc-160">C26110</a> except that the confidence level is lower. For example, the function may contain annotation errors.</p>
+<p>Warning C26160 resembles warning <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26110?view=msvc-170">C26110</a> except that the confidence level is lower. For example, the function may contain annotation errors.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26160?view=msvc-160" target="_blank">C26160</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26160?view=msvc-170" target="_blank">C26160</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8656,12 +8790,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26165</key>
-    <name>C26165: Possibly failing to release lock &lt;lock&gt; in function &lt;func&gt;</name>
+    <name>C26165: Possibly failing to release lock 'lock' in function 'func'</name>
     <description>
       <![CDATA[
-<p>Warning C26165 resembles warning <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/c26115?view=msvc-160">C26115</a> except that the confidence level is lower. For example, the function may contain annotation errors.</p>
+<p>Warning C26165 resembles warning <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26115?view=msvc-170">C26115</a> except that the confidence level is lower. For example, the function may contain annotation errors.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26165?view=msvc-160" target="_blank">C26165</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26165?view=msvc-170" target="_blank">C26165</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8669,12 +8803,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26166</key>
-    <name>C26166: Possibly failing to acquire or to hold lock &lt;lock&gt; in function &lt;func&gt;</name>
+    <name>C26166: Possibly failing to acquire or to hold lock 'lock' in function 'func'</name>
     <description>
       <![CDATA[
-<p>Warning C26166 resembles warning <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/c26116?view=msvc-160">C26116</a> except that the confidence level is lower. For example, the function may contain annotation errors.</p>
+<p>Warning C26166 resembles warning <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26116?view=msvc-170">C26116</a> except that the confidence level is lower. For example, the function may contain annotation errors.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26166?view=msvc-160" target="_blank">C26166</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26166?view=msvc-170" target="_blank">C26166</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8682,12 +8816,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26167</key>
-    <name>C26167: Possibly releasing unheld lock &lt;lock&gt; in function &lt;func&gt;</name>
+    <name>C26167: Possibly releasing unheld lock 'lock' in function 'func'</name>
     <description>
       <![CDATA[
-<p>Warning C26167 resembles warning <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/c26117?view=msvc-160">C26117</a> except that the confidence level is lower. For example, the function may contain annotation errors.</p>
+<p>Warning C26167 resembles warning <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26117?view=msvc-170">C26117</a> except that the confidence level is lower. For example, the function may contain annotation errors.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26167?view=msvc-160" target="_blank">C26167</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26167?view=msvc-170" target="_blank">C26167</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -8695,12 +8829,13 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26400</key>
-    <name>C26400: NO_RAW_POINTER_ASSIGNMENT</name>
+    <name>C26400: Do not assign the result of an allocation or a function call with an owner&lt;T&gt; return value to a raw pointer</name>
     <description>
       <![CDATA[
-<p>This check helps to enforce the <em>rule I.11: Never transfer ownership by a raw pointer (T*)</em>, which is a subset of the rule <em>R.3: A raw pointer (a T*) is non-owning</em>. Specifically, it warns on any call to <code>operator new</code>, which saves its result in a variable of raw pointer type. It also warns on calls to functions that return <code>gsl::owner&lt;T&gt;</code> if their results are assigned to raw pointers. The idea here is that you should clearly state ownership of memory resources. For more information, see the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r-resource-management">C++ Core Guidelines</a>.</p>
+<p>Do not assign the result of an allocation or a function call with an owner&lt;T&gt; return value to a raw pointer, use owner&lt;T&gt; instead (i.11).</p>
+<p>This check helps to enforce the *rule I.11: Never transfer ownership by a raw pointer (T*), which is a subset of the rule <em>R.3: A raw pointer (a T*) is non-owning</em>. Specifically, it warns on any call to <code>operator new</code>, which saves its result in a variable of raw pointer type. It also warns on calls to functions that return <code>gsl::owner&lt;T&gt;</code> if their results are assigned to raw pointers. The idea is that you should clearly state ownership of memory resources. For more information, see the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r-resource-management">C++ Core Guidelines</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26400?view=msvc-160" target="_blank">C26400</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26400?view=msvc-170" target="_blank">C26400</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>CRITICAL</severity>
@@ -8709,12 +8844,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26401</key>
-    <name>C26401: DONT_DELETE_NON_OWNER</name>
+    <name>C26401: Do not delete a raw pointer that is not an owner&lt;T&gt;</name>
     <description>
       <![CDATA[
-<p>This check detects places where moving to <code>owner&lt;T&gt;</code> can be a good option for the first stage of refactoring. Like C26400 it enforces rules I.11 and R.3, but focuses on the "release" portion of the pointer lifetime. It warns on any call to operator <strong><code>delete</code></strong> if its target is neither an <code>owner&lt;T&gt;</code> nor an implicitly assumed owner. For more information, see <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/c26400?view=msvc-160">C26400</a> regarding the <strong><code>auto</code></strong> declarations. This does include expressions that refer to global variables, formals, and so on.</p>
+<p>This check detects code where moving to <code>owner&lt;T&gt;</code> can be a good option for the first stage of refactoring. Like C26400, it enforces rules I.11 and R.3, but focuses on the "release" portion of the pointer lifetime. It warns on any call to operator <strong><code>delete</code></strong> if its target isn't an <code>owner&lt;T&gt;</code> or an implicitly assumed owner. For more information about <strong><code>auto</code></strong> declarations, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26400?view=msvc-170">C26400</a>. This check includes expressions that refer to global variables, formal parameters, and so on.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26401?view=msvc-160" target="_blank">C26401</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26401?view=msvc-170" target="_blank">C26401</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>BLOCKER</severity>
@@ -8724,12 +8859,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26402</key>
-    <name>C26402: Return a scoped object instead of a heap-allocated if it has a move constructor (r.3)</name>
+    <name>C26402: Return a scoped object instead of a heap-allocated if it has a move constructor</name>
     <description>
       <![CDATA[
 <p>To avoid confusion about whether a pointer owns an object, a function that returns a movable object should allocate it on the stack. It should then return the object by value instead of returning a heap-allocated object. If pointer semantics are required, return a smart pointer instead of a raw pointer. For more information, see <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-ptr">C++ Core Guidelines R.3</a>: <em>Warn if a function returns an object that was allocated within the function but has a move constructor. Suggest considering returning it by value instead.</em></p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26402?view=msvc-160" target="_blank">C26402</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26402?view=msvc-170" target="_blank">C26402</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>BLOCKER</severity>
@@ -8739,12 +8874,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26403</key>
-    <name>C26403: RESET_OR_DELETE_OWNER</name>
+    <name>C26403: Reset or explicitly delete an owner&lt;T&gt; pointer 'variable'</name>
     <description>
       <![CDATA[
-<p>Owner pointers are like unique pointers: they own a resource exclusively, and manage release of the resource, as well as its transfers to other owners. This check validates that a local owner pointer properly maintains its resource through all execution paths in a function. If the resource was not transferred to another owner, or was not explicitly release, the checker warns, and points to the declaration of the pointer variable.</p>
+<p>Owner pointers are like unique pointers: they own a resource exclusively, and manage release of the resource, or its transfers to other owners. This check validates that a local owner pointer properly maintains its resource through all execution paths in a function. If the resource wasn't transferred to another owner, or wasn't explicitly release, the checker warns, and points to the declaration of the pointer variable.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26403?view=msvc-160" target="_blank">C26403</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26403?view=msvc-170" target="_blank">C26403</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>BLOCKER</severity>
@@ -8754,13 +8889,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26404</key>
-    <name>C26404: DONT_DELETE_INVALID</name>
+    <name>C26404: Do not delete an owner&lt;T&gt; which may be in invalid state</name>
     <description>
       <![CDATA[
-<p>Once owner pointer releases or transfers its resource, it gets into an "invalid" state.
-Deleting such a pointer may lead to immediate memory corruption due to double delete, or to an access violation when the deleted resource is accessed from another owner pointer.</p>
+<p>Once an owner pointer releases or transfers its resource, it gets into an "invalid" state. Deleting such a pointer may lead to immediate memory corruption due to double delete, or to an access violation when the deleted resource is accessed from another owner pointer.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26404?view=msvc-160" target="_blank">C26404</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26404?view=msvc-170" target="_blank">C26404</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>BLOCKER</severity>
@@ -8770,12 +8904,12 @@ Deleting such a pointer may lead to immediate memory corruption due to double de
   </rule>
   <rule>
     <key>C26405</key>
-    <name>C26405: DONT_ASSIGN_TO_VALID</name>
+    <name>C26405: Do not assign to an owner&lt;T&gt; which may be in valid state</name>
     <description>
       <![CDATA[
-<p>If an owner pointer already points to a valid memory buffer, it must not be assigned to another value without releasing its current resource first. Such assignment may lead to a resource leak even if the resource address is copied into some raw pointer (because raw pointers shouldn’t release resources). For more information, see the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r3-a-raw-pointer-a-t-is-non-owning">C++ Core Guidelines</a>.</p>
+<p>If an owner pointer already points to a valid memory buffer, it must not be assigned to another value without releasing its current resource first. Such assignment may lead to a resource leak even if the resource address is copied into some raw pointer (because raw pointers shouldn't release resources). For more information, see the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r3-a-raw-pointer-a-t-is-non-owning">C++ Core Guidelines</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26405?view=msvc-160" target="_blank">C26405</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26405?view=msvc-170" target="_blank">C26405</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>BLOCKER</severity>
@@ -8785,12 +8919,12 @@ Deleting such a pointer may lead to immediate memory corruption due to double de
   </rule>
   <rule>
     <key>C26406</key>
-    <name>C26406: DONT_ASSIGN_RAW_TO_OWNER</name>
+    <name>C26406: Do not assign a raw pointer to an owner&lt;T&gt;</name>
     <description>
       <![CDATA[
 <p>This warning enforces R.3 from the C++ Core Guidelines. For more information, see <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r3-a-raw-pointer-a-t-is-non-owning">C++ Core Guidelines R.3</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26406?view=msvc-160" target="_blank">C26406</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26406?view=msvc-170" target="_blank">C26406</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>BLOCKER</severity>
@@ -8799,12 +8933,12 @@ Deleting such a pointer may lead to immediate memory corruption due to double de
   </rule>
   <rule>
     <key>C26407</key>
-    <name>C26407: DONT_HEAP_ALLOCATE_UNNECESSARILY</name>
+    <name>C26407: Prefer scoped objects, don't heap-allocate unnecessarily</name>
     <description>
       <![CDATA[
-<p>To avoid unnecessary use of pointers, we try to detect common patterns of local allocations. For example, we detect when the result of a call to operator <strong><code>new</code></strong> is stored in a local variable and later explicitly deleted. This supports the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r5-prefer-scoped-objects-dont-heap-allocate-unnecessarily">C++ Core Guidelines rule R.5</a>: <em>Prefer scoped objects, don't heap-allocate unnecessarily</em>. To fix the issue, use an RAII type instead of a raw pointer, and allow it to deal with resources. Obviously, it isn't necessary to create a wrapper type to allocate a single object. Instead, a local variable of the object's type would work better.</p>
+<p>To avoid unnecessary use of pointers, we try to detect common patterns of local allocations. For example, we detect when the result of a call to operator <strong><code>new</code></strong> is stored in a local variable and later explicitly deleted. This check supports the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r5-prefer-scoped-objects-dont-heap-allocate-unnecessarily">C++ Core Guidelines rule R.5</a>: <em>Prefer scoped objects, don't heap-allocate unnecessarily</em>. To fix the issue, use an RAII type instead of a raw pointer, and allow it to deal with resources. Obviously, it isn't necessary to create a wrapper type to allocate a single object. Instead, a local variable of the object's type would work better.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26407?view=msvc-160" target="_blank">C26407</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26407?view=msvc-170" target="_blank">C26407</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>BLOCKER</severity>
@@ -8813,12 +8947,12 @@ Deleting such a pointer may lead to immediate memory corruption due to double de
   </rule>
   <rule>
     <key>C26408</key>
-    <name>C26408: NO_MALLOC_FREE</name>
+    <name>C26408: Avoid malloc() and free(), prefer the nothrow version of new with delete</name>
     <description>
       <![CDATA[
-<p>This warning flags places where <code>malloc</code> or <code>free</code> is invoked explicitly in accordance to R.10: Avoid <code>malloc</code> and <code>free</code>. One potential fix for such warnings would be to use <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/standard-library/memory-functions?view=msvc-160#make_unique">std::make_unique</a> to avoid explicit creation and destruction of objects. If such a fix is not acceptable, operator <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/new-and-delete-operators?view=msvc-160">new and delete</a> should be preferred. In some cases, if exceptions are not welcome, <code>malloc</code> and <code>free</code> can be replaced with the nothrow version of operators <code>new</code> and <code>delete</code>.</p>
+<p>This warning flags places where <code>malloc</code> or <code>free</code> is invoked explicitly in accordance to R.10: Avoid <code>malloc</code> and <code>free</code>. One potential fix for such warnings would be to use <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/standard-library/memory-functions?view=msvc-170#make_unique">std::make_unique</a> to avoid explicit creation and destruction of objects. If such a fix isn't acceptable, operator <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/new-and-delete-operators?view=msvc-170">new and delete</a> should be preferred. In some cases, if exceptions aren't welcome, <code>malloc</code> and <code>free</code> can be replaced with the nothrow version of operators <code>new</code> and <code>delete</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26408?view=msvc-160" target="_blank">C26408</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26408?view=msvc-170" target="_blank">C26408</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>CRITICAL</severity>
@@ -8827,12 +8961,13 @@ Deleting such a pointer may lead to immediate memory corruption due to double de
   </rule>
   <rule>
     <key>C26409</key>
-    <name>C26409: Avoid calling new and delete explicitly, use std::make_unique&lt;T&gt; instead (r.11)</name>
+    <name>C26409: Avoid calling new and delete explicitly</name>
     <description>
       <![CDATA[
-<p>Even if code is clean of calls to <code>malloc</code> and <code>free</code>, we still suggest that you consider better options than explicit use of operators <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/cpp/new-and-delete-operators?view=msvc-160"><code>new</code> and <code>delete</code></a>.</p>
+<p>Avoid calling new and delete explicitly, use std::make_unique&lt;T&gt; instead.</p>
+<p>Even if code is clean of calls to <code>malloc</code> and <code>free</code>, we still suggest that you consider better options than explicit use of operators <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/new-and-delete-operators?view=msvc-170"><code>new</code> and <code>delete</code></a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26409?view=msvc-160" target="_blank">C26409</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26409?view=msvc-170" target="_blank">C26409</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>BLOCKER</severity>
@@ -8842,12 +8977,13 @@ Deleting such a pointer may lead to immediate memory corruption due to double de
   </rule>
   <rule>
     <key>C26410</key>
-    <name>C26410: NO_REF_TO_CONST_UNIQUE_PTR</name>
+    <name>C26410: The parameter 'parameter' is a reference to const unique pointer</name>
     <description>
       <![CDATA[
+<p>The parameter 'parameter' is a reference to const unique pointer, use const T* or const T&amp; instead.</p>
 <p>Generally, references to const unique pointer are meaningless. They can safely be replaced by a raw reference or a pointer. This warning enforces <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r32-take-a-unique_ptrwidget-parameter-to-express-that-a-function-assumes-ownership-of-a-widget">C++ Core Guidelines rule R.32</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26410?view=msvc-160" target="_blank">C26410</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26410?view=msvc-170" target="_blank">C26410</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>CRITICAL</severity>
@@ -8856,12 +8992,13 @@ Deleting such a pointer may lead to immediate memory corruption due to double de
   </rule>
   <rule>
     <key>C26411</key>
-    <name>C26411: NO_REF_TO_UNIQUE_PTR</name>
+    <name>C26411: The parameter 'parameter' is a reference to unique pointer and it is never reassigned or reset</name>
     <description>
       <![CDATA[
-<p>When you pass a unique pointer to a function by reference, it implies that its resource may be released or transferred inside the function. If the function uses its parameter only to access the resource, it's safe to pass a raw pointer or a reference. For additional information, see <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r33-take-a-unique_ptrwidget-parameter-to-express-that-a-function-reseats-thewidget">C++ Core Guidelines rule R.33</a>: <em>Take a unique_ptr&lt;widget&gt;&amp; parameter to express that a function reseats the widget</em>.</p>
+<p>The parameter 'parameter' is a reference to unique pointer and it is never reassigned or reset, use T* or T&amp; instead.</p>
+<p>When you pass a unique pointer to a function by reference, it implies that its resource may be released or transferred inside the function. If the function uses its parameter only to access the resource, it's safe to pass a raw pointer or a reference. For more information, see <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r33-take-a-unique_ptrwidget-parameter-to-express-that-a-function-reseats-thewidget">C++ Core Guidelines rule R.33</a>: <em>Take a unique_ptr&lt;widget&gt;&amp; parameter to express that a function reseats the widget</em>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26411?view=msvc-160" target="_blank">C26411</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26411?view=msvc-170" target="_blank">C26411</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>BLOCKER</severity>
@@ -8875,21 +9012,23 @@ Deleting such a pointer may lead to immediate memory corruption due to double de
     <description>
       <![CDATA[
 <p><strong>C++ Core Guidelines</strong>:<br/>
-<a data-linktype="external" href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-scoped">R.5: Prefer scoped objects, don't heap-allocate unnecessarily</a></p>
+<a data-linktype="external" href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-scoped">R.5: Prefer scoped objects, don't heap-allocate unnecessarily</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26414?view=msvc-160" target="_blank">C26414</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26414?view=msvc-170" target="_blank">C26414</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26415</key>
-    <name>C26415: SMART_PTR_NOT_NEEDED</name>
+    <name>C26415: Smart pointer parameter is used only to access contained pointer</name>
     <description>
       <![CDATA[
-<p>"Smart pointer parameter is used only to access contained pointer. Use T* or T&amp; instead."</p>
+<p>Smart pointer parameter is used only to access contained pointer. Use T* or T&amp; instead.</p>
+<p><strong>C++ Core Guidelines</strong>:
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r30-take-smart-pointers-as-parameters-only-to-explicitly-express-lifetime-semantics">R.30</a>: Take smart pointers as parameters only to explicitly express lifetime semantics.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26415?view=msvc-160" target="_blank">C26415</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26415?view=msvc-170" target="_blank">C26415</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
@@ -8899,10 +9038,11 @@ Deleting such a pointer may lead to immediate memory corruption due to double de
     <name>C26416: Shared pointer parameter is passed by rvalue reference</name>
     <description>
       <![CDATA[
+<p>Shared pointer parameter is passed by rvalue reference. Pass by value instead.</p>
 <p><strong>C++ Core Guidelines</strong>:
-<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r34-take-a-shared_ptrwidget-parameter-to-express-that-a-function-is-part-owner">R.34</a>: Take a shared_ptr&lt;widget&gt; parameter to express that a function is part owner</p>
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r34-take-a-shared_ptrwidget-parameter-to-express-that-a-function-is-part-owner">R.34</a>: Take a shared_ptr&lt;widget&gt; parameter to express that a function is part owner.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26416?view=msvc-160" target="_blank">C26416</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26416?view=msvc-170" target="_blank">C26416</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
@@ -8912,10 +9052,11 @@ Deleting such a pointer may lead to immediate memory corruption due to double de
     <name>C26417: Shared pointer parameter is passed by reference and not reset or reassigned</name>
     <description>
       <![CDATA[
+<p>Shared pointer parameter is passed by reference and not reset or reassigned. Use T* or T&amp; instead.</p>
 <p><strong>C++ Core Guidelines</strong>:
-<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r35-take-a-shared_ptrwidget-parameter-to-express-that-a-function-might-reseat-the-shared-pointer">R.35</a>: Take a shared_ptr&lt;widget&gt;&amp; parameter to express that a function might reseat the shared pointer</p>
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r35-take-a-shared_ptrwidget-parameter-to-express-that-a-function-might-reseat-the-shared-pointer">R.35</a>: Take a shared_ptr&lt;widget&gt;&amp; parameter to express that a function might reseat the shared pointer.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26417?view=msvc-160" target="_blank">C26417</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26417?view=msvc-170" target="_blank">C26417</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
@@ -8925,288 +9066,318 @@ Deleting such a pointer may lead to immediate memory corruption due to double de
     <name>C26418: Shared pointer parameter is not copied or moved</name>
     <description>
       <![CDATA[
+<p>Shared pointer parameter is not copied or moved. Use T* or T&amp; instead.</p>
 <p><strong>C++ Core Guidelines</strong>:
-<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r36-take-a-const-shared_ptrwidget-parameter-to-express-that-it-might-retain-a-reference-count-to-the-object-">R.36</a>: Take a const shared_ptr&lt;widget&gt;&amp; parameter to express that it might retain a reference count to the object</p>
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r36-take-a-const-shared_ptrwidget-parameter-to-express-that-it-might-retain-a-reference-count-to-the-object-">R.36</a>: Take a const shared_ptr&lt;widget&gt;&amp; parameter to express that it might retain a reference count to the object.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26418?view=msvc-160" target="_blank">C26418</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26418?view=msvc-170" target="_blank">C26418</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26426</key>
-    <name>C26426: NO_GLOBAL_INIT_CALLS</name>
+    <name>C26426: Global initializer calls a non-constexpr function 'symbol'</name>
     <description>
       <![CDATA[
-<p>"Global initializer calls a non-constexpr function."</p>
+<p>Global initializer calls a non-constexpr function.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#i22-avoid-complex-initialization-of-global-objects">I.22</a>: Avoid complex initialization of global objects.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26426?view=msvc-160" target="_blank">C26426</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26426?view=msvc-170" target="_blank">C26426</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26427</key>
-    <name>C26427: NO_GLOBAL_INIT_EXTERNS</name>
+    <name>C26427: Global initializer accesses extern object 'symbol'</name>
     <description>
       <![CDATA[
-<p>"Global initializer accesses extern object."</p>
+<p>Global initializer accesses extern object.</p>
+<p><strong>C++ Core Guidelines</strong>:
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#i22-avoid-complex-initialization-of-global-objects">I.22</a>: Avoid complex initialization of global objects.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26427?view=msvc-160" target="_blank">C26427</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26427?view=msvc-170" target="_blank">C26427</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26429</key>
-    <name>C26429: USE_NOTNULL</name>
+    <name>C26429: Symbol is never tested for nullness, it can be marked as gsl::not_null</name>
     <description>
       <![CDATA[
-<p>"Symbol is never tested for nullness, it can be marked as gsl::not_null."</p>
+<p>Symbol is never tested for nullness, it can be marked as gsl::not_null.</p>
+<p><strong>C++ Core Guidelines</strong>:
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f23-use-a-not_nullt-to-indicate-that-null-is-not-a-valid-value">F.23</a>: Use a <code>not_null&lt;T&gt;</code> to indicate that "null" isn't a valid value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26429?view=msvc-160" target="_blank">C26429</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26429?view=msvc-170" target="_blank">C26429</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26430</key>
-    <name>C26430: TEST_ON_ALL_PATHS</name>
+    <name>C26430: Symbol is not tested for nullness on all paths</name>
     <description>
       <![CDATA[
-<p>"Symbol is not tested for nullness on all paths."</p>
+<p>Symbol is not tested for nullness on all paths.</p>
+<p><strong>C++ Core Guidelines</strong>:
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f23-use-a-not_nullt-to-indicate-that-null-is-not-a-valid-value">F.23</a>: Use a not_null&lt;T&gt; to indicate that "null" isn't a valid value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26430?view=msvc-160" target="_blank">C26430</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26430?view=msvc-170" target="_blank">C26430</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26431</key>
-    <name>C26431: DONT_TEST_NOTNULL</name>
+    <name>C26431: The type of expression 'expr' is already gsl::not_null</name>
     <description>
       <![CDATA[
-<p>"The type of expression is already gsl::not_null. Do not test it for nullness."</p>
+<p>The type of expression is already gsl::not_null. Do not test it for nullness.</p>
+<p><strong>C++ Core Guidelines</strong>:
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f23-use-a-not_nullt-to-indicate-that-null-is-not-a-valid-value">F.23</a>: Use a not_null&lt;T&gt; to indicate that "null" isn't a valid value.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26431?view=msvc-160" target="_blank">C26431</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26431?view=msvc-170" target="_blank">C26431</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26432</key>
-    <name>C26432: If you define or delete any default operation in the type 'type-name', define or delete them all (c.21)</name>
+    <name>C26432: If you define or delete any default operation in the type 'type-name', define or delete them all</name>
     <description>
       <![CDATA[
+<p>If you define or delete any default operation in the type 'type-name', define or delete them all (c.21).</p>
 <p><strong>C++ Core Guidelines</strong>:<br/>
-<a data-linktype="external" href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all">C.21: If you define or =delete any default operation, define or =delete them all</a></p>
+<a data-linktype="external" href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all">C.21: If you define or =delete any default operation, define or =delete them all</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26432?view=msvc-160" target="_blank">C26432</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26432?view=msvc-170" target="_blank">C26432</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26433</key>
-    <name>C26433: OVERRIDE_EXPLICITLY</name>
+    <name>C26433: Function should be marked with override</name>
     <description>
       <![CDATA[
-<p>Function should be marked with <code>override</code></p>
+<p>Function should be marked with <code>override</code>.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md">C.128: Virtual functions should specify exactly one of virtual, override, or final</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26433?view=msvc-160" target="_blank">C26433</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26433?view=msvc-170" target="_blank">C26433</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26434</key>
-    <name>C26434: Function 'derived::function' hides a non-virtual function 'base::function' (c.128)</name>
+    <name>C26434: Function 'derived::function' hides a non-virtual function 'base::function'</name>
     <description>
       <![CDATA[
-<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md">C.128: Virtual functions should specify exactly one of virtual, override, or final</a></p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md">C.128: Virtual functions should specify exactly one of virtual, override, or final</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26434?view=msvc-160" target="_blank">C26434</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26434?view=msvc-170" target="_blank">C26434</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26435</key>
-    <name>C26435: SINGLE_VIRTUAL_SPECIFICATION</name>
+    <name>C26435: Function 'symbol' should specify exactly one of 'virtual', 'override', or 'final'</name>
     <description>
       <![CDATA[
-<p>"Function should specify exactly one of 'virtual', 'override', or 'final'."</p>
+<p>Function should specify exactly one of 'virtual', 'override', or 'final'.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md">C.128: Virtual functions should specify exactly one of virtual, override, or final</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26435?view=msvc-160" target="_blank">C26435</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26435?view=msvc-170" target="_blank">C26435</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26436</key>
-    <name>C26436: NEED_VIRTUAL_DTOR</name>
+    <name>C26436: The type 'symbol' with a virtual function needs either public virtual or protected non-virtual destructor</name>
     <description>
       <![CDATA[
-<p>"The type with a virtual function needs either public virtual or protected nonvirtual destructor."</p>
+<p>The type with a virtual function needs either public virtual or protected nonvirtual destructor.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c35-a-base-class-destructor-should-be-either-public-and-virtual-or-protected-and-non-virtual"><strong>C++ Core Guidelines</strong>: C.35</a>: A base class destructor should be either public and virtual, or protected and nonvirtual.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26436?view=msvc-160" target="_blank">C26436</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26436?view=msvc-170" target="_blank">C26436</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26437</key>
-    <name>C26437: DONT_SLICE</name>
+    <name>C26437: Do not slice</name>
     <description>
       <![CDATA[
-<p>"Do not slice."</p>
+<p>Do not slice.</p>
+<p><strong>C++ Core Guidelines</strong>:
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Res-slice">ES.63: Don't slice</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26437?view=msvc-160" target="_blank">C26437</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26437?view=msvc-170" target="_blank">C26437</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26438</key>
-    <name>C26438: NO_GOTO</name>
+    <name>C26438: Avoid goto</name>
     <description>
       <![CDATA[
-<p>"Avoid <strong><code>goto</code></strong>."</p>
+<p>Avoid <strong><code>goto</code></strong>.</p>
+<p><strong>C++ Core Guidelines</strong>:<br/>
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es76-avoid-goto">ES.76</a>: Avoid goto.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26438?view=msvc-160" target="_blank">C26438</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26438?view=msvc-170" target="_blank">C26438</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26439</key>
-    <name>C26439: SPECIAL_NOEXCEPT</name>
+    <name>C26439: This kind of function may not throw</name>
     <description>
       <![CDATA[
-<p>"This kind of function may not throw. Declare it 'noexcept'."</p>
+<p>This kind of function may not throw. Declare it 'noexcept'.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f6-if-your-function-may-not-throw-declare-it-noexcept"><strong>C++ Core Guidelines</strong> F.6</a>: If your function may not throw, declare it noexcept.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26439?view=msvc-160" target="_blank">C26439</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26439?view=msvc-170" target="_blank">C26439</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26440</key>
-    <name>C26440: DECLARE_NOEXCEPT</name>
+    <name>C26440: Function can be declared 'noexcept'</name>
     <description>
       <![CDATA[
-<p>"Function can be declared 'noexcept'."</p>
+<p>Function can be declared 'noexcept'.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f6-if-your-function-may-not-throw-declare-it-noexcept"><strong>C++ Core Guidelines</strong> F.6</a>: If your function may not throw, declare it <code>noexcept</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26440?view=msvc-160" target="_blank">C26440</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26440?view=msvc-170" target="_blank">C26440</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26441</key>
-    <name>C26441: NO_UNNAMED_GUARDS</name>
+    <name>C26441: Guard objects must be named</name>
     <description>
       <![CDATA[
-<p>"Guard objects must be named."</p>
+<p>Guard objects must be named.</p>
+<p><strong>C++ Core Guidelines</strong>:
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#cp44-remember-to-name-your-lock_guards-and-unique_locks">CP.44</a>: Remember to name your lock_guards and unique_locks.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26441?view=msvc-160" target="_blank">C26441</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26441?view=msvc-170" target="_blank">C26441</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26443</key>
-    <name>C26443: NO_EXPLICIT_DTOR_OVERRIDE</name>
+    <name>C26443: Overriding destructor should not use explicit 'override' or 'virtual' specifiers</name>
     <description>
       <![CDATA[
-<p>"Overriding destructor should not use explicit 'override' or 'virtual' specifiers."</p>
+<p>Overriding destructor should not use explicit 'override' or 'virtual' specifiers.</p>
+<p>This warning was removed in Visual Studio 16.8 to reflect <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/pull/1448">changes to C.128 in the C++ Core Guidelines</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26443?view=msvc-160" target="_blank">C26443</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26443?view=msvc-170" target="_blank">C26443</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26444</key>
-    <name>C26444: NO_UNNAMED_RAII_OBJECTS</name>
+    <name>C26444: Avoid unnamed objects with custom construction and destruction</name>
     <description>
       <![CDATA[
 <p>Avoid unnamed objects with custom construction and destruction.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Res-noname">ES.84: Don't (try to) declare a local variable with no name</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26444?view=msvc-160" target="_blank">C26444</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26444?view=msvc-170" target="_blank">C26444</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26445</key>
-    <name>C26445: NO_SPAN_REF</name>
+    <name>C26445: Do not assign gsl::span or std::string_view to a reference</name>
     <description>
       <![CDATA[
+<p>Do not assign gsl::span or std::string_view to a reference. They are cheap to construct and are not owners of the underlying data. (gsl.view).</p>
 <p>A reference to <code>gsl::span</code> or <code>std::string_view</code> may be an indication of a lifetime issue.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26445?view=msvc-160" target="_blank">C26445</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26445?view=msvc-170" target="_blank">C26445</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26446</key>
-    <name>C26446: Prefer to use gsl::at() instead of unchecked subscript operator (bounds.4)</name>
+    <name>C26446: Prefer to use gsl::at() instead of unchecked subscript operator</name>
     <description>
       <![CDATA[
+<p>Prefer to use gsl::at() instead of unchecked subscript operator (bounds.4).</p>
 <p>C++ Core Guidelines: <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#probounds-bounds-safety-profile">Bounds.4: Don't use standard-library functions and types that are not bounds-checked</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26446?view=msvc-160" target="_blank">C26446</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26446?view=msvc-170" target="_blank">C26446</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26447</key>
-    <name>C26447: The function is declared noexcept but calls function function_name that may throw exceptions (f.6)</name>
+    <name>C26447: The function is declared noexcept but calls function function_name that may throw exceptions</name>
     <description>
       <![CDATA[
+<p>The function is declared noexcept but calls function function_name that may throw exceptions (f.6).</p>
 <p>C++ Core Guidelines:<br/>
 <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f6-if-your-function-may-not-throw-declare-it-noexcept">F.6: If your function may not throw, declare it noexcept</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26447?view=msvc-160" target="_blank">C26447</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26447?view=msvc-170" target="_blank">C26447</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26448</key>
-    <name>C26448: USE_GSL_FINALLY</name>
+    <name>C26448: Consider using gsl::finally if final action is intended</name>
     <description>
       <![CDATA[
-<p>Consider using <code>gsl::finally</code> if final action is intended.</p>
+<p>Consider using <code>gsl::finally</code> if final action is intended (gsl.util).</p>
+<p>C++ Core Guidelines: <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#SS-utilities">GSL.util: Utilities</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26448?view=msvc-160" target="_blank">C26448</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26448?view=msvc-170" target="_blank">C26448</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26449</key>
-    <name>C26449: NO_SPAN_FROM_TEMPORARY</name>
+    <name>C26449: gsl::span or std::string_view created from a temporary will be invalid when the temporary is invalidated</name>
     <description>
       <![CDATA[
-<p><code>gsl::span</code> or <code>std::string_view</code> created from a temporary will be invalid when the temporary is invalidated.</p>
+<p><code>gsl::span</code> or <code>std::string_view</code> created from a temporary will be invalid when the temporary is invalidated (gsl.view).</p>
+<p>C++ Core Guidelines: <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#gslview-views">GSL.view: Views</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26449?view=msvc-160" target="_blank">C26449</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26449?view=msvc-170" target="_blank">C26449</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26450</key>
-    <name>C26450: Arithmetic overflow: '%operator%' operation causes overflow at compile time</name>
+    <name>C26450: Arithmetic overflow: 'operator' operation causes overflow at compile time</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an arithmetic operation was provably lossy at compile time. This can be asserted when the operands are all compile-time constants.  Currently, we check left shift, multiplication, addition, and subtraction operations for such overflows.</p>
+<p>Arithmetic overflow: 'operator' operation causes overflow at compile time. Use a wider type to store the operands (io.1).</p>
+<p>This warning indicates that an arithmetic operation was provably lossy at compile time. It can be asserted when the operands are all compile-time constants. Currently, we check left shift, multiplication, addition, and subtraction operations for such overflows.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26450?view=msvc-160" target="_blank">C26450</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26450?view=msvc-170" target="_blank">C26450</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
@@ -9216,9 +9387,10 @@ Deleting such a pointer may lead to immediate memory corruption due to double de
     <name>C26451: Arithmetic overflow: Using operator 'operator' on a size-a byte value and then casting the result to a size-b byte value</name>
     <description>
       <![CDATA[
+<p>Arithmetic overflow: Using operator 'operator' on a size-a byte value and then casting the result to a size-b byte value. Cast the value to the wider type before calling operator 'operator' to avoid overflow (io.2).</p>
 <p>This warning indicates incorrect behavior that results from integral promotion rules and types larger than the ones in which arithmetic is typically performed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26451?view=msvc-160" target="_blank">C26451</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26451?view=msvc-170" target="_blank">C26451</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
@@ -9228,10 +9400,9 @@ Deleting such a pointer may lead to immediate memory corruption due to double de
     <name>C26452: Arithmetic overflow: Left shift count is negative or greater than or equal to the operand size, which is undefined behavior</name>
     <description>
       <![CDATA[
-<p>This warning indicates the shift count is negative, or greater than or equal to the number of bits in the shifted operand. Either case results in undefined behavior.
-C4293 is a similar check in the Microsoft C++ compiler.</p>
+<p>This warning indicates the shift count is negative, or greater than or equal to the number of bits in the shifted operand. Either case results in undefined behavior (io.3).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26452?view=msvc-160" target="_blank">C26452</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26452?view=msvc-170" target="_blank">C26452</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
@@ -9241,9 +9412,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C26453: Arithmetic overflow: Left shift of a negative signed number is undefined behavior</name>
     <description>
       <![CDATA[
-<p>This warning indicates the code left shifts a negative signed integral value, which is non-portable and triggers implementation defined behavior.</p>
+<p>This warning indicates the code left shifts a negative signed integral value, which is non-portable and triggers implementation defined behavior (io.4).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26453?view=msvc-160" target="_blank">C26453</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26453?view=msvc-170" target="_blank">C26453</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>BLOCKER</severity>
@@ -9253,12 +9424,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26454</key>
-    <name>C26454: Arithmetic overflow: '%operator%' operation produces a negative unsigned result at compile time</name>
+    <name>C26454: Arithmetic overflow: 'operator' operation produces a negative unsigned result at compile time</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the subtraction operation produces a negative result which was evaluated in an unsigned context. This can result in unintended overflows.</p>
+<p>This warning indicates that the subtraction operation produces a negative result that was evaluated in an unsigned context, which can result in unintended overflows.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26454?view=msvc-160" target="_blank">C26454</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26454?view=msvc-170" target="_blank">C26454</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>BLOCKER</severity>
@@ -9268,48 +9439,50 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26455</key>
-    <name>C26455: DEFAULT_CTOR_NOEXCEPT</name>
+    <name>C26455: Default constructor should not throw</name>
     <description>
       <![CDATA[
+<p>Default constructor should not throw. Declare it 'noexcept' (f.6).</p>
 <p>The C++ Core Guidelines suggest that default constructors shouldn't do anything that can throw. If the default constructor is allowed to throw, operations such as move and swap will also throw which is undesirable because move and swap should always succeed. Parameterized constructors may throw.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26455?view=msvc-160" target="_blank">C26455</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26455?view=msvc-170" target="_blank">C26455</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26456</key>
-    <name>C26456: DONT_HIDE_OPERATORS</name>
+    <name>C26456: Operator 'symbol_1' hides a non-virtual operator 'symbol_2'</name>
     <description>
       <![CDATA[
-<p>Hiding base methods that aren't virtual is error prone and makes code harder to read.</p>
+<p>Hiding base methods that aren't virtual is error prone and makes code harder to read (c.128).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26456?view=msvc-160" target="_blank">C26456</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26456?view=msvc-170" target="_blank">C26456</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
     </rule>
   <rule>
     <key>C26457</key>
-    <name>C26457: Never cast to (void) to ignore a [[nodiscard]] return value</name>
+    <name>C26457: (void) should not be used to ignore return values</name>
     <description>
       <![CDATA[
-<p>Excerpt from the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es48-avoid-casts">C++ Core Guideline for this warning</a>:</p>
+<p>(void) should not be used to ignore return values, use 'std::ignore =' instead (es.48).</p>
+<p>Excerpt from the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es48-avoid-casts">C++ Core Guideline ES.48</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26457?view=msvc-160" target="_blank">C26457</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26457?view=msvc-170" target="_blank">C26457</a></p>]]>
       </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26460</key>
-    <name>C26460: USE_CONST_REFERENCE_ARGUMENTS</name>
+    <name>C26460: The reference argument 'argument' for function 'function' can be marked as const</name>
     <description>
       <![CDATA[
-<p>The reference argument '%argument%' for function '%function%' can be marked as <code>const</code> (con.3).</p>
+<p>Passing an object by reference indicates that the function has the potential modify the object. If that isn't the intent of the function, it's better to mark the argument as a const reference (con.3).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26460?view=msvc-160" target="_blank">C26460</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26460?view=msvc-170" target="_blank">C26460</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9317,12 +9490,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26461</key>
-    <name>C26461: USE_CONST_POINTER_ARGUMENTS</name>
+    <name>C26461: The pointer argument 'argument' for function 'function' can be marked as a pointer to const</name>
     <description>
       <![CDATA[
-<p>The pointer argument '%argument%' for function '%function%' can be marked as a pointer to <code>const</code> (con.3).</p>
+<p>A function with a <code>T*</code> argument has the potential to modify the value of the object. If that isn't the intent of the function, it's better to make the pointer a <code>const T*</code> instead (con.3).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26461?view=msvc-160" target="_blank">C26461</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26461?view=msvc-170" target="_blank">C26461</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9330,12 +9503,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26462</key>
-    <name>C26462: USE_CONST_POINTER_FOR_VARIABLE</name>
+    <name>C26462: The value pointed to by 'variable' is assigned only once, mark it as a pointer to const</name>
     <description>
       <![CDATA[
-<p>The value pointed to by '%variable%' is assigned only once, mark it as a pointer to <code>const</code> (con.4).</p>
+<p>Pointers to variables whose values remain unchanged should be marked as <code>const</code> (con.4).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26462?view=msvc-160" target="_blank">C26462</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26462?view=msvc-170" target="_blank">C26462</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9343,12 +9516,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26463</key>
-    <name>C26463: USE_CONST_FOR_ELEMENTS</name>
+    <name>C26463: The elements of array 'array' are assigned only once</name>
     <description>
       <![CDATA[
-<p>The elements of array '%array%' are assigned only once, mark elements <code>const</code> (con.4)</p>
+<p>The elements of array 'array' are assigned only once, mark elements <code>const</code> (con.4).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26463?view=msvc-160" target="_blank">C26463</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26463?view=msvc-170" target="_blank">C26463</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9356,12 +9529,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26464</key>
-    <name>C26464: USE_CONST_POINTER_FOR_ELEMENTS</name>
+    <name>C26464: The values pointed to by elements of array 'array' are assigned only once</name>
     <description>
       <![CDATA[
 <p>The values pointed to by elements of array '%array%' are assigned only once, mark elements as pointer to <code>const</code> (con.4).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26464?view=msvc-160" target="_blank">C26464</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26464?view=msvc-170" target="_blank">C26464</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9369,12 +9542,13 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26465</key>
-    <name>C26465: NO_CONST_CAST_UNNECESSARY</name>
+    <name>C26465: Don't use const_cast to cast away const</name>
     <description>
       <![CDATA[
-<p>Don't use <code>const_cast</code> to cast away <code>const</code>. <code>const_cast</code> is not required; constness or volatility is not being removed by this conversion.</p>
+<p>Don't use const_cast to cast away const. const_cast is not required; constness or volatility is not being removed by this conversion.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-constcast">C++ Core Guidelines Type.3</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26465?view=msvc-160" target="_blank">C26465</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26465?view=msvc-170" target="_blank">C26465</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9382,12 +9556,13 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26466</key>
-    <name>C26466: NO_STATIC_DOWNCAST_POLYMORPHIC</name>
+    <name>C26466: Don't use static_cast downcasts</name>
     <description>
       <![CDATA[
 <p>Don't use <code>static_cast</code> downcasts. A cast from a polymorphic type should use dynamic_cast.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-downcast">C++ Core Guidelines Type.2</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26466?view=msvc-160" target="_blank">C26466</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26466?view=msvc-170" target="_blank">C26466</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9395,12 +9570,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26471</key>
-    <name>C26471: NO_REINTERPRET_CAST_FROM_VOID_PTR</name>
+    <name>C26471: Don't use reinterpret_cast</name>
     <description>
       <![CDATA[
-<p>Don't use <code>reinterpret_cast</code>. A cast from void* can use <code>static_cast</code>.</p>
+<p>Don't use <code>reinterpret_cast</code>. A cast from void* can use <code>static_cast</code> (type.1).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26471?view=msvc-160" target="_blank">C26471</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26471?view=msvc-170" target="_blank">C26471</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>CRITICAL</severity>
@@ -9410,96 +9585,106 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26472</key>
-    <name>C26472: NO_CASTS_FOR_ARITHMETIC_CONVERSION</name>
+    <name>C26472: Don't use a static_cast for arithmetic conversions</name>
     <description>
       <![CDATA[
-<p>"Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast, or gsl::narrow."</p>
+<p>Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast, or gsl::narrow.</p>
+<p><strong>C++ Core Guidelines</strong>:
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#prosafety-type-safety-profile">Type.1</a>: Avoid casts.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26472?view=msvc-160" target="_blank">C26472</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26472?view=msvc-170" target="_blank">C26472</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26473</key>
-    <name>C26473: NO_IDENTITY_CAST</name>
+    <name>C26473: Don't cast between pointer types where the source type and the target type are the same</name>
     <description>
       <![CDATA[
-<p>"Don't cast between pointer types where the source type and the target type are the same."</p>
+<p>Don't cast between pointer types where the source type and the target type are the same.</p>
+<p><strong>C++ Core Guidelines</strong>:
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#prosafety-type-safety-profile">Type.1</a>: Avoid casts.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26473?view=msvc-160" target="_blank">C26473</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26473?view=msvc-170" target="_blank">C26473</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26474</key>
-    <name>C26474: NO_IMPLICIT_CAST</name>
+    <name>C26474: Don't cast between pointer types when the conversion could be implicit</name>
     <description>
       <![CDATA[
-<p>"Don't cast between pointer types when the conversion could be implicit."</p>
+<p>Don't cast between pointer types when the conversion could be implicit.</p>
+<p><strong>C++ Core Guidelines</strong>:<br/>
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#prosafety-type-safety-profile">Type.1</a>: Avoid casts.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26474?view=msvc-160" target="_blank">C26474</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26474?view=msvc-170" target="_blank">C26474</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26475</key>
-    <name>C26475: NO_FUNCTION_STYLE_CASTS</name>
+    <name>C26475: Do not use function style C-casts</name>
     <description>
       <![CDATA[
-<p>"Do not use function style C-casts."</p>
+<p>Do not use function style C-casts.</p>
+<p><strong>C++ Core Guidelines</strong>:
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es49-if-you-must-use-a-cast-use-a-named-cast">ES.49</a>: If you must use a cast, use a named cast.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26475?view=msvc-160" target="_blank">C26475</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26475?view=msvc-170" target="_blank">C26475</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26476</key>
-    <name>C26476: USE_VARIANT</name>
+    <name>C26476: Expression/symbol 'name' uses a naked union 'union' with multiple type pointers</name>
     <description>
       <![CDATA[
+<p>Expression/symbol 'name' uses a naked union 'union' with multiple type pointers: Use variant instead (type.7).</p>
 <p><code>std::variant</code> provides a type-safe alternative to <code>union</code> and should be preferred in modern code.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26476?view=msvc-160" target="_blank">C26476</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26476?view=msvc-170" target="_blank">C26476</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26477</key>
-    <name>C26477: USE_NULLPTR_NOT_CONSTANT</name>
+    <name>C26477: Use 'nullptr' rather than 0 or NULL</name>
     <description>
       <![CDATA[
-<p><code>nullptr</code> has a special type <code>nullptr_t</code> that allows overloads with special null handling. Using <code>0</code> or <code>NULL</code> in place of <code>nullptr</code> bypasses the type safety and deduction that <code>nullptr</code> provides.</p>
+<p><code>nullptr</code> has a special type <code>nullptr_t</code> that allows overloads with special null handling. Using <code>0</code> or <code>NULL</code> in place of <code>nullptr</code> bypasses the type safety and deduction that <code>nullptr</code> provides (es.47).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26477?view=msvc-160" target="_blank">C26477</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26477?view=msvc-170" target="_blank">C26477</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26478</key>
-    <name>C26478: Don't use std::move on constant variables. (es.56)</name>
+    <name>C26478: Don't use std::move on constant variables</name>
     <description>
       <![CDATA[
-<p>This warning is to indicate that the use of std::move not consistent with how std::move is intended to be used.</p>
+<p>This warning is to indicate that the use of <code>std::move</code> not consistent with how <code>std::move</code> is intended to be used (es.56).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26478?view=msvc-160" target="_blank">C26478</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26478?view=msvc-170" target="_blank">C26478</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26481</key>
-    <name>C26481: Don't use pointer arithmetic. Use span instead (bounds.1)</name>
+    <name>C26481: Don't use pointer arithmetic</name>
     <description>
       <![CDATA[
+<p>Don't use pointer arithmetic. Use span instead (bounds.1).</name>
 <p>This check supports the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md">C++ Core Guidelines</a> rule <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-array">I.13</a>: <em>Do not pass an array as a single pointer</em>. Whenever raw pointers are used in arithmetic operations they should be replaced with safer kinds of buffers, such as <code>span&lt;T&gt;</code> or <code>vector&lt;T&gt;</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26481?view=msvc-160" target="_blank">C26481</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26481?view=msvc-170" target="_blank">C26481</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>CRITICAL</severity>
@@ -9509,12 +9694,13 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26482</key>
-    <name>C26482: NO_DYNAMIC_ARRAY_INDEXING</name>
+    <name>C26482: Only index into arrays using constant expressions</name>
     <description>
       <![CDATA[
 <p>Only index into arrays using constant expressions.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#SS-bounds">C++ Core Guidelines Bounds.2</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26482?view=msvc-160" target="_blank">C26482</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26482?view=msvc-170" target="_blank">C26482</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>CRITICAL</severity>
@@ -9523,12 +9709,13 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26483</key>
-    <name>C26483: STATIC_INDEX_OUT_OF_RANGE</name>
+    <name>C26483: Value 'value' is outside the bounds (0, 'bound') of variable 'variable'</name>
     <description>
       <![CDATA[
-<p>Value %value% is outside the bounds (0, %bound%) of variable '%variable%'. Only index into arrays using constant expressions that are within bounds of the array (bounds.2).</p>
+<p>Value 'value' is outside the bounds (0, 'bound') of variable 'variable'. Only index into arrays using constant expressions that are within bounds of the array (bounds.2).</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#SS-bounds">C++ Core Guidelines Bounds.2</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26483?view=msvc-160" target="_blank">C26483</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26483?view=msvc-170" target="_blank">C26483</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>CRITICAL</severity>
@@ -9538,12 +9725,13 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26485</key>
-    <name>C26485: Expression 'array-name': No array to pointer decay (bounds.3)</name>
+    <name>C26485: Expression 'array-name': No array to pointer decay</name>
     <description>
       <![CDATA[
-<p>Like <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/c26481?view=msvc-160">C26481</a>, this check helps to enforce the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md">C++ Core Guidelines</a> rule <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-array">I.13</a>: <em>Do not pass an array as a single pointer</em>. The rule detects places where static array type information is lost from decay to a raw pointer. The <code>zstring</code> and <code>czstring</code> types are not excluded.</p>
+<p>Expression 'array-name': No array to pointer decay (bounds.3).</p>
+<p>Like <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26481?view=msvc-170">C26481</a>, this check helps to enforce the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md">C++ Core Guidelines</a> rule <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-array">I.13</a>: <em>Do not pass an array as a single pointer</em>. The rule detects places where static array type information is lost from decay to a raw pointer. The <code>zstring</code> and <code>czstring</code> types aren't excluded.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26485?view=msvc-160" target="_blank">C26485</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26485?view=msvc-170" target="_blank">C26485</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>CRITICAL</severity>
@@ -9552,12 +9740,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26486</key>
-    <name>C26486: LIFETIMES_FUNCTION_PRECONDITION_VIOLATION</name>
+    <name>C26486: Don't pass a pointer that may be invalid (dangling) as a parameter to a function</name>
     <description>
       <![CDATA[
 <p>Don't pass a pointer that may be invalid (dangling) as a parameter to a function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26486?view=msvc-160" target="_blank">C26486</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26486?view=msvc-170" target="_blank">C26486</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>CRITICAL</severity>
@@ -9566,12 +9754,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26487</key>
-    <name>C26487: LIFETIMES_FUNCTION_POSTCONDITION_VIOLATION</name>
+    <name>C26487: Don't allow a function to return an invalid pointer, either through a formal return statement or through output parameters</name>
     <description>
       <![CDATA[
 <p>Don't allow a function to return an invalid pointer, either through a formal return statement or through output parameters.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26487?view=msvc-160" target="_blank">C26487</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26487?view=msvc-170" target="_blank">C26487</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>CRITICAL</severity>
@@ -9580,24 +9768,24 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26488</key>
-    <name>C26488: LIFETIMES_DEREF_NULL_POINTER</name>
+    <name>C26488: Don't dereference a pointer that may be null</name>
     <description>
       <![CDATA[
 <p>Don't dereference a pointer that may be null.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26488?view=msvc-160" target="_blank">C26488</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26488?view=msvc-170" target="_blank">C26488</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26489</key>
-    <name>C26489: LIFETIMES_DEREF_INVALID_POINTER</name>
+    <name>C26489: Don't dereference a pointer that may be invalid</name>
     <description>
       <![CDATA[
 <p>Don't dereference a pointer that may be invalid.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26489?view=msvc-160" target="_blank">C26489</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26489?view=msvc-170" target="_blank">C26489</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>BLOCKER</severity>
@@ -9607,12 +9795,13 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26490</key>
-    <name>C26490: NO_REINTERPRET_CAST</name>
+    <name>C26490: Don't use reinterpret_cast</name>
     <description>
       <![CDATA[
 <p>Don't use <code>reinterpret_cast</code>.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#SS-type">C++ Core Guidelines Type.1</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26490?view=msvc-160" target="_blank">C26490</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26490?view=msvc-170" target="_blank">C26490</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>CRITICAL</severity>
@@ -9621,12 +9810,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26491</key>
-    <name>C26491: NO_STATIC_DOWNCAST</name>
+    <name>C26491: Don't use static_cast downcasts</name>
     <description>
       <![CDATA[
 <p>Don't use <code>static_cast</code> downcasts. See <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#SS-type">C++ Core Guidelines Type.2</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26491?view=msvc-160" target="_blank">C26491</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26491?view=msvc-170" target="_blank">C26491</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>CRITICAL</severity>
@@ -9635,12 +9824,13 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26492</key>
-    <name>C26492: NO_CONST_CAST</name>
+    <name>C26492: Don't use const_cast to cast away const</name>
     <description>
       <![CDATA[
 <p>Don't use <code>const_cast</code> to cast away <code>const</code>.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#SS-type">C++ Core Guidelines Type.3</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26492?view=msvc-160" target="_blank">C26492</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26492?view=msvc-170" target="_blank">C26492</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>CRITICAL</severity>
@@ -9649,12 +9839,13 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26493</key>
-    <name>C26493: NO_CSTYLE_CAST</name>
+    <name>C26493: Don't use C-style casts</name>
     <description>
       <![CDATA[
 <p>Don't use C-style casts.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#SS-type">C++ Core Guidelines Type.4</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26493?view=msvc-160" target="_blank">C26493</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26493?view=msvc-170" target="_blank">C26493</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>CRITICAL</severity>
@@ -9663,12 +9854,13 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26494</key>
-    <name>C26494: VAR_USE_BEFORE_INIT</name>
+    <name>C26494: Variable 'variable' is uninitialized</name>
     <description>
       <![CDATA[
-<p>Variable '%variable%' is uninitialized. Always initialize an object.</p>
+<p>Variable 'variable' is uninitialized. Always initialize an object.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#SS-type">C++ Core Guidelines Type.5</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26494?view=msvc-160" target="_blank">C26494</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26494?view=msvc-170" target="_blank">C26494</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <type>BUG</type>
@@ -9677,12 +9869,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26495</key>
-    <name>C26495: MEMBER_UNINIT</name>
+    <name>C26495: Variable 'variable' is uninitialized</name>
     <description>
       <![CDATA[
-<p>Variable '%variable%' is uninitialized. Always initialize a member variable (type.6).</p>
+<p>A member variable isn't initialized by a constructor or by an initializer. Make sure all variables are initialized by the end of construction. For more information, see C++ Core Guidelines <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#SS-type">Type.6</a> and <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c48-prefer-in-class-initializers-to-member-initializers-in-constructors-for-constant-initializers">C.48</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26495?view=msvc-160" target="_blank">C26495</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26495?view=msvc-170" target="_blank">C26495</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <type>BUG</type>
@@ -9696,7 +9888,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#con4-use-const-to-define-objects-with-values-that-do-not-change-after-construction">C++ Core Guidelines con.4</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26496?view=msvc-160" target="_blank">C26496</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26496?view=msvc-170" target="_blank">C26496</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9704,12 +9896,13 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26497</key>
-    <name>C26497: USE_CONSTEXPR_FOR_FUNCTION</name>
+    <name>C26497: This function function-name could be marked constexpr if compile-time evaluation is desired</name>
     <description>
       <![CDATA[
-<p>This function %function% could be marked <code>constexpr</code> if compile-time evaluation is desired (f.4).</p>
+<p>This function function-name could be marked constexpr if compile-time evaluation is desired (f.4).</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rf-constexpr">C++ Core Guidelines F.4</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26497?view=msvc-160" target="_blank">C26497</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26497?view=msvc-170" target="_blank">C26497</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9717,12 +9910,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26498</key>
-    <name>C26498: USE_CONSTEXPR_FOR_FUNCTIONCALL</name>
+    <name>C26498: The function 'function' is constexpr, mark variable 'variable' constexpr if compile-time evaluation is desired</name>
     <description>
       <![CDATA[
 <p>This rule helps to enforce Con.5 from the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#con5-use-constexpr-for-values-that-can-be-computed-at-compile-time">C++ Core Guidelines</a>: use constexpr for values that can be computed at compile time.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26498?view=msvc-160" target="_blank">C26498</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26498?view=msvc-170" target="_blank">C26498</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9730,12 +9923,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26800</key>
-    <name>C26800: Use of a moved from object: &lt;lock&gt;</name>
+    <name>C26800: Use of a moved from object: 'object'</name>
     <description>
       <![CDATA[
-<p>Warning C26800 is triggered when variable is used after it has been moved from. A variable is considered moved from after it was passed to a function as rvalue reference. There are some legitimate exceptions for uses such as assignment, destruction, and some state resetting functions such as std::vector::clear.</p>
+<p>Warning C26800 is triggered when variable is used after it has been moved from. A variable is considered moved from after it was passed to a function as rvalue reference. There are some legitimate exceptions for uses such as assignment, destruction, and some state resetting functions such as <code>std::vector::clear</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26800?view=msvc-160" target="_blank">C26800</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26800?view=msvc-170" target="_blank">C26800</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9743,12 +9936,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26810</key>
-    <name>C26810: Lifetime of captured variable &lt;var&gt; might end by the time the coroutine is resumed</name>
+    <name>C26810: Lifetime of captured variable 'var' might end by the time the coroutine is resumed</name>
     <description>
       <![CDATA[
 <p>Warning C26810 is triggered when a memory region might be used after it went out of scope in a resumed coroutine.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26810?view=msvc-160" target="_blank">C26810</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26810?view=msvc-170" target="_blank">C26810</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9756,12 +9949,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26811</key>
-    <name>C26811: Lifetime of the memory referenced by parameter &lt;var&gt; might end by the time the coroutine is resumed</name>
+    <name>C26811: Lifetime of the memory referenced by parameter 'var' might end by the time the coroutine is resumed</name>
     <description>
       <![CDATA[
 <p>Warning C26811 is triggered when a memory region might be used after it went out of scope in a resumed coroutine.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26811?view=msvc-160" target="_blank">C26811</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26811?view=msvc-170" target="_blank">C26811</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9769,108 +9962,269 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C26812</key>
-    <name>C26812: Prefer 'enum class' over 'enum' (Enum.3)</name>
+    <name>C26812: The enum type 'type-name' is unscoped. Prefer 'enum class' over 'enum'</name>
     <description>
       <![CDATA[
-<p>The enum type <em>type-name</em> is unscoped. Prefer 'enum class' over 'enum' (Enum.3)</p>
+<p>Prefer <code>enum class</code> over <code>enum</code> to prevent pollution in the global namespace (Enum.3).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26812?view=msvc-160" target="_blank">C26812</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26812?view=msvc-170" target="_blank">C26812</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
-    <key>C26814</key>
-    <name>C26814: Use constexpr for constants whose value is known at compile time. (Con.5)</name>
+    <key>C26813</key>
+    <name>C26813: Use 'bitwise and' to check if a flag is set</name>
     <description>
       <![CDATA[
-<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rconst-constexpr">Con.5 Use constexpr for all variables that can be computed at compile time</a></p>
+<p>Most <code>enum</code> types with power of two member values are intended to be used as bit flags. As a result, you rarely want to compare these flags for equality. Instead, extract the bits you're interested in by using bitwise operations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26814?view=msvc-160" target="_blank">C26814</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26813?view=msvc-170" target="_blank">C26813</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C26814</key>
+    <name>C26814: The const variable 'variable' can be computed at compile time</name>
+    <description>
+      <![CDATA[
+<p>Use <code>constexpr</code> for constants whose value is known at compile time. (Con.5).</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26814?view=msvc-170" target="_blank">C26814</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26815</key>
-    <name>C26815: The pointer is dangling because it points at a temporary instance that was destroyed. (ES.65)</name>
+    <name>C26815: The pointer is dangling because it points at a temporary instance that was destroyed</name>
     <description>
       <![CDATA[
-<p>There is a dangling pointer that is the result of an unnamed temporary that has been destroyed.</p>
+<p>There's a dangling pointer that is the result of an unnamed temporary that has been destroyed (ES.65).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26815?view=msvc-160" target="_blank">C26815</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26815?view=msvc-170" target="_blank">C26815</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26816</key>
-    <name>C26816: The pointer points to memory allocated on the stack (ES.65)</name>
+    <name>C26816: The pointer points to memory allocated on the stack</name>
     <description>
       <![CDATA[
-<p>The pointer points to a variable that is allocated on the stack.  When the variable goes out of scope it is cleaned up, which causes the pointer to be invalid.</p>
+<p>The pointer points to a variable that is allocated on the stack. When the variable goes out of scope it's cleaned up, which causes the pointer to be invalid  (ES.65).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26816?view=msvc-160" target="_blank">C26816</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26816?view=msvc-170" target="_blank">C26816</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26817</key>
-    <name>C26817: Potentially expensive copy of variable name in range-for loop. Consider making it a const reference (es.71)</name>
+    <name>C26817: Potentially expensive copy of variable name in range-for loop</name>
     <description>
       <![CDATA[
+<p>Potentially expensive copy of variable name in range-for loop. Consider making it a const reference (es.71).</p>
 <p>For more information, see <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#note-214">ES.71 notes</a> in the C++ Core Guidelines.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26817?view=msvc-160" target="_blank">C26817</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26817?view=msvc-170" target="_blank">C26817</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26818</key>
-    <name>C26818: Switch statement does not cover all cases. Consider adding a 'default' label (es.79)</name>
+    <name>C26818: Switch statement does not cover all cases</name>
     <description>
       <![CDATA[
+<p>Switch statement does not cover all cases. Consider adding a 'default' label (es.79).</p>
 <p>This check covers the missing <strong><code>default</code></strong> label in switch statements that switch over a non-enumeration type, such as <strong><code>int</code></strong>, <strong><code>char</code></strong>, and so on.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26818?view=msvc-160" target="_blank">C26818</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26818?view=msvc-170" target="_blank">C26818</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26819</key>
-    <name>C26819: Unannotated fallthrough between switch labels (es.78)</name>
+    <name>C26819: Unannotated fallthrough between switch labels</name>
     <description>
       <![CDATA[
-<p>This check covers implicit fallthrough in switch statements. Implicit fallthrough is when control flow transfers from one switch case directly into a following switch case without the use of the <code>[[fallthrough]];</code> statement. This warning is raised when an implicit fallthrough is detected in a switch case containing at least one statement.</p>
+<p>This check covers implicit fallthrough in switch statements. Implicit fallthrough is when control flow transfers from one switch case directly into a following switch case without the use of the <code>[[fallthrough]];</code> statement. This warning is raised when an implicit fallthrough is detected in a switch case containing at least one statement (es.78).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26819?view=msvc-160" target="_blank">C26819</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26819?view=msvc-170" target="_blank">C26819</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C26820</key>
-    <name>C26820: Assigning by value when a const-reference would suffice, use const auto&amp; instead (p.9)</name>
+    <name>C26820: Assigning by value when a const-reference would suffice</name>
     <description>
       <![CDATA[
+<p>Assigning by value when a const-reference would suffice, use const auto&amp; instead (p.9.</p>
 <p>For more information, see <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#p9-dont-waste-time-or-space">P.9: Don't waste time or space</a> in the C++ Core Guidelines.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c26820?view=msvc-160" target="_blank">C26820</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26820?view=msvc-170" target="_blank">C26820</a></p>]]>
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
   <rule>
-    <key>C28020</key>
-    <name>C28020: The expression &lt;expr&gt; is not true at this call</name>
+    <key>C26822</key>
+    <name>C26822: Dereferencing a null pointer 'variable'</name>
     <description>
       <![CDATA[
-<p>This warning is reported when the _Satisfies_ expression listed is not true. Frequently this indicates an incorrect parameter.</p>
+<p>Dereferencing a null pointer is frequent problem in C and C++. We have several checks to deal with such problems. See this <a data-linktype="external" href="https://devblogs.microsoft.com/cppblog/improved-null-pointer-dereference-detection-in-visual-studio-2022-version-17-0-preview-4/">blog post</a> for a comparison. When the analysis engine deduces the value of a pointer to be null and sees that pointer get dereferenced, it will emit a <code>C26822</code> warning. You can also enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26823?view=msvc-170">C26823</a> for a stricter analysis. This check also supports <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/understanding-sal?view=msvc-170">SAL annotations</a> and <a data-linktype="external" href="https://github.com/microsoft/GSL"><code>gsl::not_null</code></a> to describe invariants of the code (lifetime.1).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28020?view=msvc-160" target="_blank">C28020</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26822?view=msvc-170" target="_blank">C26822</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C26823</key>
+    <name>C26823: Dereferencing a possibly null pointer 'variable'</name>
+    <description>
+      <![CDATA[
+<p>Dereferencing a null pointer is frequent problem in C and C++. We have several checks to deal with such problems. See this <a data-linktype="external" href="https://devblogs.microsoft.com/cppblog/improved-null-pointer-dereference-detection-in-visual-studio-2022-version-17-0-preview-4/">blog post</a> for a comparison. When the analysis engine deduces that the value of a pointer might be null and sees that pointer get dereferenced, it will emit a <code>C26823</code> warning. You can enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26822?view=msvc-170">C26822</a> only for a more permissive analysis. This check also supports <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/understanding-sal?view=msvc-170">SAL annotations</a> and <a data-linktype="external" href="https://github.com/microsoft/GSL"><code>gsl::not_null</code></a> to describe invariants of the code (lifetime.1).</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26823?view=msvc-170" target="_blank">C26823</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C26824</key>
+    <name>C26824: Postcondition for null pointer 'variable' requires it to be non-null</name>
+    <description>
+      <![CDATA[
+<p>Dereferencing a null pointer is a frequent problem in C and C++. We have several checks to deal with such problems. See this <a data-linktype="external" href="https://devblogs.microsoft.com/cppblog/improved-null-pointer-dereference-detection-in-visual-studio-2022-version-17-0-preview-4/">blog post</a> for a comparison. When the analysis engine sees a null pointer returned from a function that has a contract forbidding such an operation, it will emit a <code>C26824</code> warning. You can also enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26825?view=msvc-170">C26825</a> for a stricter analysis. This check only works on functions annotated using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/understanding-sal?view=msvc-170">SAL annotations</a> (lifetime.1).</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26824?view=msvc-170" target="_blank">C26824</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C26825</key>
+    <name>C26825: Postcondition for possibly null pointer 'variable' requires it to be non-null</name>
+    <description>
+      <![CDATA[
+<p>Dereferencing a null pointer is a frequent problem in C and C++. We have several checks to deal with such problems. See this <a data-linktype="external" href="https://devblogs.microsoft.com/cppblog/improved-null-pointer-dereference-detection-in-visual-studio-2022-version-17-0-preview-4/">blog post</a> for a comparison. When the analysis engine sees a potentially null pointer returned from a function that has a contract forbidding such operation, it will emit a <code>C26825</code> warning. You can enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26824?view=msvc-170">C26824</a> only for a more permissive analysis. This check only works on functions annotated using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/understanding-sal?view=msvc-170">SAL annotations</a> (lifetime.1).</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26825?view=msvc-170" target="_blank">C26825</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C26826</key>
+    <name>C26826: Don't use C-style variable arguments</name>
+    <description>
+      <![CDATA[
+<p>Don't use C-style variable arguments (f.55).</p>
+<p>For more information, see <a data-linktype="external" href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#F-varargs">F.55: Don't use <code>va_arg</code> arguments</a> in the C++ Core Guidelines.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26826?view=msvc-170" target="_blank">C26826</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C26827</key>
+    <name>C26827: Did you forget to initialize an enum, or intend to use another type?</name>
+    <description>
+      <![CDATA[
+<p>Most <code>enum</code> types used in bitwise operations are expected to have members with values of powers of two. This warning attempts to find cases where a value wasn't given explicitly to an enumeration constant. It also finds cases where the wrong enumeration type may have been used inadvertently.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26827?view=msvc-170" target="_blank">C26827</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C26828</key>
+    <name>C26828: Different enum types have overlapping values</name>
+    <description>
+      <![CDATA[
+<p>Different enum types have overlapping values. Did you want to use another enum constant here?</p>
+<p>Most of the time, a single enumeration type describes all the bit flags that you can use for an option. If you use two different enumeration types that have overlapping values in the same bitwise expression, the chances are good those enumeration types weren't designed for use together.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26828?view=msvc-170" target="_blank">C26828</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C26829</key>
+    <name>C26829: Empty optional 'variable' is unwrapped</name>
+    <description>
+      <![CDATA[
+<p>Unwrapping empty <code>std::optional</code> values is undefined behavior. Such operation is considered a security vulnerability as it can result in a crash, reading uninitialized memory, or other unexpected behavior. This check will attempt to find cases where a <code>std::optional</code> is known to be empty and unwrapped. You can also enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26830?view=msvc-170">C26830</a>, <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26859?view=msvc-170">C26859</a>, and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26860?view=msvc-170">C26860</a> for a stricter analysis.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26829?view=msvc-170" target="_blank">C26829</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C26830</key>
+    <name>C26830: Potentially empty optional 'variable' is unwrapped</name>
+    <description>
+      <![CDATA[
+<p>Unwrapping empty <code>std::optional</code> values is undefined behavior. Such operation is considered a security vulnerability as it can result in a crash, reading uninitialized memory, or other unexpected behavior. This check will attempt to find cases where a <code>std::optional</code> isn't checked for emptiness before unwrap operations. You can enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26829?view=msvc-170">C26829</a> only for a more permissive analysis.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26830?view=msvc-170" target="_blank">C26830</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C26859</key>
+    <name>C26859: Empty optional 'variable' is unwrapped, will throw exception</name>
+    <description>
+      <![CDATA[
+<p>Unwrapping empty <code>std::optional</code> values via the <code>value</code> method will throw an exception. Such operation can result in a crash when the exception isn't handled. This check will attempt to find cases where a <code>std::optional</code> is known to be empty and unwrapped using the <code>value</code> method. You can also enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26829?view=msvc-170">C26829</a>, <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26830?view=msvc-170">C26830</a>, and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26860?view=msvc-170">C26860</a> for a stricter analysis.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26859?view=msvc-170" target="_blank">C26859</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C26860</key>
+    <name>C26860: Potentially empty optional 'variable' is unwrapped, may throw exception</name>
+    <description>
+      <![CDATA[
+<p>Unwrapping empty <code>std::optional</code> values via the <code>value</code> method will throw an exception. Such operation can result in a crash when the exception isn't handled. This check will attempt to find cases where a <code>std::optional</code> isn't checked for emptiness before unwrapping it via the <code>value</code> method. You can enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26829?view=msvc-170">C26829</a>, and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26859?view=msvc-170">C26859</a> only for a more permissive analysis.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26860?view=msvc-170" target="_blank">C26860</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    <remediationFunction>LINEAR</remediationFunction>
+    <remediationFunctionGapMultiplier>5min</remediationFunctionGapMultiplier>
+    </rule>
+  <rule>
+    <key>C28020</key>
+    <name>C28020: The expression 'expr' is not true at this call</name>
+    <description>
+      <![CDATA[
+<p>This warning is reported when the <code>_Satisfies_</code> expression listed isn't true. Frequently, the warning indicates an incorrect parameter.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28020?view=msvc-170" target="_blank">C28020</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9878,12 +10232,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28021</key>
-    <name>C28021: The parameter &lt;param&gt; being annotated with &lt;anno&gt; must be a pointer</name>
+    <name>C28021: The parameter 'param' being annotated with 'annotation' must be a pointer</name>
     <description>
       <![CDATA[
-<p>This warning is reported when the object being annotated is not a pointer type. This annotation cannot be used with <strong><code>void</code></strong> or integral types.</p>
+<p>This warning is reported when the object being annotated is not a pointer type. This annotation can't be used with <strong><code>void</code></strong> or integral types.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28021?view=msvc-160" target="_blank">C28021</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28021?view=msvc-170" target="_blank">C28021</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9891,12 +10245,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28022</key>
-    <name>C28022: The function class(es) &lt;classlist1&gt; on this function do not match the function class(es) &lt;classlist2&gt; on the typedef used to define it</name>
+    <name>C28022: The function class(es) 'classlist1' on this function do not match the function class(es) 'classlist2' on the typedef used to define it</name>
     <description>
       <![CDATA[
-<p>This warning is reported when there is an error in the annotations. Both the typedef and the function itself have <code>_Function_class_</code> annotations, but they do not match. If both are used they must match.</p>
+<p>This warning is reported when there's an error in the annotations. Both the typedef and the function itself have <code>_Function_class_</code> annotations, but they don't match. If both are used, they must match.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28022?view=msvc-160" target="_blank">C28022</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28022?view=msvc-170" target="_blank">C28022</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9904,12 +10258,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28023</key>
-    <name>C28023: The function being assigned or passed should have a _Function_class_ annotation for at least one of the class(es) in: &lt;classlist&gt;</name>
+    <name>C28023: The function being assigned or passed should have a _Function_class_ annotation for at least one of the class(es) in: 'classlist'</name>
     <description>
       <![CDATA[
-<p>This warning is usually reported when only one function class is in use and a callback of the appropriate type is not declared.</p>
+<p>This warning is often reported when only one function class is in use and a callback of the appropriate type isn't declared.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28023?view=msvc-160" target="_blank">C28023</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28023?view=msvc-170" target="_blank">C28023</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9917,12 +10271,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28024</key>
-    <name>C28024: The function pointer being assigned to is annotated with the function class &lt;class&gt;, which is not contained in the function class(es) &lt;classlist&gt;</name>
+    <name>C28024: The function pointer being assigned to is annotated with the function class 'class', which is not contained in the function class(es) 'classlist'</name>
     <description>
       <![CDATA[
-<p>This warning is reported when both functions were annotated with a function class, but the classes do not match.</p>
+<p>This warning is reported when both functions were annotated with a function class, but the classes don't match.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28024?view=msvc-160" target="_blank">C28024</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28024?view=msvc-170" target="_blank">C28024</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9930,12 +10284,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28039</key>
-    <name>C28039: The type of actual parameter &lt;operand&gt; should exactly match the type &lt;typename&gt;</name>
+    <name>C28039: The type of actual parameter 'operand' should exactly match the type 'typename'</name>
     <description>
       <![CDATA[
-<p>This warning is usually reported when an enum formal was not passed a member of the enum, but may also be used for other types.</p>
+<p>This warning is reported when an <code>enum</code> formal wasn't passed a member of the <code>enum</code>, but may also be used for other types.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28039?view=msvc-160" target="_blank">C28039</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28039?view=msvc-170" target="_blank">C28039</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9946,9 +10300,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28103: Leaking resource</name>
     <description>
       <![CDATA[
-<p>The specified object contains a resource that has not been freed. A function being called has been annotated with <code>__drv_acquiresResource</code> or <code>__drv_acquiresResourceGlobal</code> and this warning indicates that the resource named in the annotation was not freed.</p>
+<p>The specified object contains a resource that hasn't been freed. A function being called has been annotated with <code>__drv_acquiresResource</code> or <code>__drv_acquiresResourceGlobal</code> and this warning indicates that the resource named in the annotation wasn't freed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28103?view=msvc-160" target="_blank">C28103</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28103?view=msvc-170" target="_blank">C28103</a></p>]]>
     </description>
     <severity>INFO</severity>
     <type>BUG</type>
@@ -9960,9 +10314,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28104: Resource that should have been acquired before function exit was not acquired</name>
     <description>
       <![CDATA[
-<p>A function that is intended to acquire a resource before it exits has exited without acquiring the resource. This warning indicates that the function is annotated with <code>__drv_acquiresResource</code> but does not return having actually acquired the resource. If this function is a wrapper function, a path through the function did not reach the wrapped function. If the failure to reach the wrapped function is because the function returned an error and did not actually acquire the resource, you might need to use a conditional annotation (<code>__drv_when</code>).</p>
+<p>A function that is intended to acquire a resource before it exits has exited without acquiring the resource. This warning indicates that the function is annotated with <code>__drv_acquiresResource</code> but doesn't return having actually acquired the resource. If this function is a wrapper function, a path through the function didn't reach the wrapped function. If the failure to reach the wrapped function is because the function returned an error and didn't actually acquire the resource, you might need to use a conditional annotation (<code>__drv_when</code>).</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28104?view=msvc-160" target="_blank">C28104</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28104?view=msvc-170" target="_blank">C28104</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -9973,9 +10327,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28105: Leaking resource due to an exception</name>
     <description>
       <![CDATA[
-<p>The specified resource is not freed when an exception is raised. The statement specified by the path can raise an exception. This warning is similar to warning <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/c28103?view=msvc-160">C28103</a>, except that in this case an exception is involved.</p>
+<p>The specified resource isn't freed when an exception is raised. The statement specified by the path can raise an exception. This warning is similar to warning <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c28103?view=msvc-170">C28103</a>, except that in this case an exception is involved.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28105?view=msvc-160" target="_blank">C28105</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28105?view=msvc-170" target="_blank">C28105</a></p>]]>
     </description>
     <severity>INFO</severity>
     <type>BUG</type>
@@ -9987,9 +10341,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28106: Variable already holds resource possibly causing leak</name>
     <description>
       <![CDATA[
-<p>A variable that contains a resource is used in a context in which a new value can be placed in the variable. If this occurs, the resource can be lost and not properly freed, causing a resource leak.</p>
+<p>A variable that contains a resource is used in a context in which a new value can be placed in the variable. If such placement occurs, the original resource can be lost and not properly freed, causing a resource leak.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28106?view=msvc-160" target="_blank">C28106</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28106?view=msvc-170" target="_blank">C28106</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10000,9 +10354,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28107: Resource must be held when calling function</name>
     <description>
       <![CDATA[
-<p>A resource that the program must acquire before calling the function was not acquired when the function was called. As a result, the function call will fail. This warning is reported only when resources are acquired and released in the same function.</p>
+<p>A resource that the program must acquire before calling the function wasn't acquired when the function was called. As a result, the function call will fail. This warning is reported only when resources are acquired and released in the same function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28107?view=msvc-160" target="_blank">C28107</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28107?view=msvc-170" target="_blank">C28107</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10015,7 +10369,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>The resource that the driver is using is in the expected C language type, but has a different semantic type.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28108?view=msvc-160" target="_blank">C28108</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28108?view=msvc-170" target="_blank">C28108</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10026,9 +10380,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28109: Variable cannot be held at the time function is called</name>
     <description>
       <![CDATA[
-<p>The program is holding a resource that should not be held when it is calling this function. Typically, it indicates that the resource was unintentionally acquired twice. The Code Analysis tool reports this warning when resources are acquired and released in the same function.</p>
+<p>The program is holding a resource that shouldn't be held when it's calling this function. Typically, it indicates that the resource was unintentionally acquired twice. The Code Analysis tool reports this warning when resources are acquired and released in the same function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28109?view=msvc-160" target="_blank">C28109</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28109?view=msvc-170" target="_blank">C28109</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10036,12 +10390,13 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28112</key>
-    <name>C28112: A variable which is accessed via an Interlocked function must always be accessed via an Interlocked function</name>
+    <name>C28112: A variable (parameter-name) which is accessed via an Interlocked function must always be accessed via an Interlocked function</name>
     <description>
       <![CDATA[
-<p>See line <em>[number]</em>: It is not always safe to access a variable which is accessed via the Interlocked* family of functions in any other way.</p>
+<p>A variable (parameter-name) which is accessed via an Interlocked function must always be accessed via an Interlocked function. See line line-number: It is not always safe to access a variable which is accessed via the Interlocked* family of functions in any other way.</p>
+<p>A variable that is accessed by using the Interlocked executive support routines, such as InterlockedCompareExchangeAcquire, is later accessed by using a different function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28112?view=msvc-160" target="_blank">C28112</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28112?view=msvc-170" target="_blank">C28112</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10054,7 +10409,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>The driver is using an Interlocked executive support routine, such as <a data-linktype="absolute-path" href="/en-us/windows-hardware/drivers/ddi/content/wdm/nf-wdm-interlockeddecrement">InterlockedDecrement</a>, to access a local variable.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28113?view=msvc-160" target="_blank">C28113</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28113?view=msvc-170" target="_blank">C28113</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10065,9 +10420,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28125: The function must be called from within a try/except block</name>
     <description>
       <![CDATA[
-<p>The driver is calling a function that must be called from within a try/except block, such as <a data-linktype="absolute-path" href="/en-us/windows-hardware/drivers/ddi/content/wdm/nf-wdm-probeforread">ProbeForRead</a>, <a data-linktype="absolute-path" href="/en-us/windows-hardware/drivers/ddi/content/wdm/nf-wdm-probeforwrite">ProbeForWrite</a>, <a data-linktype="absolute-path" href="/en-us/windows-hardware/drivers/ddi/content/wdm/nf-wdm-mmprobeandlockpages">MmProbeAndLockPages</a>.</p>
+<p>The driver is calling a function that must be called from within a try/except block, such as <a data-linktype="absolute-path" href="/en-us/windows-hardware/drivers/ddi/content/wdm/nf-wdm-probeforread"><code>ProbeForRead</code></a>, <a data-linktype="absolute-path" href="/en-us/windows-hardware/drivers/ddi/content/wdm/nf-wdm-probeforwrite"><code>ProbeForWrite</code></a>, or <a data-linktype="absolute-path" href="/en-us/windows-hardware/drivers/ddi/content/wdm/nf-wdm-mmprobeandlockpages"><code>MmProbeAndLockPages</code></a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28125?view=msvc-160" target="_blank">C28125</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28125?view=msvc-170" target="_blank">C28125</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10080,7 +10435,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This warning is reported when a function call is missing a required (literal) constant. Consult the documentation for the function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28137?view=msvc-160" target="_blank">C28137</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28137?view=msvc-170" target="_blank">C28137</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10093,7 +10448,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This warning is reported in a function call that expects a variable or a non-constant expression, but the call includes a constant. For information about the function and its parameter, consult the WDK documentation of the function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28138?view=msvc-160" target="_blank">C28138</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28138?view=msvc-170" target="_blank">C28138</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10101,12 +10456,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28159</key>
-    <name>C28159: Consider using another function instead</name>
+    <name>C28159: Consider using *function_name_1* instead of *function_name_2*</name>
     <description>
       <![CDATA[
-<p>This warning is reported for Drivers is suggesting that you use a preferred function call that is semantically equivalent to the function that the driver is calling. This is a general warning message; the annotation <code>__drv_preferredFunction</code> was used (possibly with a conditional a <code>__drv_when</code>() annotation) to flag a bad coding practice.</p>
+<p>This warning occurs when you use a function that is semantically equivalent to an alternative, preferred function call.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28159?view=msvc-160" target="_blank">C28159</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28159?view=msvc-170" target="_blank">C28159</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10119,7 +10474,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This warning is reported when a <code>__drv_error</code> annotation has been encountered. This annotation is used to flag coding practices that should be fixed, and can be used with a <code>__drv_when</code> annotation to indicate specific combinations of parameters.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28160?view=msvc-160" target="_blank">C28160</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28160?view=msvc-170" target="_blank">C28160</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10132,7 +10487,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This warning is reported when a function is of a type that should never be enclosed in a <code>try/except</code>  block is found in a <code>try/except</code> block. The code analysis tool found at least one path in which the function called was within a <code>try/except</code> block.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28163?view=msvc-160" target="_blank">C28163</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28163?view=msvc-170" target="_blank">C28163</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10145,7 +10500,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This warning is reported when a pointer to a pointer is used in a call to a function that is expecting a pointer to an object.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28164?view=msvc-160" target="_blank">C28164</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28164?view=msvc-170" target="_blank">C28164</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10156,9 +10511,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28182: Dereferencing NULL pointer</name>
     <description>
       <![CDATA[
-<p><strong>Additional information</strong>: <em>&lt;pointer1&gt;</em> contains the same NULL value as <em>&lt;pointer2&gt;</em> did <em>&lt;note&gt;</em></p>
+<p><strong>Additional information</strong>: <em>&lt;pointer1&gt;</em> contains the same NULL value as <em>&lt;pointer2&gt;</em> did.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28182?view=msvc-160" target="_blank">C28182</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28182?view=msvc-170" target="_blank">C28182</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10169,9 +10524,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28183: The argument could be one value, and is a copy of the value found in the pointer</name>
     <description>
       <![CDATA[
-<p>This warning indicates that this value is unexpected in the current context. This warning usually appears when a <code>NULL</code> value is passed as an argument to a function that does not permit it. The value was actually found in the specified variable, and the argument is a copy of that variable.</p>
+<p>This warning indicates that this value is unexpected in the current context. This warning usually appears when a <code>NULL</code> value is passed as an argument to a function that doesn't permit it. The value was actually found in the specified variable, and the argument is a copy of that variable.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28183?view=msvc-160" target="_blank">C28183</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28183?view=msvc-170" target="_blank">C28183</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10182,9 +10537,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28193: The variable holds a value that must be examined</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the calling function is not checking the value of the specified variable, which was supplied by a function. The returned value is annotated with the <code>_Check_return_</code> annotation, but the calling function is either not using the value or is overwriting the value without examining it.</p>
+<p>This warning indicates that the calling function isn't checking the value of the specified variable, which was supplied by a function. The returned value is annotated with the <code>_Check_return_</code> annotation, but the calling function is either not using the value or is overwriting the value without examining it.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28193?view=msvc-160" target="_blank">C28193</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28193?view=msvc-170" target="_blank">C28193</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10195,9 +10550,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28194: The function was declared as aliasing the value in variable and exited without doing so</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the function prototype for the function being analyzed has a <code>__drv_isAliased</code> annotation, which indicates that it will <em>alias</em> the specified argument (that is, assign the value in a way that it will survive returning from the function). However, the function does not alias the argument along the path that is indicated by the annotation. Most functions that alias a variable save its value to a global data structure.</p>
+<p>This warning indicates that the function prototype for the function being analyzed has a <code>__drv_isAliased</code> annotation, which indicates that it will <em>alias</em> the specified argument (that is, assign the value in a way that it will survive returning from the function). However, the function doesn't alias the argument along the path that is indicated by the annotation. Most functions that alias a variable save its value to a global data structure.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28194?view=msvc-160" target="_blank">C28194</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28194?view=msvc-170" target="_blank">C28194</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10208,9 +10563,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28195: The function was declared as acquiring memory in  a variable and exited without doing so</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the function prototype for the function being analyzed has a <code>__drv_acquiresMemory</code> annotation. The <code>__drv_acquiresMemory</code> annotation indicates that the function acquires memory in the designated result location, but in at least one path, the function did not acquire the memory. Note that the Code Analysis tool will not recognize the actual implementation of a memory allocator (involving address arithmetic) and will not recognize that memory is allocated (although many wrappers will be recognized). In this case, the Code Analysis tool does not recognize that the memory was allocated and issues this warning. To suppress the false positive, use a <code>#pragma</code> warning on the line that precedes the opening brace <code>{</code> of the function body</p>
+<p>This warning indicates that the function prototype for the function being analyzed has a <code>__drv_allocatesMem</code> annotation. The <code>__drv_allocatesMem</code> annotation indicates that the function acquires memory in the designated result location, but in at least one path, the function didn't acquire the memory. The Code Analysis tool won't recognize the actual implementation of a memory allocator (involving address arithmetic) and won't recognize that memory is allocated (although many wrappers will be recognized). In this case, the Code Analysis tool doesn't recognize that the memory was allocated and issues this warning. To suppress the false positive, use a <code>#pragma</code> warning on the line that precedes the opening brace <code>{</code> of the function body.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28195?view=msvc-160" target="_blank">C28195</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28195?view=msvc-170" target="_blank">C28195</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10218,12 +10573,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28196</key>
-    <name>C28196: The requirement is not satisfied. (The expression does not evaluate to true.)</name>
+    <name>C28196: The requirement is not satisfied</name>
     <description>
       <![CDATA[
 <p>This warning indicates that the function prototype for the function being analyzed has a <code>__notnull</code>, <code>__null</code> or <code>__drv_valueIs</code> on an <code>_Out_</code> parameter or the return value, but the value returned is inconsistent with that annotation.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28196?view=msvc-160" target="_blank">C28196</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28196?view=msvc-170" target="_blank">C28196</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10236,7 +10591,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This warning is reported for both memory and resource leaks when the resource is potentially aliased to another location.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28197?view=msvc-160" target="_blank">C28197</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28197?view=msvc-170" target="_blank">C28197</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10247,9 +10602,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28198: Possibly leaking memory due to an exception</name>
     <description>
       <![CDATA[
-<p>This warning indicates that allocated memory is not being freed after an exception is raised. The statement at the end of the path can raise an exception. The memory was passed to a function that might have saved a copy to be freed later.</p>
+<p>This warning indicates that allocated memory isn't being freed after an exception is raised. The statement at the end of the path can raise an exception. The memory was passed to a function that might have saved a copy to be freed later.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28198?view=msvc-160" target="_blank">C28198</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28198?view=msvc-170" target="_blank">C28198</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10262,7 +10617,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This message indicates that the variable has had its address taken but no assignment to it has been discovered.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28199?view=msvc-160" target="_blank">C28199</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28199?view=msvc-170" target="_blank">C28199</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10273,9 +10628,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28202: Illegal reference to non-static member</name>
     <description>
       <![CDATA[
-<p>This warning is reported when there is an error in the annotations.</p>
+<p>This warning is reported when there's an error in the annotations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28202?view=msvc-160" target="_blank">C28202</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28202?view=msvc-170" target="_blank">C28202</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10283,12 +10638,13 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28203</key>
-    <name>C28203: Ambiguous reference to class member. Could be &lt;name1&gt; or &lt;name2&gt;</name>
+    <name>C28203: Ambiguous reference to class member</name>
     <description>
       <![CDATA[
-<p>This warning is reported when there is an error in the annotations.</p>
+<p>Ambiguous reference to class member. Could be 'name1' or 'name2'.</p>
+<p>This warning is reported when there's an error in the annotations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28203?view=msvc-160" target="_blank">C28203</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28203?view=msvc-170" target="_blank">C28203</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10296,12 +10652,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28204</key>
-    <name>C28204: &lt;function&gt; : Only one of this overload and the one at &lt;filename&gt;(&lt;line&gt;) are annotated for &lt;paramname&gt;: both or neither must be annotated</name>
+    <name>C28204: &lt;function&gt; : Only one of this overload and the one at 'filename'('line') are annotated for 'paramname': both or neither must be annotated</name>
     <description>
       <![CDATA[
-<p>This warning is reported when there is an error in the annotations.</p>
+<p>This warning is reported when there's an error in the annotations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28204?view=msvc-160" target="_blank">C28204</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28204?view=msvc-170" target="_blank">C28204</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10309,12 +10665,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28205</key>
-    <name>C28205: function&gt; : _Success_ or _On_failure_ used in an illegal context</name>
+    <name>C28205: 'function': _Success_ or _On_failure_ used in an illegal context</name>
     <description>
       <![CDATA[
 <p>The <code>_Success_</code> and <code>_On_failure_</code> annotations can only be used on function return values.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28205?view=msvc-160" target="_blank">C28205</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28205?view=msvc-170" target="_blank">C28205</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10322,12 +10678,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28206</key>
-    <name>C28206: &lt;expression&gt; : left operand points to a struct, use -&gt;</name>
+    <name>C28206: &lt;expression&gt; : left operand points to a struct</name>
     <description>
       <![CDATA[
 <p>This warning is reported when the struct pointer dereference notation <code>-&gt;</code> was expected.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28206?view=msvc-160" target="_blank">C28206</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28206?view=msvc-170" target="_blank">C28206</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10335,12 +10691,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28207</key>
-    <name>C28207: &lt;expression&gt;: left operand is a struct, use </name>
+    <name>C28207: &lt;expression&gt;: left operand is a struct</name>
     <description>
       <![CDATA[
 <p>This warning is reported when a struct dereference dot (.) was expected.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28207?view=msvc-160" target="_blank">C28207</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28207?view=msvc-170" target="_blank">C28207</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10348,12 +10704,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28208</key>
-    <name>C28208: Function &lt;function&gt; was previously defined with a different parameter list at &lt;file&gt;(&lt;line&gt;)</name>
+    <name>C28208: Function function_name was previously defined with a different parameter list at file_name(line_number)</name>
     <description>
       <![CDATA[
-<p>This warning is reported when a function's known definition doesn't match another occurrence.</p>
+<p>This warning almost always accompanies <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4028?view=msvc-170">Compiler Warning (level 1) C4028</a>. Both warn of a mismatch between the parameters of a function's declaration and its definition. However, this specific error indicates a more niche case than C4028. C28208 indicates not only that a mismatch exists, but that it also can cause issues with analysis tools. This warning most notably occurs when the mismatch exists between a <code>typedef</code> function pointer and the definition of that function. This warning is demonstrated in the example below.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28208?view=msvc-160" target="_blank">C28208</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28208?view=msvc-170" target="_blank">C28208</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10366,7 +10722,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This warning indicates an incorrectly constructed annotation declaration. This warning should never occur in normal use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28209?view=msvc-160" target="_blank">C28209</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28209?view=msvc-170" target="_blank">C28209</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10377,9 +10733,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28210: Annotations for the _On_failure_ context must not be in explicit pre context</name>
     <description>
       <![CDATA[
-<p>Annotations <code>_On_failure_</code> must be explicitly or implicitly indicated in <code>__post</code> context, that is, to be applied after the function returns.  Use <code>_drv_out</code> to ensure this.</p>
+<p>Annotations <code>_On_failure_</code> must be explicitly or implicitly indicated in <code>__post</code> context, that is, to be applied after the function returns.  Use <code>_drv_out</code> to ensure this annotation is indicated.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28210?view=msvc-160" target="_blank">C28210</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28210?view=msvc-170" target="_blank">C28210</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10392,7 +10748,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This warning indicates that the operand to the <code>_Static_context_</code> annotation must be the name of a tool-defined context. This warning should never occur in normal use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28211?view=msvc-160" target="_blank">C28211</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28211?view=msvc-170" target="_blank">C28211</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10405,7 +10761,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This warning indicates that the numbered parameter to an annotation (not the function being annotated) is expected to be a pointer or array type, but some other type was encountered. The annotation needs to be corrected.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28212?view=msvc-160" target="_blank">C28212</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28212?view=msvc-170" target="_blank">C28212</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10416,9 +10772,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28213: The _Use_decl_annotations_ annotation must be used to reference, without modification, a prior declaration</name>
     <description>
       <![CDATA[
-<p><code>_Use_decl_annotations_</code> tells the compiler to use the annotations from an earlier declaration of the function.  If no earlier declaration can be found, or if the current declaration makes changes to the annotations than this warning is emitted.</p>
+<p><code>_Use_decl_annotations_</code> tells the compiler to use the annotations from an earlier declaration of the function. If no earlier declaration can be found, or if the current declaration makes changes to the annotations, then this warning is emitted.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28213?view=msvc-160" target="_blank">C28213</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28213?view=msvc-170" target="_blank">C28213</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10431,7 +10787,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This warning indicates that when you construct an annotation declaration, the parameter names are limited to p1...p9. This warning should never occur in normal use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28214?view=msvc-160" target="_blank">C28214</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28214?view=msvc-170" target="_blank">C28214</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10442,9 +10798,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28215: The typefix cannot be applied to a parameter that already has a typefix</name>
     <description>
       <![CDATA[
-<p>Applying a <code>__typefix</code> annotation to a parameter that already has that annotation is an error. The <code>__typefix</code> annotations are used only in a few special cases and this warning is not expected to be seen in normal use.</p>
+<p>Applying a <code>__typefix</code> annotation to a parameter that already has that annotation is an error. The <code>__typefix</code> annotations are used only in a few special cases. We don't expect this warning to be seen in normal use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28215?view=msvc-160" target="_blank">C28215</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28215?view=msvc-170" target="_blank">C28215</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10457,7 +10813,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>The <code>_Check_return_</code> annotation has been applied in a context other than <code>__post</code>; it may need a <code>__post</code> (or <code>__drv_out</code>) modifier, or it may be placed incorrectly.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28216?view=msvc-160" target="_blank">C28216</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28216?view=msvc-170" target="_blank">C28216</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10468,9 +10824,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28217: For function, the number of parameters to annotation does not match that found at file</name>
     <description>
       <![CDATA[
-<p>The annotations on the current line and on the line in the message are inconsistent. This should not be possible if the standard macros are being used for annotations; this warning is not expected to be seen in normal use.</p>
+<p>The annotations on the current line and on the line in the message are inconsistent. This inconsistency shouldn't be possible if the standard macros are being used for annotations. We don't expect this warning to be seen in normal use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28217?view=msvc-160" target="_blank">C28217</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28217?view=msvc-170" target="_blank">C28217</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10481,9 +10837,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28218: For function parameter, the annotation's parameter does not match that found at file</name>
     <description>
       <![CDATA[
-<p>The annotations on the current line and on the line in the message are inconsistent. This should not be possible if the standard macros are being used for annotations; this warning is not expected to be seen in normal use.</p>
+<p>The annotations on the current line and on the line in the message are inconsistent. This inconsistency shouldn't be possible if the standard macros are being used for annotations. We don't expect this warning to be seen in normal use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28218?view=msvc-160" target="_blank">C28218</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28218?view=msvc-170" target="_blank">C28218</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10494,9 +10850,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28219: Member of enumeration expected for annotation the parameter in the annotation</name>
     <description>
       <![CDATA[
-<p>A parameter to an annotation is expected to be a member of the named <strong><code>enum</code></strong> type, and some other symbol was encountered; use a member of that <strong><code>enum</code></strong> type. This usually indicates an incorrectly coded annotation macro.</p>
+<p>A parameter to an annotation is expected to be a member of the named <strong><code>enum</code></strong> type, and some other symbol was encountered; use a member of that <strong><code>enum</code></strong> type. This warning usually indicates an incorrectly coded annotation macro.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28219?view=msvc-160" target="_blank">C28219</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28219?view=msvc-170" target="_blank">C28219</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10504,12 +10860,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28220</key>
-    <name>C28220: Integer expression expected for annotation '&lt;annotation&gt;'</name>
+    <name>C28220: Integer expression expected for annotation 'annotation'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an integer expression was expected as an annotation parameter, but an incompatible type was used instead. It can be caused by trying to use a SAL annotation macro that does not fit the current scenario.</p>
+<p>This warning indicates that an integer expression was expected as an annotation parameter, but an incompatible type was used instead. It can be caused by trying to use a SAL annotation macro that doesn't fit the current scenario.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28220?view=msvc-160" target="_blank">C28220</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28220?view=msvc-170" target="_blank">C28220</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10520,9 +10876,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28221: String expression expected for the parameter in the annotation</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a parameter to an annotation is expected to be a string, and some other type was encountered. This usually indicates an incorrectly coded annotation macro and is not expected to be seen in normal use.</p>
+<p>This warning indicates that a parameter to an annotation is expected to be a string, and some other type was encountered. This warning usually indicates an incorrectly coded annotation macro, and we don't expect it to be seen in normal use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28221?view=msvc-160" target="_blank">C28221</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28221?view=msvc-170" target="_blank">C28221</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10533,9 +10889,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28222: _Yes_, _No_, or _Maybe_ expected for annotation</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a parameter to an annotation is expected to be one of the symbols <code>_Yes_</code>, <code>_No_</code>, or <code>_Maybe_</code>, and some other symbol was encountered. This usually indicates an incorrectly coded annotation macro.</p>
+<p>This warning indicates that a parameter to an annotation is expected to be one of the symbols <code>_Yes_</code>, <code>_No_</code>, or <code>_Maybe_</code>, and some other symbol was encountered. This warning usually indicates an incorrectly coded annotation macro.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28222?view=msvc-160" target="_blank">C28222</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28222?view=msvc-170" target="_blank">C28222</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10546,9 +10902,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28223: Did not find expected Token/identifier for annotation, parameter</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a parameter to an annotation is expected to be an identifier, and some other symbol was encountered. This usually indicates an incorrectly coded annotation macro. The use of C or C++ keywords in this position will cause this error.</p>
+<p>This warning indicates that a parameter to an annotation is expected to be an identifier, and some other symbol was encountered. This warning usually indicates an incorrectly coded annotation macro. The use of C or C++ keywords in this position will cause this error.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28223?view=msvc-160" target="_blank">C28223</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28223?view=msvc-170" target="_blank">C28223</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10559,9 +10915,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28224: Annotation requires parameters</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the named annotation is used without parameters and at least one parameter is required. This should not be possible if the standard macros are being used for annotations; this warning is not expected to be seen in normal use.</p>
+<p>This warning indicates that the named annotation is used without parameters and at least one parameter is required. This warning shouldn't be possible if the standard macros are being used for annotations. We don't expect this warning to be seen in normal use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28224?view=msvc-160" target="_blank">C28224</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28224?view=msvc-170" target="_blank">C28224</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10572,9 +10928,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28225: Did not find the correct number of required parameters in annotation</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the named annotation is used with the incorrect number of parameters. This should not be possible if the standard macros are being used for annotations; this warning is not expected to be seen in typical use.</p>
+<p>This warning indicates that the named annotation is used with the incorrect number of parameters. This warning shouldn't be possible if the standard macros are being used for annotations. We don't expect this warning to be seen in typical use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28225?view=msvc-160" target="_blank">C28225</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28225?view=msvc-170" target="_blank">C28225</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10585,9 +10941,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28226: Annotation cannot also be a PrimOp (in current declaration)</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the named annotation is being declared as a PrimOp, and also was previously declared as a normal annotation. This should not be possible if the standard macros are being used for annotations; this warning is not expected to be seen in normal use.</p>
+<p>This warning indicates that the named annotation is being declared as a PrimOp, and also was previously declared as a normal annotation. This warning shouldn't be possible if the standard macros are being used for annotations. We don't expect this warning to be seen in typical use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28226?view=msvc-160" target="_blank">C28226</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28226?view=msvc-170" target="_blank">C28226</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10598,9 +10954,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28227: Annotation cannot also be a PrimOp (see prior declaration)</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the named annotation is being declared as an ordinary annotation, and also was previously declared as a PrimOp. This should not be possible if the standard macros are being used for annotations; this warning is not expected to be seen in typical use.</p>
+<p>This warning indicates that the named annotation is being declared as an ordinary annotation, and also was previously declared as a PrimOp. This warning shouldn't be possible if the standard macros are being used for annotations. We don't expect this warning to be seen in typical use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28227?view=msvc-160" target="_blank">C28227</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28227?view=msvc-170" target="_blank">C28227</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10611,9 +10967,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28228: Annotation parameter: cannot use type in annotations</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a parameter is of type that is not supported. Annotations can only use a limited set of types as parameters. This should not be possible if the standard macros are being used for annotations; this warning is not expected to be seen in typical use.</p>
+<p>This warning indicates that a parameter is of type that isn't supported. Annotations can only use a limited set of types as parameters. This warning shouldn't be possible if the standard macros are being used for annotations. We don't expect this warning to be seen in typical use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28228?view=msvc-160" target="_blank">C28228</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28228?view=msvc-170" target="_blank">C28228</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10624,9 +10980,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28229: Annotation does not support parameters</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an annotation was used with a parameter when the annotation is declared without parameters. This should not be possible if the standard macros are being used for annotations; this warning is not expected to be seen in typical use.</p>
+<p>This warning indicates that an annotation was used with a parameter when the annotation is declared without parameters. This warning shouldn't be possible if the standard macros are being used for annotations. We don't expect this warning to be seen in typical use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28229?view=msvc-160" target="_blank">C28229</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28229?view=msvc-170" target="_blank">C28229</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10637,9 +10993,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28230: The type of parameter has no member</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an argument to an annotation attempts to access a member of a <strong><code>struct</code></strong>, <strong><code>class</code></strong>, or <strong><code>union</code></strong> that does not exist.  This warning will also be emitted if a parameter tries to call a member function of the object.</p>
+<p>This warning indicates that an argument to an annotation attempts to access a member of a <strong><code>struct</code></strong>, <strong><code>class</code></strong>, or <strong><code>union</code></strong> that doesn't exist.  This warning will also be emitted if a parameter tries to call a member function of the object.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28230?view=msvc-160" target="_blank">C28230</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28230?view=msvc-170" target="_blank">C28230</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10652,7 +11008,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This warning indicates that an argument to an annotation should be an array, and some other type was encountered.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28231?view=msvc-160" target="_blank">C28231</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28231?view=msvc-170" target="_blank">C28231</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10663,9 +11019,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28232: _Pre_, _Post_, or _Deref_ not applied to any annotation</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a <code>_Pre_</code>, <code>_Post_</code>, or <code>_Deref_</code> operator appears in an annotation expression without a subsequent functional annotation; the modifier was ignored, but this indicates an incorrectly coded annotation.</p>
+<p>This warning indicates that a <code>_Pre_</code>, <code>_Post_</code>, or <code>_Deref_</code> operator appears in an annotation expression without a subsequent functional annotation; the modifier was ignored, but this warning indicates an incorrectly coded annotation.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28232?view=msvc-160" target="_blank">C28232</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28232?view=msvc-170" target="_blank">C28232</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10676,9 +11032,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28233: pre, post, or deref applied to a block</name>
     <description>
       <![CDATA[
-<p>C28233: pre, post, or deref applied to a block</p>
+<p>pre, post, or deref applied to a block.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28233?view=msvc-160" target="_blank">C28233</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28233?view=msvc-170" target="_blank">C28233</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10689,9 +11045,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28234: _At_ expression does not apply to current function</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the value of an <code>_At_</code> expression does not identify an accessible object.</p>
+<p>This warning indicates that the value of an <code>_At_</code> expression doesn't identify an accessible object.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28234?view=msvc-160" target="_blank">C28234</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28234?view=msvc-170" target="_blank">C28234</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10702,9 +11058,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28235: The function cannot stand alone as an annotation</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an attempt was made to use a function that was not declared to be an annotation in an annotation context. This includes using a primitive operation (PrimOp) in a standalone context. This should not be possible if the standard macros are being used for annotations. This warning is not expected to be seen in typical use.</p>
+<p>This warning indicates that an attempt was made to use a function that wasn't declared to be an annotation in an annotation context. This includes using a primitive operation (PrimOp) in a standalone context. This warning shouldn't be possible if the standard macros are being used for annotations. We don't expect this warning to be seen in typical use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28235?view=msvc-160" target="_blank">C28235</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28235?view=msvc-170" target="_blank">C28235</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10715,9 +11071,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28236: The annotation cannot be used in an expression</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an attempt was made to use a function declared to be an annotation in an expression context. This should not be possible if the standard macros are being used for annotations; this warning is not expected to be seen in typical use.</p>
+<p>This warning indicates that an attempt was made to use a function declared to be an annotation in an expression context. This warning shouldn't be possible if the standard macros are being used for annotations. We don't expect this warning to be seen in typical use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28236?view=msvc-160" target="_blank">C28236</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28236?view=msvc-170" target="_blank">C28236</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10728,9 +11084,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28237: The annotation on parameter is no longer supported</name>
     <description>
       <![CDATA[
-<p>An internal error has occurred in the PREfast model file. This warning should not occur in typical use.</p>
+<p>An internal error has occurred in the PREfast model file. This warning shouldn't occur in typical use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28237?view=msvc-160" target="_blank">C28237</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28237?view=msvc-170" target="_blank">C28237</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10741,9 +11097,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28238: The annotation on parameter has more than one of value, stringValue, and longValue</name>
     <description>
       <![CDATA[
-<p>An internal error has occurred in the PREfast model file. This warning should not occur in typical use.</p>
+<p>An internal error has occurred in the PREfast model file. This warning shouldn't occur in typical use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28238?view=msvc-160" target="_blank">C28238</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28238?view=msvc-170" target="_blank">C28238</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10754,9 +11110,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28239: The annotation on parameter has both value, stringValue, or longValue; and paramn=xxx</name>
     <description>
       <![CDATA[
-<p>An internal error has occurred in the PREfast model file. This warning should not occur in typical use.</p>
+<p>An internal error has occurred in the PREfast model file. This warning shouldn't occur in typical use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28239?view=msvc-160" target="_blank">C28239</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28239?view=msvc-170" target="_blank">C28239</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10767,9 +11123,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28240: The annotation on parameter has param2 but no param1</name>
     <description>
       <![CDATA[
-<p>An internal error has occurred in the PREfast model file. This warning should not occur in typical use.</p>
+<p>An internal error has occurred in the PREfast model file. This warning shouldn't occur in typical use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28240?view=msvc-160" target="_blank">C28240</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28240?view=msvc-170" target="_blank">C28240</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10780,9 +11136,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28241: The annotation for function on parameter is not recognized</name>
     <description>
       <![CDATA[
-<p>An unrecognized annotation name was used. This should not be possible if the standard macros are being used for annotations; this warning is not expected to be seen in typical use.</p>
+<p>An unrecognized annotation name was used. This warning shouldn't be possible if the standard macros are being used for annotations. We don't expect this warning to be seen in typical use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28241?view=msvc-160" target="_blank">C28241</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28241?view=msvc-170" target="_blank">C28241</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10795,7 +11151,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>The number of <code>__deref</code> operators on an annotation is more than the number of levels of pointer defined by the parameter type. Correct this warning by changing either the number in the annotation or the pointer levels of the parameter referenced.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28243?view=msvc-160" target="_blank">C28243</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28243?view=msvc-170" target="_blank">C28243</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10806,9 +11162,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28244: The annotation for function has an unparseable parameter/external annotation</name>
     <description>
       <![CDATA[
-<p>This should currently not be possible if the standard macros are being used for annotations; this warning is not expected to be seen in typical use.</p>
+<p>This warning shouldn't be possible if the standard macros are being used for annotations. We don't expect this warning to be seen in typical use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28244?view=msvc-160" target="_blank">C28244</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28244?view=msvc-170" target="_blank">C28244</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10819,9 +11175,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28245: The annotation for function annotates 'this' on a non-member-function</name>
     <description>
       <![CDATA[
-<p>An internal error has occurred in the PREfast model file. This warning should not occur in typical use.</p>
+<p>An internal error has occurred in the PREfast model file. This warning shouldn't occur in typical use.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28245?view=msvc-160" target="_blank">C28245</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28245?view=msvc-170" target="_blank">C28245</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10829,12 +11185,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28246</key>
-    <name>C28246: The annotation for function '&lt;name&gt;' - parameter '&lt;parameter&gt;' does not match the type of the parameter</name>
+    <name>C28246: The annotation for function 'name' - parameter 'parameter' does not match the type of the parameter</name>
     <description>
       <![CDATA[
-<p>A __deref operator was applied to a non-pointer type when creating an annotation.</p>
+<p>A <code>__deref</code> operator was applied to a non-pointer type when creating an annotation.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28246?view=msvc-160" target="_blank">C28246</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28246?view=msvc-170" target="_blank">C28246</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10847,7 +11203,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>Note: There are several prototypes for this function. This warning compares the first prototype with instance number &lt;number&gt;.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28250?view=msvc-160" target="_blank">C28250</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28250?view=msvc-170" target="_blank">C28250</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10858,9 +11214,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28251: Inconsistent annotation for function: this instance has an error</name>
     <description>
       <![CDATA[
-<p>This warning refers to an error in the annotation and reflects the requirement that the annotations on a function declaration must match those on the definition, except if a function <strong><code>typedef</code></strong> is involved. In that case, the function <strong><code>typedef</code></strong> is taken as definitive for both the declaration and the definition.</p>
+<p>This warning refers to an error in the annotation and reflects the requirement that the annotations on a function declaration must match the ones on the definition, except if a function <strong><code>typedef</code></strong> is involved. In that case, the function <strong><code>typedef</code></strong> is taken as definitive for both the declaration and the definition.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28251?view=msvc-160" target="_blank">C28251</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28251?view=msvc-170" target="_blank">C28251</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10871,9 +11227,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28252: Inconsistent annotation for function: parameter has another annotation on this instance</name>
     <description>
       <![CDATA[
-<p>This warning refers to an error in the annotation and reflects the requirement that the annotations on a function declaration must match those on the definition, except if a function <strong><code>typedef</code></strong> is involved. In that case, the function <strong><code>typedef</code></strong> is taken as definitive for both the declaration and the definition.</p>
+<p>This warning refers to an error in the annotation and reflects the requirement that the annotations on a function declaration must match the ones on the definition, except if a function <strong><code>typedef</code></strong> is involved. In that case, the function <strong><code>typedef</code></strong> is taken as definitive for both the declaration and the definition.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28252?view=msvc-160" target="_blank">C28252</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28252?view=msvc-170" target="_blank">C28252</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10884,9 +11240,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28253: Inconsistent annotation for function: parameter has another annotations on this instance</name>
     <description>
       <![CDATA[
-<p>This warning refers to an error in the annotation and reflects the requirement that the annotations on a function declaration must match those on the definition, except if a function <strong><code>typedef</code></strong> is involved. In that case, the function <strong><code>typedef</code></strong> is taken as definitive for both the declaration and the definition.</p>
+<p>This warning refers to an error in the annotation and reflects the requirement that the annotations on a function declaration must match the ones on the definition, except if a function <strong><code>typedef</code></strong> is involved. In that case, the function <strong><code>typedef</code></strong> is taken as definitive for both the declaration and the definition.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28253?view=msvc-160" target="_blank">C28253</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28253?view=msvc-170" target="_blank">C28253</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10897,9 +11253,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28254: dynamic_cast&lt;&gt;() is not supported in annotations</name>
     <description>
       <![CDATA[
-<p>The C++ <strong><code>dynamic_cast</code></strong> operator cannot be used in annotations.</p>
+<p>The C++ <strong><code>dynamic_cast</code></strong> operator can't be used in annotations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28254?view=msvc-160" target="_blank">C28254</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28254?view=msvc-170" target="_blank">C28254</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10907,12 +11263,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28262</key>
-    <name>C28262: A syntax error in the annotation was found in function &lt;function&gt; for annotation &lt;name&gt;</name>
+    <name>C28262: A syntax error in the annotation was found in function 'function' for annotation 'name'</name>
     <description>
       <![CDATA[
-<p>C28262: A syntax error in the annotation was found in function &lt;function&gt; for annotation &lt;name&gt;</p>
+<p>A syntax error in the annotation was found in function 'function' for annotation 'name'.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28262?view=msvc-160" target="_blank">C28262</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28262?view=msvc-170" target="_blank">C28262</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10925,7 +11281,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>The Code Analysis tool reports this warning when the return value for the specified function has a conditional value. This warning indicates an error in the annotations, not in the code being analyzed. If the function declaration is in a header file, the annotation should be corrected so that it matches the header file.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28263?view=msvc-160" target="_blank">C28263</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28263?view=msvc-170" target="_blank">C28263</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10933,12 +11289,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28267</key>
-    <name>C28267: A syntax error in the annotations was found annotation &lt;name&gt; in the function &lt;function&gt;</name>
+    <name>C28267: A syntax error in the annotations was found for function 'function-name', for annotation 'annotation-name'</name>
     <description>
       <![CDATA[
-<p>C28267: A syntax error in the annotations was found annotation &lt;name&gt; in the function &lt;function&gt;</p>
+<p>A syntax error in the annotations was found for function 'function-name', for annotation 'annotation-name': reason.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28267?view=msvc-160" target="_blank">C28267</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28267?view=msvc-170" target="_blank">C28267</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10946,12 +11302,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28272</key>
-    <name>C28272: The annotation for function, parameter when examining is inconsistent with the function declaration</name>
+    <name>C28272: The annotation for function 'function-name', parameter 'parameter-name' when examining 'clue' is inconsistent with the function declaration</name>
     <description>
       <![CDATA[
-<p>This warning indicates an error in the annotations, not in the code that is being analyzed. The annotations appearing on a function definition are inconsistent with those appearing on a declaration. The two annotations should be resolved to match.</p>
+<p>This warning indicates an error in the annotations, not in the code that is being analyzed. The annotations appearing on a function definition are inconsistent with the ones appearing on a declaration. The two annotations should be resolved to match.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28272?view=msvc-160" target="_blank">C28272</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28272?view=msvc-170" target="_blank">C28272</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10959,12 +11315,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28273</key>
-    <name>C28273: For function, the clues are inconsistent with the function declaration</name>
+    <name>C28273: For function 'function-name', the clues are inconsistent with the function declaration</name>
     <description>
       <![CDATA[
-<p>This warning indicates an error in the annotations, not in the code that is being analyzed. The annotations appearing on a function definition are inconsistent with those appearing on a declaration. The two annotations should be resolved to match.</p>
+<p>This warning indicates an error in the annotations, not in the code that is being analyzed. The annotations appearing on a function definition are inconsistent with the ones appearing on a declaration. The two annotations should be resolved to match.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28273?view=msvc-160" target="_blank">C28273</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28273?view=msvc-170" target="_blank">C28273</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10975,9 +11331,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28275: The parameter to _Macro_value_ is null</name>
     <description>
       <![CDATA[
-<p>This warning indicates that there is an internal error in the model file, not in the code being analyzed. The <em>macroValue</em> function was called without a parameter.</p>
+<p>This warning indicates that there's an internal error in the model file, not in the code being analyzed. The <em>macroValue</em> function was called without a parameter.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28275?view=msvc-160" target="_blank">C28275</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28275?view=msvc-170" target="_blank">C28275</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -10990,7 +11346,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This warning typically indicates that a <code>__deref</code> is needed to apply the <code>__return</code> annotation to the value returned.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28278?view=msvc-160" target="_blank">C28278</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28278?view=msvc-170" target="_blank">C28278</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11003,7 +11359,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>The annotation language supports a begin and end (<code>{</code> and <code>}</code> in C) construct, and the pairing has gotten unbalanced. This situation can be avoided if the macros are used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28279?view=msvc-160" target="_blank">C28279</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28279?view=msvc-170" target="_blank">C28279</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11016,7 +11372,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>The annotation language supports a begin and an end (<code>{</code> and <code>}</code> in C) construct, and the pairing has gotten unbalanced. This situation can be avoided if the macros are used.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28280?view=msvc-160" target="_blank">C28280</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28280?view=msvc-170" target="_blank">C28280</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11027,9 +11383,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28282: Format Strings must be in preconditions</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a <code>__drv_formatString</code> annotation is found, which is not in a <code>_Pre_</code> (<code>__drv_in</code>) annotation (function parameters are by default <code>_Pre_</code>). Check whether the annotation used in an explicit block with a <code>_Post_</code> (<code>__drv_out</code>) annotation. If so, remove the annotation from any enclosing block that has put it in a <code>_Post_</code> context.</p>
+<p>This warning indicates that a <code>__drv_formatString</code> annotation is found, which isn't in a <code>_Pre_</code> (<code>__drv_in</code>) annotation (function parameters are by default <code>_Pre_</code>). Check whether the annotation used in an explicit block with a <code>_Post_</code> (<code>__drv_out</code>) annotation. If so, remove the annotation from any enclosing block that has put it in a <code>_Post_</code> context.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28282?view=msvc-160" target="_blank">C28282</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28282?view=msvc-170" target="_blank">C28282</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11042,7 +11398,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>The warning indicates that the size specification "sentinel" annotation received a value other than zero. Essentially, the caller tried to say that the string is terminated by a character other than binary zero.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28283?view=msvc-160" target="_blank">C28283</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28283?view=msvc-170" target="_blank">C28283</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11055,7 +11411,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This warning indicates that a conditional annotation (predicate, <code>__drv_when</code>) was found on something other than a function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28284?view=msvc-160" target="_blank">C28284</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28284?view=msvc-170" target="_blank">C28284</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11063,12 +11419,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28285</key>
-    <name>C28285: For function 'function_name', syntax error in 'annotation'</name>
+    <name>C28285: For function 'function-name', syntax error in 'annotation'</name>
     <description>
       <![CDATA[
-<p>The Code Analysis tool reports this warning for syntax errors in the SAL annotation.  The SAL parser will recover by discarding the malformed annotation.</p>
+<p>The Code Analysis tool reports this warning for syntax errors in the SAL annotation. The SAL parser will recover by discarding the malformed annotation. Double check the documentation for the SAL annotations being used and try to simplify the annotation. You shouldn't use implementation layer annotations such as <code>__declspec("SAL_begin")</code> directly. If you're using that layer, then change them into higher layers such as <code>_In_</code>/<code>_Out_</code>/<code>_Ret_</code>. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/annotating-function-parameters-and-return-values?view=msvc-170">Annotating Function Parameters and Return Values</a>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28285?view=msvc-160" target="_blank">C28285</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28285?view=msvc-170" target="_blank">C28285</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11081,7 +11437,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>The Code Analysis tool reports this warning when a probable error is encountered in the model file. A few source file errors can also cause such errors.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28286?view=msvc-160" target="_blank">C28286</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28286?view=msvc-170" target="_blank">C28286</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11092,9 +11448,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28287: For function, syntax Error in _At_() annotation (unrecognized parameter name)</name>
     <description>
       <![CDATA[
-<p>The Code Analysis tool reports this warning when the <code>SAL_at</code> (<code>__drv_at</code>) annotation is used and the parameter expression cannot be interpreted in the current context. This might include using a misspelled parameter or member name, or a misspelling of "return" or "this" keywords.</p>
+<p>The Code Analysis tool reports this warning when the <code>SAL_at</code> (<code>__drv_at</code>) annotation is used and the parameter expression can't be interpreted in the current context. Reasons might include using a misspelled parameter or member name, or a misspelling of "return" or "this" keywords.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28287?view=msvc-160" target="_blank">C28287</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28287?view=msvc-170" target="_blank">C28287</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11105,9 +11461,9 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C28288: For function, syntax Error in _At_() annotation (invalid parameter name)</name>
     <description>
       <![CDATA[
-<p>The Code Analysis tool reports this warning when the <code>SAL_at</code> (<code>__drv_at</code>) annotation is used and the parameter expression cannot be interpreted in the current context. This might include using a misspelled parameter or member name, or a misspelling of "return" or "this" keywords.</p>
+<p>The Code Analysis tool reports this warning when the <code>SAL_at</code> (<code>__drv_at</code>) annotation is used and the parameter expression can't be interpreted in the current context. Reasons might include using a misspelled parameter or member name, or a misspelling of "return" or "this" keywords.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28288?view=msvc-160" target="_blank">C28288</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28288?view=msvc-170" target="_blank">C28288</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11120,7 +11476,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>The Code Analysis tool reports this warning when the function/parameter annotation is miscoded as noted.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28289?view=msvc-160" target="_blank">C28289</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28289?view=msvc-170" target="_blank">C28289</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11133,7 +11489,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>The Code Analysis tool reports this warning when the annotation for the function contains more Externals than the actual number of parameters.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28290?view=msvc-160" target="_blank">C28290</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28290?view=msvc-170" target="_blank">C28290</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11141,12 +11497,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28291</key>
-    <name>C28291: Post null/notnull at deref level 0 is meaningless for function &lt;x&gt; at param &lt;number&gt;</name>
+    <name>C28291: Post null/notnull at deref level 0 is meaningless for function 'x' at param 'number'</name>
     <description>
       <![CDATA[
-<p>The Code Analysis tool reports this warning when the post condition of a dereference level-zero parameter is specified to have a null/non-null property. This error occurs because a value at dereference level zero cannot change.</p>
+<p>The Code Analysis tool reports this warning when the post condition of a dereference level-zero parameter is specified to have a null/non-null property. This error occurs because a value at dereference level zero can't change.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28291?view=msvc-160" target="_blank">C28291</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28291?view=msvc-170" target="_blank">C28291</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11159,7 +11515,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>This warning fires a SAL annotation contains an expression containing incompatible types.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28300?view=msvc-160" target="_blank">C28300</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28300?view=msvc-170" target="_blank">C28300</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11167,12 +11523,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28301</key>
-    <name>C28301: No annotations for first declaration of &lt;function&gt;</name>
+    <name>C28301: No annotations for first declaration of 'function'</name>
     <description>
       <![CDATA[
-<p>This warning is reported when annotations were not found at the first declaration of a given function.</p>
+<p>This warning is reported when annotations weren't found at the first declaration of a given function.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28301?view=msvc-160" target="_blank">C28301</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28301?view=msvc-170" target="_blank">C28301</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11180,12 +11536,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28302</key>
-    <name>C28302: For C++ reference-parameter &lt;parameter_name&gt;, an extra _Deref_ operator was found on &lt;annotation&gt;</name>
+    <name>C28302: For C++ reference-parameter 'parameter_name', an extra _Deref_ operator was found on 'annotation'</name>
     <description>
       <![CDATA[
-<p>This warning is reported when an extra level of <code>_Deref_</code> is used on a parameter of a reference type such as <code>T &amp;a</code>.  A common mistake when using SAL1 annotations is to use <code>__deref</code> on a reference type.  Reference types are understood by SAL so all annotations are already applied to the underlying type.  This is typically not an issue in SAL2 because the free-floating <code>__deref</code> annotation was removed.  If the intention is to apply an annotation to a sub-type then you should instead use the SAL2 <code>_AT_</code> or <code>_Outref_</code> annotations.</p>
+<p>This warning is reported when an extra level of <code>_Deref_</code> is used on a parameter of a reference type such as <code>T &amp;a</code>. A common mistake when using SAL1 annotations is to use <code>__deref</code> on a reference type. Reference types are understood by SAL, so all annotations are already applied to the underlying type. It's typically not an issue in SAL2 because the free-floating <code>__deref</code> annotation was removed. If you intend to apply an annotation to a subtype, then you should instead use the SAL2 <code>_AT_</code> or <code>_Outref_</code> annotations.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28302?view=msvc-160" target="_blank">C28302</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28302?view=msvc-170" target="_blank">C28302</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11193,12 +11549,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28303</key>
-    <name>C28303: For C++ reference-parameter &lt;parameter_name&gt;, an ambiguous _Deref_ operator was found on &lt;annotation&gt;</name>
+    <name>C28303: For C++ reference-parameter &lt;parameter_name&gt;, an ambiguous _Deref_ operator was found on 'annotation'</name>
     <description>
       <![CDATA[
 <p>This warning similar to warning C28302 and is reported when an extra level of <code>_Deref_</code> is used on a parameter.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28303?view=msvc-160" target="_blank">C28303</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28303?view=msvc-170" target="_blank">C28303</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11206,12 +11562,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28304</key>
-    <name>C28304: For C++ reference-parameter &lt;parameter_name&gt;, an improperly placed _Notref_ operator was found applied to &lt;token&gt;</name>
+    <name>C28304: For C++ reference-parameter &lt;parameter_name&gt;, an improperly placed _Notref_ operator was found applied to 'token'</name>
     <description>
       <![CDATA[
 <p>The <code>_Notref_</code> operator should only be used in special circumstances involving C++ reference parameters and only in system-provided macros. It must be immediately followed by a <code>_Deref_</code> operator or a functional annotation.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28304?view=msvc-160" target="_blank">C28304</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28304?view=msvc-170" target="_blank">C28304</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11219,12 +11575,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28305</key>
-    <name>C28305: An error while parsing &lt;token&gt; was discovered</name>
+    <name>C28305: An error while parsing 'token' was discovered</name>
     <description>
       <![CDATA[
 <p>This warning is reported when the expression containing the specified token is ill-formed.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28305?view=msvc-160" target="_blank">C28305</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28305?view=msvc-170" target="_blank">C28305</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11237,7 +11593,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>Use <code>_String_length_</code> with the appropriate SAL2 annotation instead.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28306?view=msvc-160" target="_blank">C28306</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28306?view=msvc-170" target="_blank">C28306</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11250,7 +11606,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>Use <code>_String_length_</code> with the appropriate SAL2 annotation instead.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28307?view=msvc-160" target="_blank">C28307</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28307?view=msvc-170" target="_blank">C28307</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11263,7 +11619,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>The format list argument position must be either a parameter name, or an integer offset that's in the parameter list, or zero.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28308?view=msvc-160" target="_blank">C28308</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28308?view=msvc-170" target="_blank">C28308</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11276,7 +11632,7 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
       <![CDATA[
 <p>You've tried to use a void or a function in an annotation expression, and Code Analysis can't handle it.  This error typically occurs when an <code>operator==</code> that's implemented as a function is used, but other cases may also occur. Examine the types in &lt;typelist&gt; for clues about what's wrong.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28309?view=msvc-160" target="_blank">C28309</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28309?view=msvc-170" target="_blank">C28309</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11284,12 +11640,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28310</key>
-    <name>C28310: The &lt;annotation_name&gt; annotation on &lt;function&gt; &lt;parameter&gt; has no SAL version</name>
+    <name>C28310: The &lt;annotation_name&gt; annotation on 'function' 'parameter' has no SAL version</name>
     <description>
       <![CDATA[
-<p>All SAL annotations used in source code should have an annotation version applied by the use of SAL_name. This needs to be corrected in the macro definition.</p>
+<p>All SAL annotations used in source code should have an annotation version applied by the use of SAL_name. This issue needs to be corrected in the macro definition.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28310?view=msvc-160" target="_blank">C28310</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28310?view=msvc-170" target="_blank">C28310</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11297,12 +11653,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28311</key>
-    <name>C28311: The &lt;annotation_name&gt; annotation on &lt;function&gt; &lt;parameter&gt; is an obsolescent version of SAL</name>
+    <name>C28311: The &lt;annotation_name&gt; annotation on 'function' 'parameter' is an obsolescent version of SAL</name>
     <description>
       <![CDATA[
-<p>The annotation is an old version and should be updated to the equivalent <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-160">SAL2</a>. This warning is not emitted if a prior inconsistent annotation warning has been emitted, and is reported only once per declaration. Inspect the rest of the declaration for more obsolete SAL.</p>
+<p>The annotation is an old version and should be updated to the equivalent <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">SAL2</a>. This warning isn't emitted if a prior inconsistent annotation warning has been emitted, and is reported only once per declaration. Inspect the rest of the declaration for more obsolete SAL.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28311?view=msvc-160" target="_blank">C28311</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28311?view=msvc-170" target="_blank">C28311</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11310,12 +11666,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28312</key>
-    <name>C28312: The &lt;annotation_name&gt; annotation on the repeated declaration of &lt;function&gt; &lt;parameter&gt; is an obsolescent version of SAL</name>
+    <name>C28312: The &lt;annotation_name&gt; annotation on the repeated declaration of 'function' 'parameter' is an obsolescent version of SAL</name>
     <description>
       <![CDATA[
-<p>The annotation is an old version and should be updated to the equivalent <a data-linktype="relative-path" href="https://docs.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-160">SAL2</a>. This warning is not emitted if a prior inconsistent annotation warning has been emitted, and is reported only once per declaration. Inspect the rest of the declaration for more obsolete SAL.</p>
+<p>The annotation is an old version and should be updated to the equivalent <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">SAL2</a>. This warning isn't emitted if a prior inconsistent annotation warning has been emitted, and is reported only once per declaration. Inspect the rest of the declaration for more obsolete SAL.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28312?view=msvc-160" target="_blank">C28312</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28312?view=msvc-170" target="_blank">C28312</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11323,12 +11679,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28350</key>
-    <name>C28350: The annotation &lt;annotation&gt; describes a situation that is not conditionally applicable</name>
+    <name>C28350: The annotation 'annotation' describes a situation that is not conditionally applicable</name>
     <description>
       <![CDATA[
 <p>Usually this warning is generated when an annotation is applied where the C/C++ type is being inspected.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28350?view=msvc-160" target="_blank">C28350</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28350?view=msvc-170" target="_blank">C28350</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11336,12 +11692,12 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
   </rule>
   <rule>
     <key>C28351</key>
-    <name>C28351: The annotation &lt;annotation&gt; describes where a dynamic value (a variable) cannot be used in the condition</name>
+    <name>C28351: The annotation 'annotation' describes where a dynamic value (a variable) cannot be used in the condition</name>
     <description>
       <![CDATA[
 <p>This warning is reported when an annotation is applied where the C/C++ type is being inspected.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c28351?view=msvc-160" target="_blank">C28351</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28351?view=msvc-170" target="_blank">C28351</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11352,10 +11708,10 @@ C4293 is a similar check in the Microsoft C++ compiler.</p>
     <name>C33001: VARIANT 'var' was cleared when it was uninitialized (expression 'expr')</name>
     <description>
       <![CDATA[
-<p>This warning is triggered when an uninitialized VARIANT is passed to an API such as VariantClear
-that expects an initialized VARIANT.</p>
+<p>This warning is triggered when an uninitialized <code>VARIANT</code> is passed to an API such as <code>VariantClear</code>
+that expects an initialized <code>VARIANT</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c33001?view=msvc-160" target="_blank">C33001</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c33001?view=msvc-170" target="_blank">C33001</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11363,13 +11719,13 @@ that expects an initialized VARIANT.</p>
   </rule>
   <rule>
     <key>C33004</key>
-    <name>C33004: VARIANT 'var', which is marked as Out was cleared before being initialized (expression 'expr')</name>
+    <name>C33004: VARIANT 'var', which is marked as _Out_ was cleared before being initialized (expression 'expr')</name>
     <description>
       <![CDATA[
-<p>This warning is triggered when a VARIANT parameter with _Out_ SAL annotation, which may haven't been
-initialized on input, is passed to an API such as VariantClear that expects an initialized VARIANT.</p>
+<p>This warning is triggered when a <code>VARIANT</code> parameter with <code>_Out_</code> SAL annotation may not have been
+initialized on input, and is then passed to an API such as <code>VariantClear</code> that expects an initialized <code>VARIANT</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c33004?view=msvc-160" target="_blank">C33004</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c33004?view=msvc-170" target="_blank">C33004</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11377,13 +11733,12 @@ initialized on input, is passed to an API such as VariantClear that expects an i
   </rule>
   <rule>
     <key>C33005</key>
-    <name>C33005: VARIANT 'var' was provided as an input or input/output parameter but was not initialized (expression 'expr')</name>
+    <name>C33005: VARIANT 'var' was provided as an _In_ or _InOut_ parameter but was not initialized (expression 'expr')</name>
     <description>
       <![CDATA[
-<p>This warning is triggered when an uninitialized VARIANT is passed to a function as input-only or input/output
-parameter - for example, a pass-by-refrence parameter without an _Out_ SAL annotation.</p>
+<p>This warning is triggered when an uninitialized <code>VARIANT</code> is passed to a function as an input-only or input/output parameter. For example, a pass-by-reference parameter without an <code>_Out_</code> SAL annotation.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c33005?view=msvc-160" target="_blank">C33005</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c33005?view=msvc-170" target="_blank">C33005</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11391,13 +11746,12 @@ parameter - for example, a pass-by-refrence parameter without an _Out_ SAL annot
   </rule>
   <rule>
     <key>C33010</key>
-    <name>C33010: Unchecked lower bound for enum 'enum' used as index</name>
+    <name>C33010: Unchecked lower bound for enum enum_name used as index</name>
     <description>
       <![CDATA[
-<p>This warning is triggered for an enum that is used as an index into an array,
-if the upper bound is checked for its value, but not the lower bound.</p>
+<p>This warning is triggered if an enum is both used as an index into an array and isn't checked on the lower bound.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c33010?view=msvc-160" target="_blank">C33010</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c33010?view=msvc-170" target="_blank">C33010</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11411,7 +11765,7 @@ if the upper bound is checked for its value, but not the lower bound.</p>
 <p>This warning is triggered for an enum that is used as an index into an array,
 if the lower bound is checked for its value, but not the upper bound.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c33011?view=msvc-160" target="_blank">C33011</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c33011?view=msvc-170" target="_blank">C33011</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11422,9 +11776,9 @@ if the lower bound is checked for its value, but not the upper bound.</p>
     <name>C33020: Likely incorrect HRESULT usage detected</name>
     <description>
       <![CDATA[
-<p>This is high-confidence warning indicating that HRESULT-returning function returns FALSE.</p>
+<p>This warning is a high-confidence indication that an HRESULT-returning function returns <code>FALSE</code>.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c33020?view=msvc-160" target="_blank">C33020</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c33020?view=msvc-170" target="_blank">C33020</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>
@@ -11435,10 +11789,9 @@ if the lower bound is checked for its value, but not the upper bound.</p>
     <name>C33022: Potentially incorrect HRESULT usage detected (low confidence)</name>
     <description>
       <![CDATA[
-<p>This is low-confidence warning for a function that returns HRESULT, if there is "FALSE"
-somewhere along the line that eventually returns it or assigns it to a variable that is returned.</p>
+<p>This warning is a low-confidence indicator for a function that returns HRESULT, that there's a <code>FALSE</code> that is either eventually returned, or it's assigned to a variable that is returned.</p>
 <h2>Microsoft Documentation</h2>
-<p><a href="https://docs.microsoft.com/en-us/cpp/code-quality/c33022?view=msvc-160" target="_blank">C33022</a></p>]]>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c33022?view=msvc-170" target="_blank">C33022</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <remediationFunction>LINEAR</remediationFunction>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcRuleRepositoryTest.java
@@ -38,7 +38,7 @@ class CxxCompilerVcRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxCompilerVcRuleRepository.KEY);
-    assertThat(repo.rules()).hasSize(960);
+    assertThat(repo.rules()).hasSize(982);
   }
 
 }

--- a/cxx-sensors/src/tools/requirements.txt
+++ b/cxx-sensors/src/tools/requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4==4.11.1
+selenium==4.7.2
+selenium-requests==2.0.2

--- a/cxx-sensors/src/tools/vc_createrules.pyproj
+++ b/cxx-sensors/src/tools/vc_createrules.pyproj
@@ -25,5 +25,8 @@
   <ItemGroup>
     <InterpreterReference Include="Global|PythonCore|3.7" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="requirements.txt" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
 </Project>


### PR DESCRIPTION
new msvc-170 messages:
`C1258` , `C1259` , `C1260` , `C4770` , `C5033` , `C5054` , `C5055` , `C5056` , `C5240` , `C6390` , `C26813` , `C26822` , `C26823` , `C26824` , `C26825` , `C26826` , `C26827` , `C26828` , `C26829` , `C26830` , `C26859` , `C26860`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2460)
<!-- Reviewable:end -->
