### PR TITLE
MSBuild .LOG support of Visual Studio 2022: Platform toolset v143

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/config/MsBuild.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/config/MsBuild.java
@@ -67,7 +67,7 @@ public class MsBuild {
   private static final Pattern PATH_TO_VCXPROJ = Pattern.compile(
     "^\\S+\\s\\\"ClCompile\\\".+\\\"((?>[^\\\\]{1,260}\\\\)*[^\\\\]{1,260}\\.vcxproj)\\\".*$");
 
-  private String platformToolset = "V142";
+  private String platformToolset = "V143";
   private String platform = "Win32";
 
   private final CxxSquidConfiguration squidConfig;
@@ -123,8 +123,8 @@ public class MsBuild {
     LOG.info("Processing MsBuild log '{}', Encoding= '{}'", buildLog.getName(), encodingName);
 
     var detectedPlatform = false;
-    try (var br = new BufferedReader(new InputStreamReader(java.nio.file.Files.newInputStream(buildLog.toPath()),
-                                                       encodingName))) {
+    try ( var br = new BufferedReader(new InputStreamReader(java.nio.file.Files.newInputStream(buildLog.toPath()),
+                                                        encodingName))) {
       String line;
       LOG.debug("build log parser baseDir='{}'", baseDir);
       var currentProjectPath = Path.of(baseDir);
@@ -277,6 +277,9 @@ public class MsBuild {
         break;
       case "V142":
         parseV142CompilerOptions(line, fileElement);
+        break;
+      case "V143":
+        parseV143CompilerOptions(line, fileElement);
         break;
       default:
       // do nothing
@@ -615,6 +618,19 @@ public class MsBuild {
     }
     addMacro("_MSC_VER=1920", fileElement);
     addMacro("_MSC_FULL_VER=192829913", fileElement);
+    addMacro("_MFC_VER=0x0E00", fileElement);
+    addMacro("_ATL_VER=0x0E00", fileElement);
+  }
+
+  void parseV143CompilerOptions(String line, String fileElement) {
+    // Visual Studio 2022 RTW (17.5)
+    addMacro("__cplusplus=201402L", fileElement); // C++14
+    // __cplusplus_winrt Defined when you use the /ZW option to compile. The value of __cplusplus_winrt is 201009.
+    if (line.contains("/ZW ")) {
+      addMacro("__cplusplus_winrt=201009", fileElement);
+    }
+    addMacro("_MSC_VER=1935", fileElement);
+    addMacro("_MSC_FULL_VER=193532215", fileElement);
     addMacro("_MFC_VER=0x0E00", fileElement);
     addMacro("_ATL_VER=0x0E00", fileElement);
   }

--- a/cxx-squid/src/test/java/org/sonar/cxx/config/CxxSquidConfigurationTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/config/CxxSquidConfigurationTest.java
@@ -664,6 +664,48 @@ class CxxSquidConfigurationTest {
   }
 
   @Test
+  void shouldHandleSpecificV143x86OptionsCorrectly() {
+    var squidConfig = new CxxSquidConfiguration(".");
+    var files = new ArrayList<File>();
+    files.add(new File("src/test/resources/msbuild/platformToolsetv143x86.txt"));
+    squidConfig.readMsBuildFiles(files, VC_CHARSET);
+
+    var softly = new SoftAssertions();
+    softly.assertThat(getIncludeDirectories(squidConfig)).isEmpty();
+    List<String> defines = getDefines(squidConfig);
+    assertThat(defines).hasSize(15 + 12);
+    ValidateDefaultAsserts(softly, defines);
+    softly.assertThat(defines).contains("_M_IX86 600");
+    softly.assertThat(defines).contains("__cplusplus 201402L");
+    softly.assertThat(defines).contains("_MSC_VER 1935");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 193532215");
+    // check atldef.h for _ATL_VER
+    softly.assertThat(defines).contains("_ATL_VER 0x0E00");
+    softly.assertAll();
+  }
+
+  @Test
+  void shouldHandleSpecificV143x64OptionsCorrectly() {
+    var squidConfig = new CxxSquidConfiguration(".");
+    var files = new ArrayList<File>();
+    files.add(new File("src/test/resources/msbuild/platformToolsetv143x64.txt"));
+    squidConfig.readMsBuildFiles(files, VC_CHARSET);
+
+    var softly = new SoftAssertions();
+    softly.assertThat(getIncludeDirectories(squidConfig)).isEmpty();
+    List<String> defines = getDefines(squidConfig);
+    assertThat(defines).hasSize(15 + 14);
+    ValidateDefaultAsserts(softly, defines);
+    softly.assertThat(defines.contains("_M_IX86 600")).isFalse();
+    softly.assertThat(defines).contains("__cplusplus 201402L");
+    softly.assertThat(defines).contains("_MSC_VER 1935");
+    softly.assertThat(defines).contains("_MSC_FULL_VER 193532215");
+    // check atldef.h for _ATL_VER
+    softly.assertThat(defines).contains("_ATL_VER 0x0E00");
+    softly.assertAll();
+  }
+
+  @Test
   void shouldHandleBuildLog() {
     var squidConfig = new CxxSquidConfiguration(".");
     var files = new ArrayList<File>();

--- a/cxx-squid/src/test/resources/msbuild/platformToolsetv143x64.txt
+++ b/cxx-squid/src/test/resources/msbuild/platformToolsetv143x64.txt
@@ -1,0 +1,38 @@
+Build started 11/20/2016 10:00:15 AM.
+Project "C:\visual studio 2022\Projects\test_VS2022\test_VS2022.sln" on node 1 (rebuild target(s)).
+ValidateSolutionConfiguration:
+  Building solution configuration "Release|x64".
+Project "C:\visual studio 2022\Projects\test_VS2022\test_VS2022.sln" (1) is building "C:\visual studio 2022\Projects\test_VS2022\test_VS2022\test_VS2022.vcxproj" (2) on node 1 (Rebuild target(s)).
+_PrepareForClean:
+  Deleting file "x64\Release\test_VS2022.tlog\test_VS2022.lastbuildstate".
+InitializeBuildStatus:
+  Touching "x64\Release\test_VS2022.tlog\unsuccessfulbuild".
+ClCompile:
+  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\bin\Hostx64\x64\CL.exe /c /Zi /nologo /W3 /WX- /diagnostics:classic /O2 /Oi /GL /D NDEBUG /D _CONSOLE /D _UNICODE /D UNICODE /D _AFXDLL /Gm- /EHsc /MD /GS /Gy /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /Yc"stdafx.h" /Fp"x64\Release\test_VS2022.pch" /Fo"x64\Release\\" /Fd"x64\Release\vc141.pdb" /Gd /TP /errorReport:queue stdafx.cpp
+  stdafx.cpp
+  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\bin\Hostx64\x64\CL.exe /c /Zi /nologo /W3 /WX- /diagnostics:classic /O2 /Oi /GL /D NDEBUG /D _CONSOLE /D _UNICODE /D UNICODE /D _AFXDLL /Gm- /EHsc /MD /GS /Gy /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /Yu"stdafx.h" /Fp"x64\Release\test_VS2022.pch" /Fo"x64\Release\\" /Fd"x64\Release\vc141.pdb" /Gd /TP /errorReport:queue test_VS2022.cpp
+  test_VS2022.cpp
+ResourceCompile:
+  C:\Program Files (x86)\Windows Kits\10\bin\x86\rc.exe /D _UNICODE /D UNICODE /D _AFXDLL /l"0x0409" /nologo /fo"x64\Release\test_VS2022.res" test_VS2022.rc
+Link:
+  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\bin\Hostx64\x64\link.exe /ERRORREPORT:QUEUE /OUT:"C:\visual studio 2022\Projects\test_VS2022\x64\Release\test_VS2022.exe" /INCREMENTAL:NO /NOLOGO /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /manifestinput:"C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\\Common7\IDE\VC\VCTargets\..\..\..\..\VC\Tools\MSVC\14.10.24629\Include\Manifest\dpiaware.manifest" /DEBUG /PDB:"C:\visual studio 2022\Projects\test_VS2022\x64\Release\test_VS2022.pdb" /SUBSYSTEM:CONSOLE /OPT:REF /OPT:ICF /LTCG:incremental /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"C:\visual studio 2022\Projects\test_VS2022\x64\Release\test_VS2022.lib" /MACHINE:X64 x64\Release\test_VS2022.res
+  x64\Release\stdafx.obj
+  x64\Release\test_VS2022.obj
+  Generating code
+  All 118 functions were compiled because no usable IPDB/IOBJ from previous compilation was found.
+  Finished generating code
+  test_VS2022.vcxproj -> C:\visual studio 2022\Projects\test_VS2022\x64\Release\test_VS2022.exe
+  test_VS2022.vcxproj -> C:\visual studio 2022\Projects\test_VS2022\x64\Release\test_VS2022.pdb (Full PDB)
+FinalizeBuildStatus:
+  Deleting file "x64\Release\test_VS2022.tlog\unsuccessfulbuild".
+  Touching "x64\Release\test_VS2022.tlog\test_VS2022.lastbuildstate".
+Done Building Project "C:\visual studio 2022\Projects\test_VS2022\test_VS2022\test_VS2022.vcxproj" (Rebuild target(s)).
+
+Done Building Project "C:\visual studio 2022\Projects\test_VS2022\test_VS2022.sln" (rebuild target(s)).
+
+
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+
+Time Elapsed 00:00:11.23

--- a/cxx-squid/src/test/resources/msbuild/platformToolsetv143x86.txt
+++ b/cxx-squid/src/test/resources/msbuild/platformToolsetv143x86.txt
@@ -1,0 +1,38 @@
+Build started 11/20/2016 10:18:33 AM.
+Project "C:\visual studio 2022\Projects\test_VS2022\test_VS2022.sln" on node 1 (rebuild target(s)).
+ValidateSolutionConfiguration:
+  Building solution configuration "Release|Win32".
+Project "C:\visual studio 2022\Projects\test_VS2022\test_VS2022.sln" (1) is building "C:\visual studio 2022\Projects\test_VS2022\test_VS2022\test_VS2022.vcxproj" (2) on node 1 (Rebuild target(s)).
+_PrepareForClean:
+  Deleting file "Release\test_VS2022.tlog\test_VS2022.lastbuildstate".
+InitializeBuildStatus:
+  Creating "Release\test_VS2022.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+ClCompile:
+  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\bin\Hostx86\x86\CL.exe /c /Zi /nologo /W4 /WX- /diagnostics:classic /O2 /Oi /Oy- /GL /D WIN32 /D NDEBUG /D _CONSOLE /D _UNICODE /D UNICODE /D _AFXDLL /Gm- /EHsc /MD /GS /Gy /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /Yc"stdafx.h" /Fp"Release\test_VS2022.pch" /Fo"Release\\" /Fd"Release\vc141.pdb" /Gd /TP /analyze- /errorReport:queue stdafx.cpp
+  stdafx.cpp
+  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\bin\Hostx86\x86\CL.exe /c /Zi /nologo /W4 /WX- /diagnostics:classic /O2 /Oi /Oy- /GL /D WIN32 /D NDEBUG /D _CONSOLE /D _UNICODE /D UNICODE /D _AFXDLL /Gm- /EHsc /MD /GS /Gy /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /Yu"stdafx.h" /Fp"Release\test_VS2022.pch" /Fo"Release\\" /Fd"Release\vc141.pdb" /Gd /TP /analyze- /errorReport:queue test_VS2022.cpp
+  test_VS2022.cpp
+ResourceCompile:
+  C:\Program Files (x86)\Windows Kits\10\bin\x86\rc.exe /D _UNICODE /D UNICODE /D _AFXDLL /l"0x0409" /nologo /fo"Release\test_VS2022.res" test_VS2022.rc
+Link:
+  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\bin\Hostx86\x86\link.exe /ERRORREPORT:QUEUE /OUT:"C:\visual studio 2022\Projects\test_VS2022\Release\test_VS2022.exe" /INCREMENTAL:NO /NOLOGO /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /manifestinput:"C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\\Common7\IDE\VC\VCTargets\..\..\..\..\VC\Tools\MSVC\14.10.24629\Include\Manifest\dpiaware.manifest" /DEBUG /PDB:"C:\visual studio 2022\Projects\test_VS2022\Release\test_VS2022.pdb" /SUBSYSTEM:CONSOLE /OPT:REF /OPT:ICF /LTCG:incremental /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"C:\visual studio 2022\Projects\test_VS2022\Release\test_VS2022.lib" /MACHINE:X86 /SAFESEH Release\test_VS2022.res
+  Release\stdafx.obj
+  Release\test_VS2022.obj
+  Generating code
+  All 118 functions were compiled because no usable IPDB/IOBJ from previous compilation was found.
+  Finished generating code
+  test_VS2022.vcxproj -> C:\visual studio 2022\Projects\test_VS2022\Release\test_VS2022.exe
+  test_VS2022.vcxproj -> C:\visual studio 2022\Projects\test_VS2022\Release\test_VS2022.pdb (Full PDB)
+FinalizeBuildStatus:
+  Deleting file "Release\test_VS2022.tlog\unsuccessfulbuild".
+  Touching "Release\test_VS2022.tlog\test_VS2022.lastbuildstate".
+Done Building Project "C:\visual studio 2022\Projects\test_VS2022\test_VS2022\test_VS2022.vcxproj" (Rebuild target(s)).
+
+Done Building Project "C:\visual studio 2022\Projects\test_VS2022\test_VS2022.sln" (rebuild target(s)).
+
+
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+
+Time Elapsed 00:00:06.30


### PR DESCRIPTION
MSBuild sensor support for VS2022 ([sonar.cxx.msbuild.reportPaths](https://github.com/SonarOpenCommunity/sonar-cxx/wiki/sonar.cxx.msbuild.reportPaths))
close #2491

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2523)
<!-- Reviewable:end -->
