### PR TITLE
New feature to report unknown rules / warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ This plugin is free software; you can redistribute it and/or modify it under the
   * GNU extensions
   * `CUDA` extensions
 * Microsoft Windows and Linux for runtime environment
+* Handling of unknown / new errors and warnings (e.g. new compiler warnings)
+  * unknown warnings/errors (that are not defined in sonar) will now be mapped to the rule id="unknown"
+  * the rule id can be customized with the property sonar.cxx.unknown.rule.id and is valid for all sensors
 
 Sensors for **static and dynamic code analysis**:
 * **Cppcheck** warnings support (http://cppcheck.sourceforge.net/)

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccSensor.java
@@ -43,7 +43,7 @@ public class CxxCompilerGccSensor extends CxxCompilerSensor {
   public static final String DEFAULT_ID = "default";
   public static final String DEFAULT_REGEX_DEF
                                = "(?<file>[^:]*+):(?<line>\\d{1,5}):\\d{1,5}:\\x20warning:\\x20"
-                                   + "(?<message>.*?)(\\x20\\[(?<id>.*)\\])?\\s*$";
+                                   + "(?<message>.*?)(\\x20\\[(?<id>[^\\[]*)\\])?\\s*$";
 
   public static List<PropertyDefinition> properties() {
     var subcateg = "GCC";

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/CxxIssuesReportSensor.java
@@ -20,15 +20,23 @@
 package org.sonar.cxx.sensors.utils;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+
 import javax.annotation.CheckForNull;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.TextRange;
 import org.sonar.api.batch.sensor.issue.NewIssue;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
+import org.sonar.api.config.PropertyDefinition;
+import org.sonar.api.resources.Qualifiers;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
@@ -40,11 +48,21 @@ import org.sonar.cxx.utils.CxxReportLocation;
  * such as saving issues in SonarQube
  */
 public abstract class CxxIssuesReportSensor extends CxxReportSensor {
+  /**
+   * Key for rules that are not yet defined in sonar
+   */
+  public static final String UNKNOWN_RULE_ID = "sonar.cxx.unknown.rule.id";
+  
+  public static final String DEFAULT_UNKNOWN_RULE_ID = "unknown";
 
+
+	
   private static final Logger LOG = Loggers.get(CxxIssuesReportSensor.class);
 
   private final Set<CxxReportIssue> uniqueIssues = new HashSet<>();
   private int savedNewIssues = 0;
+  
+  private final Map<String, List<String>> knownRulesPerRepositoryKey=new HashMap<>();
 
   /**
    * {@inheritDoc}
@@ -52,11 +70,38 @@ public abstract class CxxIssuesReportSensor extends CxxReportSensor {
   protected CxxIssuesReportSensor() {
   }
 
+  public static List<PropertyDefinition> properties() {
+	    return Collections.unmodifiableList(Arrays.asList(
+	      PropertyDefinition.builder(UNKNOWN_RULE_ID)
+	        .name("Key id to be used to upload not yet defined new rules")
+	        .description(
+	          "This key is used to upload e.g., compiler warnings that are not yet defined in sonar. "
+	          + "The used key must be defined for each cxx sensor in sonar, e.g. compiler-gcc:unknown. "
+	          + "Default value is \"unknown\""
+	        )
+	        .category("CXX")
+	        .subCategory("(1) General")
+	        .defaultValue(DEFAULT_UNKNOWN_RULE_ID)
+	        .onQualifiers(Qualifiers.PROJECT)
+	        .build()
+	    ));
+	  }
+
+  
   /**
    * {@inheritDoc}
    */
   @Override
   public void executeImpl() {
+	List<String> ruleKeys;
+	try {
+		LOG.info("Downloading rule keys for {} from {}",getRuleRepositoryKey(),context.config().get("sonar.host.url").orElse("http://localhost:9000"));
+		ruleKeys = SonarRulesKeyLoader.getRulesFor(context.config().get("sonar.host.url").orElse("http://localhost:9000"),context.config().get("sonar.login").orElse(""),"cxx", getRuleRepositoryKey());
+		knownRulesPerRepositoryKey.put(getRuleRepositoryKey(), ruleKeys);
+		LOG.info("Donwloaded {} known rule keys for {}",ruleKeys.size(),getRuleRepositoryKey());
+	} catch (IOException | InterruptedException e) {
+		LOG.warn("Could not download known rule ids for "+ getRuleRepositoryKey(), e);
+	}
     List<File> reports = getReports(getReportPathsKey());
     for (var report : reports) {
       executeReport(report);
@@ -64,6 +109,13 @@ public abstract class CxxIssuesReportSensor extends CxxReportSensor {
   }
 
   private void saveIssue(String ruleId, CxxReportIssue issue) {
+	String unknownRuleId=context.config().get(UNKNOWN_RULE_ID).orElse(DEFAULT_UNKNOWN_RULE_ID);  
+	if (knownRulesPerRepositoryKey.containsKey(getRuleRepositoryKey()) && !knownRulesPerRepositoryKey.get(getRuleRepositoryKey()).contains(ruleId)) {
+		LOG.warn("Rule {} is not known in sonar, will map to {}",ruleId,unknownRuleId);
+		issue.overRideRuleId(unknownRuleId);
+		issue.getLocations().get(0).prefixInfo("Unknown warning: "+ruleId+"; ");
+		ruleId=unknownRuleId;
+	}
     var newIssue = context.newIssue();
     if (addLocations(newIssue, ruleId, issue)) {
       addFlow(newIssue, issue);

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/Response.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/Response.java
@@ -1,0 +1,68 @@
+/*
+ * C++ Community Plugin (cxx plugin)
+ * Copyright (C) 2010-2023 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.sensors.utils;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Response {
+
+	int total;
+	int p;
+	int ps;
+	
+	List<Rule> rules;
+
+	public int getTotal() {
+		return total;
+	}
+
+	public void setTotal(int total) {
+		this.total = total;
+	}
+
+	public int getP() {
+		return p;
+	}
+
+	public void setP(int p) {
+		this.p = p;
+	}
+
+	public int getPs() {
+		return ps;
+	}
+
+	public void setPs(int ps) {
+		this.ps = ps;
+	}
+
+	public List<Rule> getRules() {
+		return rules;
+	}
+
+	public void setRules(List<Rule> rules) {
+		this.rules = rules;
+	}
+	
+	
+}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/Rule.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/Rule.java
@@ -1,0 +1,49 @@
+/*
+ * C++ Community Plugin (cxx plugin)
+ * Copyright (C) 2010-2023 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.sensors.utils;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Rule {
+	
+	String key;
+	
+	String type;
+
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+	
+	
+
+}

--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/SonarRulesKeyLoader.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/SonarRulesKeyLoader.java
@@ -1,0 +1,84 @@
+/*
+ * C++ Community Plugin (cxx plugin)
+ * Copyright (C) 2010-2023 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.sensors.utils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class SonarRulesKeyLoader {
+	
+	private SonarRulesKeyLoader() {}
+	
+	static ObjectMapper objectMapper = new ObjectMapper();
+
+	public static List<String> getRulesFor(String sonarUrl, String sonarLogin, String language, String tag) throws IOException, InterruptedException {
+		int p=0;
+		int total=0;
+		Response response=null;
+		String requestURL=getUrl(sonarUrl,language, tag);
+		do {
+			p++;
+			Response res=objectMapper.readValue(get(requestURL+p, sonarLogin), Response.class);
+			if (response==null || response.getRules()==null) {
+				response=res;
+			}else {
+				response.getRules().addAll(res.getRules());
+			}
+			total=res.getTotal();
+		} while (total-p*500>0);
+		return response.getRules().stream().map(Rule::getKey).map(k->k.replace(tag+":", "")).collect(Collectors.toList());
+	}
+
+	private static String getUrl(String sonarUrl, String language, String tag) {
+		StringBuilder builder = new StringBuilder(1024);
+		builder.append(sonarUrl);
+		if (!sonarUrl.endsWith("/")) {
+			builder.append("/");
+		}
+		builder.append("api/rules/search?f=internalKey&ps=500");
+		builder.append("&language=").append(language);
+		builder.append("&tags=").append(tag);
+		builder.append("&p=");
+		return builder.toString();
+	}
+
+	public static String get(String uri, String sonarLogin) throws IOException, InterruptedException {
+	    HttpClient client = HttpClient.newHttpClient();
+	    HttpRequest request = HttpRequest.newBuilder()
+	          .uri(URI.create(uri))
+	          .header("Authorization", "Basic " + Base64.getEncoder().encodeToString((sonarLogin+":").getBytes()))
+	          .build();
+
+	    HttpResponse<String> response =
+	          client.send(request, BodyHandlers.ofString());
+	    return response.body();
+	}
+
+
+}

--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -51,6 +51,15 @@
       ]]></description>
     <severity>INFO</severity>
   </rule>
+  <rule>
+    <key>unknown</key>
+    <name>undefined clang-diagnostic-message</name>
+    <description><![CDATA[
+      <p>This is a placeholder for not yet covered clang errors and warnings</p>
+      ]]></description>
+    <severity>INFO</severity>
+    <type>BUG</type>
+  </rule>
 
   <!-- Clang-Tidy Rules -->
 

--- a/cxx-sensors/src/main/resources/compiler-gcc.xml
+++ b/cxx-sensors/src/main/resources/compiler-gcc.xml
@@ -28,6 +28,14 @@ Follow these steps to make your custom rules available in SonarQube:
     <severity>CRITICAL</severity>
   </rule>
   <rule>
+    <key>unknown</key>
+    <name>Unknown compiler warnings</name>
+    <description>
+      Unknown compiler warnings.
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
     <key>-Wabi</key>
     <name>Warn about things that will change when compiling with an ABI-compliant compiler</name>
     <description>

--- a/cxx-sensors/src/main/resources/cppcheck.xml
+++ b/cxx-sensors/src/main/resources/cppcheck.xml
@@ -20,6 +20,18 @@ Follow these steps to make your custom rules available in SonarQube:
     </description>
   </rule>
   <rule>
+    <key>unknown</key>
+    <name>Unknown rule id was returned by cppcheck</name>
+    <description>
+      <![CDATA[
+      <p> This code is returned, if the rule for the returned cppcheck message was not yet defined in sonar</p>
+
+]]>
+    </description>
+    <tag>cwe</tag>
+    <severity>MINOR</severity>
+    <type>BUG</type>
+  </rule>  <rule>
     <key>AssignmentAddressToInteger</key>
     <name>Assigning a pointer to an integer is not portable</name>
     <description>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
@@ -36,7 +36,7 @@ class CxxClangTidyRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxClangTidyRuleRepository.KEY);
-    assertThat(repo.rules()).hasSize(1355);
+    assertThat(repo.rules()).hasSize(1356);
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/gcc/CxxCompilerGccRuleRepositoryTest.java
@@ -38,7 +38,7 @@ class CxxCompilerGccRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxCompilerGccRuleRepository.KEY);
-    assertThat(repo.rules()).hasSize(230);
+    assertThat(repo.rules()).hasSize(231);
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
@@ -37,7 +37,7 @@ class CxxCppCheckRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxCppCheckRuleRepository.KEY);
-    assertThat(repo.rules()).hasSize(674);
+    assertThat(repo.rules()).hasSize(675);
   }
 
 }

--- a/cxx-sensors/src/tools/cppcheck-errorlist.xml
+++ b/cxx-sensors/src/tools/cppcheck-errorlist.xml
@@ -1,0 +1,524 @@
+cppcheck: Windows 64-bit binaries currently default to the 'win64' platform. Starting with Cppcheck 2.13 they will default to 'native' instead. Please specify '--platform=win64' explicitly if you rely on this.
+<?xml version="1.0" encoding="UTF-8"?>
+<results version="2">
+    <cppcheck version="2.12.0"/>
+    <errors>        <error id="purgedConfiguration" severity="information" msg="The configuration &apos;&apos; was not checked because its code equals another one." verbose="The configuration &apos;&apos; was not checked because its code equals another one."/>
+        <error id="toomanyconfigs" severity="information" msg="Too many #ifdef configurations - cppcheck only checks 12 configurations. Use --force to check all configurations. For more details, use --enable=information." verbose="The checking of the file will be interrupted because there are too many #ifdef configurations. Checking of all #ifdef configurations can be forced by --force command line option or from GUI preferences. However that may increase the checking time. For more details, use --enable=information." cwe="398"/>
+        <error id="AssignmentAddressToInteger" severity="portability" msg="Assigning a pointer to an integer is not portable." verbose="Assigning a pointer to an integer (int/long/etc) is not portable across different platforms and compilers. For example in 32-bit Windows and linux they are same width, but in 64-bit Windows and linux they are of different width. In worst case you end up assigning 64-bit address to 32-bit integer. The safe way is to store addresses only in pointer types (or typedefs like uintptr_t)." cwe="758"/>
+        <error id="AssignmentIntegerToAddress" severity="portability" msg="Assigning an integer to a pointer is not portable." verbose="Assigning an integer (int/long/etc) to a pointer is not portable across different platforms and compilers. For example in 32-bit Windows and linux they are same width, but in 64-bit Windows and linux they are of different width. In worst case you end up assigning 64-bit integer to 32-bit pointer. The safe way is to store addresses only in pointer types (or typedefs like uintptr_t)." cwe="758"/>
+        <error id="CastIntegerToAddressAtReturn" severity="portability" msg="Returning an integer in a function with pointer return type is not portable." verbose="Returning an integer (int/long/etc) in a function with pointer return type is not portable across different platforms and compilers. For example in 32-bit Windows and Linux they are same width, but in 64-bit Windows and Linux they are of different width. In worst case you end up casting 64-bit integer down to 32-bit pointer. The safe way is to always return a pointer." cwe="758"/>
+        <error id="CastAddressToIntegerAtReturn" severity="portability" msg="Returning an address value in a function with integer return type is not portable." verbose="Returning an address value in a function with integer (int/long/etc) return type is not portable across different platforms and compilers. For example in 32-bit Windows and Linux they are same width, but in 64-bit Windows and Linux they are of different width. In worst case you end up casting 64-bit address down to 32-bit integer. The safe way is to always return an integer." cwe="758"/>
+        <error id="assertWithSideEffect" severity="warning" msg="Assert statement calls a function which may have desired side effects: &apos;function&apos;." verbose="Non-pure function: &apos;function&apos; is called inside assert statement. Assert statements are removed from release builds so the code inside assert statement is not executed. If the code is needed also in release builds, this is a bug." cwe="398">
+            <symbol>function</symbol>
+        </error>
+        <error id="assignmentInAssert" severity="warning" msg="Assert statement modifies &apos;var&apos;." verbose="Variable &apos;var&apos; is modified inside assert statement. Assert statements are removed from release builds so the code inside assert statement is not executed. If the code is needed also in release builds, this is a bug." cwe="398">
+            <symbol>var</symbol>
+        </error>
+        <error id="autoVariables" severity="error" msg="Address of local auto-variable assigned to a function parameter." verbose="Dangerous assignment - the function parameter is assigned the address of a local auto-variable. Local auto-variables are reserved from the stack which is freed when the function ends. So the pointer to a local variable is invalid after the function ends." cwe="562"/>
+        <error id="returnReference" severity="error" msg="Reference to local variable returned." verbose="Reference to local variable returned." cwe="562"/>
+        <error id="danglingReference" severity="error" msg="Non-local reference variable &apos;x&apos; to local variable &apos;y&apos;" verbose="Non-local reference variable &apos;x&apos; to local variable &apos;y&apos;" cwe="562"/>
+        <error id="returnTempReference" severity="error" msg="Reference to temporary returned." verbose="Reference to temporary returned." cwe="562"/>
+        <error id="danglingTempReference" severity="error" msg="Using reference to dangling temporary." verbose="Using reference to dangling temporary." cwe="562"/>
+        <error id="autovarInvalidDeallocation" severity="error" msg="Deallocation of an auto-variable results in undefined behaviour." verbose="The deallocation of an auto-variable results in undefined behaviour. You should only free memory that has been allocated dynamically." cwe="590"/>
+        <error id="uselessAssignmentArg" severity="style" msg="Assignment of function parameter has no effect outside the function." verbose="Assignment of function parameter has no effect outside the function." cwe="398"/>
+        <error id="uselessAssignmentPtrArg" severity="warning" msg="Assignment of function parameter has no effect outside the function. Did you forget dereferencing it?" verbose="Assignment of function parameter has no effect outside the function. Did you forget dereferencing it?" cwe="398"/>
+        <error id="returnDanglingLifetime" severity="error" msg="Returning object that will be invalid when returning." verbose="Returning object that will be invalid when returning." cwe="562"/>
+        <error id="invalidLifetime" severity="error" msg="Using object that is out of scope." verbose="Using object that is out of scope." cwe="562"/>
+        <error id="danglingLifetime" severity="error" msg="Non-local variable &apos;x&apos; will use object." verbose="Non-local variable &apos;x&apos; will use object." cwe="562"/>
+        <error id="danglingTemporaryLifetime" severity="error" msg="Using object that is a temporary." verbose="Using object that is a temporary." cwe="562"/>
+        <error id="assignBoolToPointer" severity="error" msg="Boolean value assigned to pointer." verbose="Boolean value assigned to pointer." cwe="587"/>
+        <error id="assignBoolToFloat" severity="style" msg="Boolean value assigned to floating point variable." verbose="Boolean value assigned to floating point variable." cwe="704"/>
+        <error id="comparisonOfFuncReturningBoolError" severity="style" msg="Comparison of a function returning boolean value using relational (&lt;, &gt;, &lt;= or &gt;=) operator." verbose="The return type of function &apos;func_name&apos; is &apos;bool&apos; and result is of type &apos;bool&apos;. Comparing &apos;bool&apos; value using relational (&lt;, &gt;, &lt;= or &gt;=) operator could cause unexpected results." cwe="398"/>
+        <error id="comparisonOfTwoFuncsReturningBoolError" severity="style" msg="Comparison of two functions returning boolean value using relational (&lt;, &gt;, &lt;= or &gt;=) operator." verbose="The return type of function &apos;func_name1&apos; and function &apos;func_name2&apos; is &apos;bool&apos; and result is of type &apos;bool&apos;. Comparing &apos;bool&apos; value using relational (&lt;, &gt;, &lt;= or &gt;=) operator could cause unexpected results." cwe="398"/>
+        <error id="comparisonOfBoolWithBoolError" severity="style" msg="Comparison of a variable having boolean value using relational (&lt;, &gt;, &lt;= or &gt;=) operator." verbose="The variable &apos;var_name&apos; is of type &apos;bool&apos; and comparing &apos;bool&apos; value using relational (&lt;, &gt;, &lt;= or &gt;=) operator could cause unexpected results." cwe="398"/>
+        <error id="incrementboolean" severity="style" msg="Incrementing a variable of type &apos;bool&apos; with postfix operator++ is deprecated by the C++ Standard. You should assign it the value &apos;true&apos; instead." verbose="The operand of a postfix increment operator may be of type bool but it is deprecated by C++ Standard (Annex D-1) and the operand is always set to true. You should assign it the value &apos;true&apos; instead." cwe="398"/>
+        <error id="bitwiseOnBoolean" severity="style" msg="Boolean expression &apos;expression&apos; is used in bitwise operation. Did you mean &apos;&amp;&amp;&apos;?" verbose="Boolean expression &apos;expression&apos; is used in bitwise operation. Did you mean &apos;&amp;&amp;&apos;?" cwe="398" inconclusive="true"/>
+        <error id="compareBoolExpressionWithInt" severity="warning" msg="Comparison of a boolean expression with an integer other than 0 or 1." verbose="Comparison of a boolean expression with an integer other than 0 or 1." cwe="398"/>
+        <error id="pointerArithBool" severity="error" msg="Converting pointer arithmetic result to bool. The bool is always true unless there is undefined behaviour." verbose="Converting pointer arithmetic result to bool. The boolean result is always true unless there is pointer arithmetic overflow, and overflow is undefined behaviour. Probably a dereference is forgotten." cwe="571"/>
+        <error id="comparisonOfBoolWithInvalidComparator" severity="warning" msg="Comparison of a boolean value using relational operator (&lt;, &gt;, &lt;= or &gt;=)." verbose="The result of the expression &apos;expression&apos; is of type &apos;bool&apos;. Comparing &apos;bool&apos; value using relational (&lt;, &gt;, &lt;= or &gt;=) operator could cause unexpected results."/>
+        <error id="returnNonBoolInBooleanFunction" severity="style" msg="Non-boolean value returned from function returning bool" verbose="Non-boolean value returned from function returning bool"/>
+        <error id="boostForeachError" severity="error" msg="BOOST_FOREACH caches the end() iterator. It&apos;s undefined behavior if you modify the container inside." verbose="BOOST_FOREACH caches the end() iterator. It&apos;s undefined behavior if you modify the container inside." cwe="664"/>
+        <error id="arrayIndexOutOfBounds" severity="error" msg="Array &apos;arr[16]&apos; accessed at index 16, which is out of bounds." verbose="Array &apos;arr[16]&apos; accessed at index 16, which is out of bounds." cwe="788"/>
+        <error id="arrayIndexOutOfBoundsCond" severity="warning" msg="Array &apos;arr[16]&apos; accessed at index 16, which is out of bounds." verbose="Array &apos;arr[16]&apos; accessed at index 16, which is out of bounds." cwe="788"/>
+        <error id="pointerOutOfBounds" severity="portability" msg="Pointer arithmetic overflow." verbose="Pointer arithmetic overflow." cwe="758"/>
+        <error id="pointerOutOfBoundsCond" severity="portability" msg="Pointer arithmetic overflow." verbose="Pointer arithmetic overflow." cwe="758"/>
+        <error id="negativeIndex" severity="error" msg="Negative array index" verbose="Negative array index" cwe="786"/>
+        <error id="arrayIndexThenCheck" severity="style" msg="Array index &apos;i&apos; is used before limits check." verbose="Defensive programming: The variable &apos;i&apos; is used as an array index before it is checked that is within limits. This can mean that the array might be accessed out of bounds. Reorder conditions such as &apos;(a[i] &amp;&amp; i &lt; 10)&apos; to &apos;(i &lt; 10 &amp;&amp; a[i])&apos;. That way the array will not be accessed if the index is out of limits." cwe="398">
+            <symbol>i</symbol>
+        </error>
+        <error id="bufferAccessOutOfBounds" severity="error" msg="Buffer is accessed out of bounds: buf" verbose="Buffer is accessed out of bounds: buf" cwe="788"/>
+        <error id="objectIndex" severity="error" msg="The address of local variable &apos;&apos; is accessed at non-zero index." verbose="The address of local variable &apos;&apos; is accessed at non-zero index." cwe="758"/>
+        <error id="argumentSize" severity="warning" msg="Buffer &apos;buffer&apos; is too small, the function &apos;function&apos; expects a bigger buffer in 2nd argument" verbose="Buffer &apos;buffer&apos; is too small, the function &apos;function&apos; expects a bigger buffer in 2nd argument" cwe="398">
+            <symbol>function</symbol>
+        </error>
+        <error id="negativeMemoryAllocationSize" severity="error" msg="Memory allocation size is negative." verbose="Memory allocation size is negative." cwe="131"/>
+        <error id="negativeArraySize" severity="error" msg="Declaration of array &apos;&apos; with negative size is undefined behaviour" verbose="Declaration of array &apos;&apos; with negative size is undefined behaviour" cwe="758"/>
+        <error id="invalidFunctionArg" severity="error" msg="Invalid func_name() argument nr 1. The value is 0 or 1 (boolean) but the valid values are &apos;1:4&apos;." verbose="Invalid func_name() argument nr 1. The value is 0 or 1 (boolean) but the valid values are &apos;1:4&apos;." cwe="628">
+            <symbol>func_name</symbol>
+        </error>
+        <error id="invalidFunctionArgBool" severity="error" msg="Invalid func_name() argument nr 1. A non-boolean value is required." verbose="Invalid func_name() argument nr 1. A non-boolean value is required." cwe="628">
+            <symbol>func_name</symbol>
+        </error>
+        <error id="invalidFunctionArgStr" severity="error" msg="Invalid func_name() argument nr 1. A nul-terminated string is required." verbose="Invalid func_name() argument nr 1. A nul-terminated string is required." cwe="628">
+            <symbol>func_name</symbol>
+        </error>
+        <error id="ignoredReturnValue" severity="warning" msg="Return value of function malloc() is not used." verbose="Return value of function malloc() is not used." cwe="252">
+            <symbol>malloc</symbol>
+        </error>
+        <error id="wrongmathcall" severity="warning" msg="Passing value &apos;#&apos; to #() leads to implementation-defined result." verbose="Passing value &apos;#&apos; to #() leads to implementation-defined result." cwe="758"/>
+        <error id="unpreciseMathCall" severity="style" msg="Expression &apos;1 - erf(x)&apos; can be replaced by &apos;erfc(x)&apos; to avoid loss of precision." verbose="Expression &apos;1 - erf(x)&apos; can be replaced by &apos;erfc(x)&apos; to avoid loss of precision." cwe="758"/>
+        <error id="memsetZeroBytes" severity="warning" msg="memset() called to fill 0 bytes." verbose="memset() called to fill 0 bytes. The second and third arguments might be inverted. The function memset ( void * ptr, int value, size_t num ) sets the first num bytes of the block of memory pointed by ptr to the specified value." cwe="687"/>
+        <error id="memsetFloat" severity="portability" msg="The 2nd memset() argument &apos;varname&apos; is a float, its representation is implementation defined." verbose="The 2nd memset() argument &apos;varname&apos; is a float, its representation is implementation defined. memset() is used to set each byte of a block of memory to a specific value and the actual representation of a floating-point value is implementation defined." cwe="688"/>
+        <error id="memsetValueOutOfRange" severity="warning" msg="The 2nd memset() argument &apos;varname&apos; doesn&apos;t fit into an &apos;unsigned char&apos;." verbose="The 2nd memset() argument &apos;varname&apos; doesn&apos;t fit into an &apos;unsigned char&apos;. The 2nd parameter is passed as an &apos;int&apos;, but the function fills the block of memory using the &apos;unsigned char&apos; conversion of this value." cwe="686"/>
+        <error id="missingReturn" severity="error" msg="Found an exit path from function with non-void return type that has missing return statement" verbose="Found an exit path from function with non-void return type that has missing return statement" cwe="758"/>
+        <error id="returnStdMoveLocal" severity="performance" msg="Using std::move for returning object by-value from function will affect copy elision optimization. More: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-return-move-local" verbose="Using std::move for returning object by-value from function will affect copy elision optimization. More: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-return-move-local"/>
+        <error id="useStandardLibrary" severity="style" msg="Consider using memcpy instead of loop." verbose="Consider using memcpy instead of loop."/>
+        <error id="noConstructor" severity="style" msg="The class &apos;classname&apos; does not declare a constructor although it has private member variables which likely require initialization." verbose="The class &apos;classname&apos; does not declare a constructor although it has private member variables which likely require initialization. Member variables of native types, pointers, or references are left uninitialized when the class is instantiated. That may cause bugs or undefined behavior." cwe="398">
+            <symbol>classname</symbol>
+        </error>
+        <error id="noExplicitConstructor" severity="style" msg="Class &apos;classname&apos; has a constructor with 1 argument that is not explicit." verbose="Class &apos;classname&apos; has a constructor with 1 argument that is not explicit. Such, so called &quot;Converting constructors&quot;, should in general be explicit for type safety reasons as that prevents unintended implicit conversions." cwe="398">
+            <symbol>classname</symbol>
+        </error>
+        <error id="copyCtorPointerCopying" severity="warning" msg="Value of pointer &apos;var&apos;, which points to allocated memory, is copied in copy constructor instead of allocating new memory." verbose="Value of pointer &apos;var&apos;, which points to allocated memory, is copied in copy constructor instead of allocating new memory." cwe="398">
+            <symbol>var</symbol>
+        </error>
+        <error id="noCopyConstructor" severity="warning" msg="Class &apos;class&apos; does not have a copy constructor which is recommended since it has dynamic memory/resource allocation(s)." verbose="Class &apos;class&apos; does not have a copy constructor which is recommended since it has dynamic memory/resource allocation(s)." cwe="398">
+            <symbol>class</symbol>
+        </error>
+        <error id="noOperatorEq" severity="warning" msg="Class &apos;class&apos; does not have a operator= which is recommended since it has dynamic memory/resource allocation(s)." verbose="Class &apos;class&apos; does not have a operator= which is recommended since it has dynamic memory/resource allocation(s)." cwe="398">
+            <symbol>class</symbol>
+        </error>
+        <error id="noDestructor" severity="warning" msg="Class &apos;class&apos; does not have a destructor which is recommended since it has dynamic memory/resource allocation(s)." verbose="Class &apos;class&apos; does not have a destructor which is recommended since it has dynamic memory/resource allocation(s)." cwe="398">
+            <symbol>class</symbol>
+        </error>
+        <error id="uninitMemberVar" severity="warning" msg="Member variable &apos;classname::varname&apos; is not initialized in the constructor." verbose="Member variable &apos;classname::varname&apos; is not initialized in the constructor. Member variables of native types, pointers, or references are left uninitialized when the class is instantiated. That may cause bugs or undefined behavior." cwe="398">
+            <symbol>classname::varname</symbol>
+        </error>
+        <error id="uninitMemberVarPrivate" severity="warning" msg="Member variable &apos;classname::varnamepriv&apos; is not initialized in the constructor." verbose="Member variable &apos;classname::varnamepriv&apos; is not initialized in the constructor. Member variables of native types, pointers, or references are left uninitialized when the class is instantiated. That may cause bugs or undefined behavior." cwe="398">
+            <symbol>classname::varnamepriv</symbol>
+        </error>
+        <error id="uninitDerivedMemberVar" severity="warning" msg="Member variable &apos;classname::varname&apos; is not initialized in the constructor. Maybe it should be initialized directly in the class classname?" verbose="Member variable &apos;classname::varname&apos; is not initialized in the constructor. Maybe it should be initialized directly in the class classname? Member variables of native types, pointers, or references are left uninitialized when the class is instantiated. That may cause bugs or undefined behavior." cwe="398">
+            <symbol>classname::varname</symbol>
+        </error>
+        <error id="uninitDerivedMemberVarPrivate" severity="warning" msg="Member variable &apos;classname::varnamepriv&apos; is not initialized in the constructor. Maybe it should be initialized directly in the class classname?" verbose="Member variable &apos;classname::varnamepriv&apos; is not initialized in the constructor. Maybe it should be initialized directly in the class classname? Member variables of native types, pointers, or references are left uninitialized when the class is instantiated. That may cause bugs or undefined behavior." cwe="398">
+            <symbol>classname::varnamepriv</symbol>
+        </error>
+        <error id="missingMemberCopy" severity="warning" msg="Member variable &apos;classname::varnamepriv&apos; is not assigned in the move constructor. Should it be moved?" verbose="Member variable &apos;classname::varnamepriv&apos; is not assigned in the move constructor. Should it be moved?" cwe="398" inconclusive="true">
+            <symbol>classname::varnamepriv</symbol>
+        </error>
+        <error id="operatorEqVarError" severity="warning" msg="Member variable &apos;classname::&apos; is not assigned a value in &apos;classname::operator=&apos;." verbose="Member variable &apos;classname::&apos; is not assigned a value in &apos;classname::operator=&apos;." cwe="398">
+            <symbol>classname::</symbol>
+        </error>
+        <error id="unusedPrivateFunction" severity="style" msg="Unused private function: &apos;classname::funcname&apos;" verbose="Unused private function: &apos;classname::funcname&apos;" cwe="398">
+            <symbol>classname::funcname</symbol>
+        </error>
+        <error id="memsetClass" severity="error" msg="Using &apos;memfunc&apos; on class that contains a classname." verbose="Using &apos;memfunc&apos; on class that contains a classname is unsafe, because constructor, destructor and copy operator calls are omitted. These are necessary for this non-POD type to ensure that a valid object is created." cwe="762">
+            <symbol>memfunc</symbol>
+            <symbol>classname</symbol>
+        </error>
+        <error id="memsetClassReference" severity="error" msg="Using &apos;memfunc&apos; on class that contains a reference." verbose="Using &apos;memfunc&apos; on class that contains a reference." cwe="665">
+            <symbol>memfunc</symbol>
+        </error>
+        <error id="memsetClassFloat" severity="portability" msg="Using memset() on class which contains a floating point number." verbose="Using memset() on class which contains a floating point number. This is not portable because memset() sets each byte of a block of memory to a specific value and the actual representation of a floating-point value is implementation defined. Note: In case of an IEEE754-1985 compatible implementation setting all bits to zero results in the value 0.0." cwe="758"/>
+        <error id="mallocOnClassWarning" severity="warning" msg="Memory for class instance allocated with malloc(), but class provides constructors." verbose="Memory for class instance allocated with malloc(), but class provides constructors. This is unsafe, since no constructor is called and class members remain uninitialized. Consider using &apos;new&apos; instead." cwe="762">
+            <symbol>malloc</symbol>
+        </error>
+        <error id="mallocOnClassError" severity="error" msg="Memory for class instance allocated with malloc(), but class contains a std::string." verbose="Memory for class instance allocated with malloc(), but class a std::string. This is unsafe, since no constructor is called and class members remain uninitialized. Consider using &apos;new&apos; instead." cwe="665">
+            <symbol>malloc</symbol>
+            <symbol>std::string</symbol>
+        </error>
+        <error id="virtualDestructor" severity="error" msg="Class &apos;Base&apos; which is inherited by class &apos;Derived&apos; does not have a virtual destructor." verbose="Class &apos;Base&apos; which is inherited by class &apos;Derived&apos; does not have a virtual destructor. If you destroy instances of the derived class by deleting a pointer that points to the base class, only the destructor of the base class is executed. Thus, dynamic memory that is managed by the derived class could leak. This can be avoided by adding a virtual destructor to the base class." cwe="404">
+            <symbol>Base</symbol>
+            <symbol>Derived</symbol>
+        </error>
+        <error id="thisSubtraction" severity="warning" msg="Suspicious pointer subtraction. Did you intend to write &apos;-&gt;&apos;?" verbose="Suspicious pointer subtraction. Did you intend to write &apos;-&gt;&apos;?" cwe="398"/>
+        <error id="operatorEqRetRefThis" severity="style" msg="&apos;operator=&apos; should return reference to &apos;this&apos; instance." verbose="&apos;operator=&apos; should return reference to &apos;this&apos; instance." cwe="398"/>
+        <error id="operatorEqMissingReturnStatement" severity="error" msg="No &apos;return&apos; statement in non-void function causes undefined behavior." verbose="No &apos;return&apos; statement in non-void function causes undefined behavior." cwe="398"/>
+        <error id="operatorEqShouldBeLeftUnimplemented" severity="style" msg="&apos;operator=&apos; should either return reference to &apos;this&apos; instance or be declared private and left unimplemented." verbose="&apos;operator=&apos; should either return reference to &apos;this&apos; instance or be declared private and left unimplemented." cwe="398"/>
+        <error id="operatorEqToSelf" severity="warning" msg="&apos;operator=&apos; should check for assignment to self to avoid problems with dynamic memory." verbose="&apos;operator=&apos; should check for assignment to self to ensure that each block of dynamically allocated memory is owned and managed by only one instance of the class." cwe="398"/>
+        <error id="functionConst" severity="style" msg="Technically the member function &apos;class::function&apos; can be const." verbose="The member function &apos;class::function&apos; can be made a const function. Making this function &apos;const&apos; should not cause compiler errors. Even though the function can be made const function technically it may not make sense conceptually. Think about your design and the task of the function first - is it a function that must not change object internal state?" cwe="398" inconclusive="true">
+            <symbol>class::function</symbol>
+        </error>
+        <error id="functionStatic" severity="performance" msg="Technically the member function &apos;class::function&apos; can be static (but you may consider moving to unnamed namespace)." verbose="The member function &apos;class::function&apos; can be made a static function. Making a function static can bring a performance benefit since no &apos;this&apos; instance is passed to the function. This change should not cause compiler errors but it does not necessarily make sense conceptually. Think about your design and the task of the function first - is it a function that must not access members of class instances? And maybe it is more appropriate to move this function to an unnamed namespace." cwe="398" inconclusive="true">
+            <symbol>class::function</symbol>
+        </error>
+        <error id="initializerList" severity="style" msg="Member variable &apos;class::variable&apos; is in the wrong place in the initializer list." verbose="Member variable &apos;class::variable&apos; is in the wrong place in the initializer list. Members are initialized in the order they are declared, not in the order they are in the initializer list.  Keeping the initializer list in the same order that the members were declared prevents order dependent initialization errors." cwe="398" inconclusive="true">
+            <symbol>class::variable</symbol>
+        </error>
+        <error id="useInitializationList" severity="performance" msg="Variable &apos;variable&apos; is assigned in constructor body. Consider performing initialization in initialization list." verbose="When an object of a class is created, the constructors of all member variables are called consecutively in the order the variables are declared, even if you don&apos;t explicitly write them to the initialization list. You could avoid assigning &apos;variable&apos; a value by passing the value to the constructor in the initialization list." cwe="398">
+            <symbol>variable</symbol>
+        </error>
+        <error id="selfInitialization" severity="error" msg="Member variable &apos;var&apos; is initialized by itself." verbose="Member variable &apos;var&apos; is initialized by itself." cwe="665">
+            <symbol>var</symbol>
+        </error>
+        <error id="duplInheritedMember" severity="warning" msg="The class &apos;class&apos; defines member variable with name &apos;variable&apos; also defined in its parent class &apos;class&apos;." verbose="The class &apos;class&apos; defines member variable with name &apos;variable&apos; also defined in its parent class &apos;class&apos;." cwe="398">
+            <symbol>class</symbol>
+            <symbol>variable</symbol>
+            <symbol>class</symbol>
+        </error>
+        <error id="copyCtorAndEqOperator" severity="warning" msg="The class &apos;class&apos; has &apos;operator=&apos; but lack of &apos;copy constructor&apos;." verbose="The class &apos;class&apos; has &apos;operator=&apos; but lack of &apos;copy constructor&apos;.">
+            <symbol>class</symbol>
+        </error>
+        <error id="pureVirtualCall" severity="warning" msg="Call of pure virtual function &apos;f&apos; in constructor." verbose="Call of pure virtual function &apos;f&apos; in constructor. The call will fail during runtime.">
+            <symbol>f</symbol>
+        </error>
+        <error id="virtualCallInConstructor" severity="style" msg="Virtual function &apos;f&apos; is called from constructor &apos;&apos; at line 1. Dynamic binding is not used." verbose="Virtual function &apos;f&apos; is called from constructor &apos;&apos; at line 1. Dynamic binding is not used."/>
+        <error id="missingOverride" severity="style" msg="The function &apos;&apos; overrides a function in a base class but is not marked with a &apos;override&apos; specifier." verbose="The function &apos;&apos; overrides a function in a base class but is not marked with a &apos;override&apos; specifier.">
+            <symbol></symbol>
+        </error>
+        <error id="thisUseAfterFree" severity="warning" msg="Using member &apos;x&apos; when &apos;this&apos; might be invalid" verbose="Using member &apos;x&apos; when &apos;this&apos; might be invalid">
+            <symbol>ptr</symbol>
+        </error>
+        <error id="unsafeClassRefMember" severity="warning" msg="Unsafe class: The const reference member &apos;UnsafeClass::var&apos; is initialized by a const reference constructor argument. You need to be careful about lifetime issues." verbose="Unsafe class checking: The const reference member &apos;UnsafeClass::var&apos; is initialized by a const reference constructor argument. You need to be careful about lifetime issues. If you pass a local variable or temporary value in this constructor argument, be extra careful. If the argument is always some global object that is never destroyed then this is safe usage. However it would be defensive to make the member &apos;UnsafeClass::var&apos; a non-reference variable or a smart pointer.">
+            <symbol>UnsafeClass::var</symbol>
+        </error>
+        <error id="assignIfError" severity="style" msg="Mismatching assignment and comparison, comparison &apos;&apos; is always false." verbose="Mismatching assignment and comparison, comparison &apos;&apos; is always false." cwe="398"/>
+        <error id="badBitmaskCheck" severity="warning" msg="Result of operator &apos;|&apos; is always true if one operand is non-zero. Did you intend to use &apos;&amp;&apos;?" verbose="Result of operator &apos;|&apos; is always true if one operand is non-zero. Did you intend to use &apos;&amp;&apos;?" cwe="571"/>
+        <error id="comparisonError" severity="style" msg="Expression &apos;(X &amp; 0x6) == 0x1&apos; is always false." verbose="The expression &apos;(X &amp; 0x6) == 0x1&apos; is always false. Check carefully constants and operators used, these errors might be hard to spot sometimes. In case of complex expression it might help to split it to separate expressions." cwe="398"/>
+        <error id="duplicateCondition" severity="style" msg="The if condition is the same as the previous if condition" verbose="The if condition is the same as the previous if condition" cwe="398"/>
+        <error id="multiCondition" severity="style" msg="Expression is always false because &apos;else if&apos; condition matches previous condition at line 1." verbose="Expression is always false because &apos;else if&apos; condition matches previous condition at line 1." cwe="398"/>
+        <error id="mismatchingBitAnd" severity="style" msg="Mismatching bitmasks. Result is always 0 (X = Y &amp; 0xf0; Z = X &amp; 0x1; =&gt; Z=0)." verbose="Mismatching bitmasks. Result is always 0 (X = Y &amp; 0xf0; Z = X &amp; 0x1; =&gt; Z=0)." cwe="398"/>
+        <error id="oppositeInnerCondition" severity="warning" msg="Opposite inner &apos;if&apos; condition leads to a dead code block." verbose="Opposite inner &apos;if&apos; condition leads to a dead code block (outer condition is &apos;x&apos; and inner condition is &apos;!x&apos;)." cwe="398"/>
+        <error id="identicalInnerCondition" severity="warning" msg="Identical inner &apos;if&apos; condition is always true." verbose="Identical inner &apos;if&apos; condition is always true (outer condition is &apos;x&apos; and inner condition is &apos;x&apos;)." cwe="398"/>
+        <error id="identicalConditionAfterEarlyExit" severity="warning" msg="Identical condition &apos;x&apos;, second condition is always false" verbose="Identical condition &apos;x&apos;, second condition is always false" cwe="398"/>
+        <error id="incorrectLogicOperator" severity="warning" msg="Logical disjunction always evaluates to true: foo &gt; 3 &amp;&amp; foo &lt; 4." verbose="Logical disjunction always evaluates to true: foo &gt; 3 &amp;&amp; foo &lt; 4. Are these conditions necessary? Did you intend to use &amp;&amp; instead? Are the numbers correct? Are you comparing the correct variables?" cwe="571"/>
+        <error id="redundantCondition" severity="style" msg="Redundant condition: If x &gt; 11 the condition x &gt; 10 is always true." verbose="Redundant condition: If x &gt; 11 the condition x &gt; 10 is always true." cwe="398"/>
+        <error id="moduloAlwaysTrueFalse" severity="warning" msg="Comparison of modulo result is predetermined, because it is always less than 1." verbose="Comparison of modulo result is predetermined, because it is always less than 1." cwe="398"/>
+        <error id="clarifyCondition" severity="style" msg="Suspicious condition (assignment + comparison); Clarify expression with parentheses." verbose="Suspicious condition (assignment + comparison); Clarify expression with parentheses." cwe="398"/>
+        <error id="knownConditionTrueFalse" severity="style" msg="Condition &apos;x&apos; is always false" verbose="Condition &apos;x&apos; is always false" cwe="570"/>
+        <error id="invalidTestForOverflow" severity="warning" msg="Invalid test for overflow &apos;x + c &lt; x&apos;; signed integer overflow is undefined behavior. Some mainstream compilers remove such overflow tests when optimising the code and assume it&apos;s always false." verbose="Invalid test for overflow &apos;x + c &lt; x&apos;; signed integer overflow is undefined behavior. Some mainstream compilers remove such overflow tests when optimising the code and assume it&apos;s always false." cwe="391"/>
+        <error id="pointerAdditionResultNotNull" severity="warning" msg="Comparison is wrong. Result of &apos;ptr+1&apos; can&apos;t be 0 unless there is pointer overflow, and pointer overflow is undefined behaviour." verbose="Comparison is wrong. Result of &apos;ptr+1&apos; can&apos;t be 0 unless there is pointer overflow, and pointer overflow is undefined behaviour."/>
+        <error id="duplicateConditionalAssign" severity="style" msg="Duplicate expression for the condition and assignment." verbose="Duplicate expression for the condition and assignment." cwe="398"/>
+        <error id="assignmentInCondition" severity="style" msg="Suspicious assignment in condition. Condition &apos;x=y&apos; is always true." verbose="Suspicious assignment in condition. Condition &apos;x=y&apos; is always true." cwe="571"/>
+        <error id="compareValueOutOfTypeRangeError" severity="style" msg="Comparing expression of type &apos;unsigned char&apos; against value 256. Condition is always true." verbose="Comparing expression of type &apos;unsigned char&apos; against value 256. Condition is always true." cwe="398"/>
+        <error id="exceptThrowInDestructor" severity="warning" msg="Class Class is not safe, destructor throws exception" verbose="The class Class is not safe because its destructor throws an exception. If Class is used and an exception is thrown that is caught in an outer scope the program will terminate." cwe="398"/>
+        <error id="exceptDeallocThrow" severity="warning" msg="Exception thrown in invalid state, &apos;p&apos; points at deallocated memory." verbose="Exception thrown in invalid state, &apos;p&apos; points at deallocated memory." cwe="398"/>
+        <error id="exceptRethrowCopy" severity="style" msg="Throwing a copy of the caught exception instead of rethrowing the original exception." verbose="Rethrowing an exception with &apos;throw varname;&apos; creates an unnecessary copy of &apos;varname&apos;. To rethrow the caught exception without unnecessary copying or slicing, use a bare &apos;throw;&apos;." cwe="398"/>
+        <error id="catchExceptionByValue" severity="style" msg="Exception should be caught by reference." verbose="The exception is caught by value. It could be caught as a (const) reference which is usually recommended in C++." cwe="398"/>
+        <error id="throwInNoexceptFunction" severity="error" msg="Exception thrown in function declared not to throw exceptions." verbose="Exception thrown in function declared not to throw exceptions." cwe="398"/>
+        <error id="unhandledExceptionSpecification" severity="style" msg="Unhandled exception specification when calling function foo()." verbose="Unhandled exception specification when calling function foo(). Either use a try/catch around the function call, or add a exception specification for funcname() also." cwe="703" inconclusive="true"/>
+        <error id="rethrowNoCurrentException" severity="error" msg="Rethrowing current exception with &apos;throw;&apos;, it seems there is no current exception to rethrow. If there is no current exception this calls std::terminate(). More: https://isocpp.org/wiki/faq/exceptions#throw-without-an-object" verbose="Rethrowing current exception with &apos;throw;&apos;, it seems there is no current exception to rethrow. If there is no current exception this calls std::terminate(). More: https://isocpp.org/wiki/faq/exceptions#throw-without-an-object" cwe="480"/>
+        <error id="coutCerrMisusage" severity="error" msg="Invalid usage of output stream: &apos;&lt;&lt; std::cout&apos;." verbose="Invalid usage of output stream: &apos;&lt;&lt; std::cout&apos;." cwe="398"/>
+        <error id="fflushOnInputStream" severity="portability" msg="fflush() called on input stream &apos;stdin&apos; may result in undefined behaviour on non-linux systems." verbose="fflush() called on input stream &apos;stdin&apos; may result in undefined behaviour on non-linux systems." cwe="398"/>
+        <error id="IOWithoutPositioning" severity="error" msg="Read and write operations without a call to a positioning function (fseek, fsetpos or rewind) or fflush in between result in undefined behaviour." verbose="Read and write operations without a call to a positioning function (fseek, fsetpos or rewind) or fflush in between result in undefined behaviour." cwe="664"/>
+        <error id="readWriteOnlyFile" severity="error" msg="Read operation on a file that was opened only for writing." verbose="Read operation on a file that was opened only for writing." cwe="664"/>
+        <error id="writeReadOnlyFile" severity="error" msg="Write operation on a file that was opened only for reading." verbose="Write operation on a file that was opened only for reading." cwe="664"/>
+        <error id="useClosedFile" severity="error" msg="Used file that is not opened." verbose="Used file that is not opened." cwe="910"/>
+        <error id="seekOnAppendedFile" severity="warning" msg="Repositioning operation performed on a file opened in append mode has no effect." verbose="Repositioning operation performed on a file opened in append mode has no effect." cwe="398"/>
+        <error id="incompatibleFileOpen" severity="warning" msg="The file &apos;tmp&apos; is opened for read and write access at the same time on different streams" verbose="The file &apos;tmp&apos; is opened for read and write access at the same time on different streams" cwe="664"/>
+        <error id="invalidscanf" severity="warning" msg="scanf() without field width limits can crash with huge input data." verbose="scanf() without field width limits can crash with huge input data. Add a field width specifier to fix this problem.\012\012Sample program that can crash:\012\012#include &lt;stdio.h&gt;\012int main()\012{\012    char c[5];\012    scanf(&quot;%s&quot;, c);\012    return 0;\012}\012\012Typing in 5 or more characters may make the program crash. The correct usage here is &apos;scanf(&quot;%4s&quot;, c);&apos;, as the maximum field width does not include the terminating null byte.\012Source: http://linux.die.net/man/3/scanf\012Source: http://www.opensource.apple.com/source/xnu/xnu-1456.1.26/libkern/stdio/scanf.c" cwe="119"/>
+        <error id="wrongPrintfScanfArgNum" severity="error" msg="printf format string requires 3 parameters but only 2 are given." verbose="printf format string requires 3 parameters but only 2 are given." cwe="685"/>
+        <error id="invalidScanfArgType_s" severity="warning" msg="%s in format string (no. 1) requires a &apos;char *&apos; but the argument type is Unknown." verbose="%s in format string (no. 1) requires a &apos;char *&apos; but the argument type is Unknown." cwe="686"/>
+        <error id="invalidScanfArgType_int" severity="warning" msg="%d in format string (no. 1) requires &apos;int *&apos; but the argument type is Unknown." verbose="%d in format string (no. 1) requires &apos;int *&apos; but the argument type is Unknown." cwe="686"/>
+        <error id="invalidScanfArgType_float" severity="warning" msg="%f in format string (no. 1) requires &apos;float *&apos; but the argument type is Unknown." verbose="%f in format string (no. 1) requires &apos;float *&apos; but the argument type is Unknown." cwe="686"/>
+        <error id="invalidPrintfArgType_s" severity="warning" msg="%s in format string (no. 1) requires &apos;char *&apos; but the argument type is Unknown." verbose="%s in format string (no. 1) requires &apos;char *&apos; but the argument type is Unknown." cwe="686"/>
+        <error id="invalidPrintfArgType_n" severity="warning" msg="%n in format string (no. 1) requires &apos;int *&apos; but the argument type is Unknown." verbose="%n in format string (no. 1) requires &apos;int *&apos; but the argument type is Unknown." cwe="686"/>
+        <error id="invalidPrintfArgType_p" severity="warning" msg="%p in format string (no. 1) requires an address but the argument type is Unknown." verbose="%p in format string (no. 1) requires an address but the argument type is Unknown." cwe="686"/>
+        <error id="invalidPrintfArgType_uint" severity="warning" msg="%u in format string (no. 1) requires &apos;unsigned int&apos; but the argument type is Unknown." verbose="%u in format string (no. 1) requires &apos;unsigned int&apos; but the argument type is Unknown." cwe="686"/>
+        <error id="invalidPrintfArgType_sint" severity="warning" msg="%i in format string (no. 1) requires &apos;int&apos; but the argument type is Unknown." verbose="%i in format string (no. 1) requires &apos;int&apos; but the argument type is Unknown." cwe="686"/>
+        <error id="invalidPrintfArgType_float" severity="warning" msg="%f in format string (no. 1) requires &apos;double&apos; but the argument type is Unknown." verbose="%f in format string (no. 1) requires &apos;double&apos; but the argument type is Unknown." cwe="686"/>
+        <error id="invalidLengthModifierError" severity="warning" msg="&apos;I&apos; in format string (no. 1) is a length modifier and cannot be used without a conversion specifier." verbose="&apos;I&apos; in format string (no. 1) is a length modifier and cannot be used without a conversion specifier." cwe="704"/>
+        <error id="invalidScanfFormatWidth" severity="error" msg="Width 5 given in format string (no. 10) is larger than destination buffer &apos;[0]&apos;, use %-1s to prevent overflowing it." verbose="Width 5 given in format string (no. 10) is larger than destination buffer &apos;[0]&apos;, use %-1s to prevent overflowing it." cwe="687"/>
+        <error id="invalidScanfFormatWidth_smaller" severity="warning" msg="Width -1 given in format string (no. 99) is smaller than destination buffer &apos;[0]&apos;." verbose="Width -1 given in format string (no. 99) is smaller than destination buffer &apos;[0]&apos;." inconclusive="true"/>
+        <error id="wrongPrintfScanfParameterPositionError" severity="warning" msg="printf: referencing parameter 2 while 1 arguments given" verbose="printf: referencing parameter 2 while 1 arguments given" cwe="685"/>
+        <error id="deallocret" severity="error" msg="Returning/dereferencing &apos;p&apos; after it is deallocated / released" verbose="Returning/dereferencing &apos;p&apos; after it is deallocated / released" cwe="672">
+            <symbol>p</symbol>
+        </error>
+        <error id="doubleFree" severity="error" msg="Memory pointed to by &apos;varname&apos; is freed twice." verbose="Memory pointed to by &apos;varname&apos; is freed twice." cwe="415">
+            <symbol>varname</symbol>
+        </error>
+        <error id="leakNoVarFunctionCall" severity="error" msg="Allocation with funcName, funcName doesn&apos;t release it." verbose="Allocation with funcName, funcName doesn&apos;t release it." cwe="772"/>
+        <error id="leakReturnValNotUsed" severity="error" msg="Return value of allocation function &apos;funcName&apos; is not stored." verbose="Return value of allocation function &apos;funcName&apos; is not stored." cwe="771">
+            <symbol>funcName</symbol>
+        </error>
+        <error id="leakUnsafeArgAlloc" severity="warning" msg="Unsafe allocation. If funcName() throws, memory could be leaked. Use make_shared&lt;int&gt;() instead." verbose="Unsafe allocation. If funcName() throws, memory could be leaked. Use make_shared&lt;int&gt;() instead." cwe="401" inconclusive="true">
+            <symbol>funcName</symbol>
+        </error>
+        <error id="publicAllocationError" severity="warning" msg="Possible leak in public function. The pointer &apos;varname&apos; is not deallocated before it is allocated." verbose="Possible leak in public function. The pointer &apos;varname&apos; is not deallocated before it is allocated." cwe="398">
+            <symbol>varname</symbol>
+        </error>
+        <error id="unsafeClassCanLeak" severity="style" msg="Class &apos;class&apos; is unsafe, &apos;class::varname&apos; can leak by wrong usage." verbose="The class &apos;class&apos; is unsafe, wrong usage can cause memory/resource leaks for &apos;class::varname&apos;. This can for instance be fixed by adding proper cleanup in the destructor." cwe="398">
+            <symbol>class</symbol>
+            <symbol>class::varname</symbol>
+        </error>
+        <error id="memleak" severity="error" msg="Memory leak: varname" verbose="Memory leak: varname" cwe="401">
+            <symbol>varname</symbol>
+        </error>
+        <error id="resourceLeak" severity="error" msg="Resource leak: varname" verbose="Resource leak: varname" cwe="775">
+            <symbol>varname</symbol>
+        </error>
+        <error id="deallocuse" severity="error" msg="Dereferencing &apos;varname&apos; after it is deallocated / released" verbose="Dereferencing &apos;varname&apos; after it is deallocated / released" cwe="416">
+            <symbol>varname</symbol>
+        </error>
+        <error id="mismatchAllocDealloc" severity="error" msg="Mismatching allocation and deallocation: varname" verbose="Mismatching allocation and deallocation: varname" cwe="762">
+            <symbol>varname</symbol>
+        </error>
+        <error id="memleakOnRealloc" severity="error" msg="Common realloc mistake: &apos;varname&apos; nulled but not freed upon failure" verbose="Common realloc mistake: &apos;varname&apos; nulled but not freed upon failure" cwe="401">
+            <symbol>varname</symbol>
+        </error>
+        <error id="nullPointer" severity="error" msg="Null pointer dereference" verbose="Null pointer dereference" cwe="476"/>
+        <error id="nullPointerDefaultArg" severity="warning" msg="Possible null pointer dereference if the default parameter value is used: pointer" verbose="Possible null pointer dereference if the default parameter value is used: pointer" cwe="476">
+            <symbol>pointer</symbol>
+        </error>
+        <error id="nullPointerRedundantCheck" severity="warning" msg="Either the condition is redundant or there is possible null pointer dereference: pointer." verbose="Either the condition is redundant or there is possible null pointer dereference: pointer." cwe="476">
+            <symbol>pointer</symbol>
+        </error>
+        <error id="nullPointerArithmetic" severity="error" msg="Pointer arithmetic with NULL pointer." verbose="Pointer arithmetic with NULL pointer." cwe="682"/>
+        <error id="nullPointerArithmeticRedundantCheck" severity="warning" msg="Either the condition is redundant or there is pointer arithmetic with NULL pointer." verbose="Either the condition is redundant or there is pointer arithmetic with NULL pointer." cwe="682"/>
+        <error id="zerodiv" severity="error" msg="Division by zero." verbose="Division by zero." cwe="369"/>
+        <error id="zerodivcond" severity="warning" msg="Either the condition is redundant or there is division by zero." verbose="Either the condition is redundant or there is division by zero." cwe="369"/>
+        <error id="unusedScopedObject" severity="style" msg="Instance of &apos;varname&apos; object is destroyed immediately." verbose="Instance of &apos;varname&apos; object is destroyed immediately." cwe="563">
+            <symbol>varname</symbol>
+        </error>
+        <error id="invalidPointerCast" severity="portability" msg="Casting between float * and double * which have an incompatible binary data representation." verbose="Casting between float * and double * which have an incompatible binary data representation." cwe="704"/>
+        <error id="shiftNegativeLHS" severity="portability" msg="Shifting a negative value is technically undefined behaviour" verbose="Shifting a negative value is technically undefined behaviour" cwe="758"/>
+        <error id="shiftNegative" severity="error" msg="Shifting by a negative value is undefined behaviour" verbose="Shifting by a negative value is undefined behaviour" cwe="758"/>
+        <error id="raceAfterInterlockedDecrement" severity="error" msg="Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead." verbose="Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead." cwe="362"/>
+        <error id="invalidFree" severity="error" msg="Mismatching address is freed. The address you get from malloc() must be freed without offset." verbose="Mismatching address is freed. The address you get from malloc() must be freed without offset."/>
+        <error id="overlappingWriteUnion" severity="error" msg="Overlapping read/write of union is undefined behavior" verbose="Overlapping read/write of union is undefined behavior"/>
+        <error id="overlappingWriteFunction" severity="error" msg="Overlapping read/write in () is undefined behavior" verbose="Overlapping read/write in () is undefined behavior"/>
+        <error id="redundantCopyLocalConst" severity="performance" msg="Use const reference for &apos;varname&apos; to avoid unnecessary data copying." verbose="The const variable &apos;varname&apos; is assigned a copy of the data. You can avoid the unnecessary data copying by converting &apos;varname&apos; to const reference." cwe="398" inconclusive="true">
+            <symbol>varname</symbol>
+        </error>
+        <error id="redundantCopy" severity="performance" msg="Buffer &apos;var&apos; is being written before its old content has been used." verbose="Buffer &apos;var&apos; is being written before its old content has been used." cwe="563">
+            <symbol>var</symbol>
+        </error>
+        <error id="comparisonFunctionIsAlwaysTrueOrFalse" severity="warning" msg="Comparison of two identical variables with isless(varName,varName) always evaluates to false." verbose="The function isless is designed to compare two variables. Calling this function with one variable (varName) for both parameters leads to a statement which is always false." cwe="570">
+            <symbol>isless</symbol>
+        </error>
+        <error id="checkCastIntToCharAndBack" severity="warning" msg="Storing func_name() return value in char variable and then comparing with EOF." verbose="When saving func_name() return value in char variable there is loss of precision.  When func_name() returns EOF this value is truncated. Comparing the char variable with EOF can have unexpected results. For instance a loop &quot;while (EOF != (c = func_name());&quot; loops forever on some compilers/platforms and on other compilers/platforms it will stop when the file contains a matching character." cwe="197">
+            <symbol>func_name</symbol>
+        </error>
+        <error id="cstyleCast" severity="style" msg="C-style pointer casting" verbose="C-style pointer casting detected. C++ offers four different kinds of casts as replacements: static_cast, const_cast, dynamic_cast and reinterpret_cast. A C-style cast could evaluate to any of those automatically, thus it is considered safer if the programmer explicitly states which kind of cast is expected." cwe="398"/>
+        <error id="passedByValue" severity="performance" msg="Function parameter &apos;parametername&apos; should be passed by const reference." verbose="Parameter &apos;parametername&apos; is passed by value. It could be passed as a const reference which is usually faster and recommended in C++." cwe="398">
+            <symbol>parametername</symbol>
+        </error>
+        <error id="constParameter" severity="style" msg="Parameter &apos;x&apos; can be declared with const" verbose="Parameter &apos;x&apos; can be declared with const"/>
+        <error id="constVariable" severity="style" msg="Variable &apos;x&apos; can be declared with const" verbose="Variable &apos;x&apos; can be declared with const"/>
+        <error id="constParameterReference" severity="style" msg="Parameter &apos;x&apos; can be declared with const" verbose="Parameter &apos;x&apos; can be declared with const"/>
+        <error id="constVariableReference" severity="style" msg="Variable &apos;x&apos; can be declared with const" verbose="Variable &apos;x&apos; can be declared with const"/>
+        <error id="constParameterPointer" severity="style" msg="Parameter &apos;x&apos; can be declared with const" verbose="Parameter &apos;x&apos; can be declared with const"/>
+        <error id="constVariablePointer" severity="style" msg="Variable &apos;x&apos; can be declared with const" verbose="Variable &apos;x&apos; can be declared with const"/>
+        <error id="constParameterCallback" severity="style" msg="Parameter &apos;x&apos; can be declared with const, however it seems that &apos;f&apos; is a callback function." verbose="Parameter &apos;x&apos; can be declared with const, however it seems that &apos;f&apos; is a callback function."/>
+        <error id="constStatement" severity="warning" msg="Redundant code: Found a statement that begins with type constant." verbose="Redundant code: Found a statement that begins with type constant." cwe="398"/>
+        <error id="signedCharArrayIndex" severity="warning" msg="Signed &apos;char&apos; type used as array index." verbose="Signed &apos;char&apos; type used as array index. If the value can be greater than 127 there will be a buffer underflow because of sign extension." cwe="128"/>
+        <error id="unknownSignCharArrayIndex" severity="portability" msg="&apos;char&apos; type used as array index." verbose="&apos;char&apos; type used as array index. Values greater than 127 will be treated depending on whether &apos;char&apos; is signed or unsigned on target platform." cwe="758"/>
+        <error id="charBitOp" severity="warning" msg="When using &apos;char&apos; variables in bit operations, sign extension can generate unexpected results." verbose="When using &apos;char&apos; variables in bit operations, sign extension can generate unexpected results. For example:\012    char c = 0x80;\012    int i = 0 | c;\012    if (i &amp; 0x8000)\012        printf(&quot;not expected&quot;);\012The &quot;not expected&quot; will be printed on the screen." cwe="398"/>
+        <error id="variableScope" severity="style" msg="The scope of the variable &apos;varname&apos; can be reduced." verbose="The scope of the variable &apos;varname&apos; can be reduced. Warning: Be careful when fixing this message, especially when there are inner loops. Here is an example where cppcheck will write that the scope for &apos;i&apos; can be reduced:\012void f(int x)\012{\012    int i = 0;\012    if (x) {\012        // it&apos;s safe to move &apos;int i = 0;&apos; here\012        for (int n = 0; n &lt; 10; ++n) {\012            // it is possible but not safe to move &apos;int i = 0;&apos; here\012            do_something(&amp;i);\012        }\012    }\012}\012When you see this message it is always safe to reduce the variable scope 1 level." cwe="398">
+            <symbol>varname</symbol>
+        </error>
+        <error id="redundantAssignInSwitch" severity="style" msg="Variable &apos;var&apos; is reassigned a value before the old one has been used. &apos;break;&apos; missing?" verbose="Variable &apos;var&apos; is reassigned a value before the old one has been used. &apos;break;&apos; missing?" cwe="563">
+            <symbol>var</symbol>
+        </error>
+        <error id="suspiciousCase" severity="warning" msg="Found suspicious case label in switch(). Operator &apos;||&apos; probably doesn&apos;t work as intended." verbose="Using an operator like &apos;||&apos; in a case label is suspicious. Did you intend to use a bitwise operator, multiple case labels or if/else instead?" cwe="398" inconclusive="true"/>
+        <error id="selfAssignment" severity="warning" msg="Redundant assignment of &apos;varname&apos; to itself." verbose="Redundant assignment of &apos;varname&apos; to itself." cwe="398">
+            <symbol>varname</symbol>
+        </error>
+        <error id="clarifyCalculation" severity="style" msg="Clarify calculation precedence for &apos;+&apos; and &apos;?&apos;." verbose="Suspicious calculation. Please use parentheses to clarify the code. The code &apos;&apos;a+b?c:d&apos;&apos; should be written as either &apos;&apos;(a+b)?c:d&apos;&apos; or &apos;&apos;a+(b?c:d)&apos;&apos;." cwe="783"/>
+        <error id="clarifyStatement" severity="warning" msg="In expression like &apos;*A++&apos; the result of &apos;*&apos; is unused. Did you intend to write &apos;(*A)++;&apos;?" verbose="A statement like &apos;*A++;&apos; might not do what you intended. Postfix &apos;operator++&apos; is executed before &apos;operator*&apos;. Thus, the dereference is meaningless. Did you intend to write &apos;(*A)++;&apos;?" cwe="783"/>
+        <error id="duplicateBranch" severity="style" msg="Found duplicate branches for &apos;if&apos; and &apos;else&apos;." verbose="Finding the same code in an &apos;if&apos; and related &apos;else&apos; branch is suspicious and might indicate a cut and paste or logic error. Please examine this code carefully to determine if it is correct." cwe="398" inconclusive="true"/>
+        <error id="duplicateAssignExpression" severity="style" msg="Same expression used in consecutive assignments of &apos;x&apos; and &apos;x&apos;." verbose="Finding variables &apos;x&apos; and &apos;x&apos; that are assigned the same expression is suspicious and might indicate a cut and paste or logic error. Please examine this code carefully to determine if it is correct." cwe="398" inconclusive="true"/>
+        <error id="oppositeExpression" severity="style" msg="Opposite expression on both sides of &apos;&amp;&amp;&apos;." verbose="Finding the opposite expression on both sides of an operator is suspicious and might indicate a cut and paste or logic error. Please examine this code carefully to determine if it is correct." cwe="398"/>
+        <error id="duplicateExpression" severity="style" msg="Same expression on both sides of &apos;&amp;&amp;&apos;." verbose="Finding the same expression on both sides of an operator is suspicious and might indicate a cut and paste or logic error. Please examine this code carefully to determine if it is correct." cwe="398"/>
+        <error id="duplicateValueTernary" severity="style" msg="Same value in both branches of ternary operator." verbose="Finding the same value in both branches of ternary operator is suspicious as the same code is executed regardless of the condition." cwe="398"/>
+        <error id="duplicateExpressionTernary" severity="style" msg="Same expression in both branches of ternary operator." verbose="Finding the same expression in both branches of ternary operator is suspicious as the same code is executed regardless of the condition." cwe="398"/>
+        <error id="duplicateBreak" severity="style" msg="Consecutive return, break, continue, goto or throw statements are unnecessary." verbose="Consecutive return, break, continue, goto or throw statements are unnecessary. The second statement can never be executed, and so should be removed." cwe="561"/>
+        <error id="unreachableCode" severity="style" msg="Statements following return, break, continue, goto or throw will never be executed." verbose="Statements following return, break, continue, goto or throw will never be executed." cwe="561"/>
+        <error id="unsignedLessThanZero" severity="style" msg="Checking if unsigned expression &apos;varname&apos; is less than zero." verbose="The unsigned expression &apos;varname&apos; will never be negative so it is either pointless or an error to check if it is." cwe="570">
+            <symbol>varname</symbol>
+        </error>
+        <error id="unsignedPositive" severity="style" msg="Unsigned expression &apos;varname&apos; can&apos;t be negative so it is unnecessary to test it." verbose="Unsigned expression &apos;varname&apos; can&apos;t be negative so it is unnecessary to test it." cwe="570">
+            <symbol>varname</symbol>
+        </error>
+        <error id="pointerLessThanZero" severity="style" msg="A pointer can not be negative so it is either pointless or an error to check if it is." verbose="A pointer can not be negative so it is either pointless or an error to check if it is." cwe="570"/>
+        <error id="pointerPositive" severity="style" msg="A pointer can not be negative so it is either pointless or an error to check if it is not." verbose="A pointer can not be negative so it is either pointless or an error to check if it is not." cwe="570"/>
+        <error id="suspiciousSemicolon" severity="warning" msg="Suspicious use of ; at the end of &apos;&apos; statement." verbose="Suspicious use of ; at the end of &apos;&apos; statement." cwe="398"/>
+        <error id="incompleteArrayFill" severity="warning" msg="Array &apos;buffer&apos; is filled incompletely. Did you forget to multiply the size given to &apos;memset()&apos; with &apos;sizeof(*buffer)&apos;?" verbose="The array &apos;buffer&apos; is filled incompletely. The function &apos;memset()&apos; needs the size given in bytes, but an element of the given array is larger than one byte. Did you forget to multiply the size with &apos;sizeof(*buffer)&apos;?" cwe="131" inconclusive="true">
+            <symbol>buffer</symbol>
+            <symbol>memset</symbol>
+        </error>
+        <error id="varFuncNullUB" severity="portability" msg="Passing NULL after the last typed argument to a variadic function leads to undefined behaviour." verbose="Passing NULL after the last typed argument to a variadic function leads to undefined behaviour.\012The C99 standard, in section 7.15.1.1, states that if the type used by va_arg() is not compatible with the type of the actual next argument (as promoted according to the default argument promotions), the behavior is undefined.\012The value of the NULL macro is an implementation-defined null pointer constant (7.17), which can be any integer constant expression with the value 0, or such an expression casted to (void*) (6.3.2.3). This includes values like 0, 0L, or even 0LL.\012In practice on common architectures, this will cause real crashes if sizeof(int) != sizeof(void*), and NULL is defined to 0 or any other null pointer constant that promotes to int.\012To reproduce you might be able to use this little code example on 64bit platforms. If the output includes &quot;ERROR&quot;, the sentinel had only 4 out of 8 bytes initialized to zero and was not detected as the final argument to stop argument processing via va_arg(). Changing the 0 to (void*)0 or 0L will make the &quot;ERROR&quot; output go away.\012#include &lt;stdarg.h&gt;\012#include &lt;stdio.h&gt;\012\012void f(char *s, ...) {\012    va_list ap;\012    va_start(ap,s);\012    for (;;) {\012        char *p = va_arg(ap,char*);\012        printf(&quot;%018p, %s\n&quot;, p, (long)p &amp; 255 ? p : &quot;&quot;);\012        if(!p) break;\012    }\012    va_end(ap);\012}\012\012void g() {\012    char *s2 = &quot;x&quot;;\012    char *s3 = &quot;ERROR&quot;;\012\012    // changing 0 to 0L for the 7th argument (which is intended to act as sentinel) makes the error go away on x86_64\012    f(&quot;first&quot;, s2, s2, s2, s2, s2, 0, s3, (char*)0);\012}\012\012void h() {\012    int i;\012    volatile unsigned char a[1000];\012    for (i = 0; i&lt;sizeof(a); i++)\012        a[i] = -1;\012}\012\012int main() {\012    h();\012    g();\012    return 0;\012}" cwe="475"/>
+        <error id="nanInArithmeticExpression" severity="style" msg="Using NaN/Inf in a computation." verbose="Using NaN/Inf in a computation. Although nothing bad really happens, it is suspicious." cwe="369"/>
+        <error id="commaSeparatedReturn" severity="style" msg="Comma is used in return statement. The comma can easily be misread as a &apos;;&apos;." verbose="Comma is used in return statement. When comma is used in a return statement it can easily be misread as a semicolon. For example in the code below the value of &apos;b&apos; is returned if the condition is true, but it is easy to think that &apos;a+1&apos; is returned:\012    if (x)\012        return a + 1,\012    b++;\012However it can be useful to use comma in macros. Cppcheck does not warn when such a macro is then used in a return statement, it is less likely such code is misunderstood." cwe="398"/>
+        <error id="redundantPointerOp" severity="style" msg="Redundant pointer operation on &apos;varname&apos; - it&apos;s already a pointer." verbose="Redundant pointer operation on &apos;varname&apos; - it&apos;s already a pointer." cwe="398">
+            <symbol>varname</symbol>
+        </error>
+        <error id="unusedLabel" severity="style" msg="Label &apos;&apos; is not used." verbose="Label &apos;&apos; is not used." cwe="398">
+            <symbol></symbol>
+        </error>
+        <error id="unusedLabelConfiguration" severity="style" msg="Label &apos;&apos; is not used. There is #if in function body so the label might be used in code that is removed by the preprocessor." verbose="Label &apos;&apos; is not used. There is #if in function body so the label might be used in code that is removed by the preprocessor." cwe="398">
+            <symbol></symbol>
+        </error>
+        <error id="unusedLabelSwitch" severity="warning" msg="Label &apos;&apos; is not used. Should this be a &apos;case&apos; of the enclosing switch()?" verbose="Label &apos;&apos; is not used. Should this be a &apos;case&apos; of the enclosing switch()?" cwe="398">
+            <symbol></symbol>
+        </error>
+        <error id="unusedLabelSwitchConfiguration" severity="warning" msg="Label &apos;&apos; is not used. There is #if in function body so the label might be used in code that is removed by the preprocessor. Should this be a &apos;case&apos; of the enclosing switch()?" verbose="Label &apos;&apos; is not used. There is #if in function body so the label might be used in code that is removed by the preprocessor. Should this be a &apos;case&apos; of the enclosing switch()?" cwe="398">
+            <symbol></symbol>
+        </error>
+        <error id="unknownEvaluationOrder" severity="error" msg="Expression &apos;x = x++;&apos; depends on order of evaluation of side effects" verbose="Expression &apos;x = x++;&apos; depends on order of evaluation of side effects" cwe="768"/>
+        <error id="accessMoved" severity="warning" msg="Access of moved variable &apos;v&apos;." verbose="Access of moved variable &apos;v&apos;." cwe="672"/>
+        <error id="accessForwarded" severity="warning" msg="Access of forwarded variable &apos;v&apos;." verbose="Access of forwarded variable &apos;v&apos;." cwe="672"/>
+        <error id="funcArgNamesDifferent" severity="style" msg="Function &apos;function&apos; argument 2 names different: declaration &apos;A&apos; definition &apos;B&apos;." verbose="Function &apos;function&apos; argument 2 names different: declaration &apos;A&apos; definition &apos;B&apos;." cwe="628" inconclusive="true">
+            <symbol>function</symbol>
+        </error>
+        <error id="redundantBitwiseOperationInSwitch" severity="style" msg="Redundant bitwise operation on &apos;varname&apos; in &apos;switch&apos; statement. &apos;break;&apos; missing?" verbose="Redundant bitwise operation on &apos;varname&apos; in &apos;switch&apos; statement. &apos;break;&apos; missing?">
+            <symbol>varname</symbol>
+        </error>
+        <error id="shadowVariable" severity="style" msg="Local variable &apos;variable&apos; shadows outer variable" verbose="Local variable &apos;variable&apos; shadows outer variable" cwe="398">
+            <symbol>variable</symbol>
+        </error>
+        <error id="shadowFunction" severity="style" msg="Local variable &apos;function&apos; shadows outer function" verbose="Local variable &apos;function&apos; shadows outer function" cwe="398">
+            <symbol>function</symbol>
+        </error>
+        <error id="shadowArgument" severity="style" msg="Local variable &apos;argument&apos; shadows outer argument" verbose="Local variable &apos;argument&apos; shadows outer argument" cwe="398">
+            <symbol>argument</symbol>
+        </error>
+        <error id="knownArgument" severity="style" msg="Argument &apos;x-x&apos; to function &apos;func&apos; is always 0. It does not matter what value &apos;x&apos; has." verbose="Argument &apos;x-x&apos; to function &apos;func&apos; is always 0. It does not matter what value &apos;x&apos; has."/>
+        <error id="knownArgumentHiddenVariableExpression" severity="style" msg="Argument &apos;x*0&apos; to function &apos;func&apos; is always 0. Constant literal calculation disable/hide variable expression &apos;x&apos;." verbose="Argument &apos;x*0&apos; to function &apos;func&apos; is always 0. Constant literal calculation disable/hide variable expression &apos;x&apos;."/>
+        <error id="knownPointerToBool" severity="style" msg="Pointer expression &apos;p&apos; converted to bool is always true." verbose="Pointer expression &apos;p&apos; converted to bool is always true."/>
+        <error id="comparePointers" severity="error" msg="Comparing pointers that point to different objects" verbose="Comparing pointers that point to different objects" cwe="570"/>
+        <error id="redundantAssignment" severity="style" msg="Variable &apos;var&apos; is reassigned a value before the old one has been used." verbose="Variable &apos;var&apos; is reassigned a value before the old one has been used." cwe="563">
+            <symbol>var</symbol>
+        </error>
+        <error id="redundantInitialization" severity="style" msg="Redundant initialization for &apos;var&apos;. The initialized value is overwritten before it is read." verbose="Redundant initialization for &apos;var&apos;. The initialized value is overwritten before it is read." cwe="563">
+            <symbol>var</symbol>
+        </error>
+        <error id="funcArgOrderDifferent" severity="warning" msg="Function &apos;function&apos; argument order different: declaration &apos;&apos; definition &apos;&apos;" verbose="Function &apos;function&apos; argument order different: declaration &apos;&apos; definition &apos;&apos;" cwe="683">
+            <symbol>function</symbol>
+        </error>
+        <error id="moduloofone" severity="style" msg="Modulo of one is always equal to zero" verbose="Modulo of one is always equal to zero"/>
+        <error id="containerOutOfBounds" severity="error" msg="Out of bounds access in expression &apos;container[x]&apos;" verbose="Out of bounds access in expression &apos;container[x]&apos;" cwe="398">
+            <symbol>container</symbol>
+        </error>
+        <error id="invalidIterator1" severity="error" msg="Invalid iterator: iterator" verbose="Invalid iterator: iterator" cwe="664">
+            <symbol>iterator</symbol>
+        </error>
+        <error id="iterators1" severity="error" msg="Same iterator is used with different containers &apos;container1&apos; and &apos;container2&apos;." verbose="Same iterator is used with different containers &apos;container1&apos; and &apos;container2&apos;." cwe="664">
+            <symbol>container1</symbol>
+            <symbol>container2</symbol>
+        </error>
+        <error id="iterators2" severity="error" msg="Same iterator is used with different containers &apos;container0&apos; and &apos;container1&apos;." verbose="Same iterator is used with different containers &apos;container0&apos; and &apos;container1&apos;." cwe="664">
+            <symbol>container0</symbol>
+            <symbol>container1</symbol>
+        </error>
+        <error id="iterators3" severity="error" msg="Same iterator is used with containers &apos;container&apos; that are temporaries or defined in different scopes." verbose="Same iterator is used with containers &apos;container&apos; that are temporaries or defined in different scopes." cwe="664">
+            <symbol>container</symbol>
+        </error>
+        <error id="invalidContainerLoop" severity="error" msg="Calling &apos;erase&apos; while iterating the container is invalid." verbose="Calling &apos;erase&apos; while iterating the container is invalid." cwe="664"/>
+        <error id="invalidContainer" severity="error" msg="Using object that may be invalid." verbose="Using object that may be invalid." cwe="664"/>
+        <error id="mismatchingContainerIterator" severity="error" msg="Iterator &apos;it&apos; from different container &apos;v1&apos; are used together." verbose="Iterator &apos;it&apos; from different container &apos;v1&apos; are used together." cwe="664"/>
+        <error id="mismatchingContainers" severity="error" msg="Iterators of different containers &apos;v1&apos; and &apos;v2&apos; are used together." verbose="Iterators of different containers &apos;v1&apos; and &apos;v2&apos; are used together." cwe="664"/>
+        <error id="mismatchingContainerExpression" severity="warning" msg="Iterators to containers from different expressions &apos;v1&apos; and &apos;v2&apos; are used together." verbose="Iterators to containers from different expressions &apos;v1&apos; and &apos;v2&apos; are used together." cwe="664"/>
+        <error id="sameIteratorExpression" severity="style" msg="Same iterators expression are used for algorithm." verbose="Same iterators expression are used for algorithm." cwe="664"/>
+        <error id="eraseDereference" severity="error" msg="Invalid iterator &apos;iter&apos; used." verbose="The iterator &apos;iter&apos; is invalid before being assigned. Dereferencing or comparing it with another iterator is invalid operation." cwe="664">
+            <symbol>iter</symbol>
+        </error>
+        <error id="stlOutOfBounds" severity="error" msg="When i==foo.size(), foo[i] is out of bounds." verbose="When i==foo.size(), foo[i] is out of bounds." cwe="788">
+            <symbol>foo</symbol>
+        </error>
+        <error id="negativeContainerIndex" severity="warning" msg="Array index -1 is out of bounds." verbose="Array index -1 is out of bounds." cwe="786"/>
+        <error id="stlBoundaries" severity="error" msg="Dangerous comparison using operator&lt; on iterator." verbose="Iterator compared with operator&lt;. This is dangerous since the order of items in the container is not guaranteed. One should use operator!= instead to compare iterators." cwe="664"/>
+        <error id="stlIfFind" severity="warning" msg="Suspicious condition. The result of find() is an iterator, but it is not properly checked." verbose="Suspicious condition. The result of find() is an iterator, but it is not properly checked." cwe="398"/>
+        <error id="stlIfStrFind" severity="performance" msg="Inefficient usage of string::find() in condition; string::starts_with() could be faster." verbose="Either inefficient or wrong usage of string::find(). string::starts_with() will be faster if string::find&apos;s result is compared with 0, because it will not scan the whole string. If your intention is to check that there are no findings in the string, you should compare with std::string::npos." cwe="597"/>
+        <error id="stlFindInsert" severity="performance" msg="Searching before insertion is not necessary." verbose="Searching before insertion is not necessary." cwe="398"/>
+        <error id="stlcstr" severity="error" msg="Dangerous usage of c_str(). The value returned by c_str() is invalid after this call." verbose="Dangerous usage of c_str(). The c_str() return value is only valid until its string is deleted." cwe="664"/>
+        <error id="stlcstrReturn" severity="performance" msg="Returning the result of c_str() in a function that returns std::string is slow and redundant." verbose="The conversion from const char* as returned by c_str() to std::string creates an unnecessary string copy. Solve that by directly returning the string." cwe="704"/>
+        <error id="stlcstrParam" severity="performance" msg="Passing the result of c_str() to a function that takes std::string as argument no. 0 is slow and redundant." verbose="The conversion from const char* as returned by c_str() to std::string creates an unnecessary string copy or length calculation. Solve that by directly passing the string." cwe="704"/>
+        <error id="stlcstrthrow" severity="error" msg="Dangerous usage of c_str(). The value returned by c_str() is invalid after throwing exception." verbose="Dangerous usage of c_str(). The string is destroyed after the c_str() call so the thrown pointer is invalid."/>
+        <error id="stlSize" severity="performance" msg="Possible inefficient checking for &apos;list&apos; emptiness." verbose="Checking for &apos;list&apos; emptiness might be inefficient. Using list.empty() instead of list.size() can be faster. list.size() can take linear time but list.empty() is guaranteed to take constant time." cwe="398">
+            <symbol>list</symbol>
+        </error>
+        <error id="StlMissingComparison" severity="warning" msg="Missing bounds check for extra iterator increment in loop." verbose="The iterator incrementing is suspicious - it is incremented at line  and then at line . The loop might unintentionally skip an element in the container. There is no comparison between these increments to prevent that the iterator is incremented beyond the end." cwe="834"/>
+        <error id="redundantIfRemove" severity="style" msg="Redundant checking of STL container element existence before removing it." verbose="Redundant checking of STL container element existence before removing it. It is safe to call the remove method on a non-existing element." cwe="398"/>
+        <error id="uselessCallsCompare" severity="warning" msg="It is inefficient to call &apos;str.find(str)&apos; as it always returns 0." verbose="&apos;std::string::find()&apos; returns zero when given itself as parameter (str.find(str)). As it is currently the code is inefficient. It is possible either the string searched (&apos;str&apos;) or searched for (&apos;str&apos;) is wrong." cwe="628">
+            <symbol>str</symbol>
+            <symbol>find</symbol>
+        </error>
+        <error id="uselessCallsSwap" severity="performance" msg="It is inefficient to swap a object with itself by calling &apos;str.swap(str)&apos;" verbose="The &apos;swap()&apos; function has no logical effect when given itself as parameter (str.swap(str)). As it is currently the code is inefficient. Is the object or the parameter wrong here?" cwe="628">
+            <symbol>str</symbol>
+        </error>
+        <error id="uselessCallsSubstr" severity="performance" msg="Ineffective call of function &apos;substr&apos; because it returns a copy of the object. Use operator= instead." verbose="Ineffective call of function &apos;substr&apos; because it returns a copy of the object. Use operator= instead." cwe="398"/>
+        <error id="uselessCallsEmpty" severity="warning" msg="Ineffective call of function &apos;empty()&apos;. Did you intend to call &apos;clear()&apos; instead?" verbose="Ineffective call of function &apos;empty()&apos;. Did you intend to call &apos;clear()&apos; instead?" cwe="398"/>
+        <error id="uselessCallsRemove" severity="warning" msg="Return value of std::remove() ignored. Elements remain in container." verbose="The return value of std::remove() is ignored. This function returns an iterator to the end of the range containing those elements that should be kept. Elements past new end remain valid but with unspecified values. Use the erase method of the container to delete them." cwe="762">
+            <symbol>remove</symbol>
+        </error>
+        <error id="derefInvalidIterator" severity="warning" msg="Possible dereference of an invalid iterator: i" verbose="Possible dereference of an invalid iterator: i. Make sure to check that the iterator is valid before dereferencing it - not after." cwe="825">
+            <symbol>i</symbol>
+        </error>
+        <error id="useStlAlgorithm" severity="style" msg="Consider using  algorithm instead of a raw loop." verbose="Consider using  algorithm instead of a raw loop." cwe="398"/>
+        <error id="knownEmptyContainer" severity="style" msg="Iterating over container &apos;var&apos; that is always empty." verbose="Iterating over container &apos;var&apos; that is always empty." cwe="398"/>
+        <error id="globalLockGuard" severity="warning" msg="Lock guard is defined globally. Lock guards are intended to be local. A global lock guard could lead to a deadlock since it won&apos;t unlock until the end of the program." verbose="Lock guard is defined globally. Lock guards are intended to be local. A global lock guard could lead to a deadlock since it won&apos;t unlock until the end of the program." cwe="833"/>
+        <error id="localMutex" severity="warning" msg="The lock is ineffective because the mutex is locked at the same scope as the mutex itself." verbose="The lock is ineffective because the mutex is locked at the same scope as the mutex itself." cwe="667"/>
+        <error id="sizeofwithsilentarraypointer" severity="warning" msg="Using &apos;sizeof&apos; on array given as function argument returns size of a pointer." verbose="Using &apos;sizeof&apos; for array given as function argument returns the size of a pointer. It does not return the size of the whole array in bytes as might be expected. For example, this code:\012     int f(char a[100]) {\012         return sizeof(a);\012     }\012returns 4 (in 32-bit systems) or 8 (in 64-bit systems) instead of 100 (the size of the array in bytes)." cwe="467"/>
+        <error id="pointerSize" severity="warning" msg="Size of pointer &apos;varname&apos; used instead of size of its data." verbose="Size of pointer &apos;varname&apos; used instead of size of its data. This is likely to lead to a buffer overflow. You probably intend to write &apos;sizeof(*varname)&apos;." cwe="467"/>
+        <error id="sizeofDivisionMemfunc" severity="warning" msg="Division by result of sizeof(). memset() expects a size in bytes, did you intend to multiply instead?" verbose="Division by result of sizeof(). memset() expects a size in bytes, did you intend to multiply instead?" cwe="682"/>
+        <error id="sizeofwithnumericparameter" severity="warning" msg="Suspicious usage of &apos;sizeof&apos; with a numeric constant as parameter." verbose="It is unusual to use a constant value with sizeof. For example, &apos;sizeof(10)&apos; returns 4 (in 32-bit systems) or 8 (in 64-bit systems) instead of 10. &apos;sizeof(&apos;A&apos;)&apos; and &apos;sizeof(char)&apos; can return different results." cwe="682"/>
+        <error id="sizeofsizeof" severity="warning" msg="Calling &apos;sizeof&apos; on &apos;sizeof&apos;." verbose="Calling sizeof for &apos;sizeof looks like a suspicious code and most likely there should be just one &apos;sizeof&apos;. The current code is equivalent to &apos;sizeof(size_t)&apos;" cwe="682"/>
+        <error id="sizeofCalculation" severity="warning" msg="Found calculation inside sizeof()." verbose="Found calculation inside sizeof()." cwe="682"/>
+        <error id="sizeofFunctionCall" severity="warning" msg="Found function call inside sizeof()." verbose="Found function call inside sizeof()." cwe="682"/>
+        <error id="multiplySizeof" severity="warning" msg="Multiplying sizeof() with sizeof() indicates a logic error." verbose="Multiplying sizeof() with sizeof() indicates a logic error." cwe="682" inconclusive="true"/>
+        <error id="divideSizeof" severity="warning" msg="Division of result of sizeof() on pointer type." verbose="Division of result of sizeof() on pointer type. sizeof() returns the size of the pointer, not the size of the memory area it points to." cwe="682" inconclusive="true"/>
+        <error id="sizeofVoid" severity="portability" msg="Behaviour of &apos;sizeof(void)&apos; is not covered by the ISO C standard." verbose="Behaviour of &apos;sizeof(void)&apos; is not covered by the ISO C standard. A value for &apos;sizeof(void)&apos; is defined only as part of a GNU C extension, which defines &apos;sizeof(void)&apos; to be 1." cwe="682"/>
+        <error id="sizeofDereferencedVoidPointer" severity="portability" msg="&apos;*varname&apos; is of type &apos;void&apos;, the behaviour of &apos;sizeof(void)&apos; is not covered by the ISO C standard." verbose="&apos;*varname&apos; is of type &apos;void&apos;, the behaviour of &apos;sizeof(void)&apos; is not covered by the ISO C standard. A value for &apos;sizeof(void)&apos; is defined only as part of a GNU C extension, which defines &apos;sizeof(void)&apos; to be 1." cwe="682"/>
+        <error id="arithOperationsOnVoidPointer" severity="portability" msg="&apos;varname&apos; is of type &apos;vartype&apos;. When using void pointers in calculations, the behaviour is undefined." verbose="&apos;varname&apos; is of type &apos;vartype&apos;. When using void pointers in calculations, the behaviour is undefined. Arithmetic operations on &apos;void *&apos; is a GNU C extension, which defines the &apos;sizeof(void)&apos; to be 1." cwe="467">
+            <symbol>varname</symbol>
+        </error>
+        <error id="stringLiteralWrite" severity="error" msg="Modifying string literal directly or indirectly is undefined behaviour." verbose="Modifying string literal directly or indirectly is undefined behaviour." cwe="758"/>
+        <error id="sprintfOverlappingData" severity="error" msg="Undefined behavior: Variable &apos;varname&apos; is used as parameter and destination in s[n]printf()." verbose="The variable &apos;varname&apos; is used both as a parameter and as destination in s[n]printf(). The origin and destination buffers overlap. Quote from glibc (C-library) documentation (http://www.gnu.org/software/libc/manual/html_mono/libc.html#Formatted-Output-Functions): &quot;If copying takes place between objects that overlap as a result of a call to sprintf() or snprintf(), the results are undefined.&quot;" cwe="628">
+            <symbol>varname</symbol>
+        </error>
+        <error id="strPlusChar" severity="error" msg="Unusual pointer arithmetic. A value of type &apos;char&apos; is added to a string literal." verbose="Unusual pointer arithmetic. A value of type &apos;char&apos; is added to a string literal." cwe="665"/>
+        <error id="incorrectStringCompare" severity="warning" msg="String literal &quot;Hello World&quot; doesn&apos;t match length argument for substr()." verbose="String literal &quot;Hello World&quot; doesn&apos;t match length argument for substr()." cwe="570">
+            <symbol>substr</symbol>
+        </error>
+        <error id="literalWithCharPtrCompare" severity="warning" msg="String literal compared with variable &apos;foo&apos;. Did you intend to use strcmp() instead?" verbose="String literal compared with variable &apos;foo&apos;. Did you intend to use strcmp() instead?" cwe="595">
+            <symbol>foo</symbol>
+        </error>
+        <error id="charLiteralWithCharPtrCompare" severity="warning" msg="Char literal compared with pointer &apos;foo&apos;. Did you intend to dereference it?" verbose="Char literal compared with pointer &apos;foo&apos;. Did you intend to dereference it?" cwe="595">
+            <symbol>foo</symbol>
+        </error>
+        <error id="incorrectStringBooleanError" severity="warning" msg="Conversion of string literal &quot;Hello World&quot; to bool always evaluates to true." verbose="Conversion of string literal &quot;Hello World&quot; to bool always evaluates to true." cwe="571"/>
+        <error id="incorrectCharBooleanError" severity="warning" msg="Conversion of char literal &apos;x&apos; to bool always evaluates to true." verbose="Conversion of char literal &apos;x&apos; to bool always evaluates to true." cwe="571"/>
+        <error id="staticStringCompare" severity="warning" msg="Unnecessary comparison of static strings." verbose="The compared strings, &apos;str1&apos; and &apos;str2&apos;, are always unequal. Therefore the comparison is unnecessary and looks suspicious." cwe="570"/>
+        <error id="stringCompare" severity="warning" msg="Comparison of identical string variables." verbose="The compared strings, &apos;varname1&apos; and &apos;varname2&apos;, are identical. This could be a logic bug." cwe="571"/>
+        <error id="overlappingStrcmp" severity="warning" msg="The expression &apos;strcmp(x,&quot;def&quot;) != 0&apos; is suspicious. It overlaps &apos;strcmp(x,&quot;abc&quot;) == 0&apos;." verbose="The expression &apos;strcmp(x,&quot;def&quot;) != 0&apos; is suspicious. It overlaps &apos;strcmp(x,&quot;abc&quot;) == 0&apos;."/>
+        <error id="shiftTooManyBits" severity="error" msg="Shifting 32-bit value by 40 bits is undefined behaviour" verbose="Shifting 32-bit value by 40 bits is undefined behaviour" cwe="758"/>
+        <error id="shiftTooManyBitsSigned" severity="error" msg="Shifting signed 32-bit value by 31 bits is implementation-defined behaviour" verbose="Shifting signed 32-bit value by 31 bits is implementation-defined behaviour" cwe="758"/>
+        <error id="integerOverflow" severity="error" msg="Signed integer overflow for expression &apos;&apos;." verbose="Signed integer overflow for expression &apos;&apos;." cwe="190"/>
+        <error id="signConversion" severity="warning" msg="Expression &apos;var&apos; can have a negative value. That is converted to an unsigned value and used in an unsigned calculation." verbose="Expression &apos;var&apos; can have a negative value. That is converted to an unsigned value and used in an unsigned calculation." cwe="195"/>
+        <error id="truncLongCastAssignment" severity="style" msg="int result is assigned to long variable. If the variable is long to avoid loss of information, then you have loss of information." verbose="int result is assigned to long variable. If the variable is long to avoid loss of information, then there is loss of information. To avoid loss of information you must cast a calculation operand to long, for example &apos;l = a * b;&apos; =&gt; &apos;l = (long)a * b;&apos;." cwe="197"/>
+        <error id="truncLongCastReturn" severity="style" msg="int result is returned as long value. If the return value is long to avoid loss of information, then you have loss of information." verbose="int result is returned as long value. If the return value is long to avoid loss of information, then there is loss of information. To avoid loss of information you must cast a calculation operand to long, for example &apos;return a*b;&apos; =&gt; &apos;return (long)a*b&apos;." cwe="197"/>
+        <error id="floatConversionOverflow" severity="error" msg="Undefined behaviour: float (1e+100) to integer conversion overflow." verbose="Undefined behaviour: float (1e+100) to integer conversion overflow." cwe="190"/>
+        <error id="uninitdata" severity="error" msg="Memory is allocated but not initialized: varname" verbose="Memory is allocated but not initialized: varname" cwe="457">
+            <symbol>varname</symbol>
+        </error>
+        <error id="uninitStructMember" severity="error" msg="Uninitialized struct member: a.b" verbose="Uninitialized struct member: a.b" cwe="457">
+            <symbol>a.b</symbol>
+        </error>
+        <error id="unusedFunction" severity="style" msg="The function &apos;funcName&apos; is never used." verbose="The function &apos;funcName&apos; is never used." cwe="561">
+            <symbol>funcName</symbol>
+        </error>
+        <error id="unusedVariable" severity="style" msg="Unused variable: varname" verbose="Unused variable: varname" cwe="563">
+            <symbol>varname</symbol>
+        </error>
+        <error id="unusedAllocatedMemory" severity="style" msg="Variable &apos;varname&apos; is allocated memory that is never used." verbose="Variable &apos;varname&apos; is allocated memory that is never used." cwe="563">
+            <symbol>varname</symbol>
+        </error>
+        <error id="unreadVariable" severity="style" msg="Variable &apos;varname&apos; is assigned a value that is never used." verbose="Variable &apos;varname&apos; is assigned a value that is never used." cwe="563">
+            <symbol>varname</symbol>
+        </error>
+        <error id="unassignedVariable" severity="style" msg="Variable &apos;varname&apos; is not assigned a value." verbose="Variable &apos;varname&apos; is not assigned a value." cwe="665">
+            <symbol>varname</symbol>
+        </error>
+        <error id="unusedStructMember" severity="style" msg="struct member &apos;structname::variable&apos; is never used." verbose="struct member &apos;structname::variable&apos; is never used." cwe="563">
+            <symbol>structname::variable</symbol>
+        </error>
+        <error id="postfixOperator" severity="performance" msg="Prefer prefix ++/-- operators for non-primitive types." verbose="Prefix ++/-- operators should be preferred for non-primitive types. Pre-increment/decrement can be more efficient than post-increment/decrement. Post-increment/decrement usually involves keeping a copy of the previous value around and adds a little extra code." cwe="398"/>
+        <error id="va_start_wrongParameter" severity="warning" msg="&apos;arg1&apos; given to va_start() is not last named argument of the function. Did you intend to pass &apos;arg2&apos;?" verbose="&apos;arg1&apos; given to va_start() is not last named argument of the function. Did you intend to pass &apos;arg2&apos;?" cwe="688"/>
+        <error id="va_start_referencePassed" severity="error" msg="Using reference &apos;arg1&apos; as parameter for va_start() results in undefined behaviour." verbose="Using reference &apos;arg1&apos; as parameter for va_start() results in undefined behaviour." cwe="758"/>
+        <error id="va_end_missing" severity="error" msg="va_list &apos;vl&apos; was opened but not closed by va_end()." verbose="va_list &apos;vl&apos; was opened but not closed by va_end()." cwe="664"/>
+        <error id="va_list_usedBeforeStarted" severity="error" msg="va_list &apos;vl&apos; used before va_start() was called." verbose="va_list &apos;vl&apos; used before va_start() was called." cwe="664"/>
+        <error id="va_start_subsequentCalls" severity="error" msg="va_start() or va_copy() called subsequently on &apos;vl&apos; without va_end() in between." verbose="va_start() or va_copy() called subsequently on &apos;vl&apos; without va_end() in between." cwe="664"/>
+        <error id="preprocessorErrorDirective" severity="error" msg="#error message" verbose="#error message"/>
+    </errors>
+</results>

--- a/cxx-squid/src/main/java/org/sonar/cxx/utils/CxxReportIssue.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/utils/CxxReportIssue.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
  */
 public class CxxReportIssue {
 
-  private final String ruleId;
+  private String ruleId;
   private final List<String> aliasRuleIds = new ArrayList<>();
   private final List<CxxReportLocation> locations = new ArrayList<>();
   private final List<CxxReportLocation> flow = new ArrayList<>();
@@ -40,6 +40,10 @@ public class CxxReportIssue {
                         String info) {
     this.ruleId = ruleId;
     addLocation(file, line, column, info);
+  }
+  
+  public final void overRideRuleId(String ruleId) {
+	  this.ruleId=ruleId;
   }
 
   public final void addLocation(@Nullable String file, @Nullable String line, @Nullable String column, String info) {

--- a/cxx-squid/src/main/java/org/sonar/cxx/utils/CxxReportLocation.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/utils/CxxReportLocation.java
@@ -31,7 +31,7 @@ public class CxxReportLocation {
   private final String file;
   private final String line;
   private final String column;
-  private final String info;
+  private String info;
 
   public CxxReportLocation(@Nullable String file, @Nullable String line, @Nullable String column, String info) {
     super();
@@ -58,6 +58,10 @@ public class CxxReportLocation {
     return info;
   }
 
+  public void prefixInfo(String prefix) {
+	  info=prefix+info;
+  }
+  
   @Override
   public String toString() {
     return "CxxReportLocation ["

--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxPlugin.java
@@ -53,6 +53,7 @@ import org.sonar.cxx.sensors.rats.CxxRatsSensor;
 import org.sonar.cxx.sensors.tests.dotnet.CxxUnitTestResultsAggregator;
 import org.sonar.cxx.sensors.tests.dotnet.CxxUnitTestResultsImportSensor;
 import org.sonar.cxx.sensors.tests.xunit.CxxXunitSensor;
+import org.sonar.cxx.sensors.utils.CxxIssuesReportSensor;
 import org.sonar.cxx.sensors.utils.RulesDefinitionXmlLoader;
 import org.sonar.cxx.sensors.valgrind.CxxValgrindRuleRepository;
 import org.sonar.cxx.sensors.valgrind.CxxValgrindSensor;
@@ -82,6 +83,7 @@ public final class CxxPlugin implements Plugin {
     // properties elements
     l.addAll(CxxLanguage.properties());
     l.addAll(CxxSquidSensor.properties());
+    l.addAll(CxxIssuesReportSensor.properties());
     l.addAll(CxxCppCheckSensor.properties());
     l.addAll(CxxValgrindSensor.properties());
     l.addAll(CxxDrMemorySensor.properties());

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/CxxPluginTest.java
@@ -40,7 +40,7 @@ class CxxPluginTest {
     var context = new Plugin.Context(runtime);
     var plugin = new CxxPlugin();
     plugin.define(context);
-    assertThat(context.getExtensions()).hasSize(83);
+    assertThat(context.getExtensions()).hasSize(84);
   }
 
 }


### PR DESCRIPTION
This is a fix for https://github.com/SonarOpenCommunity/sonar-cxx/issues/2586

 I tested it with gcc, cppcheck and clangtidy.

Open points:

1. Default unknown rule is right now only for the tested frameworks in the xml definitions
2. We could use protobuf instead of json (but at least for my local use case it was so fast, that I didn't see a reason to invest time here)
3. In the long run we might need to replace all "-" with "_" in the rule ids.... (due to sonar community changes)
4. I'm not sure, I covered all possible exceptions (e.g. with login/authentication); but they should occur already before the cxx plugin
5. Right now only login with token is supported

close #2586

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2606)
<!-- Reviewable:end -->
