### PR TITLE
Clang Static Analyzer LLVM 16.0.0 support

### DIFF
--- a/cxx-sensors/src/main/resources/clangsa.xml
+++ b/cxx-sensors/src/main/resources/clangsa.xml
@@ -20,7 +20,7 @@ Follow these steps to make your custom rules available in SonarQube:
     </description>
   </rule>
   <!-- C and C++ rules for Clang Static Analyzer. https://clang-analyzer.llvm.org/
-Rules list was generated based on clang version 11.0.1 -->
+Rules list was generated based on clang version 16.0.0 (https://github.com/llvm/llvm-project.git 61be261549243deed84b1fae11195f76f1769584) -->
   <rule>
     <key>core.CallAndMessage</key>
     <name>core.CallAndMessage</name>
@@ -28,7 +28,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for logical errors for function calls and Objective-C message expressions (e.g., uninitialized arguments, null function pointers)
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>core</tag>
@@ -40,7 +40,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for division by zero
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>core</tag>
@@ -52,7 +52,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for null pointers passed as arguments to a function whose arguments are references or marked with the 'nonnull' attribute
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>core</tag>
@@ -64,7 +64,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for dereferences of null pointers
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>core</tag>
@@ -76,7 +76,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check that addresses to stack memory do not escape the function
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>core</tag>
@@ -88,7 +88,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for undefined results of binary operators
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>core</tag>
@@ -100,7 +100,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for declarations of VLA of undefined or zero size
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>core</tag>
@@ -112,7 +112,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for uninitialized values used as array subscripts
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>core</tag>
@@ -124,7 +124,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for assigning uninitialized values
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>core</tag>
@@ -136,7 +136,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for uninitialized values used as branch conditions
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>core</tag>
@@ -148,7 +148,19 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for blocks that capture uninitialized values
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
+]]>    </description>
+    <type>BUG</type>
+    <tag>core</tag>
+  </rule>
+  <rule>
+    <key>core.uninitialized.NewArraySize</key>
+    <name>core.uninitialized.NewArraySize</name>
+    <description>
+<![CDATA[
+<p>Check if the size of the array in a new[] expression is undefined
+</p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>core</tag>
@@ -160,7 +172,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for uninitialized values being returned to the caller
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>core</tag>
@@ -172,7 +184,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for inner pointers of C++ containers used after re/deallocation
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>cplusplus</tag>
@@ -184,7 +196,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Find use-after-move bugs in C++
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>cplusplus</tag>
@@ -196,7 +208,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for double-free and use-after-free problems. Traces memory managed by new/delete.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>cplusplus</tag>
@@ -208,7 +220,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for memory leaks. Traces memory managed by new/delete.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>cplusplus</tag>
@@ -220,7 +232,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check if default placement new is provided with pointers to sufficient storage capacity
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>cplusplus</tag>
@@ -232,7 +244,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check pure virtual function calls during construction/destruction
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>cplusplus</tag>
@@ -244,7 +256,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Checks C++ std::string bugs
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>cplusplus</tag>
@@ -256,7 +268,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for values stored to variables that are never read afterwards
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>deadcode</tag>
@@ -268,7 +280,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>A Checker that detect leaks related to Fuchsia handles
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>fuchsia</tag>
@@ -280,7 +292,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warns when a null pointer is passed to a pointer which has a _Nonnull type.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>nullability</tag>
@@ -292,7 +304,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warns when a null pointer is returned from a function that has _Nonnull return type.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>nullability</tag>
@@ -304,7 +316,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warns when a nullable pointer is dereferenced.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>nullability</tag>
@@ -316,7 +328,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warns when a nullable pointer is passed to a pointer which has a _Nonnull type.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>nullability</tag>
@@ -328,7 +340,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warns when a nullable pointer is returned from a function that has _Nonnull return type.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>nullability</tag>
@@ -340,7 +352,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Reports uninitialized fields after object construction
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>optin</tag>
@@ -352,7 +364,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check virtual function calls during construction/destruction
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>optin</tag>
@@ -364,7 +376,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Checks MPI code
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>optin</tag>
@@ -376,7 +388,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Checker for C-style casts of OSObjects
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>optin</tag>
@@ -388,7 +400,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check that NSLocalizedString macros include a comment for context
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>optin</tag>
@@ -400,7 +412,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warns about uses of non-localized NSStrings passed to UI methods expecting localized NSStrings
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>optin</tag>
@@ -412,7 +424,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for performance anti-patterns when using Grand Central Dispatch
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>optin</tag>
@@ -424,7 +436,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for excessively padded structs.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>optin</tag>
@@ -436,7 +448,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Finds implementation-defined behavior in UNIX/Posix functions
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>optin</tag>
@@ -448,7 +460,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for proper uses of various Apple APIs
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -460,7 +472,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Find violations of the Mach Interface Generator calling convention
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -472,7 +484,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for erroneous conversions of objects representing numbers into numbers
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -484,7 +496,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for leaks and improper reference count management for OSObject
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -496,7 +508,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for proper uses of Objective-C properties
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -508,7 +520,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for proper uses of Secure Keychain APIs
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -520,7 +532,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for nil pointers used as mutexes for @synchronized
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -532,7 +544,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn about potentially crashing writes to autoreleasing objects from different autoreleasing pools in Objective-C
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -544,7 +556,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for sending 'retain', 'release', or 'autorelease' directly to a Class
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -556,7 +568,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn about Objective-C classes that lack a correct implementation of -dealloc
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -568,7 +580,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn about Objective-C method signatures with type incompatibilities
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -580,7 +592,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Improved modeling of loops using Cocoa collection types
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -592,7 +604,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn about Objective-C methods that lack a necessary call to super
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -604,7 +616,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn for suboptimal uses of NSAutoreleasePool in Objective-C GC mode
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -616,7 +628,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check usage of NSError** parameters
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -628,7 +640,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for prohibited nil arguments to ObjC method calls
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -640,7 +652,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Model the APIs that are guaranteed to return a non-nil value
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -652,7 +664,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for type errors when using Objective-C generics
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -664,7 +676,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for leaks and improper reference count management
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -676,7 +688,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for leaked memory in autorelease pools that will never be drained
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -688,7 +700,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check that 'self' is properly initialized inside an initializer method
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -700,7 +712,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn about improper use of '[super dealloc]' in Objective-C
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -712,7 +724,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn about private ivars that are never used
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -724,7 +736,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for passing non-Objective-C types to variadic collection initialization methods that expect only Objective-C types
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -736,7 +748,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check usage of CFErrorRef* parameters
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -748,7 +760,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for proper uses of CFNumber APIs
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -760,7 +772,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for null arguments to CFRetain/CFRelease/CFMakeCollectable
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -772,7 +784,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Checks for index out-of-bounds when using 'CFArray' API
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -784,7 +796,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warns if 'CFArray', 'CFDictionary', 'CFSet' are created with non-pointer-size values
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>osx</tag>
@@ -796,7 +808,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn on using a floating point value as a loop counter (CERT: FLP30-C, FLP30-CPP)
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>security</tag>
@@ -808,7 +820,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn on uses of unsecure or deprecated buffer manipulating functions
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>security</tag>
@@ -820,7 +832,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn on uses of functions whose return values must be always checked
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>security</tag>
@@ -832,7 +844,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn on uses of the 'bcmp' function
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>security</tag>
@@ -844,7 +856,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn on uses of the 'bcopy' function
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>security</tag>
@@ -856,7 +868,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn on uses of the 'bzero' function
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>security</tag>
@@ -868,7 +880,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn on uses of the '-decodeValueOfObjCType:at:' method
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>security</tag>
@@ -880,7 +892,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn on uses of the 'getpw' function
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>security</tag>
@@ -892,7 +904,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn on uses of the 'gets' function
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>security</tag>
@@ -904,7 +916,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn when 'mkstemp' is passed fewer than 6 X's in the format string
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>security</tag>
@@ -916,7 +928,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn on uses of the 'mktemp' function
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>security</tag>
@@ -928,7 +940,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn on uses of the 'rand', 'random', and related functions
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>security</tag>
@@ -940,7 +952,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn on uses of the 'strcpy' and 'strcat' functions
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>security</tag>
@@ -952,7 +964,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Warn on uses of the 'vfork' function
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>security</tag>
@@ -964,7 +976,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check calls to various UNIX/Posix functions
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>unix</tag>
@@ -976,7 +988,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for memory leaks, double free, and use-after-free problems. Traces memory managed by malloc()/free().
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>unix</tag>
@@ -988,7 +1000,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for dubious malloc arguments involving sizeof
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>unix</tag>
@@ -1000,7 +1012,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for mismatched deallocators.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>unix</tag>
@@ -1012,7 +1024,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for proper usage of vfork
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>unix</tag>
@@ -1024,7 +1036,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check the size argument passed into C string functions for common erroneous patterns
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>unix</tag>
@@ -1036,7 +1048,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for null pointers being passed as arguments to C string functions
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>unix</tag>
@@ -1048,7 +1060,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for va_lists which are copied onto itself.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>valist</tag>
@@ -1060,7 +1072,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for usages of uninitialized (or already released) va_lists.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>valist</tag>
@@ -1072,7 +1084,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for va_lists which are not released by a va_end call.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>valist</tag>
@@ -1084,7 +1096,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for no uncounted member variables.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>webkit</tag>
@@ -1096,7 +1108,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check for any ref-countable base class having virtual destructor.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>webkit</tag>
@@ -1108,7 +1120,7 @@ Rules list was generated based on clang version 11.0.1 -->
 <![CDATA[
 <p>Check uncounted lambda captures.
 </p>
- <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/" target="_blank">clang-analyzer.llvm.org</a></p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>
     <type>BUG</type>
     <tag>webkit</tag>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepositoryTest.java
@@ -37,7 +37,7 @@ class CxxClangSARuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxClangSARuleRepository.KEY);
-    assertThat(repo.rules()).hasSize(92);
+    assertThat(repo.rules()).hasSize(93);
   }
 
 }

--- a/cxx-sensors/src/tools/clangsa_createrules.py
+++ b/cxx-sensors/src/tools/clangsa_createrules.py
@@ -162,21 +162,29 @@ def main():
 
     for checker_name, description in checker_data.items():
 
-        rule = ET.SubElement(rules, "rule")
-        key = ET.SubElement(rule, "key")
-        name = ET.SubElement(rule, "name")
-        desc = ET.SubElement(rule, "description")
-        sev = ET.SubElement(rule, "severity")
-        c_type = ET.SubElement(rule, "type")
+        rule = ET.SubElement(rules, 'rule')
+        key = ET.SubElement(rule, 'key')
+        name = ET.SubElement(rule, 'name')
+        desc = ET.SubElement(rule, 'description')
 
         key.text = checker_name
         name.text = checker_name
-        sev.text = "MAJOR"
-        c_type.text = "BUG"
+        rule_severity = 'MAJOR'
+        rule_type = 'BUG'
+        remediationFunction = 'CONSTANT_ISSUE'
+        remediationFunctionBaseEffort = '5min'
 
-        if sev.text != 'INFO':
-            ET.SubElement(rule, 'remediationFunction').text = 'CONSTANT_ISSUE'
-            ET.SubElement(rule, 'remediationFunctionBaseEffort').text = '5min'
+        if rule_severity != 'MAJOR': # MAJOR is the default
+            ET.SubElement(rule, "severity").text = rule_severity
+        
+        if rule_type != 'CODE_SMELL': # CODE_SMELL is the default
+            ET.SubElement(rule, "type").text = rule_type
+        
+        if rule_severity != 'INFO':
+            if remediationFunction != 'CONSTANT_ISSUE':
+                ET.SubElement(rule, 'remediationFunction').text = remediationFunction
+            if remediationFunctionBaseEffort != '5min':
+                ET.SubElement(rule, 'remediationFunctionBaseEffort').text = remediationFunctionBaseEffort
 
         auto_tag = checker_name.split('.')[0]
         tag = ET.SubElement(rule, "tag")
@@ -184,8 +192,8 @@ def main():
 
         cdata = CDATA('\n<p>' + description.strip() +
                       '\n</p>\n <h2>References</h2>'
-                      ' <p><a href="https://clang-analyzer.llvm.org/"'
-                      ' target="_blank">clang-analyzer.llvm.org</a></p> \n')
+                      ' <p><a href="https://clang-analyzer.llvm.org/available_checks.html"'
+                      ' target="_blank">Available Checkers</a></p> \n')
         desc.append(cdata)
 
     xmlstr = minidom.parseString(


### PR DESCRIPTION
- new rule: 'core.uninitialized.NewArraySize'
- https://clang-analyzer.llvm.org/available_checks.html

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonaropencommunity/sonar-cxx/2470)
<!-- Reviewable:end -->
