### PR TITLE
Sonar 10

### DIFF
--- a/cxx-sensors/pom.xml
+++ b/cxx-sensors/pom.xml
@@ -37,6 +37,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.sonarsource.api.plugin</groupId>
+      <artifactId>sonar-plugin-api-test-fixtures</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api-impl</artifactId>
       <scope>test</scope>

--- a/cxx-sensors/pom.xml
+++ b/cxx-sensors/pom.xml
@@ -47,6 +47,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/postjobs/FinalReportTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/postjobs/FinalReportTest.java
@@ -36,7 +36,7 @@ import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.postjob.PostJobContext;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.utils.log.LogTesterJUnit5;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.cxx.CxxAstScanner;
 import org.sonar.cxx.preprocessor.CxxPreprocessor;

--- a/cxx-sensors/src/test/java/org/sonar/cxx/postjobs/FinalReportTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/postjobs/FinalReportTest.java
@@ -37,7 +37,7 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.postjob.PostJobContext;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
-import org.sonar.api.utils.log.LoggerLevel;
+import org.slf4j.event.Level;
 import org.sonar.cxx.CxxAstScanner;
 import org.sonar.cxx.preprocessor.CxxPreprocessor;
 import org.sonar.cxx.visitors.CxxParseErrorLoggerVisitor;
@@ -68,7 +68,7 @@ class FinalReportTest {
     var postjob = new FinalReport();
     postjob.execute(postJobContext);
 
-    var log = logTester.logs(LoggerLevel.WARN);
+    var log = logTester.logs(Level.WARN);
     assertThat(log).hasSize(2);
     assertThat(log.get(0)).contains("include directive error(s)");
     assertThat(log.get(1)).contains("syntax error(s) detected");

--- a/cxx-sensors/src/test/java/org/sonar/cxx/prejobs/XlstSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/prejobs/XlstSensorTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
-import org.sonar.api.utils.log.LogTesterJUnit5;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;

--- a/cxx-sensors/src/test/java/org/sonar/cxx/prejobs/XlstSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/prejobs/XlstSensorTest.java
@@ -30,7 +30,7 @@ import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
-import org.sonar.api.utils.log.LoggerLevel;
+import org.slf4j.event.Level;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 
@@ -60,9 +60,9 @@ class XlstSensorTest {
     logTester.clear();
     sensor.execute(context);
 
-    assertThat(logTester.logs(LoggerLevel.ERROR)).isEmpty();
-    assertThat(logTester.logs(LoggerLevel.WARN)).isEmpty();
-    assertThat(logTester.logs(LoggerLevel.INFO)).isEmpty();
+    assertThat(logTester.logs(Level.ERROR)).isEmpty();
+    assertThat(logTester.logs(Level.WARN)).isEmpty();
+    assertThat(logTester.logs(Level.INFO)).isEmpty();
   }
 
   @Test
@@ -108,7 +108,7 @@ class XlstSensorTest {
     logTester.clear();
     sensor.execute(context);
 
-    List<String> log = logTester.logs(LoggerLevel.ERROR);
+    List<String> log = logTester.logs(Level.ERROR);
     assertThat(log).contains("XLST: 'sonar.cxx.xslt.1.stylesheet' value is not defined.");
   }
 
@@ -124,7 +124,7 @@ class XlstSensorTest {
     logTester.clear();
     sensor.execute(context);
 
-    List<String> log = logTester.logs(LoggerLevel.ERROR);
+    List<String> log = logTester.logs(Level.ERROR);
     assertThat(log).contains("XLST: 'sonar.cxx.xslt.1.inputs' value is not defined.");
   }
 
@@ -141,7 +141,7 @@ class XlstSensorTest {
     logTester.clear();
     sensor.execute(context);
 
-    List<String> log = logTester.logs(LoggerLevel.ERROR);
+    List<String> log = logTester.logs(Level.ERROR);
     assertThat(log).contains("XLST: 'sonar.cxx.xslt.1.outputs' value is not defined.");
   }
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/CxxCompilerSensorTest.java
@@ -30,7 +30,7 @@ import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
-import org.sonar.api.utils.log.LogTesterJUnit5;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxCoberturaSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/coverage/CxxCoberturaSensorTest.java
@@ -35,7 +35,7 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.utils.PathUtils;
-import org.sonar.api.utils.log.LogTesterJUnit5;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.cxx.sensors.coverage.cobertura.CoberturaParser;
 import org.sonar.cxx.sensors.coverage.cobertura.CxxCoverageCoberturaSensor;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherSensorTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/other/CxxOtherSensorTest.java
@@ -29,7 +29,7 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
-import org.sonar.api.utils.log.LogTesterJUnit5;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.cxx.sensors.utils.CxxReportSensor;
 import org.sonar.cxx.sensors.utils.TestUtils;
 

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/NUnitTestResultsFileParserTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/NUnitTestResultsFileParserTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import static org.mockito.Mockito.mock;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
-import org.sonar.api.utils.log.LoggerLevel;
+import org.slf4j.event.Level;
 
 class NUnitTestResultsFileParserTest {
 
@@ -96,7 +96,7 @@ class NUnitTestResultsFileParserTest {
     var results = new UnitTestResults();
     new NUnitTestResultsFileParser().accept(new File(REPORT_PATH + "empty.xml"), results);
 
-    assertThat(logTester.logs(LoggerLevel.WARN))
+    assertThat(logTester.logs(Level.WARN))
       .contains("One of the assemblies contains no test result, please make sure this is expected.");
     assertThat(results.tests()).isZero();
     assertThat(results.passedPercentage()).isZero();

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/NUnitTestResultsFileParserTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/tests/dotnet/NUnitTestResultsFileParserTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import static org.mockito.Mockito.mock;
-import org.sonar.api.utils.log.LogTesterJUnit5;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
 
 class NUnitTestResultsFileParserTest {

--- a/cxx-squid/pom.xml
+++ b/cxx-squid/pom.xml
@@ -52,6 +52,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>

--- a/cxx-squid/pom.xml
+++ b/cxx-squid/pom.xml
@@ -42,6 +42,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.sonarsource.api.plugin</groupId>
+      <artifactId>sonar-plugin-api-test-fixtures</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api-impl</artifactId>
       <scope>test</scope>

--- a/cxx-squid/src/test/java/org/sonar/cxx/AggregateMeasureComputerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/AggregateMeasureComputerTest.java
@@ -23,11 +23,11 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.ce.measure.Component;
 import org.sonar.api.ce.measure.Component.Type;
-import org.sonar.api.ce.measure.test.TestComponent;
-import org.sonar.api.ce.measure.test.TestComponent.FileAttributesImpl;
-import org.sonar.api.ce.measure.test.TestMeasureComputerContext;
-import org.sonar.api.ce.measure.test.TestMeasureComputerDefinition.MeasureComputerDefinitionBuilderImpl;
-import org.sonar.api.ce.measure.test.TestSettings;
+import org.sonar.api.testfixtures.measure.TestComponent;
+import org.sonar.api.testfixtures.measure.TestComponent.FileAttributesImpl;
+import org.sonar.api.testfixtures.measure.TestMeasureComputerContext;
+import org.sonar.api.testfixtures.measure.TestMeasureComputerDefinition.MeasureComputerDefinitionBuilderImpl;
+import org.sonar.api.testfixtures.measure.TestSettings;
 
 class AggregateMeasureComputerTest {
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/DensityMeasureComputerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/DensityMeasureComputerTest.java
@@ -22,11 +22,11 @@ package org.sonar.cxx;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.ce.measure.Component.Type;
-import org.sonar.api.ce.measure.test.TestComponent;
-import org.sonar.api.ce.measure.test.TestComponent.FileAttributesImpl;
-import org.sonar.api.ce.measure.test.TestMeasureComputerContext;
-import org.sonar.api.ce.measure.test.TestMeasureComputerDefinition.MeasureComputerDefinitionBuilderImpl;
-import org.sonar.api.ce.measure.test.TestSettings;
+import org.sonar.api.testfixtures.measure.TestComponent;
+import org.sonar.api.testfixtures.measure.TestComponent.FileAttributesImpl;
+import org.sonar.api.testfixtures.measure.TestMeasureComputerContext;
+import org.sonar.api.testfixtures.measure.TestMeasureComputerDefinition.MeasureComputerDefinitionBuilderImpl;
+import org.sonar.api.testfixtures.measure.TestSettings;
 
 class DensityMeasureComputerTest {
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
@@ -22,7 +22,7 @@ package org.sonar.cxx.visitors;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.sonar.api.utils.log.LogTesterJUnit5;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.cxx.CxxAstScanner;
 import org.sonar.cxx.CxxFileTesterHelper;

--- a/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/visitors/CxxParseErrorLoggerVisitorTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
-import org.sonar.api.utils.log.LoggerLevel;
+import org.slf4j.event.Level;
 import org.sonar.cxx.CxxAstScanner;
 import org.sonar.cxx.CxxFileTesterHelper;
 
@@ -34,11 +34,11 @@ class CxxParseErrorLoggerVisitorTest {
 
   @Test
   void handleParseErrorTest() throws Exception {
-    logTester.setLevel(LoggerLevel.DEBUG);
+    logTester.setLevel(Level.DEBUG);
     var tester = CxxFileTesterHelper.create("src/test/resources/visitors/syntaxerror.cc", ".", "");
     CxxAstScanner.scanSingleInputFile(tester.asInputFile());
 
-    var log = String.join("\n", logTester.logs(LoggerLevel.DEBUG));
+    var log = String.join("\n", logTester.logs(Level.DEBUG));
 
     assertThat(log)
       .isNotEmpty()

--- a/cxx-sslr-toolkit/pom.xml
+++ b/cxx-sslr-toolkit/pom.xml
@@ -103,7 +103,7 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>8500000</maxsize>
+                  <maxsize>8600000</maxsize>
                   <minsize>6000000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>

--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>1.7.30</version>
+      </dependency>
+
+      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${commons-io.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
     <aggregate.report.dir>integration-tests/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
 
     <!-- we depend on API ${sonar.version} but we keep backward compatibility with LTS -->
-    <sonar.version>9.9.0.65466</sonar.version>
+    <sonar.version>10.3.0.82913</sonar.version>
     <sonar.plugin.api.version>10.3.0.1951</sonar.plugin.api.version>
     <sonarQubeMinVersion>8.9</sonarQubeMinVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
 
     <!-- we depend on API ${sonar.version} but we keep backward compatibility with LTS -->
     <sonar.version>9.9.0.65466</sonar.version>
-    <sonar.plugin.api.version>9.15.0.435</sonar.plugin.api.version>
+    <sonar.plugin.api.version>10.3.0.1951</sonar.plugin.api.version>
     <sonarQubeMinVersion>8.9</sonarQubeMinVersion>
 
     <!-- dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
 
     <!-- we depend on API ${sonar.version} but we keep backward compatibility with LTS -->
     <sonar.version>9.9.0.65466</sonar.version>
-    <sonar.plugin.api.version>9.14.0.375</sonar.plugin.api.version>
+    <sonar.plugin.api.version>9.15.0.435</sonar.plugin.api.version>
     <sonarQubeMinVersion>8.9</sonarQubeMinVersion>
 
     <!-- dependencies -->
@@ -311,6 +311,11 @@
       <dependency>
         <groupId>org.sonarsource.api.plugin</groupId>
         <artifactId>sonar-plugin-api</artifactId>
+        <version>${sonar.plugin.api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.sonarsource.api.plugin</groupId>
+        <artifactId>sonar-plugin-api-test-fixtures</artifactId>
         <version>${sonar.plugin.api.version}</version>
       </dependency>
       <dependency>

--- a/sonar-cxx-plugin/pom.xml
+++ b/sonar-cxx-plugin/pom.xml
@@ -33,6 +33,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.sonarsource.api.plugin</groupId>
+      <artifactId>sonar-plugin-api-test-fixtures</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api-impl</artifactId>
       <scope>test</scope>

--- a/sonar-cxx-plugin/pom.xml
+++ b/sonar-cxx-plugin/pom.xml
@@ -43,6 +43,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>cxx-squid</artifactId>
       <version>${project.version}</version>

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/DroppedPropertiesSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/DroppedPropertiesSensorTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
-import org.sonar.api.utils.log.LogTesterJUnit5;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
 
 class DroppedPropertiesSensorTest {

--- a/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/DroppedPropertiesSensorTest.java
+++ b/sonar-cxx-plugin/src/test/java/org/sonar/plugins/cxx/DroppedPropertiesSensorTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
-import org.sonar.api.utils.log.LoggerLevel;
+import org.slf4j.event.Level;
 
 class DroppedPropertiesSensorTest {
 
@@ -48,7 +48,7 @@ class DroppedPropertiesSensorTest {
     var sensor = new DroppedPropertiesSensor(analysisWarnings::add);
     sensor.execute(contextTester);
 
-    assertThat(logTester.logs(LoggerLevel.WARN)).isEmpty();
+    assertThat(logTester.logs(Level.WARN)).isEmpty();
     assertThat(analysisWarnings).isEmpty();
   }
 
@@ -62,7 +62,7 @@ class DroppedPropertiesSensorTest {
     sensor.execute(contextTester);
 
     var msg = "CXX property 'sonar.cxx.cppncss.reportPaths' is no longer supported.";
-    assertThat(logTester.logs(LoggerLevel.WARN)).contains(msg);
+    assertThat(logTester.logs(Level.WARN)).contains(msg);
     assertThat(analysisWarnings).containsExactly(msg);
   }
 
@@ -77,7 +77,7 @@ class DroppedPropertiesSensorTest {
 
     var msg = "CXX property 'sonar.cxx.suffixes.sources' is no longer supported."
             + " Use key 'sonar.cxx.file.suffixes' instead.";
-    assertThat(logTester.logs(LoggerLevel.WARN)).contains(msg);
+    assertThat(logTester.logs(Level.WARN)).contains(msg);
     assertThat(analysisWarnings).containsExactly(msg);
   }
 


### PR DESCRIPTION
With these changes you can use 10.x version of org.sonarsource.sonarqube:sonar-plugin-api-impl and 
org.sonarsource.api.plugin:sonar-plugin-api .

I fixed all compile issues with the help of https://sonarsource.atlassian.net/browse/SONARTEXT-57 .

I did not test the result.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2612)
<!-- Reviewable:end -->
