### PR TITLE
correct handling of # in preprocessor

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/channels/PreprocessorChannel.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/channels/PreprocessorChannel.java
@@ -57,6 +57,14 @@ public class PreprocessorChannel extends Channel<Lexer> {
     int line = code.getLinePosition();
     int column = code.getColumnPosition();
 
+    // if there was already a token in the line it's not a preprocessor command
+    var previousTokens = output.getTokens();
+    if (!previousTokens.isEmpty()) {
+      if (previousTokens.get(previousTokens.size() - 1).getLine() == line) {
+        return false;
+      }
+    }
+
     if (code.popTo(matcher, sb) <= 0) {
       return false;
     }

--- a/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithPreprocessingTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithPreprocessingTest.java
@@ -1030,4 +1030,21 @@ class CxxLexerWithPreprocessingTest {
     softly.assertAll();
   }
 
+  @Test
+  void undefined_macro_with_hash_parameter() {
+    List<Token> tokens = lexer.lex("BOOST_PP_EXPAND(#) define BOOST_FT_config_valid 1");
+    assertThat(tokens).hasSize(8);
+  }
+
+  @Test
+  void defined_macro_with_hash_parameter() {
+    List<Token> tokens = lexer.lex("#define BOOST_PP_EXPAND(p) p\n"
+                                     + "BOOST_PP_EXPAND(#) define BOOST_FT_config_valid 1\n"
+                                     + "BOOST_FT_config_valid");
+
+    assertThat(tokens).anySatisfy(token -> assertThat(token)
+      .isValue("1")
+      .hasType(CxxTokenType.NUMBER));
+  }
+
 }

--- a/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithoutPreprocessorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithoutPreprocessorTest.java
@@ -40,6 +40,9 @@ class CxxLexerWithoutPreprocessorTest {
   @Test
   void preprocessor_directives() {
     var softly = new SoftAssertions();
+
+    softly.assertThat(lexer.lex("#")).anySatisfy(token -> assertThat(token).isValue(
+      "#").hasType(CxxTokenType.PREPROCESSOR));
     softly.assertThat(lexer.lex("#include <iostream>")).anySatisfy(token -> assertThat(token).isValue(
       "#include <iostream>").hasType(CxxTokenType.PREPROCESSOR));
     softly.assertThat(lexer.lex("# include <iostream>")).anySatisfy(token -> assertThat(token).isValue(


### PR DESCRIPTION
- Check if # is the first token in the line, only then it is a preprocessor command. Otherwise it is a special character which is treated e.g. in macros like any other string.
- close #2505

Sample:
```C++
BOOST_PP_EXPAND(#) ifndef BOOST_FT_config_valid
BOOST_PP_EXPAND(#)   define BOOST_FT_cc_id 1
BOOST_PP_EXPAND(#)   define BOOST_FT_cc_name implicit_cc
BOOST_PP_EXPAND(#)   define BOOST_FT_cc BOOST_PP_EMPTY
BOOST_PP_EXPAND(#)   define BOOST_FT_cond callable_builtin
#define _()
BOOST_PP_EXPAND(#)   include BOOST_FT_cc_file
#undef _
BOOST_PP_EXPAND(#)   undef BOOST_FT_cond
BOOST_PP_EXPAND(#)   undef BOOST_FT_cc_name
BOOST_PP_EXPAND(#)   undef BOOST_FT_cc
BOOST_PP_EXPAND(#)   undef BOOST_FT_cc_id
BOOST_PP_EXPAND(#) else
BOOST_PP_EXPAND(#)   undef BOOST_FT_config_valid
BOOST_PP_EXPAND(#) endif
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2528)
<!-- Reviewable:end -->
