### PR TITLE
Code scanning: CodeQL Action v1 is now deprecated

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
To upgrade to the CodeQL Action v2, open your CodeQL workflow file(s) in the .github/workflows directory of your repository and look for references to:

    github/codeql-action/init@v1
    github/codeql-action/autobuild@v1
    github/codeql-action/analyze@v1
    github/codeql-action/upload-sarif@v1

These entries need to be replaced with their v2 equivalents:

    github/codeql-action/init@v2
    github/codeql-action/autobuild@v2
    github/codeql-action/analyze@v2
    github/codeql-action/upload-sarif@v2

https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2530)
<!-- Reviewable:end -->
