### PR TITLE
maxsize cxx-sslr-toolkit

### DIFF
--- a/cxx-sslr-toolkit/pom.xml
+++ b/cxx-sslr-toolkit/pom.xml
@@ -103,7 +103,7 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>8000000</maxsize>
+                  <maxsize>8100000</maxsize>
                   <minsize>6000000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>


### PR DESCRIPTION
size is bigger with new packages

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2512)
<!-- Reviewable:end -->
