### PR TITLE
replace deprecated RulesDefinitionXmlLoader

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepository.java
@@ -20,8 +20,8 @@
 package org.sonar.cxx.sensors.clangsa;
 
 import org.sonar.api.platform.ServerFileSystem;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.utils.RulesDefinitionXml;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepository.java
@@ -20,8 +20,8 @@
 package org.sonar.cxx.sensors.clangtidy;
 
 import org.sonar.api.platform.ServerFileSystem;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.utils.RulesDefinitionXml;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccRuleRepository.java
@@ -20,8 +20,8 @@
 package org.sonar.cxx.sensors.compiler.gcc;
 
 import org.sonar.api.platform.ServerFileSystem;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.utils.RulesDefinitionXml;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcRuleRepository.java
@@ -20,8 +20,8 @@
 package org.sonar.cxx.sensors.compiler.vc;
 
 import org.sonar.api.platform.ServerFileSystem;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.utils.RulesDefinitionXml;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepository.java
@@ -20,8 +20,8 @@
 package org.sonar.cxx.sensors.cppcheck;
 
 import org.sonar.api.platform.ServerFileSystem;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.utils.RulesDefinitionXml;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/CxxDrMemoryRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/drmemory/CxxDrMemoryRuleRepository.java
@@ -20,8 +20,8 @@
 package org.sonar.cxx.sensors.drmemory;
 
 import org.sonar.api.platform.ServerFileSystem;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.utils.RulesDefinitionXml;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/infer/CxxInferRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/infer/CxxInferRuleRepository.java
@@ -20,8 +20,8 @@
 package org.sonar.cxx.sensors.infer;
 
 import org.sonar.api.platform.ServerFileSystem;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.utils.RulesDefinitionXml;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/other/CxxOtherRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/other/CxxOtherRepository.java
@@ -23,9 +23,9 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.server.rule.RulesDefinition;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 /**
  * Loads the external rules configuration file.

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/pclint/CxxPCLintRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/pclint/CxxPCLintRuleRepository.java
@@ -20,8 +20,8 @@
 package org.sonar.cxx.sensors.pclint;
 
 import org.sonar.api.platform.ServerFileSystem;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.utils.RulesDefinitionXml;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/rats/CxxRatsRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/rats/CxxRatsRuleRepository.java
@@ -20,8 +20,8 @@
 package org.sonar.cxx.sensors.rats;
 
 import org.sonar.api.platform.ServerFileSystem;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.utils.RulesDefinitionXml;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/RulesDefinitionXml.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/RulesDefinitionXml.java
@@ -29,7 +29,6 @@ import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
@@ -77,7 +76,7 @@ public class RulesDefinitionXml implements RulesDefinition {
       xmlLoader.load(repository, xmlStream, encoding);
 
       for (var userExtensionXml : getExtensions(repositoryKey, "xml")) {
-        try ( var input = java.nio.file.Files.newInputStream(userExtensionXml.toPath())) {
+        try (var input = java.nio.file.Files.newInputStream(userExtensionXml.toPath())) {
           xmlRuleLoader.load(repository, input, encoding);
         } catch (IOException | IllegalStateException e) {
           LOG.error("Cannot load Rules Definions '{}'", e.getMessage());

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader.java
@@ -1,0 +1,485 @@
+/*
+ * C++ Community Plugin (cxx plugin)
+ * Copyright (C) 2010-2022 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+// copy of https://github.com/SonarSource/sonar-plugin-api/blob/master/plugin-api/src/main/java/org/sonar/api/server/rule/RulesDefinitionXmlLoader.java
+// Don't remove copyright below!
+
+/*
+ * Sonar Plugin API
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.sensors.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import static java.lang.String.format;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
+import org.apache.commons.lang.StringUtils;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.apache.commons.lang.StringUtils.trim;
+import org.sonar.api.ce.ComputeEngineSide;
+import org.sonar.api.rule.RuleStatus;
+import org.sonar.api.rule.Severity;
+import org.sonar.api.rules.RuleType;
+import org.sonar.api.server.ServerSide;
+import org.sonar.api.server.debt.DebtRemediationFunction;
+import org.sonar.api.server.rule.RuleParamType;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.check.Cardinality;
+import org.sonarsource.api.sonarlint.SonarLintSide;
+
+/**
+ * Loads definitions of rules from a XML file.
+ *
+ * <h3>Usage</h3>
+ * <pre>
+ * public class MyJsRulesDefinition implements RulesDefinition {
+ *
+ *   private static final String PATH = "my-js-rules.xml";
+ *   private final RulesDefinitionXmlLoader xmlLoader;
+ *
+ *   public MyJsRulesDefinition(RulesDefinitionXmlLoader xmlLoader) {
+ *     this.xmlLoader = xmlLoader;
+ *   }
+ *
+ *   {@literal @}Override
+ *   public void define(Context context) {
+ *     try (Reader reader = new InputStreamReader(getClass().getResourceAsStream(PATH), StandardCharsets.UTF_8)) {
+ *       NewRepository repository = context.createRepository("my_js", "js").setName("My Javascript Analyzer");
+ *       xmlLoader.load(repository, reader);
+ *       repository.done();
+ *     } catch (IOException e) {
+ *       throw new IllegalStateException(String.format("Fail to read file %s", PATH), e);
+ *     }
+ *   }
+ * }
+ * </pre>
+ *
+ * <h3>XML Format</h3>
+ * <pre>
+ * &lt;rules&gt;
+ *   &lt;rule&gt;
+ *     &lt;!-- Required key. Max length is 200 characters. --&gt;
+ *     &lt;key&gt;the-rule-key&lt;/key&gt;
+ *
+ *     &lt;!-- Required name. Max length is 200 characters. --&gt;
+ *     &lt;name&gt;The purpose of the rule&lt;/name&gt;
+ *
+ *     &lt;!-- Required description. No max length. --&gt;
+ *     &lt;description&gt;
+ *       &lt;![CDATA[The description]]&gt;
+ *     &lt;/description&gt;
+ *     &lt;!-- Optional format of description. Supported values are HTML (default) and MARKDOWN. --&gt;
+ *     &lt;descriptionFormat&gt;HTML&lt;/descriptionFormat&gt;
+ *
+ *     &lt;!-- Optional key for configuration of some rule engines --&gt;
+ *     &lt;internalKey&gt;Checker/TreeWalker/LocalVariableName&lt;/internalKey&gt;
+ *
+ *     &lt;!-- Default severity when enabling the rule in a Quality profile.  --&gt;
+ *     &lt;!-- Possible values are INFO, MINOR, MAJOR (default), CRITICAL, BLOCKER. --&gt;
+ *     &lt;severity&gt;BLOCKER&lt;/severity&gt;
+ *
+ *     &lt;!-- Possible values are SINGLE (default) and MULTIPLE for template rules --&gt;
+ *     &lt;cardinality&gt;SINGLE&lt;/cardinality&gt;
+ *
+ *     &lt;!-- Status displayed in rules console. Possible values are BETA, READY (default), DEPRECATED. --&gt;
+ *     &lt;status&gt;BETA&lt;/status&gt;
+ *
+ *     &lt;!-- Type as defined by the SonarQube Quality Model. Possible values are CODE_SMELL (default), BUG and VULNERABILITY.--&gt;
+ *     &lt;type&gt;BUG&lt;/type&gt;
+ *
+ *     &lt;!-- Optional tags. See org.sonar.api.server.rule.RuleTagFormat. The maximal length of all tags is 4000 characters. --&gt;
+ *     &lt;tag&gt;misra&lt;/tag&gt;
+ *     &lt;tag&gt;multi-threading&lt;/tag&gt;
+ *
+ *     &lt;!-- Optional parameters --&gt;
+ *     &lt;param&gt;
+ *       &lt;!-- Required key. Max length is 128 characters. --&gt;
+ *       &lt;key&gt;the-param-key&lt;/key&gt;
+ *       &lt;description&gt;
+ *         &lt;![CDATA[the optional description, in HTML format. Max length is 4000 characters.]]&gt;
+ *       &lt;/description&gt;
+ *       &lt;!-- Optional default value, used when enabling the rule in a Quality profile. Max length is 4000 characters. --&gt;
+ *       &lt;defaultValue&gt;42&lt;/defaultValue&gt;
+ *     &lt;/param&gt;
+ *     &lt;param&gt;
+ *       &lt;key&gt;another-param&lt;/key&gt;
+ *     &lt;/param&gt;
+ *
+ *     &lt;!-- Quality Model - type of debt remediation function --&gt;
+ *     &lt;!-- See enum {@link org.sonar.api.server.debt.DebtRemediationFunction.Type} for supported values --&gt;
+ *     &lt;!-- It was previously named 'debtRemediationFunction'. --&gt;
+ *     &lt;!-- Since 5.5 --&gt;
+ *     &lt;remediationFunction&gt;LINEAR_OFFSET&lt;/remediationFunction&gt;
+ *
+ *     &lt;!-- Quality Model - raw description of the "gap", used for some types of remediation functions. --&gt;
+ *     &lt;!-- See {@link org.sonar.api.server.rule.RulesDefinition.NewRule#setGapDescription(String)} --&gt;
+ *     &lt;!-- It was previously named 'effortToFixDescription'. --&gt;
+ *     &lt;!-- Since 5.5 --&gt;
+ *     &lt;gapDescription&gt;Effort to test one uncovered condition&lt;/gapFixDescription&gt;
+ *
+ *     &lt;!-- Quality Model - gap multiplier of debt remediation function. Must be defined only for some function types. --&gt;
+ *     &lt;!-- See {@link org.sonar.api.server.rule.RulesDefinition.DebtRemediationFunctions} --&gt;
+ *     &lt;!-- It was previously named 'debtRemediationFunctionCoefficient'. --&gt;
+ *     &lt;!-- Since 5.5 --&gt;
+ *     &lt;remediationFunctionGapMultiplier&gt;10min&lt;/remediationFunctionGapMultiplier&gt;
+ *
+ *     &lt;!-- Quality Model - base effort of debt remediation function. Must be defined only for some function types. --&gt;
+ *     &lt;!-- See {@link org.sonar.api.server.rule.RulesDefinition.DebtRemediationFunctions} --&gt;
+ *     &lt;!-- It was previously named 'debtRemediationFunctionOffset'. --&gt;
+ *     &lt;!-- Since 5.5 --&gt;
+ *     &lt;remediationFunctionBaseEffort&gt;2min&lt;/remediationFunctionBaseEffort&gt;
+ *
+ *     &lt;!-- Deprecated field, replaced by "internalKey" --&gt;
+ *     &lt;configKey&gt;Checker/TreeWalker/LocalVariableName&lt;/configKey&gt;
+ *
+ *     &lt;!-- Deprecated field, replaced by "severity" --&gt;
+ *     &lt;priority&gt;BLOCKER&lt;/priority&gt;
+ *
+ *   &lt;/rule&gt;
+ * &lt;/rules&gt;
+ * </pre>
+ *
+ * <h3>XML Example</h3>
+ * <pre>
+ * &lt;rules&gt;
+ *   &lt;rule&gt;
+ *     &lt;key&gt;S1442&lt;/key&gt;
+ *     &lt;name&gt;"alert(...)" should not be used&lt;/name&gt;
+ *     &lt;description&gt;alert(...) can be useful for debugging during development, but ...&lt;/description&gt;
+ *     &lt;tag&gt;cwe&lt;/tag&gt;
+ *     &lt;tag&gt;security&lt;/tag&gt;
+ *     &lt;tag&gt;user-experience&lt;/tag&gt;
+ *     &lt;debtRemediationFunction&gt;CONSTANT_ISSUE&lt;/debtRemediationFunction&gt;
+ *     &lt;debtRemediationFunctionBaseOffset&gt;10min&lt;/debtRemediationFunctionBaseOffset&gt;
+ *   &lt;/rule&gt;
+ *
+ *   &lt;!-- another rules... --&gt;
+ * &lt;/rules&gt;
+ * </pre>
+ *
+ * @see org.sonar.api.server.rule.RulesDefinition
+ * @since 4.3
+ */
+@ServerSide
+@ComputeEngineSide
+@SonarLintSide
+public class RulesDefinitionXmlLoader {
+
+  private static final String ELEMENT_RULES = "rules";
+  private static final String ELEMENT_RULE = "rule";
+  private static final String ELEMENT_PARAM = "param";
+
+  private enum DescriptionFormat {
+    HTML, MARKDOWN
+  }
+
+  /**
+   * Loads rules by reading the XML input stream. The input stream is not always closed by the method, so it
+   * should be handled by the caller.
+   *
+   * @since 4.3
+   */
+  public void load(RulesDefinition.NewRepository repo, InputStream input, String encoding) {
+    load(repo, input, Charset.forName(encoding));
+  }
+
+  /**
+   * @since 5.1
+   */
+  public void load(RulesDefinition.NewRepository repo, InputStream input, Charset charset) {
+    try (Reader reader = new InputStreamReader(new BOMInputStream(input,
+                                                                  ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE,
+                                                                  ByteOrderMark.UTF_16BE,
+                                                                  ByteOrderMark.UTF_32LE, ByteOrderMark.UTF_32BE),
+                                               charset)) {
+      load(repo, reader);
+    } catch (IOException e) {
+      throw new IllegalStateException("Error while reading XML rules definition for repository " + repo.key(), e);
+    }
+  }
+
+  /**
+   * Loads rules by reading the XML input stream. The reader is not closed by the method, so it
+   * should be handled by the caller.
+   *
+   * @since 4.3
+   */
+  public void load(RulesDefinition.NewRepository repo, Reader inputReader) {
+    XMLInputFactory xmlFactory = XMLInputFactory.newInstance();
+    xmlFactory.setProperty(XMLInputFactory.IS_COALESCING, Boolean.TRUE);
+    xmlFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.FALSE);
+    // just so it won't try to load DTD in if there's DOCTYPE
+    xmlFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+    xmlFactory.setProperty(XMLInputFactory.IS_VALIDATING, Boolean.FALSE);
+    try {
+      final XMLEventReader reader = xmlFactory.createXMLEventReader(inputReader);
+      while (reader.hasNext()) {
+        final XMLEvent event = reader.nextEvent();
+        if (event.isStartElement() && event.asStartElement().getName()
+          .getLocalPart().equals(ELEMENT_RULES)) {
+          parseRules(repo, reader);
+        }
+      }
+    } catch (XMLStreamException e) {
+      throw new IllegalStateException("XML is not valid", e);
+    }
+  }
+
+  private static void parseRules(RulesDefinition.NewRepository repo, XMLEventReader reader) throws XMLStreamException {
+    while (reader.hasNext()) {
+      final XMLEvent event = reader.nextEvent();
+      if (event.isEndElement() && event.asEndElement().getName().getLocalPart().equals(ELEMENT_RULES)) {
+        return;
+      }
+      if (event.isStartElement()) {
+        final StartElement element = event.asStartElement();
+        final String elementName = element.getName().getLocalPart();
+        if (ELEMENT_RULE.equals(elementName)) {
+          processRule(repo, element, reader);
+        }
+      }
+    }
+  }
+
+  private static void processRule(RulesDefinition.NewRepository repo, StartElement ruleElement, XMLEventReader reader)
+    throws XMLStreamException {
+    String key = null;
+    String name = null;
+    String description = null;
+    // enum is not used as variable type as we want to raise an exception with the rule key when format is not supported
+    String descriptionFormat = DescriptionFormat.HTML.name();
+    String internalKey = null;
+    String severity = Severity.defaultSeverity();
+    String type = null;
+    RuleStatus status = RuleStatus.defaultStatus();
+    boolean template = false;
+    String gapDescription = null;
+    String debtRemediationFunction = null;
+    String debtRemediationFunctionGapMultiplier = null;
+    String debtRemediationFunctionBaseEffort = null;
+    List<ParamStruct> params = new ArrayList<>();
+    List<String> tags = new ArrayList<>();
+
+    /* BACKWARD COMPATIBILITY WITH VERY OLD FORMAT */
+    Attribute keyAttribute = ruleElement.getAttributeByName(new QName("key"));
+    if (keyAttribute != null && StringUtils.isNotBlank(keyAttribute.getValue())) {
+      key = trim(keyAttribute.getValue());
+    }
+    Attribute priorityAttribute = ruleElement.getAttributeByName(new QName("priority"));
+    if (priorityAttribute != null && StringUtils.isNotBlank(priorityAttribute.getValue())) {
+      severity = trim(priorityAttribute.getValue());
+    }
+
+    while (reader.hasNext()) {
+      final XMLEvent event = reader.nextEvent();
+      if (event.isEndElement() && event.asEndElement().getName().getLocalPart().equals(ELEMENT_RULE)) {
+        buildRule(repo, key, name, description, descriptionFormat, internalKey, severity, type, status, template,
+                  gapDescription, debtRemediationFunction, debtRemediationFunctionGapMultiplier,
+                  debtRemediationFunctionBaseEffort, params, tags);
+        return;
+      }
+      if (event.isStartElement()) {
+        final StartElement element = event.asStartElement();
+        final String elementName = element.getName().getLocalPart();
+        if ("name".equalsIgnoreCase(elementName)) {
+          name = StringUtils.trim(reader.getElementText());
+        } else if ("type".equalsIgnoreCase(elementName)) {
+          type = StringUtils.trim(reader.getElementText());
+        } else if ("description".equalsIgnoreCase(elementName)) {
+          description = StringUtils.trim(reader.getElementText());
+        } else if ("descriptionFormat".equalsIgnoreCase(elementName)) {
+          descriptionFormat = StringUtils.trim(reader.getElementText());
+        } else if ("key".equalsIgnoreCase(elementName)) {
+          key = StringUtils.trim(reader.getElementText());
+        } else if ("configKey".equalsIgnoreCase(elementName)) {
+          // deprecated field, replaced by internalKey
+          internalKey = StringUtils.trim(reader.getElementText());
+        } else if ("internalKey".equalsIgnoreCase(elementName)) {
+          internalKey = StringUtils.trim(reader.getElementText());
+        } else if ("priority".equalsIgnoreCase(elementName) || "severity".equalsIgnoreCase(elementName)) {
+          // "priority" is deprecated field and has been replaced by "severity"
+          severity = StringUtils.trim(reader.getElementText());
+        } else if ("cardinality".equalsIgnoreCase(elementName)) {
+          template = Cardinality.MULTIPLE == Cardinality.valueOf(StringUtils.trim(reader.getElementText()));
+        } else if ("gapDescription".equalsIgnoreCase(elementName) || "effortToFixDescription".equalsIgnoreCase(
+          elementName)) {
+          gapDescription = StringUtils.trim(reader.getElementText());
+        } else if ("remediationFunction".equalsIgnoreCase(elementName) || "debtRemediationFunction".equalsIgnoreCase(
+          elementName)) {
+          debtRemediationFunction = StringUtils.trim(reader.getElementText());
+        } else if ("remediationFunctionBaseEffort".equalsIgnoreCase(elementName) || "debtRemediationFunctionOffset"
+          .equalsIgnoreCase(elementName)) {
+          debtRemediationFunctionGapMultiplier = StringUtils.trim(reader.getElementText());
+        } else if ("remediationFunctionGapMultiplier".equalsIgnoreCase(elementName)
+                     || "debtRemediationFunctionCoefficient".equalsIgnoreCase(elementName)) {
+          debtRemediationFunctionBaseEffort = StringUtils.trim(reader.getElementText());
+        } else if ("status".equalsIgnoreCase(elementName)) {
+          String s = StringUtils.trim(reader.getElementText());
+          if (s != null) {
+            status = RuleStatus.valueOf(s);
+          }
+        } else if (ELEMENT_PARAM.equalsIgnoreCase(elementName)) {
+          params.add(processParameter(element, reader));
+        } else if ("tag".equalsIgnoreCase(elementName)) {
+          tags.add(StringUtils.trim(reader.getElementText()));
+        }
+      }
+    }
+  }
+
+  private static void buildRule(RulesDefinition.NewRepository repo, String key, String name,
+                                @Nullable String description,
+                                String descriptionFormat, @Nullable String internalKey, String severity,
+                                @Nullable String type, RuleStatus status,
+                                boolean template, @Nullable String gapDescription,
+                                @Nullable String debtRemediationFunction,
+                                @Nullable String debtRemediationFunctionGapMultiplier,
+                                @Nullable String debtRemediationFunctionBaseEffort, List<ParamStruct> params,
+                                List<String> tags) {
+    try {
+      RulesDefinition.NewRule rule = repo.createRule(key)
+        .setSeverity(severity)
+        .setName(name)
+        .setInternalKey(internalKey)
+        .setTags(tags.toArray(new String[tags.size()]))
+        .setTemplate(template)
+        .setStatus(status)
+        .setGapDescription(gapDescription);
+      if (type != null) {
+        rule.setType(RuleType.valueOf(type));
+      }
+      fillDescription(rule, descriptionFormat, description);
+      fillRemediationFunction(rule, debtRemediationFunction, debtRemediationFunctionGapMultiplier,
+                              debtRemediationFunctionBaseEffort);
+      fillParams(rule, params);
+    } catch (Exception e) {
+      throw new IllegalStateException(format("Fail to load the rule with key [%s:%s]", repo.key(), key), e);
+    }
+  }
+
+  private static void fillDescription(RulesDefinition.NewRule rule, String descriptionFormat,
+                                      @Nullable String description) {
+    if (isNotBlank(description)) {
+      switch (DescriptionFormat.valueOf(descriptionFormat)) {
+        case HTML:
+          rule.setHtmlDescription(description);
+          break;
+        case MARKDOWN:
+          rule.setMarkdownDescription(description);
+          break;
+        default:
+          throw new IllegalArgumentException("Value of descriptionFormat is not supported: " + descriptionFormat);
+      }
+    }
+  }
+
+  private static void fillRemediationFunction(RulesDefinition.NewRule rule, @Nullable String debtRemediationFunction,
+                                              @Nullable String functionOffset, @Nullable String functionCoeff) {
+    if (isNotBlank(debtRemediationFunction)) {
+      DebtRemediationFunction.Type functionType = DebtRemediationFunction.Type.valueOf(debtRemediationFunction);
+      rule.setDebtRemediationFunction(rule.debtRemediationFunctions()
+        .create(functionType, functionCoeff, functionOffset));
+    }
+  }
+
+  private static void fillParams(RulesDefinition.NewRule rule, List<ParamStruct> params) {
+    for (ParamStruct param : params) {
+      rule.createParam(param.key)
+        .setDefaultValue(param.defaultValue)
+        .setType(param.type)
+        .setDescription(param.description);
+    }
+  }
+
+  private static class ParamStruct {
+
+    String key;
+    String description;
+    String defaultValue;
+    RuleParamType type = RuleParamType.STRING;
+  }
+
+  private static ParamStruct processParameter(StartElement paramElement, XMLEventReader reader) throws
+    XMLStreamException {
+    ParamStruct param = new ParamStruct();
+
+    // BACKWARD COMPATIBILITY WITH DEPRECATED FORMAT
+    Attribute keyAttribute = paramElement.getAttributeByName(new QName("key"));
+    if (keyAttribute != null && StringUtils.isNotBlank(keyAttribute.getValue())) {
+      param.key = StringUtils.trim(keyAttribute.getValue());
+    }
+
+    // BACKWARD COMPATIBILITY WITH DEPRECATED FORMAT
+    Attribute typeAttribute = paramElement.getAttributeByName(new QName("type"));
+    if (typeAttribute != null && StringUtils.isNotBlank(typeAttribute.getValue())) {
+      param.type = RuleParamType.parse(StringUtils.trim(typeAttribute.getValue()));
+    }
+
+    while (reader.hasNext()) {
+      final XMLEvent event = reader.nextEvent();
+      if (event.isEndElement() && event.asEndElement().getName().getLocalPart().equals(ELEMENT_PARAM)) {
+        return param;
+      }
+      if (event.isStartElement()) {
+        final StartElement element = event.asStartElement();
+        final String elementName = element.getName().getLocalPart();
+        if ("key".equalsIgnoreCase(elementName)) {
+          param.key = StringUtils.trim(reader.getElementText());
+        } else if ("description".equalsIgnoreCase(elementName)) {
+          param.description = StringUtils.trim(reader.getElementText());
+        } else if ("type".equalsIgnoreCase(elementName)) {
+          param.type = RuleParamType.parse(StringUtils.trim(reader.getElementText()));
+        } else if ("defaultValue".equalsIgnoreCase(elementName)) {
+          param.defaultValue = StringUtils.trim(reader.getElementText());
+        }
+      }
+    }
+    return param;
+  }
+}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/valgrind/CxxValgrindRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/valgrind/CxxValgrindRuleRepository.java
@@ -20,8 +20,8 @@
 package org.sonar.cxx.sensors.valgrind;
 
 import org.sonar.api.platform.ServerFileSystem;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.utils.RulesDefinitionXml;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxRuleRepository.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxRuleRepository.java
@@ -20,8 +20,8 @@
 package org.sonar.cxx.sensors.veraxx;
 
 import org.sonar.api.platform.ServerFileSystem;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.utils.RulesDefinitionXml;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 /**
  * {@inheritDoc}

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepositoryTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 class CxxClangSARuleRepositoryTest {
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 class CxxClangTidyRuleRepositoryTest {
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccRuleRepositoryTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 class CxxCompilerGccRuleRepositoryTest {
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcRuleRepositoryTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 class CxxCompilerVcRuleRepositoryTest {
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 class CxxCppCheckRuleRepositoryTest {
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/CxxDrMemoryRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/drmemory/CxxDrMemoryRuleRepositoryTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.mock;
 import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.Rule;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 class CxxDrMemoryRuleRepositoryTest {
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/infer/CxxInferRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/infer/CxxInferRuleRepositoryTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 class CxxInferRuleRepositoryTest {
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherRepositoryTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.server.rule.RulesDefinition;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 class CxxOtherRepositoryTest {
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/pclint/CxxPCLintRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/pclint/CxxPCLintRuleRepositoryTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 class CxxPCLintRuleRepositoryTest {
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/rats/CxxRatsRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/rats/CxxRatsRuleRepositoryTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 class CxxRatsRuleRepositoryTest {
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoaderTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoaderTest.java
@@ -1,0 +1,291 @@
+/*
+ * C++ Community Plugin (cxx plugin)
+ * Copyright (C) 2010-2022 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+// copy of https://github.com/SonarSource/sonar-plugin-api/blob/master/plugin-api/src/test/java/org/sonar/api/server/rule/RulesDefinitionXmlLoaderTest.java
+// Don't remove copyright below!
+
+/*
+ * Sonar Plugin API
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.sensors.utils;
+
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import static org.assertj.core.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.impl.server.RulesDefinitionContext;
+import org.sonar.api.rule.RuleStatus;
+import org.sonar.api.rule.Severity;
+import org.sonar.api.rules.RuleType;
+import org.sonar.api.server.debt.DebtRemediationFunction;
+import org.sonar.api.server.rule.RulesDefinition;
+
+public class RulesDefinitionXmlLoaderTest {
+
+  RulesDefinitionXmlLoader underTest = new RulesDefinitionXmlLoader();
+
+  @Test
+  public void parse_xml() {
+    InputStream input = getClass()
+      .getResourceAsStream("/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/rules.xml");
+    RulesDefinition.Repository repository = load(input, StandardCharsets.UTF_8.name());
+    assertThat(repository.rules()).hasSize(2);
+
+    RulesDefinition.Rule rule = repository.rule("complete");
+    assertThat(rule.key()).isEqualTo("complete");
+    assertThat(rule.name()).isEqualTo("Complete");
+    assertThat(rule.htmlDescription()).isEqualTo("Description of Complete");
+    assertThat(rule.severity()).isEqualTo(Severity.BLOCKER);
+    assertThat(rule.template()).isTrue();
+    assertThat(rule.status()).isEqualTo(RuleStatus.BETA);
+    assertThat(rule.internalKey()).isEqualTo("Checker/TreeWalker/LocalVariableName");
+    assertThat(rule.type()).isEqualTo(RuleType.BUG);
+    assertThat(rule.tags()).containsOnly("misra", "spring");
+
+    assertThat(rule.params()).hasSize(2);
+    RulesDefinition.Param ignore = rule.param("ignore");
+    assertThat(ignore.key()).isEqualTo("ignore");
+    assertThat(ignore.description()).isEqualTo("Ignore ?");
+    assertThat(ignore.defaultValue()).isEqualTo("false");
+
+    rule = repository.rule("minimal");
+    assertThat(rule.key()).isEqualTo("minimal");
+    assertThat(rule.name()).isEqualTo("Minimal");
+    assertThat(rule.htmlDescription()).isEqualTo("Description of Minimal");
+    assertThat(rule.params()).isEmpty();
+    assertThat(rule.status()).isEqualTo(RuleStatus.READY);
+    assertThat(rule.severity()).isEqualTo(Severity.MAJOR);
+    assertThat(rule.type()).isEqualTo(RuleType.CODE_SMELL);
+  }
+
+  @Test
+  public void fail_if_missing_rule_key() {
+    assertThatThrownBy(() -> load(IOUtils.toInputStream("<rules><rule><name>Foo</name></rule></rules>"),
+                                  StandardCharsets.UTF_8.name()))
+      .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void fail_if_missing_property_key() {
+    assertThatThrownBy(() -> load(IOUtils.toInputStream(
+      "<rules><rule><key>foo</key><name>Foo</name><param></param></rule></rules>"),
+                                  StandardCharsets.UTF_8.name()))
+      .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void fail_on_invalid_rule_parameter_type() {
+    assertThatThrownBy(() -> load(IOUtils.toInputStream(
+      "<rules><rule><key>foo</key><name>Foo</name><param><key>key</key><type>INVALID</type></param></rule></rules>"),
+                                  StandardCharsets.UTF_8.name()))
+      .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void fail_if_invalid_xml() {
+    InputStream input = getClass().getResourceAsStream(
+      "/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/invalid.xml");
+
+    assertThatThrownBy(() -> load(input, StandardCharsets.UTF_8.name()))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("XML is not valid");
+  }
+
+  @Test
+  public void test_utf8_encoding() {
+    InputStream input = getClass().getResourceAsStream("/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/utf8.xml");
+    RulesDefinition.Repository repository = load(input, StandardCharsets.UTF_8.name());
+
+    assertThat(repository.rules()).hasSize(1);
+    RulesDefinition.Rule rule = repository.rules().get(0);
+    assertThat(rule.key()).isEqualTo("com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck");
+    assertThat(rule.name()).isEqualTo("M & M");
+    assertThat(rule.htmlDescription().charAt(0)).isEqualTo('\u00E9');
+    assertThat(rule.htmlDescription().charAt(1)).isEqualTo('\u00E0');
+    assertThat(rule.htmlDescription().charAt(2)).isEqualTo('\u0026');
+  }
+
+  @Test
+  public void test_utf8_encoding_with_bom() {
+    InputStream input = getClass().getResourceAsStream(
+      "/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/utf8-with-bom.xml");
+    RulesDefinition.Repository repository = load(input, StandardCharsets.UTF_8.name());
+
+    assertThat(repository.rules()).hasSize(1);
+    RulesDefinition.Rule rule = repository.rules().get(0);
+    assertThat(rule.key()).isEqualTo("com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck");
+    assertThat(rule.name()).isEqualTo("M & M");
+    assertThat(rule.htmlDescription().charAt(0)).isEqualTo('\u00E9');
+    assertThat(rule.htmlDescription().charAt(1)).isEqualTo('\u00E0');
+    assertThat(rule.htmlDescription().charAt(2)).isEqualTo('\u0026');
+  }
+
+  @Test
+  public void support_deprecated_format() {
+    // the deprecated format uses some attributes instead of nodes
+    InputStream input = getClass().getResourceAsStream(
+      "/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/deprecated.xml");
+    RulesDefinition.Repository repository = load(input, StandardCharsets.UTF_8.name());
+
+    assertThat(repository.rules()).hasSize(1);
+    RulesDefinition.Rule rule = repository.rules().get(0);
+    assertThat(rule.key()).isEqualTo("org.sonar.it.checkstyle.MethodsCountCheck");
+    assertThat(rule.internalKey()).isEqualTo("Checker/TreeWalker/org.sonar.it.checkstyle.MethodsCountCheck");
+    assertThat(rule.severity()).isEqualTo(Severity.CRITICAL);
+    assertThat(rule.htmlDescription()).isEqualTo("Count methods");
+    assertThat(rule.param("minMethodsCount")).isNotNull();
+  }
+
+  @Test
+  public void test_linear_remediation_function() {
+    String xml = "" + "<rules>" + "  <rule>" + "    <key>1</key>" + "    <name>One</name>"
+                   + "    <description>Desc</description>" + "    <gapDescription>lines</gapDescription>"
+                   + "    <remediationFunction>LINEAR</remediationFunction>"
+                   + "    <remediationFunctionGapMultiplier>2d 3h</remediationFunctionGapMultiplier>" + "  </rule>"
+                   + "</rules>";
+    RulesDefinition.Rule rule = load(xml).rule("1");
+    assertThat(rule.gapDescription()).isEqualTo("lines");
+    DebtRemediationFunction function = rule.debtRemediationFunction();
+    assertThat(function).isNotNull();
+    assertThat(function.type()).isEqualTo(DebtRemediationFunction.Type.LINEAR);
+    assertThat(function.gapMultiplier()).isEqualTo("2d3h");
+    assertThat(function.baseEffort()).isNull();
+  }
+
+  @Test
+  public void test_linear_with_offset_remediation_function() {
+    String xml = "" + "<rules>" + "  <rule>" + "    <key>1</key>" + "    <name>One</name>"
+                   + "    <description>Desc</description>"
+                   + "    <effortToFixDescription>lines</effortToFixDescription>"
+                   + "    <remediationFunction>LINEAR_OFFSET</remediationFunction>"
+                   + "    <remediationFunctionGapMultiplier>2d 3h</remediationFunctionGapMultiplier>"
+                   + "    <remediationFunctionBaseEffort>5min</remediationFunctionBaseEffort>" + "  </rule>"
+                   + "</rules>";
+    RulesDefinition.Rule rule = load(xml).rule("1");
+    assertThat(rule.gapDescription()).isEqualTo("lines");
+    DebtRemediationFunction function = rule.debtRemediationFunction();
+    assertThat(function).isNotNull();
+    assertThat(function.type()).isEqualTo(DebtRemediationFunction.Type.LINEAR_OFFSET);
+    assertThat(function.gapMultiplier()).isEqualTo("2d3h");
+    assertThat(function.baseEffort()).isEqualTo("5min");
+  }
+
+  @Test
+  public void test_constant_remediation_function() {
+    String xml = "" + "<rules>" + "  <rule>" + "    <key>1</key>" + "    <name>One</name>"
+                   + "    <description>Desc</description>"
+                   + "    <remediationFunction>CONSTANT_ISSUE</remediationFunction>"
+                   + "    <remediationFunctionBaseEffort>5min</remediationFunctionBaseEffort>" + "  </rule>"
+                   + "</rules>";
+    RulesDefinition.Rule rule = load(xml).rule("1");
+    DebtRemediationFunction function = rule.debtRemediationFunction();
+    assertThat(function).isNotNull();
+    assertThat(function.type()).isEqualTo(DebtRemediationFunction.Type.CONSTANT_ISSUE);
+    assertThat(function.gapMultiplier()).isNull();
+    assertThat(function.baseEffort()).isEqualTo("5min");
+  }
+
+  @Test
+  public void fail_if_invalid_remediation_function() {
+    assertThatThrownBy(() -> load("" + "<rules>" + "  <rule>" + "    <key>1</key>" + "    <name>One</name>"
+                                    + "    <description>Desc</description>"
+                                    + "    <remediationFunction>UNKNOWN</remediationFunction>" + "  </rule>"
+                                    + "</rules>"))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Fail to load the rule with key [squid:1]")
+      .hasCauseInstanceOf(IllegalArgumentException.class)
+      .hasRootCauseMessage("No enum constant org.sonar.api.server.debt.DebtRemediationFunction.Type.UNKNOWN");
+  }
+
+  @Test
+  public void markdown_description() {
+    String xml = "" + "<rules>" + "  <rule>" + "    <key>1</key>" + "    <name>One</name>"
+                   + "    <description>Desc</description>" + "    <descriptionFormat>MARKDOWN</descriptionFormat>"
+                   + "  </rule>" + "</rules>";
+    RulesDefinition.Rule rule = load(xml).rule("1");
+    assertThat(rule.markdownDescription()).isEqualTo("Desc");
+    assertThat(rule.htmlDescription()).isNull();
+  }
+
+  @Test
+  public void fail_if_unsupported_description_format() {
+    String xml = "" + "<rules>" + "  <rule>" + "    <key>1</key>" + "    <name>One</name>"
+                   + "    <description>Desc</description>" + "    <descriptionFormat>UNKNOWN</descriptionFormat>"
+                   + "  </rule>" + "</rules>";
+
+    assertThatThrownBy(() -> load(xml).rule("1"))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Fail to load the rule with key [squid:1]")
+      .hasCauseInstanceOf(IllegalArgumentException.class)
+      .hasRootCauseMessage(
+        "No enum constant org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader.DescriptionFormat.UNKNOWN");
+  }
+
+  @Test
+  public void test_deprecated_remediation_function() {
+    String xml = "" + "<rules>" + "  <rule>" + "    <key>1</key>" + "    <name>One</name>"
+                   + "    <description>Desc</description>"
+                   + "    <effortToFixDescription>lines</effortToFixDescription>"
+                   + "    <debtRemediationFunction>LINEAR_OFFSET</debtRemediationFunction>"
+                   + "    <debtRemediationFunctionCoefficient>2d 3h</debtRemediationFunctionCoefficient>"
+                   + "    <debtRemediationFunctionOffset>5min</debtRemediationFunctionOffset>" + "  </rule>"
+                   + "</rules>";
+    RulesDefinition.Rule rule = load(xml).rule("1");
+    assertThat(rule.gapDescription()).isEqualTo("lines");
+    DebtRemediationFunction function = rule.debtRemediationFunction();
+    assertThat(function).isNotNull();
+    assertThat(function.type()).isEqualTo(DebtRemediationFunction.Type.LINEAR_OFFSET);
+    assertThat(function.gapMultiplier()).isEqualTo("2d3h");
+    assertThat(function.baseEffort()).isEqualTo("5min");
+  }
+
+  private RulesDefinition.Repository load(InputStream input, String encoding) {
+    RulesDefinition.Context context = new RulesDefinitionContext();
+    RulesDefinition.NewRepository newRepository = context.createRepository("squid", "java");
+    underTest.load(newRepository, input, encoding);
+    newRepository.done();
+    return context.repository("squid");
+  }
+
+  private RulesDefinition.Repository load(String xml) {
+    RulesDefinition.Context context = new RulesDefinitionContext();
+    RulesDefinition.NewRepository newRepository = context.createRepository("squid", "java");
+    underTest.load(newRepository, new StringReader(xml));
+    newRepository.done();
+    return context.repository("squid");
+  }
+}

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/CxxValgrindRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/valgrind/CxxValgrindRuleRepositoryTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
 class CxxValgrindRuleRepositoryTest {

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/veraxx/CxxVeraxxRuleRepositoryTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import org.sonar.api.platform.ServerFileSystem;
 import org.sonar.api.server.rule.RulesDefinition;
-import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 
 class CxxVeraxxRuleRepositoryTest {
 

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/deprecated.xml
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/deprecated.xml
@@ -1,0 +1,10 @@
+<rules>
+  <rule key="org.sonar.it.checkstyle.MethodsCountCheck" priority="CRITICAL">
+    <name>Methods Count Check</name>
+    <configKey>Checker/TreeWalker/org.sonar.it.checkstyle.MethodsCountCheck</configKey>
+    <description>Count methods</description>
+    <param key="minMethodsCount" type="i">
+      <description>description of param</description>
+    </param>
+  </rule>
+</rules>

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/invalid.xml
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/invalid.xml
@@ -1,0 +1,2 @@
+<rules>
+  <rule>

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/rules.xml
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/rules.xml
@@ -1,0 +1,42 @@
+<rules>
+  <rule>
+    <!-- with exhaustive fields -->
+    <key>complete</key>
+    <name>Complete</name>
+    <description>
+      <![CDATA[Description of Complete]]>
+    </description>
+    <internalKey>Checker/TreeWalker/LocalVariableName</internalKey>
+    <severity>BLOCKER</severity>
+    <cardinality>MULTIPLE</cardinality>
+    <status>BETA</status>
+    <type>BUG</type>
+    <tag>misra</tag>
+    <tag>spring</tag>
+    <param>
+      <key>tokens</key>
+      <description>
+        <![CDATA[
+          Controls whether the check applies to variable declarations or catch clause parameters
+          ]]>
+      </description>
+    </param>
+    <param>
+      <key>ignore</key>
+      <description>
+        Ignore ?
+      </description>
+      <defaultValue>false</defaultValue>
+    </param>
+  </rule>
+
+
+  <rule>
+    <!-- with only required fields -->
+    <key>minimal</key>
+    <name>Minimal</name>
+    <description>
+      <![CDATA[Description of Minimal]]>
+    </description>
+  </rule>
+</rules>

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/utf8-with-bom.xml
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/utf8-with-bom.xml
@@ -1,0 +1,11 @@
+﻿<rules>
+  <rule>
+    <key>com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck</key>
+    <priority>BLOCKER</priority>
+    <configKey>Checker/TreeWalker/LocalVariableName</configKey>
+    <name>M &amp; M</name>
+    <description>
+      <![CDATA[éà&]]>
+    </description>
+  </rule>
+</rules>

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/utf8.xml
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/utils/RulesDefinitionXmlLoader/utf8.xml
@@ -1,0 +1,11 @@
+<rules>
+  <rule>
+    <key>com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck</key>
+    <priority>BLOCKER</priority>
+    <configKey>Checker/TreeWalker/LocalVariableName</configKey>
+    <name>M &amp; M</name>
+    <description>
+      <![CDATA[éà&]]>
+    </description>
+  </rule>
+</rules>

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -53,6 +53,7 @@ import org.sonar.cxx.sensors.rats.CxxRatsSensor;
 import org.sonar.cxx.sensors.tests.dotnet.CxxUnitTestResultsAggregator;
 import org.sonar.cxx.sensors.tests.dotnet.CxxUnitTestResultsImportSensor;
 import org.sonar.cxx.sensors.tests.xunit.CxxXunitSensor;
+import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.valgrind.CxxValgrindRuleRepository;
 import org.sonar.cxx.sensors.valgrind.CxxValgrindSensor;
 import org.sonar.cxx.sensors.veraxx.CxxVeraxxRuleRepository;
@@ -107,6 +108,7 @@ public final class CxxPlugin implements Plugin {
 
     // utility classes
     l.add(CxxUnitTestResultsAggregator.class);
+    l.add(RulesDefinitionXmlLoader.class);
 
     // metrics
     l.add(CxxMetricDefinition.class);

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -40,7 +40,7 @@ class CxxPluginTest {
     var context = new Plugin.Context(runtime);
     var plugin = new CxxPlugin();
     plugin.define(context);
-    assertThat(context.getExtensions()).hasSize(82);
+    assertThat(context.getExtensions()).hasSize(83);
   }
 
 }


### PR DESCRIPTION
[API Changes / Release 9.0](https://docs.sonarqube.org/latest/extension-guide/developing-a-plugin/plugin-basics/#api-changes)
* Deprecated: `org.sonar.api.server.rule.RulesDefinitionXmlLoader` is deprecated. Use the sonar-check-api to annotate rule classes instead of loading the metadata from XML files.
* use own `RulesDefinitionXmlLoader` to continue with XML format

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2461)
<!-- Reviewable:end -->
