### PR TITLE
LLVM 19 support

### DIFF
--- a/cxx-sensors/src/main/resources/clangsa.xml
+++ b/cxx-sensors/src/main/resources/clangsa.xml
@@ -22,6 +22,18 @@ Follow these steps to make your custom rules available in SonarQube:
   <!-- C and C++ rules for Clang Static Analyzer. https://clang-analyzer.llvm.org/
 Rules list was generated based on clang version 16.0.0 (https://github.com/llvm/llvm-project.git 61be261549243deed84b1fae11195f76f1769584) -->
   <rule>
+    <key>core.BitwiseShift</key>
+    <name>core.BitwiseShift</name>
+    <description>
+<![CDATA[
+<p>Finds cases where bitwise shift operation causes undefined behaviour.
+</p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
+]]>    </description>
+    <type>BUG</type>
+    <tag>core</tag>
+  </rule>
+  <rule>
     <key>core.CallAndMessage</key>
     <name>core.CallAndMessage</name>
     <description>
@@ -344,6 +356,18 @@ Rules list was generated based on clang version 16.0.0 (https://github.com/llvm/
 ]]>    </description>
     <type>BUG</type>
     <tag>nullability</tag>
+  </rule>
+  <rule>
+    <key>optin.core.EnumCastOutOfRange</key>
+    <name>optin.core.EnumCastOutOfRange</name>
+    <description>
+<![CDATA[
+<p>Check integer to enumeration casts for out of range values
+</p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
+]]>    </description>
+    <type>BUG</type>
+    <tag>optin</tag>
   </rule>
   <rule>
     <key>optin.cplusplus.UninitializedObject</key>
@@ -814,6 +838,18 @@ Rules list was generated based on clang version 16.0.0 (https://github.com/llvm/
     <tag>security</tag>
   </rule>
   <rule>
+    <key>security.cert.env.InvalidPtr</key>
+    <name>security.cert.env.InvalidPtr</name>
+    <description>
+<![CDATA[
+<p>Finds usages of possibly invalidated pointers
+</p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
+]]>    </description>
+    <type>BUG</type>
+    <tag>security</tag>
+  </rule>
+  <rule>
     <key>security.insecureAPI.DeprecatedOrUnsafeBufferHandling</key>
     <name>security.insecureAPI.DeprecatedOrUnsafeBufferHandling</name>
     <description>
@@ -982,6 +1018,18 @@ Rules list was generated based on clang version 16.0.0 (https://github.com/llvm/
     <tag>unix</tag>
   </rule>
   <rule>
+    <key>unix.Errno</key>
+    <name>unix.Errno</name>
+    <description>
+<![CDATA[
+<p>Check for improper use of 'errno'
+</p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
+]]>    </description>
+    <type>BUG</type>
+    <tag>unix</tag>
+  </rule>
+  <rule>
     <key>unix.Malloc</key>
     <name>unix.Malloc</name>
     <description>
@@ -1011,6 +1059,18 @@ Rules list was generated based on clang version 16.0.0 (https://github.com/llvm/
     <description>
 <![CDATA[
 <p>Check for mismatched deallocators.
+</p>
+ <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
+]]>    </description>
+    <type>BUG</type>
+    <tag>unix</tag>
+  </rule>
+  <rule>
+    <key>unix.StdCLibraryFunctions</key>
+    <name>unix.StdCLibraryFunctions</name>
+    <description>
+<![CDATA[
+<p>Check for invalid arguments of C standard library functions, and apply relations between arguments and return value
 </p>
  <h2>References</h2> <p><a href="https://clang-analyzer.llvm.org/available_checks.html" target="_blank">Available Checkers</a></p> 
 ]]>    </description>

--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -3,7 +3,7 @@
   C and C++ rules from
   * https://clang.llvm.org/extra/clang-tidy/checks/list.html
   * https://clang-analyzer.llvm.org/available_checks.html
-  * last update: llvmorg-16-init-15404-g61be26154924 (git describe)
+  * last update: llvmorg-19-init (git describe)
 -->
 <rules>
 
@@ -54,6 +54,28 @@
 
   <!-- Clang-Tidy Rules -->
 
+  <rule>
+    <key>abseil-cleanup-ctad</key>
+    <name>abseil-cleanup-ctad</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - abseil-cleanup-ctad</p>
+</div>
+<h1 id="abseil-cleanup-ctad">abseil-cleanup-ctad</h1>
+<p>Suggests switching the initialization pattern of <code>absl::Cleanup</code> instances from the factory function to class template argument deduction (CTAD), in C++17 and higher.</p>
+<pre class="c++"><code>auto c1 = absl::MakeCleanup([] {});
+
+const auto c2 = absl::MakeCleanup(std::function&lt;void()&gt;([] {}));</code></pre>
+<p>becomes</p>
+<pre class="c++"><code>absl::Cleanup c1 = [] {};
+
+const absl::Cleanup c2 = std::function&lt;void()&gt;([] {});</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/cleanup-ctad.html" target="_blank">clang.llvm.org</a></p>]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
   <rule>
     <key>abseil-duration-addition</key>
     <name>abseil-duration-addition</name>
@@ -442,7 +464,9 @@ absl::StrAppend(&amp;s, &quot;E&quot;, &quot;F&quot;, &quot;G&quot;);
 <p>clang-tidy - abseil-string-find-startswith</p>
 </div>
 <h1 id="abseil-string-find-startswith">abseil-string-find-startswith</h1>
-<p>Checks whether a <code>std::string::find()</code> or <code>std::string::rfind()</code> result is compared with 0, and suggests replacing with <code>absl::StartsWith()</code>. This is both a readability and performance issue.</p>
+<p>Checks whether a <code>std::string::find()</code> or <code>std::string::rfind()</code> (and corresponding <code>std::string_view</code> methods) result is compared with 0, and suggests replacing with <code>absl::StartsWith()</code>. This is both a readability and performance issue.</p>
+<p><code>starts_with</code> was added as a built-in function on those types in C++20. If available, prefer enabling <code class="interpreted-text" role="doc">modernize-use-starts-ends-with
+&lt;../modernize/use-starts-ends-with&gt;</code> instead of this check.</p>
 <pre class="c++"><code>string s = &quot;...&quot;;
 if (s.find(&quot;Hello World&quot;) == 0) { /* do something */ }
 if (s.rfind(&quot;Hello World&quot;, 0) == 0) { /* do something */ }</code></pre>
@@ -453,7 +477,7 @@ if (absl::StartsWith(s, &quot;Hello World&quot;)) { /* do something */ }</code><
 <h2 id="options">Options</h2>
 <div class="option">
 <p>StringLikeClasses</p>
-<p>Semicolon-separated list of names of string-like classes. By default only <code>std::basic_string</code> is considered. The list of methods to considered is fixed.</p>
+<p>Semicolon-separated list of names of string-like classes. By default both <code>std::basic_string</code> and <code>std::basic_string_view</code> are considered. The list of methods to be considered is fixed.</p>
 </div>
 <div class="option">
 <p>IncludeStyle</p>
@@ -1325,6 +1349,29 @@ foo(/*Value=*/nullptr);</code></pre>
     <type>BUG</type>
     </rule>
   <rule>
+    <key>bugprone-assignment-in-if-condition</key>
+    <name>bugprone-assignment-in-if-condition</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-assignment-in-if-condition</p>
+</div>
+<h1 id="bugprone-assignment-in-if-condition">bugprone-assignment-in-if-condition</h1>
+<p>Finds assignments within conditions of <span class="title-ref">if</span> statements. Such assignments are bug-prone because they may have been intended as equality tests.</p>
+<p>This check finds all assignments within <span class="title-ref">if</span> conditions, including ones that are not flagged by <span class="title-ref">-Wparentheses</span> due to an extra set of parentheses, and including assignments that call an overloaded <span class="title-ref">operator=()</span>. The identified assignments violate <a href="https://barrgroup.com/embedded-systems/books/embedded-c-coding-standard/statement-rules/if-else-statements">BARR group "Rule 8.2.c"</a>.</p>
+<pre class="c++"><code>int f = 3;
+if(f = 4) { // This is identified by both `Wparentheses` and this check - should it have been: `if (f == 4)` ?
+  f = f + 1;
+}
+
+if((f == 5) || (f = 6)) { // the assignment here `(f = 6)` is identified by this check, but not by `-Wparentheses`. Should it have been `(f == 6)` ?
+  f = f + 2;
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/assignment-in-if-condition.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>bugprone-bad-signal-to-kill-thread</key>
     <name>bugprone-bad-signal-to-kill-thread</name>
     <description>
@@ -1333,9 +1380,7 @@ foo(/*Value=*/nullptr);</code></pre>
 </div>
 <h1 id="bugprone-bad-signal-to-kill-thread">bugprone-bad-signal-to-kill-thread</h1>
 <p>Finds <code>pthread_kill</code> function calls when a thread is terminated by raising <code>SIGTERM</code> signal and the signal kills the entire process, not just the individual thread. Use any signal except <code>SIGTERM</code>.</p>
-<blockquote>
-<p>pthread_kill(thread, SIGTERM);</p>
-</blockquote>
+<pre class="c++"><code>pthread_kill(thread, SIGTERM);</code></pre>
 <p>This check corresponds to the CERT C Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/c/POS44-C.+Do+not+use+signals+to+terminate+threads">POS44-C. Do not use signals to terminate threads</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/bad-signal-to-kill-thread.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -1410,12 +1455,123 @@ default:
   return 10;
 }</code></pre>
 <p>Here the check does not warn for the repeated <code>return 10;</code>, which is good if we want to preserve that <code>'a'</code> is before <code>'b'</code> and <code>default:</code> is the last branch.</p>
+<p>Switch cases marked with the <code>[[fallthrough]]</code> attribute are ignored.</p>
 <p>Finally, the check also examines conditional operators and reports code like:</p>
 <pre class="c++"><code>return test_value(x) ? x : x;</code></pre>
 <p>Unlike if statements, the check does not detect chains of conditional operators.</p>
 <p>Note: This check also reports situations where branches become identical only after preprocessing.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/branch-clone.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>bugprone-casting-through-void</key>
+    <name>bugprone-casting-through-void</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-casting-through-void</p>
+</div>
+<h1 id="bugprone-casting-through-void">bugprone-casting-through-void</h1>
+<p>Detects unsafe or redundant two-step casting operations involving <code>void*</code>.</p>
+<p>Two-step type conversions via <code>void*</code> are discouraged for several reasons.</p>
+<ul>
+<li>They obscure code and impede its understandability, complicating maintenance.</li>
+<li>These conversions bypass valuable compiler support, erasing warnings related to pointer alignment. It may violate strict aliasing rule and leading to undefined behavior.</li>
+<li>In scenarios involving multiple inheritance, ambiguity and unexpected outcomes can arise due to the loss of type information, posing runtime issues.</li>
+</ul>
+<p>In summary, avoiding two-step type conversions through <code>void*</code> ensures clearer code, maintains essential compiler warnings, and prevents ambiguity and potential runtime errors, particularly in complex inheritance scenarios.</p>
+<p>Examples:</p>
+<pre class="c++"><code>using IntegerPointer = int *;
+double *ptr;
+
+static_cast&lt;IntegerPointer&gt;(static_cast&lt;void *&gt;(ptr)); // WRONG
+reinterpret_cast&lt;IntegerPointer&gt;(reinterpret_cast&lt;void *&gt;(ptr)); // WRONG
+(IntegerPointer)(void *)ptr; // WRONG
+IntegerPointer(static_cast&lt;void *&gt;(ptr)); // WRONG</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/casting-through-void.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>bugprone-chained-comparison</key>
+    <name>bugprone-chained-comparison</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-chained-comparison</p>
+</div>
+<h1 id="bugprone-chained-comparison">bugprone-chained-comparison</h1>
+<p>Check detects chained comparison operators that can lead to unintended behavior or logical errors.</p>
+<p>Chained comparisons are expressions that use multiple comparison operators to compare three or more values. For example, the expression <code>a &lt; b &lt; c</code> compares the values of <code>a</code>, <code>b</code>, and <code>c</code>. However, this expression does not evaluate as <code>(a &lt; b) &amp;&amp; (b &lt; c)</code>, which is probably what the developer intended. Instead, it evaluates as <code>(a &lt; b) &lt; c</code>, which may produce unintended results, especially when the types of <code>a</code>, <code>b</code>, and <code>c</code> are different.</p>
+<p>To avoid such errors, the check will issue a warning when a chained comparison operator is detected, suggesting to use parentheses to specify the order of evaluation or to use a logical operator to separate comparison expressions.</p>
+<p>Consider the following examples:</p>
+<pre class="c++"><code>int a = 2, b = 6, c = 4;
+if (a &lt; b &lt; c) {
+    // This block will be executed
+}</code></pre>
+<p>In this example, the developer intended to check if <code>a</code> is less than <code>b</code> and <code>b</code> is less than <code>c</code>. However, the expression <code>a &lt; b &lt; c</code> is equivalent to <code>(a &lt; b) &lt; c</code>. Since <code>a &lt; b</code> is <code>true</code>, the expression <code>(a &lt; b) &lt; c</code> is evaluated as <code>1 &lt; c</code>, which is equivalent to <code>true &lt; c</code> and is invalid in this case as <code>b &lt; c</code> is <code>false</code>.</p>
+<p>Even that above issue could be detected as comparison of <code>int</code> to <code>bool</code>, there is more dangerous example:</p>
+<pre class="c++"><code>bool a = false, b = false, c = true;
+if (a == b == c) {
+    // This block will be executed
+}</code></pre>
+<p>In this example, the developer intended to check if <code>a</code>, <code>b</code>, and <code>c</code> are all equal. However, the expression <code>a == b == c</code> is evaluated as <code>(a == b) == c</code>. Since <code>a == b</code> is true, the expression <code>(a == b) == c</code> is evaluated as <code>true == c</code>, which is equivalent to <code>true == true</code>. This comparison yields <code>true</code>, even though <code>a</code> and <code>b</code> are <code>false</code>, and are not equal to <code>c</code>.</p>
+<p>To avoid this issue, the developer can use a logical operator to separate the comparison expressions, like this:</p>
+<pre class="c++"><code>if (a == b &amp;&amp; b == c) {
+    // This block will not be executed
+}</code></pre>
+<p>Alternatively, use of parentheses in the comparison expressions can make the developer's intention more explicit and help avoid misunderstanding.</p>
+<pre class="c++"><code>if ((a == b) == c) {
+    // This block will be executed
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/chained-comparison.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>bugprone-compare-pointer-to-member-virtual-function</key>
+    <name>bugprone-compare-pointer-to-member-virtual-function</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-compare-pointer-to-member-virtual-function</p>
+</div>
+<h1 id="bugprone-compare-pointer-to-member-virtual-function">bugprone-compare-pointer-to-member-virtual-function</h1>
+<p>Detects unspecified behavior about equality comparison between pointer to member virtual function and anything other than null-pointer-constant.</p>
+<pre class="c++"><code>struct A {
+  void f1();
+  void f2();
+  virtual void f3();
+  virtual void f4();
+
+  void g1(int);
+};
+
+void fn() {
+  bool r1 = (&amp;A::f1 == &amp;A::f2);  // ok
+  bool r2 = (&amp;A::f1 == &amp;A::f3);  // bugprone
+  bool r3 = (&amp;A::f1 != &amp;A::f3);  // bugprone
+  bool r4 = (&amp;A::f3 == nullptr); // ok
+  bool r5 = (&amp;A::f3 == &amp;A::f4);  // bugprone
+
+  void (A::*v1)() = &amp;A::f3;
+  bool r6 = (v1 == &amp;A::f1); // bugprone
+  bool r6 = (v1 == nullptr); // ok
+
+  void (A::*v2)() = &amp;A::f2;
+  bool r7 = (v2 == &amp;A::f1); // false positive, but potential risk if assigning other value to v2.
+
+  void (A::*v3)(int) = &amp;A::g1;
+  bool r8 = (v3 == &amp;A::g1); // ok, no virtual function match void(A::*)(int) signature.
+}</code></pre>
+<p>Provide warnings on equality comparisons involve pointers to member virtual function or variables which is potential pointer to member virtual function and any entity other than a null-pointer constant.</p>
+<p>In certain compilers, virtual function addresses are not conventional pointers but instead consist of offsets and indexes within a virtual function table (vtable). Consequently, these pointers may vary between base and derived classes, leading to unpredictable behavior when compared directly. This issue becomes particularly challenging when dealing with pointers to pure virtual functions, as they may not even have a valid address, further complicating comparisons.</p>
+<p>Instead, it is recommended to utilize the <code>typeid</code> operator or other appropriate mechanisms for comparing objects to ensure robust and predictable behavior in your codebase. By heeding this detection and adopting a more reliable comparison method, you can mitigate potential issues related to unspecified behavior, especially when dealing with pointers to member virtual functions or pure virtual functions, thereby improving the overall stability and maintainability of your code. In scenarios involving pointers to member virtual functions, it's only advisable to employ <code>nullptr</code> for comparisons.</p>
+<h2 id="limitations">Limitations</h2>
+<p>Does not analyze values stored in a variable. For variable, only analyze all virtual methods in the same <code>class</code> or <code>struct</code> and diagnose when assigning a pointer to member virtual function to this variable is possible.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/compare-pointer-to-member-virtual-function.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -1432,14 +1588,23 @@ default:
 public:
   Copyable() = default;
   Copyable(const Copyable &amp;) = default;
+
+  int memberToBeCopied = 0;
 };
 class X2 : public Copyable {
   X2(const X2 &amp;other) {} // Copyable(other) is missing
 };</code></pre>
 <p>Also finds copy constructors where the constructor of the base class don't have parameter.</p>
-<pre class="c++"><code>class X4 : public Copyable {
-  X4(const X4 &amp;other) : Copyable() {} // other is missing
+<pre class="c++"><code>class X3 : public Copyable {
+  X3(const X3 &amp;other) : Copyable() {} // other is missing
 };</code></pre>
+<p>Failure to properly initialize base class sub-objects during copy construction can result in undefined behavior, crashes, data corruption, or other unexpected outcomes. The check ensures that the copy constructor of a derived class properly calls the copy constructor of the base class, helping to prevent bugs and improve code quality.</p>
+<p>Limitations:</p>
+<ul>
+<li>It won't generate warnings for empty classes, as there are no class members (including base class sub-objects) to worry about.</li>
+<li>It won't generate warnings for base classes that have copy constructor private or deleted.</li>
+<li>It won't generate warnings for base classes that are initialized using other non-default constructor, as this could be intentional.</li>
+</ul>
 <p>The check also suggests a fix-its in some cases.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/copy-constructor-init.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -1569,7 +1734,7 @@ void compare(const char *CharBuf, std::string String) { /* ... */ }</code></pre>
 <p>Currently, the following heuristics are implemented which will suppress the warning about the parameter pair involved:</p>
 <ul>
 <li><p>The parameters are used in the same expression, e.g. <code>f(a, b)</code> or <code>a &lt; b</code>.</p></li>
-<li><p>The parameters are further passed to the same function to the same parameter of that function, of the same overload. e.g. <code>f(a, 1)</code> and <code>f(b, 2)</code> to some <code>f(T, int)</code>.</p>
+<li><p>The parameters are further passed to the same function to the same parameter of that function, of the same overload. E.g. <code>f(a, 1)</code> and <code>f(b, 2)</code> to some <code>f(T, int)</code>.</p>
 <div class="note">
 <div class="title">
 <p>Note</p>
@@ -1635,6 +1800,85 @@ void cStr(StringView SV, const char *Buf() { /* ... */ }</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>bugprone-empty-catch</key>
+    <name>bugprone-empty-catch</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-empty-catch</p>
+</div>
+<h1 id="bugprone-empty-catch">bugprone-empty-catch</h1>
+<p>Detects and suggests addressing issues with empty catch statements.</p>
+<pre class="c++"><code>try {
+  // Some code that can throw an exception
+} catch(const std::exception&amp;) {
+}</code></pre>
+<p>Having empty catch statements in a codebase can be a serious problem that developers should be aware of. Catch statements are used to handle exceptions that are thrown during program execution. When an exception is thrown, the program jumps to the nearest catch statement that matches the type of the exception.</p>
+<p>Empty catch statements, also known as "swallowing" exceptions, catch the exception but do nothing with it. This means that the exception is not handled properly, and the program continues to run as if nothing happened. This can lead to several issues, such as:</p>
+<ul>
+<li><em>Hidden Bugs</em>: If an exception is caught and ignored, it can lead to hidden bugs that are difficult to diagnose and fix. The root cause of the problem may not be apparent, and the program may continue to behave in unexpected ways.</li>
+<li><em>Security Issues</em>: Ignoring exceptions can lead to security issues, such as buffer overflows or null pointer dereferences. Hackers can exploit these vulnerabilities to gain access to sensitive data or execute malicious code.</li>
+<li><em>Poor Code Quality</em>: Empty catch statements can indicate poor code quality and a lack of attention to detail. This can make the codebase difficult to maintain and update, leading to longer development cycles and increased costs.</li>
+<li><em>Unreliable Code</em>: Code that ignores exceptions is often unreliable and can lead to unpredictable behavior. This can cause frustration for users and erode trust in the software.</li>
+</ul>
+<p>To avoid these issues, developers should always handle exceptions properly. This means either fixing the underlying issue that caused the exception or propagating the exception up the call stack to a higher-level handler. If an exception is not important, it should still be logged or reported in some way so that it can be tracked and addressed later.</p>
+<p>If the exception is something that can be handled locally, then it should be handled within the catch block. This could involve logging the exception or taking other appropriate action to ensure that the exception is not ignored.</p>
+<p>Here is an example:</p>
+<pre class="c++"><code>try {
+  // Some code that can throw an exception
+} catch (const std::exception&amp; ex) {
+  // Properly handle the exception, e.g.:
+  std::cerr &lt;&lt; &quot;Exception caught: &quot; &lt;&lt; ex.what() &lt;&lt; std::endl;
+}</code></pre>
+<p>If the exception cannot be handled locally and needs to be propagated up the call stack, it should be re-thrown or new exception should be thrown.</p>
+<p>Here is an example:</p>
+<pre class="c++"><code>try {
+  // Some code that can throw an exception
+} catch (const std::exception&amp; ex) {
+  // Re-throw the exception
+  throw;
+}</code></pre>
+<p>In some cases, catching the exception at this level may not be necessary, and it may be appropriate to let the exception propagate up the call stack. This can be done simply by not using <code>try/catch</code> block.</p>
+<p>Here is an example:</p>
+<pre class="c++"><code>void function() {
+  // Some code that can throw an exception
+}
+
+void callerFunction() {
+  try {
+    function();
+  } catch (const std::exception&amp; ex) {
+    // Handling exception on higher level
+    std::cerr &lt;&lt; &quot;Exception caught: &quot; &lt;&lt; ex.what() &lt;&lt; std::endl;
+  }
+}</code></pre>
+<p>Other potential solution to avoid empty catch statements is to modify the code to avoid throwing the exception in the first place. This can be achieved by using a different API, checking for error conditions beforehand, or handling errors in a different way that does not involve exceptions. By eliminating the need for try-catch blocks, the code becomes simpler and less error-prone.</p>
+<p>Here is an example:</p>
+<pre class="c++"><code>// Old code:
+try {
+  mapContainer[&quot;Key&quot;].callFunction();
+} catch(const std::out_of_range&amp;) {
+}
+
+// New code
+if (auto it = mapContainer.find(&quot;Key&quot;); it != mapContainer.end()) {
+  it-&gt;second.callFunction();
+}</code></pre>
+<p>In conclusion, empty catch statements are a bad practice that can lead to hidden bugs, security issues, poor code quality, and unreliable code. By handling exceptions properly, developers can ensure that their code is robust, secure, and maintainable.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreCatchWithKeywords</p>
+<p>This option can be used to ignore specific catch statements containing certain keywords. If a <code>catch</code> statement body contains (case-insensitive) any of the keywords listed in this semicolon-separated option, then the catch will be ignored, and no warning will be raised. Default value: <span class="title-ref">@TODO;@FIXME</span>.</p>
+</div>
+<div class="option">
+<p>AllowEmptyCatchForExceptions</p>
+<p>This option can be used to ignore empty catch statements for specific exception types. By default, the check will raise a warning if an empty catch statement is detected, regardless of the type of exception being caught. However, in certain situations, such as when a developer wants to intentionally ignore certain exceptions or handle them in a different way, it may be desirable to allow empty catch statements for specific exception types. To configure this option, a semicolon-separated list of exception type names should be provided. If an exception type name in the list is caught in an empty catch statement, no warning will be raised. Default value: empty string.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/empty-catch.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>bugprone-exception-escape</key>
     <name>bugprone-exception-escape</name>
     <description>
@@ -1649,10 +1893,13 @@ void cStr(StringView SV, const char *Buf() { /* ... */ }</code></pre>
 <li>Move assignment operators</li>
 <li>The <code>main()</code> functions</li>
 <li><code>swap()</code> functions</li>
+<li><code>iter_swap()</code> functions</li>
+<li><code>iter_move()</code> functions</li>
 <li>Functions marked with <code>throw()</code> or <code>noexcept</code></li>
 <li>Other functions given as option</li>
 </ul>
 <p>A destructor throwing an exception may result in undefined behavior, resource leaks or unexpected termination of the program. Throwing move constructor or move assignment also may result in undefined behavior or resource leak. The <code>swap()</code> operations expected to be non throwing most of the cases and they are always possible to implement in a non throwing way. Non throwing <code>swap()</code> operations are also used to create move operations. A throwing <code>main()</code> function also results in unexpected termination.</p>
+<p>Functions declared explicitly with <code>noexcept(false)</code> or <code>throw(exception)</code> will be excluded from the analysis, as even though it is not recommended for functions like <code>swap()</code>, <code>main()</code>, move constructors, move assignment operators and destructors, it is a clear indication of the developer's intention and should be respected.</p>
 <p>WARNING! This check may be expensive on large source files.</p>
 <h2 id="options">Options</h2>
 <div class="option">
@@ -1742,10 +1989,20 @@ public:
   template&lt;typename... A,
     enable_if_t&lt;is_constructible_v&lt;tuple&lt;string, int&gt;, A&amp;&amp;...&gt;, int&gt; = 0&gt;
   explicit Person(A&amp;&amp;... a) {}
+
+  // C5: perfect forwarding ctor guarded with requires expression
+  template&lt;typename T&gt;
+  requires requires { is_special&lt;T&gt;; }
+  explicit Person(T&amp;&amp; n) {}
+
+  // C6: perfect forwarding ctor guarded with concept requirement
+  template&lt;Special T&gt;
+  explicit Person(T&amp;&amp; n) {}
+
   // (possibly compiler generated) copy ctor
   Person(const Person&amp; rhs);
 };</code></pre>
-<p>The check warns for constructors C1 and C2, because those can hide copy and move constructors. We suppress warnings if the copy and the move constructors are both disabled (deleted or private), because there is nothing the perfect forwarding constructor could hide in this case. We also suppress warnings for constructors like C3 and C4 that are guarded with an <code>enable_if</code>, assuming the programmer was aware of the possible hiding.</p>
+<p>The check warns for constructors C1 and C2, because those can hide copy and move constructors. We suppress warnings if the copy and the move constructors are both disabled (deleted or private), because there is nothing the perfect forwarding constructor could hide in this case. We also suppress warnings for constructors like C3-C6 that are guarded with an <code>enable_if</code> or a concept, assuming the programmer was aware of the possible hiding.</p>
 <h2 id="background">Background</h2>
 <p>For deciding whether a constructor is guarded with enable_if, we consider the types of the constructor parameters, the default values of template type parameters and the types of non-type template parameters with a default literal value. If any part of these types is <code>std::enable_if</code> or <code>std::enable_if_t</code>, we assume the constructor is guarded.</p>
 <h2>References</h2>
@@ -1821,6 +2078,77 @@ xs.erase(std::remove(xs.begin(), xs.end(), 10), xs.end());</code></pre>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
+    </rule>
+  <rule>
+    <key>bugprone-inc-dec-in-conditions</key>
+    <name>bugprone-inc-dec-in-conditions</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-inc-dec-in-conditions</p>
+</div>
+<h1 id="bugprone-inc-dec-in-conditions">bugprone-inc-dec-in-conditions</h1>
+<p>Detects when a variable is both incremented/decremented and referenced inside a complex condition and suggests moving them outside to avoid ambiguity in the variable's value.</p>
+<p>When a variable is modified and also used in a complex condition, it can lead to unexpected behavior. The side-effect of changing the variable's value within the condition can make the code difficult to reason about. Additionally, the developer's intended timing for the modification of the variable may not be clear, leading to misunderstandings and errors. This can be particularly problematic when the condition involves logical operators like <code>&amp;&amp;</code> and <code>||</code>, where the order of evaluation can further complicate the situation.</p>
+<p>Consider the following example:</p>
+<pre class="c++"><code>int i = 0;
+// ...
+if (i++ &lt; 5 &amp;&amp; i &gt; 0) {
+  // do something
+}</code></pre>
+<p>In this example, the result of the expression may not be what the developer intended. The original intention of the developer could be to increment <code>i</code> after the entire condition is evaluated, but in reality, i will be incremented before <code>i &gt; 0</code> is executed. This can lead to unexpected behavior and bugs in the code. To fix this issue, the developer should separate the increment operation from the condition and perform it separately. For example, they can increment <code>i</code> in a separate statement before or after the condition is evaluated. This ensures that the value of <code>i</code> is predictable and consistent throughout the code.</p>
+<pre class="c++"><code>int i = 0;
+// ...
+i++;
+if (i &lt;= 5 &amp;&amp; i &gt; 0) {
+  // do something
+}</code></pre>
+<p>Another common issue occurs when multiple increments or decrements are performed on the same variable inside a complex condition. For example:</p>
+<pre class="c++"><code>int i = 4;
+// ...
+if (i++ &lt; 5 || --i &gt; 2) {
+  // do something
+}</code></pre>
+<p>There is a potential issue with this code due to the order of evaluation in C++. The <code>||</code> operator used in the condition statement guarantees that if the first operand evaluates to <code>true</code>, the second operand will not be evaluated. This means that if <code>i</code> were initially <code>4</code>, the first operand <code>i &lt; 5</code> would evaluate to <code>true</code> and the second operand <code>i &gt; 2</code> would not be evaluated. As a result, the decrement operation <code>--i</code> would not be executed and <code>i</code> would hold value <code>5</code>, which may not be the intended behavior for the developer.</p>
+<p>To avoid this potential issue, the both increment and decrement operation on <code>i</code> should be moved outside the condition statement.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/inc-dec-in-conditions.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>bugprone-incorrect-enable-if</key>
+    <name>bugprone-incorrect-enable-if</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-incorrect-enable-if</p>
+</div>
+<h1 id="bugprone-incorrect-enable-if">bugprone-incorrect-enable-if</h1>
+<p>Detects incorrect usages of <code>std::enable_if</code> that don't name the nested <code>type</code> type.</p>
+<p>In C++11 introduced <code>std::enable_if</code> as a convenient way to leverage SFINAE. One form of using <code>std::enable_if</code> is to declare an unnamed template type parameter with a default type equal to <code>typename std::enable_if&lt;condition&gt;::type</code>. If the author forgets to name the nested type <code>type</code>, then the code will always consider the candidate template even if the condition is not met.</p>
+<p>Below are some examples of code using <code>std::enable_if</code> correctly and incorrect examples that this check flags.</p>
+<pre class="c++"><code>template &lt;typename T, typename = typename std::enable_if&lt;T::some_trait&gt;::type&gt;
+void valid_usage() { ... }
+
+template &lt;typename T, typename = std::enable_if_t&lt;T::some_trait&gt;&gt;
+void valid_usage_with_trait_helpers() { ... }
+
+// The below code is not a correct application of SFINAE. Even if
+// T::some_trait is not true, the function will still be considered in the
+// set of function candidates. It can either incorrectly select the function
+// when it should not be a candidates, and/or lead to hard compile errors
+// if the body of the template does not compile if the condition is not
+// satisfied.
+template &lt;typename T, typename = std::enable_if&lt;T::some_trait&gt;&gt;
+void invalid_usage() { ... }
+
+// The tool suggests the following replacement for &#39;invalid_usage&#39;:
+template &lt;typename T, typename = typename std::enable_if&lt;T::some_trait&gt;::type&gt;
+void fixed_invalid_usage() { ... }</code></pre>
+<p>C++14 introduced the trait helper <code>std::enable_if_t</code> which reduces the likelihood of this error. C++20 introduces constraints, which generally supersede the use of <code>std::enable_if</code>. See <code class="interpreted-text" role="doc">modernize-type-traits &lt;../modernize/type-traits&gt;</code> for another tool that will replace <code>std::enable_if</code> with <code>std::enable_if_t</code>, and see <code class="interpreted-text" role="doc">modernize-use-constraints &lt;../modernize/use-constraints&gt;</code> for another tool that replaces <code>std::enable_if</code> with C++20 constraints. Consider these newer mechanisms where possible.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/incorrect-enable-if.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>bugprone-incorrect-roundings</key>
@@ -1930,6 +2258,11 @@ Now called from operator()</code></pre>
 <p>Likely intended output:</p>
 <pre><code>Called from FancyFunction
 Now called from FancyFunction</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>The value <span class="title-ref">true</span> specifies that attempting to get the name of a function from within a macro should not be diagnosed. The default value is <span class="title-ref">false</span>.</p>
+</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/lambda-function-name.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -2089,6 +2422,109 @@ foo(s);</code></pre>
     <type>BUG</type>
     </rule>
   <rule>
+    <key>bugprone-multi-level-implicit-pointer-conversion</key>
+    <name>bugprone-multi-level-implicit-pointer-conversion</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-multi-level-implicit-pointer-conversion</p>
+</div>
+<h1 id="bugprone-multi-level-implicit-pointer-conversion">bugprone-multi-level-implicit-pointer-conversion</h1>
+<p>Detects implicit conversions between pointers of different levels of indirection.</p>
+<p>Conversions between pointer types of different levels of indirection can be dangerous and may lead to undefined behavior, particularly if the converted pointer is later cast to a type with a different level of indirection. For example, converting a pointer to a pointer to an <code>int</code> (<code>int**</code>) to a <code>void*</code> can result in the loss of information about the original level of indirection, which can cause problems when attempting to use the converted pointer. If the converted pointer is later cast to a type with a different level of indirection and dereferenced, it may lead to access violations, memory corruption, or other undefined behavior.</p>
+<p>Consider the following example:</p>
+<pre class="c++"><code>void foo(void* ptr);
+
+int main() {
+  int x = 42;
+  int* ptr = &amp;x;
+  int** ptr_ptr = &amp;ptr;
+  foo(ptr_ptr); // warning will trigger here
+  return 0;
+}</code></pre>
+<p>In this example, <code>foo()</code> is called with <code>ptr_ptr</code> as its argument. However, <code>ptr_ptr</code> is a <code>int**</code> pointer, while <code>foo()</code> expects a <code>void*</code> pointer. This results in an implicit pointer level conversion, which could cause issues if <code>foo()</code> dereferences the pointer assuming it's a <code>int*</code> pointer.</p>
+<p>Using an explicit cast is a recommended solution to prevent issues caused by implicit pointer level conversion, as it allows the developer to explicitly state their intention and show their reasoning for the type conversion. Additionally, it is recommended that developers thoroughly check and verify the safety of the conversion before using an explicit cast. This extra level of caution can help catch potential issues early on in the development process, improving the overall reliability and maintainability of the code.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/multi-level-implicit-pointer-conversion.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>bugprone-multiple-new-in-one-expression</key>
+    <name>bugprone-multiple-new-in-one-expression</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-multiple-new-in-one-expression</p>
+</div>
+<h1 id="bugprone-multiple-new-in-one-expression">bugprone-multiple-new-in-one-expression</h1>
+<p>Finds multiple <code>new</code> operator calls in a single expression, where the allocated memory by the first <code>new</code> may leak if the second allocation fails and throws exception.</p>
+<p>C++ does often not specify the exact order of evaluation of the operands of an operator or arguments of a function. Therefore if a first allocation succeeds and a second fails, in an exception handler it is not possible to tell which allocation has failed and free the memory. Even if the order is fixed the result of a first <code>new</code> may be stored in a temporary location that is not reachable at the time when a second allocation fails. It is best to avoid any expression that contains more than one <code>operator new</code> call, if exception handling is used to check for allocation errors.</p>
+<p>Different rules apply for are the short-circuit operators <code>||</code> and <code>&amp;&amp;</code> and the <code>,</code> operator, where evaluation of one side must be completed before the other starts. Expressions of a list-initialization (initialization or construction using <code>{</code> and <code>}</code> characters) are evaluated in fixed order. Similarly, condition of a <code>?</code> operator is evaluated before the branches are evaluated.</p>
+<p>The check reports warning if two <code>new</code> calls appear in one expression at different sides of an operator, or if <code>new</code> calls appear in different arguments of a function call (that can be an object construction with <code>()</code> syntax). These <code>new</code> calls can be nested at any level. For any warning to be emitted the <code>new</code> calls should be in a code block where exception handling is used with catch for <code>std::bad_alloc</code> or <code>std::exception</code>. At <code>||</code>, <code>&amp;&amp;</code>, <code>,</code>, <code>?</code> (condition and one branch) operators no warning is emitted. No warning is emitted if both of the memory allocations are not assigned to a variable or not passed directly to a function. The reason is that in this case the memory may be intentionally not freed or the allocated objects can be self-destructing objects.</p>
+<p>Examples:</p>
+<pre class="c++"><code>struct A {
+  int Var;
+};
+struct B {
+  B();
+  B(A *);
+  int Var;
+};
+struct C {
+  int *X1;
+  int *X2;
+};
+
+void f(A *, B *);
+int f1(A *);
+int f1(B *);
+bool f2(A *);
+
+void foo() {
+  A *PtrA;
+  B *PtrB;
+  try {
+    // Allocation of &#39;B&#39;/&#39;A&#39; may fail after memory for &#39;A&#39;/&#39;B&#39; was allocated.
+    f(new A, new B); // warning: memory allocation may leak if an other allocation is sequenced after it and throws an exception; order of these allocations is undefined
+
+    // List (aggregate) initialization is used.
+    C C1{new int, new int}; // no warning
+
+    // Allocation of &#39;B&#39;/&#39;A&#39; may fail after memory for &#39;A&#39;/&#39;B&#39; was allocated but not yet passed to function &#39;f1&#39;.
+    int X = f1(new A) + f1(new B); // warning: memory allocation may leak if an other allocation is sequenced after it and throws an exception; order of these allocations is undefined
+
+    // Allocation of &#39;B&#39; may fail after memory for &#39;A&#39; was allocated.
+    // From C++17 on memory for &#39;B&#39; is allocated first but still may leak if allocation of &#39;A&#39; fails.
+    PtrB = new B(new A); // warning: memory allocation may leak if an other allocation is sequenced after it and throws an exception
+
+    // &#39;new A&#39; and &#39;new B&#39; may be performed in any order.
+    // &#39;new B&#39;/&#39;new A&#39; may fail after memory for &#39;A&#39;/&#39;B&#39; was allocated but not assigned to &#39;PtrA&#39;/&#39;PtrB&#39;.
+    (PtrA = new A)-&gt;Var = (PtrB = new B)-&gt;Var; // warning: memory allocation may leak if an other allocation is sequenced after it and throws an exception; order of these allocations is undefined
+
+    // Evaluation of &#39;f2(new A)&#39; must be finished before &#39;f1(new B)&#39; starts.
+    // If &#39;new B&#39; fails the allocated memory for &#39;A&#39; is supposedly handled correctly because function &#39;f2&#39; could take the ownership.
+    bool Z = f2(new A) || f1(new B); // no warning
+
+    X = (f2(new A) ? f1(new A) : f1(new B)); // no warning
+
+    // No warning if the result of both allocations is not passed to a function
+    // or stored in a variable.
+    (new A)-&gt;Var = (new B)-&gt;Var; // no warning
+
+    // No warning if at least one non-throwing allocation is used.
+    f(new(std::nothrow) A, new B); // no warning
+  } catch(std::bad_alloc) {
+  }
+
+  // No warning if the allocation is outside a try block (or no catch handler exists for std::bad_alloc).
+  // (The fact if exceptions can escape from &#39;foo&#39; is not taken into account.)
+  f(new A, new B); // no warning
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/multiple-new-in-one-expression.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>bugprone-multiple-statement-macro</key>
     <name>bugprone-multiple-statement-macro</name>
     <description>
@@ -2106,6 +2542,23 @@ if (do_increment)
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
+    </rule>
+  <rule>
+    <key>bugprone-narrowing-conversions</key>
+    <name>bugprone-narrowing-conversions</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-narrowing-conversions</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../cppcoreguidelines/narrowing-conversions.html">
+
+</div>
+<h1 id="bugprone-narrowing-conversions">bugprone-narrowing-conversions</h1>
+<p>The bugprone-narrowing-conversions check is an alias, please see <code class="interpreted-text" role="doc">cppcoreguidelines-narrowing-conversions &lt;../cppcoreguidelines/narrowing-conversions&gt;</code> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/narrowing-conversions.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>bugprone-no-escape</key>
@@ -2126,6 +2579,42 @@ if (do_increment)
 </blockquote>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/no-escape.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>bugprone-non-zero-enum-to-bool-conversion</key>
+    <name>bugprone-non-zero-enum-to-bool-conversion</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-non-zero-enum-to-bool-conversion</p>
+</div>
+<h1 id="bugprone-non-zero-enum-to-bool-conversion">bugprone-non-zero-enum-to-bool-conversion</h1>
+<p>Detect implicit and explicit casts of <code>enum</code> type into <code>bool</code> where <code>enum</code> type doesn't have a zero-value enumerator. If the <code>enum</code> is used only to hold values equal to its enumerators, then conversion to <code>bool</code> will always result in <code>true</code> value. This can lead to unnecessary code that reduces readability and maintainability and can result in bugs.</p>
+<p>May produce false positives if the <code>enum</code> is used to store other values (used as a bit-mask or zero-initialized on purpose). To deal with them, <code>// NOLINT</code> or casting first to the underlying type before casting to <code>bool</code> can be used.</p>
+<p>It is important to note that this check will not generate warnings if the definition of the enumeration type is not available. Additionally, C++11 enumeration classes are supported by this check.</p>
+<p>Overall, this check serves to improve code quality and readability by identifying and flagging instances where implicit or explicit casts from enumeration types to boolean could cause potential issues.</p>
+<h2 id="example">Example</h2>
+<pre class="c++"><code>enum EStatus {
+  OK = 1,
+  NOT_OK,
+  UNKNOWN
+};
+
+void process(EStatus status) {
+  if (!status) {
+    // this true-branch won&#39;t be executed
+    return;
+  }
+  // proceed with &quot;valid data&quot;
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>EnumIgnoreList</p>
+<p>Option is used to ignore certain enum types when checking for implicit/explicit casts to bool. It accepts a semicolon-separated list of (fully qualified) enum type names or regular expressions that match the enum type names. The default value is an empty string, which means no enums will be ignored.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/non-zero-enum-to-bool-conversion.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -2196,6 +2685,64 @@ if (do_increment)
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
+    </rule>
+  <rule>
+    <key>bugprone-optional-value-conversion</key>
+    <name>bugprone-optional-value-conversion</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-optional-value-conversion</p>
+</div>
+<h1 id="bugprone-optional-value-conversion">bugprone-optional-value-conversion</h1>
+<p>Detects potentially unintentional and redundant conversions where a value is extracted from an optional-like type and then used to create a new instance of the same optional-like type.</p>
+<p>These conversions might be the result of developer oversight, leftovers from code refactoring, or other situations that could lead to unintended exceptions or cases where the resulting optional is always initialized, which might be unexpected behavior.</p>
+<p>To illustrate, consider the following problematic code snippet:</p>
+<pre class="c++"><code>#include &lt;optional&gt;
+
+void print(std::optional&lt;int&gt;);
+
+int main()
+{
+  std::optional&lt;int&gt; opt;
+  // ...
+
+  // Unintentional conversion from std::optional&lt;int&gt; to int and back to
+  // std::optional&lt;int&gt;:
+  print(opt.value());
+
+  // ...
+}</code></pre>
+<p>A better approach would be to directly pass <code>opt</code> to the <code>print</code> function without extracting its value:</p>
+<pre class="c++"><code>#include &lt;optional&gt;
+
+void print(std::optional&lt;int&gt;);
+
+int main()
+{
+  std::optional&lt;int&gt; opt;
+  // ...
+
+  // Proposed code: Directly pass the std::optional&lt;int&gt; to the print
+  // function.
+  print(opt);
+
+  // ...
+}</code></pre>
+<p>By passing <code>opt</code> directly to the print function, unnecessary conversions are avoided, and potential unintended behavior or exceptions are minimized.</p>
+<p>Value extraction using <code>operator *</code> is matched by default. The support for non-standard optional types such as <code>boost::optional</code> or <code>absl::optional</code> may be limited.</p>
+<h2 id="options">Options:</h2>
+<div class="option">
+<p>OptionalTypes</p>
+<p>Semicolon-separated list of (fully qualified) optional type names or regular expressions that match the optional types. Default value is <span class="title-ref">::std::optional;::absl::optional;::boost::optional</span>.</p>
+</div>
+<div class="option">
+<p>ValueMethods</p>
+<p>Semicolon-separated list of (fully qualified) method names or regular expressions that match the methods. Default value is <span class="title-ref">::value$;::get$</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/optional-value-conversion.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>bugprone-parent-virtual-call</key>
@@ -2342,7 +2889,7 @@ int _g(); // disallowed in global namespace only</code></pre>
 </div>
 <div class="option">
 <p>AllowedIdentifiers</p>
-<p>Semicolon-separated list of names that the check ignores. Default is an empty list.</p>
+<p>Semicolon-separated list of regular expressions that the check ignores. Default is an empty list.</p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/reserved-identifier.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -2396,7 +2943,7 @@ struct S {
 <li>Calls to functions with non-C linkage are not allowed (including the signal handler itself).</li>
 </ul>
 <p>The check is disabled on C++17 and later.</p>
-<p>Asnychronous-safety is determined by comparing the function's name against a set of known functions. In addition, the function must come from a system header include and in a global namespace. The (possible) arguments passed to the function are not checked. Any function that cannot be determined to be asynchronous-safe is assumed to be non-asynchronous-safe by the check, including user functions for which only the declaration is visible. Calls to user-defined functions with visible definitions are checked recursively.</p>
+<p>Asynchronous-safety is determined by comparing the function's name against a set of known functions. In addition, the function must come from a system header include and in a global namespace. The (possible) arguments passed to the function are not checked. Any function that cannot be determined to be asynchronous-safe is assumed to be non-asynchronous-safe by the check, including user functions for which only the declaration is visible. Calls to user-defined functions with visible definitions are checked recursively.</p>
 <p>This check implements the CERT C Coding Standard rule <a href="https://www.securecoding.cert.org/confluence/display/c/SIG30-C.+Call+only+asynchronous-safe+functions+within+signal+handlers">SIG30-C. Call only asynchronous-safe functions within signal handlers</a> and the rule <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/MSC54-CPP.+A+signal+handler+must+be+a+plain+old+function">MSC54-CPP. A signal handler must be a plain old function</a>. It has the alias names <code>cert-sig30-c</code> and <code>cert-msc54-cpp</code>.</p>
 <h2 id="options">Options</h2>
 <div class="option">
@@ -2630,28 +3177,46 @@ void getInt(int* dst) {
 </div>
 <h1 id="bugprone-spuriously-wake-up-functions">bugprone-spuriously-wake-up-functions</h1>
 <p>Finds <code>cnd_wait</code>, <code>cnd_timedwait</code>, <code>wait</code>, <code>wait_for</code>, or <code>wait_until</code> function calls when the function is not invoked from a loop that checks whether a condition predicate holds or the function has a condition parameter.</p>
-<blockquote>
-<dl>
-<dt>if (condition_predicate) {</dt>
-<dd><p>condition.wait(lk);</p>
-</dd>
-</dl>
-<p>}</p>
-</blockquote>
-<blockquote>
-<dl>
-<dt>if (condition_predicate) {</dt>
-<dd><p>if (thrd_success != cnd_wait(&amp;condition, &amp;lock)) { }</p>
-</dd>
-</dl>
-<p>}</p>
-</blockquote>
+<pre class="c++"><code>if (condition_predicate) {
+    condition.wait(lk);
+}</code></pre>
+<pre class="c"><code>if (condition_predicate) {
+    if (thrd_success != cnd_wait(&amp;condition, &amp;lock)) {
+    }
+}</code></pre>
 <p>This check corresponds to the CERT C++ Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/CON54-CPP.+Wrap+functions+that+can+spuriously+wake+up+in+a+loop">CON54-CPP. Wrap functions that can spuriously wake up in a loop</a>. and CERT C Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/c/CON36-C.+Wrap+functions+that+can+spuriously+wake+up+in+a+loop">CON36-C. Wrap functions that can spuriously wake up in a loop</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/spuriously-wake-up-functions.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
+    </rule>
+  <rule>
+    <key>bugprone-standalone-empty</key>
+    <name>bugprone-standalone-empty</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-standalone-empty</p>
+</div>
+<h1 id="bugprone-standalone-empty">bugprone-standalone-empty</h1>
+<p>Warns when <code>empty()</code> is used on a range and the result is ignored. Suggests <code>clear()</code> if it is an existing member function.</p>
+<p>The <code>empty()</code> method on several common ranges returns a Boolean indicating whether or not the range is empty, but is often mistakenly interpreted as a way to clear the contents of a range. Some ranges offer a <code>clear()</code> method for this purpose. This check warns when a call to empty returns a result that is ignored, and suggests replacing it with a call to <code>clear()</code> if it is available as a member function of the range.</p>
+<p>For example, the following code could be used to indicate whether a range is empty or not, but the result is ignored:</p>
+<pre class="c++"><code>std::vector&lt;int&gt; v;
+...
+v.empty();</code></pre>
+<p>A call to <code>clear()</code> would appropriately clear the contents of the range:</p>
+<pre class="c++"><code>std::vector&lt;int&gt; v;
+...
+v.clear();</code></pre>
+<p>Limitations:</p>
+<ul>
+<li>Doesn't warn if <code>empty()</code> is defined and used with the ignore result in the class template definition (for example in the library implementation). These error cases can be caught with <code>[[nodiscard]]</code> attribute.</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/standalone-empty.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>bugprone-string-constructor</key>
@@ -2886,10 +3451,12 @@ flag |=
 <h2 id="options">Options</h2>
 <div class="option">
 <p>HeaderFileExtensions</p>
+<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">HeaderFileExtensions</span>.</p>
 <p>Default value: <code>";h;hh;hpp;hxx"</code> A semicolon-separated list of filename extensions of header files (the filename extensions should not contain a "." prefix). For extension-less header files, use an empty string or leave an empty string between ";" if there are other filename extensions.</p>
 </div>
 <div class="option">
 <p>ImplementationFileExtensions</p>
+<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">ImplementationFileExtensions</span>.</p>
 <p>Default value: <code>"c;cc;cpp;cxx"</code> Likewise, a semicolon-separated list of filename extensions of implementation files.</p>
 </div>
 <h2>References</h2>
@@ -3005,6 +3572,39 @@ const char* B[] = &quot;This&quot; &quot; is a &quot;    &quot;test&quot;;</code
       </description>
     </rule>
   <rule>
+    <key>bugprone-suspicious-realloc-usage</key>
+    <name>bugprone-suspicious-realloc-usage</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-suspicious-realloc-usage</p>
+</div>
+<h1 id="bugprone-suspicious-realloc-usage">bugprone-suspicious-realloc-usage</h1>
+<p>This check finds usages of <code>realloc</code> where the return value is assigned to the same expression as passed to the first argument: <code>p = realloc(p, size);</code> The problem with this construct is that if <code>realloc</code> fails it returns a null pointer but does not deallocate the original memory. If no other variable is pointing to it, the original memory block is not available any more for the program to use or free. In either case <code>p = realloc(p, size);</code> indicates bad coding style and can be replaced by <code>q = realloc(p, size);</code>.</p>
+<p>The pointer expression (used at <code>realloc</code>) can be a variable or a field member of a data structure, but can not contain function calls or unresolved types.</p>
+<p>In obvious cases when the pointer used at realloc is assigned to another variable before the <code>realloc</code> call, no warning is emitted. This happens only if a simple expression in form of <code>q = p</code> or <code>void *q = p</code> is found in the same function where <code>p = realloc(p, ...)</code> is found. The assignment has to be before the call to realloc (but otherwise at any place) in the same function. This suppression works only if <code>p</code> is a single variable.</p>
+<p>Examples:</p>
+<pre class="c++"><code>struct A {
+  void *p;
+};
+
+A &amp;getA();
+
+void foo(void *p, A *a, int new_size) {
+  p = realloc(p, new_size); // warning: &#39;p&#39; may be set to null if &#39;realloc&#39; fails, which may result in a leak of the original buffer
+  a-&gt;p = realloc(a-&gt;p, new_size); // warning: &#39;a-&gt;p&#39; may be set to null if &#39;realloc&#39; fails, which may result in a leak of the original buffer
+  getA().p = realloc(getA().p, new_size); // no warning
+}
+
+void foo1(void *p, int new_size) {
+  void *p1 = p;
+  p = realloc(p, new_size); // no warning
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-realloc-usage.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>bugprone-suspicious-semicolon</key>
     <name>bugprone-suspicious-semicolon</name>
     <description>
@@ -3090,12 +3690,71 @@ if (strcmp(...) != 0)  // Won&#39;t warn</code></pre>
 <p>clang-tidy - bugprone-swapped-arguments</p>
 </div>
 <h1 id="bugprone-swapped-arguments">bugprone-swapped-arguments</h1>
-<p>Finds potentially swapped arguments by looking at implicit conversions.</p>
+<p>Finds potentially swapped arguments by examining implicit conversions. It analyzes the types of the arguments being passed to a function and compares them to the expected types of the corresponding parameters. If there is a mismatch or an implicit conversion that indicates a potential swap, a warning is raised.</p>
+<pre class="c++"><code>void printNumbers(int a, float b);
+
+int main() {
+  // Swapped arguments: float passed as int, int as float)
+  printNumbers(10.0f, 5);
+  return 0;
+}</code></pre>
+<p>Covers a wide range of implicit conversions, including: - User-defined conversions - Conversions from floating-point types to boolean or integral types - Conversions from integral types to boolean or floating-point types - Conversions from boolean to integer types or floating-point types - Conversions from (member) pointers to boolean</p>
+<p>It is important to note that for most argument swaps, the types need to match exactly. However, there are exceptions to this rule. Specifically, when the swapped argument is of integral type, an exact match is not always necessary. Implicit casts from other integral types are also accepted. Similarly, when dealing with floating-point arguments, implicit casts between different floating-point types are considered acceptable.</p>
+<p>To avoid confusion, swaps where both swapped arguments are of integral types or both are of floating-point types do not trigger the warning. In such cases, it's assumed that the developer intentionally used different integral or floating-point types and does not raise a warning. This approach prevents false positives and provides flexibility in handling situations where varying integral or floating-point types are intentionally utilized.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/swapped-arguments.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
+    </rule>
+  <rule>
+    <key>bugprone-switch-missing-default-case</key>
+    <name>bugprone-switch-missing-default-case</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-switch-missing-default-case</p>
+</div>
+<h1 id="bugprone-switch-missing-default-case">bugprone-switch-missing-default-case</h1>
+<p>Ensures that switch statements without default cases are flagged, focuses only on covering cases with non-enums where the compiler may not issue warnings.</p>
+<p>Switch statements without a default case can lead to unexpected behavior and incomplete handling of all possible cases. When a switch statement lacks a default case, if a value is encountered that does not match any of the specified cases, the program will continue execution without any defined behavior or handling.</p>
+<p>This check helps identify switch statements that are missing a default case, allowing developers to ensure that all possible cases are handled properly. Adding a default case allows for graceful handling of unexpected or unmatched values, reducing the risk of program errors and unexpected behavior.</p>
+<p>Example:</p>
+<pre class="c++"><code>// Example 1:
+// warning: switching on non-enum value without default case may not cover all cases
+switch (i) {
+case 0:
+  break;
+}
+
+// Example 2:
+enum E { eE1 };
+E e = eE1;
+switch (e) { // no-warning
+case eE1:
+  break;
+}
+
+// Example 3:
+int i = 0;
+switch (i) { // no-warning
+case 0:
+  break;
+default:
+  break;
+}</code></pre>
+<div class="note">
+<div class="title">
+<p>Note</p>
+</div>
+<p>Enum types are already covered by compiler warnings (comes under -Wswitch) when a switch statement does not handle all enum values. This check focuses on non-enum types where the compiler warnings may not be present.</p>
+</div>
+<div class="seealso">
+<p>The <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-default">CppCoreGuideline ES.79</a> provide guidelines on switch statements, including the recommendation to always provide a default case.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/switch-missing-default-case.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>bugprone-terminating-continue</key>
@@ -3173,6 +3832,158 @@ do {
     <type>BUG</type>
     </rule>
   <rule>
+    <key>bugprone-unchecked-optional-access</key>
+    <name>bugprone-unchecked-optional-access</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-unchecked-optional-access</p>
+</div>
+<h1 id="bugprone-unchecked-optional-access">bugprone-unchecked-optional-access</h1>
+<p><em>Note</em>: This check uses a flow-sensitive static analysis to produce its results. Therefore, it may be more resource intensive (RAM, CPU) than the average clang-tidy check.</p>
+<p>This check identifies unsafe accesses to values contained in <code>std::optional&lt;T&gt;</code>, <code>absl::optional&lt;T&gt;</code>, <code>base::Optional&lt;T&gt;</code>, or <code>folly::Optional&lt;T&gt;</code> objects. Below we will refer to all these types collectively as <code>optional&lt;T&gt;</code>.</p>
+<p>An access to the value of an <code>optional&lt;T&gt;</code> occurs when one of its <code>value</code>, <code>operator*</code>, or <code>operator-&gt;</code> member functions is invoked. To align with common misconceptions, the check considers these member functions as equivalent, even though there are subtle differences related to exceptions versus undefined behavior. See <em>Additional notes</em>, below, for more information on this topic.</p>
+<p>An access to the value of an <code>optional&lt;T&gt;</code> is considered safe if and only if code in the local scope (for example, a function body) ensures that the <code>optional&lt;T&gt;</code> has a value in all possible execution paths that can reach the access. That should happen either through an explicit check, using the <code>optional&lt;T&gt;::has_value</code> member function, or by constructing the <code>optional&lt;T&gt;</code> in a way that shows that it unambiguously holds a value (e.g using <code>std::make_optional</code> which always returns a populated <code>std::optional&lt;T&gt;</code>).</p>
+<p>Below we list some examples, starting with unsafe optional access patterns, followed by safe access patterns.</p>
+<h2 id="unsafe-access-patterns">Unsafe access patterns</h2>
+<h3 id="access-the-value-without-checking-if-it-exists">Access the value without checking if it exists</h3>
+<p>The check flags accesses to the value that are not locally guarded by existence check:</p>
+<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
+  use(*opt); // unsafe: it is unclear whether `opt` has a value.
+}</code></pre>
+<h3 id="access-the-value-in-the-wrong-branch">Access the value in the wrong branch</h3>
+<p>The check is aware of the state of an optional object in different branches of the code. For example:</p>
+<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
+  if (opt.has_value()) {
+  } else {
+    use(opt.value()); // unsafe: it is clear that `opt` does *not* have a value.
+  }
+}</code></pre>
+<h3 id="assume-a-function-result-to-be-stable">Assume a function result to be stable</h3>
+<p>The check is aware that function results might not be stable. That is, consecutive calls to the same function might return different values. For example:</p>
+<pre class="c++"><code>void f(Foo foo) {
+  if (foo.opt().has_value()) {
+    use(*foo.opt()); // unsafe: it is unclear whether `foo.opt()` has a value.
+  }
+}</code></pre>
+<h3 id="rely-on-invariants-of-uncommon-apis">Rely on invariants of uncommon APIs</h3>
+<p>The check is unaware of invariants of uncommon APIs. For example:</p>
+<pre class="c++"><code>void f(Foo foo) {
+  if (foo.HasProperty(&quot;bar&quot;)) {
+    use(*foo.GetProperty(&quot;bar&quot;)); // unsafe: it is unclear whether `foo.GetProperty(&quot;bar&quot;)` has a value.
+  }
+}</code></pre>
+<h3 id="check-if-a-value-exists-then-pass-the-optional-to-another-function">Check if a value exists, then pass the optional to another function</h3>
+<p>The check relies on local reasoning. The check and value access must both happen in the same function. An access is considered unsafe even if the caller of the function performing the access ensures that the optional has a value. For example:</p>
+<pre class="c++"><code>void g(std::optional&lt;int&gt; opt) {
+  use(*opt); // unsafe: it is unclear whether `opt` has a value.
+}
+
+void f(std::optional&lt;int&gt; opt) {
+  if (opt.has_value()) {
+    g(opt);
+  }
+}</code></pre>
+<h2 id="safe-access-patterns">Safe access patterns</h2>
+<h3 id="check-if-a-value-exists-then-access-the-value">Check if a value exists, then access the value</h3>
+<p>The check recognizes all straightforward ways for checking if a value exists and accessing the value contained in an optional object. For example:</p>
+<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
+  if (opt.has_value()) {
+    use(*opt);
+  }
+}</code></pre>
+<h3 id="check-if-a-value-exists-then-access-the-value-from-a-copy">Check if a value exists, then access the value from a copy</h3>
+<p>The criteria that the check uses is semantic, not syntactic. It recognizes when a copy of the optional object being accessed is known to have a value. For example:</p>
+<pre class="c++"><code>void f(std::optional&lt;int&gt; opt1) {
+  if (opt1.has_value()) {
+    std::optional&lt;int&gt; opt2 = opt1;
+    use(*opt2);
+  }
+}</code></pre>
+<h3 id="ensure-that-a-value-exists-using-common-macros">Ensure that a value exists using common macros</h3>
+<p>The check is aware of common macros like <code>CHECK</code> and <code>DCHECK</code>. Those can be used to ensure that an optional object has a value. For example:</p>
+<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
+  DCHECK(opt.has_value());
+  use(*opt);
+}</code></pre>
+<h3 id="ensure-that-a-value-exists-then-access-the-value-in-a-correlated-branch">Ensure that a value exists, then access the value in a correlated branch</h3>
+<p>The check is aware of correlated branches in the code and can figure out when an optional object is ensured to have a value on all execution paths that lead to an access. For example:</p>
+<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
+  bool safe = false;
+  if (opt.has_value() &amp;&amp; SomeOtherCondition()) {
+    safe = true;
+  }
+  // ... more code...
+  if (safe) {
+    use(*opt);
+  }
+}</code></pre>
+<h2 id="stabilize-function-results">Stabilize function results</h2>
+<p>Since function results are not assumed to be stable across calls, it is best to store the result of the function call in a local variable and use that variable to access the value. For example:</p>
+<pre class="c++"><code>void f(Foo foo) {
+  if (const auto&amp; foo_opt = foo.opt(); foo_opt.has_value()) {
+    use(*foo_opt);
+  }
+}</code></pre>
+<h2 id="do-not-rely-on-uncommon-api-invariants">Do not rely on uncommon-API invariants</h2>
+<p>When uncommon APIs guarantee that an optional has contents, do not rely on it --instead, check explicitly that the optional object has a value. For example:</p>
+<pre class="c++"><code>void f(Foo foo) {
+  if (const auto&amp; property = foo.GetProperty(&quot;bar&quot;)) {
+    use(*property);
+  }
+}</code></pre>
+<p>instead of the <span class="title-ref">HasProperty</span>, <span class="title-ref">GetProperty</span> pairing we saw above.</p>
+<h2 id="do-not-rely-on-caller-performed-checks">Do not rely on caller-performed checks</h2>
+<p>If you know that all of a function's callers have checked that an optional argument has a value, either change the function to take the value directly or check the optional again in the local scope of the callee. For example:</p>
+<pre class="c++"><code>void g(int val) {
+  use(val);
+}
+
+void f(std::optional&lt;int&gt; opt) {
+  if (opt.has_value()) {
+    g(*opt);
+  }
+}</code></pre>
+<p>and</p>
+<pre class="c++"><code>struct S {
+  std::optional&lt;int&gt; opt;
+  int x;
+};
+
+void g(const S &amp;s) {
+  if (s.opt.has_value() &amp;&amp; s.x &gt; 10) {
+    use(*s.opt);
+}
+
+void f(S s) {
+  if (s.opt.has_value()) {
+    g(s);
+  }
+}</code></pre>
+<h2 id="additional-notes">Additional notes</h2>
+<h3 id="aliases-created-via-using-declarations">Aliases created via <code>using</code> declarations</h3>
+<p>The check is aware of aliases of optional types that are created via <code>using</code> declarations. For example:</p>
+<pre class="c++"><code>using OptionalInt = std::optional&lt;int&gt;;
+
+void f(OptionalInt opt) {
+  use(opt.value()); // unsafe: it is unclear whether `opt` has a value.
+}</code></pre>
+<h3 id="lambdas">Lambdas</h3>
+<p>The check does not currently report unsafe optional accesses in lambdas. A future version will expand the scope to lambdas, following the rules outlined above. It is best to follow the same principles when using optionals in lambdas.</p>
+<h3 id="access-with-operator-vs.-value">Access with <code>operator*()</code> vs. <code>value()</code></h3>
+<p>Given that <code>value()</code> has well-defined behavior (either throwing an exception or terminating the program), why treat it the same as <code>operator*()</code> which causes undefined behavior (UB)? That is, why is it considered unsafe to access an optional with <code>value()</code>, if it's not provably populated with a value? For that matter, why is <code>CHECK()</code> followed by <code>operator*()</code> any better than <code>value()</code>, given that they are semantically equivalent (on configurations that disable exceptions)?</p>
+<p>The answer is that we assume most users do not realize the difference between <code>value()</code> and <code>operator*()</code>. Shifting to <code>operator*()</code> and some form of explicit value-presence check or explicit program termination has two advantages:</p>
+<blockquote>
+<ul>
+<li>Readability. The check, and any potential side effects like program shutdown, are very clear in the code. Separating access from checks can actually make the checks more obvious.</li>
+<li>Performance. A single check can cover many or even all accesses within scope. This gives the user the best of both worlds -- the safety of a dynamic check, but without incurring redundant costs.</li>
+</ul>
+</blockquote>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/unchecked-optional-access.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>bugprone-undefined-memory-manipulation</key>
     <name>bugprone-undefined-memory-manipulation</name>
     <description>
@@ -3180,7 +3991,21 @@ do {
 <p>clang-tidy - bugprone-undefined-memory-manipulation</p>
 </div>
 <h1 id="bugprone-undefined-memory-manipulation">bugprone-undefined-memory-manipulation</h1>
-<p>Finds calls of memory manipulation functions <code>memset()</code>, <code>memcpy()</code> and <code>memmove()</code> on not TriviallyCopyable objects resulting in undefined behavior.</p>
+<p>Finds calls of memory manipulation functions <code>memset()</code>, <code>memcpy()</code> and <code>memmove()</code> on non-TriviallyCopyable objects resulting in undefined behavior.</p>
+<p>Using memory manipulation functions on non-TriviallyCopyable objects can lead to a range of subtle and challenging issues in C++ code. The most immediate concern is the potential for undefined behavior, where the state of the object may become corrupted or invalid. This can manifest as crashes, data corruption, or unexpected behavior at runtime, making it challenging to identify and diagnose the root cause. Additionally, misuse of memory manipulation functions can bypass essential object-specific operations, such as constructors and destructors, leading to resource leaks or improper initialization.</p>
+<p>For example, when using <code>memcpy</code> to copy <code>std::string</code>, pointer data is being copied, and it can result in a double free issue.</p>
+<pre class="c++"><code>#include &lt;cstring&gt;
+#include &lt;string&gt;
+
+int main() {
+    std::string source = &quot;Hello&quot;;
+    std::string destination;
+
+    std::memcpy(&amp;destination, &amp;source, sizeof(std::string));
+
+    // Undefined behavior may occur here, during std::string destructor call.
+    return 0;
+}</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/undefined-memory-manipulation.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -3346,6 +4171,202 @@ public:
     <type>BUG</type>
     </rule>
   <rule>
+    <key>bugprone-unique-ptr-array-mismatch</key>
+    <name>bugprone-unique-ptr-array-mismatch</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-unique-ptr-array-mismatch</p>
+</div>
+<h1 id="bugprone-unique-ptr-array-mismatch">bugprone-unique-ptr-array-mismatch</h1>
+<p>Finds initializations of C++ unique pointers to non-array type that are initialized with an array.</p>
+<p>If a pointer <code>std::unique_ptr&lt;T&gt;</code> is initialized with a new-expression <code>new T[]</code> the memory is not deallocated correctly. A plain <code>delete</code> is used in this case to deallocate the target memory. Instead a <code>delete[]</code> call is needed. A <code>std::unique_ptr&lt;T[]&gt;</code> uses the correct delete operator. The check does not emit warning if an <code>unique_ptr</code> with user-specified deleter type is used.</p>
+<p>The check offers replacement of <code>unique_ptr&lt;T&gt;</code> to <code>unique_ptr&lt;T[]&gt;</code> if it is used at a single variable declaration (one variable in one statement).</p>
+<p>Example:</p>
+<pre class="c++"><code>std::unique_ptr&lt;Foo&gt; x(new Foo[10]); // -&gt; std::unique_ptr&lt;Foo[]&gt; x(new Foo[10]);
+//                     ^ warning: unique pointer to non-array is initialized with array
+std::unique_ptr&lt;Foo&gt; x1(new Foo), x2(new Foo[10]); // no replacement
+//                                   ^ warning: unique pointer to non-array is initialized with array
+
+D d;
+std::unique_ptr&lt;Foo, D&gt; x3(new Foo[10], d); // no warning (custom deleter used)
+
+struct S {
+  std::unique_ptr&lt;Foo&gt; x(new Foo[10]); // no replacement in this case
+  //                     ^ warning: unique pointer to non-array is initialized with array
+};</code></pre>
+<p>This check partially covers the CERT C++ Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/MEM51-CPP.+Properly+deallocate+dynamically+allocated+resources">MEM51-CPP. Properly deallocate dynamically allocated resources</a> However, only the <code>std::unique_ptr</code> case is detected by this check.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/unique-ptr-array-mismatch.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>bugprone-unsafe-functions</key>
+    <name>bugprone-unsafe-functions</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-unsafe-functions</p>
+</div>
+<h1 id="bugprone-unsafe-functions">bugprone-unsafe-functions</h1>
+<p>Checks for functions that have safer, more secure replacements available, or are considered deprecated due to design flaws. The check heavily relies on the functions from the <strong>Annex K.</strong> "Bounds-checking interfaces" of C11.</p>
+<dl>
+<dt>The check implements the following rules from the CERT C Coding Standard:</dt>
+<dd><ul>
+<li>Recommendation <a href="https://wiki.sei.cmu.edu/confluence/display/c/MSC24-C.+Do+not+use+deprecated+or+obsolescent+functions">MSC24-C. Do not use deprecated or obsolescent functions</a>.</li>
+<li>Rule <a href="https://wiki.sei.cmu.edu/confluence/display/c/MSC33-C.+Do+not+pass+invalid+data+to+the+asctime%28%29+function">MSC33-C. Do not pass invalid data to the asctime() function</a>.</li>
+</ul>
+</dd>
+</dl>
+<p><span class="title-ref">cert-msc24-c</span> and <span class="title-ref">cert-msc33-c</span> redirect here as aliases of this check.</p>
+<h2 id="unsafe-functions">Unsafe functions</h2>
+<p>If <em>Annex K.</em> is available, a replacement from <em>Annex K.</em> is suggested for the following functions:</p>
+<p><code>asctime</code>, <code>asctime_r</code>, <code>bsearch</code>, <code>ctime</code>, <code>fopen</code>, <code>fprintf</code>, <code>freopen</code>, <code>fscanf</code>, <code>fwprintf</code>, <code>fwscanf</code>, <code>getenv</code>, <code>gets</code>, <code>gmtime</code>, <code>localtime</code>, <code>mbsrtowcs</code>, <code>mbstowcs</code>, <code>memcpy</code>, <code>memmove</code>, <code>memset</code>, <code>printf</code>, <code>qsort</code>, <code>scanf</code>, <code>snprintf</code>, <code>sprintf</code>, <code>sscanf</code>, <code>strcat</code>, <code>strcpy</code>, <code>strerror</code>, <code>strlen</code>, <code>strncat</code>, <code>strncpy</code>, <code>strtok</code>, <code>swprintf</code>, <code>swscanf</code>, <code>vfprintf</code>, <code>vfscanf</code>, <code>vfwprintf</code>, <code>vfwscanf</code>, <code>vprintf</code>, <code>vscanf</code>, <code>vsnprintf</code>, <code>vsprintf</code>, <code>vsscanf</code>, <code>vswprintf</code>, <code>vswscanf</code>, <code>vwprintf</code>, <code>vwscanf</code>, <code>wcrtomb</code>, <code>wcscat</code>, <code>wcscpy</code>, <code>wcslen</code>, <code>wcsncat</code>, <code>wcsncpy</code>, <code>wcsrtombs</code>, <code>wcstok</code>, <code>wcstombs</code>, <code>wctomb</code>, <code>wmemcpy</code>, <code>wmemmove</code>, <code>wprintf</code>, <code>wscanf</code>.</p>
+<p>If <em>Annex K.</em> is not available, replacements are suggested only for the following functions from the previous list:</p>
+<blockquote>
+<ul>
+<li><code>asctime</code>, <code>asctime_r</code>, suggested replacement: <code>strftime</code></li>
+<li><code>gets</code>, suggested replacement: <code>fgets</code></li>
+</ul>
+</blockquote>
+<p>The following functions are always checked, regardless of <em>Annex K</em> availability:</p>
+<blockquote>
+<ul>
+<li><code>rewind</code>, suggested replacement: <code>fseek</code></li>
+<li><code>setbuf</code>, suggested replacement: <code>setvbuf</code></li>
+</ul>
+</blockquote>
+<p>If <a href="unsafe-functions.html#cmdoption-arg-ReportMoreUnsafeFunctions">ReportMoreUnsafeFunctions</a> is enabled, the following functions are also checked:</p>
+<blockquote>
+<ul>
+<li><code>bcmp</code>, suggested replacement: <code>memcmp</code></li>
+<li><code>bcopy</code>, suggested replacement: <code>memcpy_s</code> if <em>Annex K</em> is available, or <code>memcpy</code></li>
+<li><code>bzero</code>, suggested replacement: <code>memset_s</code> if <em>Annex K</em> is available, or <code>memset</code></li>
+<li><code>getpw</code>, suggested replacement: <code>getpwuid</code></li>
+<li><code>vfork</code>, suggested replacement: <code>posix_spawn</code></li>
+</ul>
+</blockquote>
+<p>Although mentioned in the associated CERT rules, the following functions are <strong>ignored</strong> by the check:</p>
+<p><code>atof</code>, <code>atoi</code>, <code>atol</code>, <code>atoll</code>, <code>tmpfile</code>.</p>
+<p>The availability of <em>Annex K</em> is determined based on the following macros:</p>
+<blockquote>
+<ul>
+<li><code>__STDC_LIB_EXT1__</code>: feature macro, which indicates the presence of <em>Annex K. "Bounds-checking interfaces"</em> in the library implementation</li>
+<li><code>__STDC_WANT_LIB_EXT1__</code>: user-defined macro, which indicates that the user requests the functions from <em>Annex K.</em> to be defined.</li>
+</ul>
+</blockquote>
+<p>Both macros have to be defined to suggest replacement functions from <em>Annex K.</em> <code>__STDC_LIB_EXT1__</code> is defined by the library implementation, and <code>__STDC_WANT_LIB_EXT1__</code> must be defined to <code>1</code> by the user <strong>before</strong> including any system headers.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>ReportMoreUnsafeFunctions</p>
+<p>When <span class="title-ref">true</span>, additional functions from widely used APIs (such as POSIX) are added to the list of reported functions. See the main documentation of the check for the complete list as to what this option enables. Default is <span class="title-ref">true</span>.</p>
+</div>
+<h2 id="examples">Examples</h2>
+<pre class="c++"><code>#ifndef __STDC_LIB_EXT1__
+#error &quot;Annex K is not supported by the current standard library implementation.&quot;
+#endif
+
+#define __STDC_WANT_LIB_EXT1__ 1
+
+#include &lt;string.h&gt; // Defines functions from Annex K.
+#include &lt;stdio.h&gt;
+
+enum { BUFSIZE = 32 };
+
+void Unsafe(const char *Msg) {
+  static const char Prefix[] = &quot;Error: &quot;;
+  static const char Suffix[] = &quot;\n&quot;;
+  char Buf[BUFSIZE] = {0};
+
+  strcpy(Buf, Prefix); // warning: function &#39;strcpy&#39; is not bounds-checking; &#39;strcpy_s&#39; should be used instead.
+  strcat(Buf, Msg);    // warning: function &#39;strcat&#39; is not bounds-checking; &#39;strcat_s&#39; should be used instead.
+  strcat(Buf, Suffix); // warning: function &#39;strcat&#39; is not bounds-checking; &#39;strcat_s&#39; should be used instead.
+  if (fputs(buf, stderr) &lt; 0) {
+    // error handling
+    return;
+  }
+}
+
+void UsingSafeFunctions(const char *Msg) {
+  static const char Prefix[] = &quot;Error: &quot;;
+  static const char Suffix[] = &quot;\n&quot;;
+  char Buf[BUFSIZE] = {0};
+
+  if (strcpy_s(Buf, BUFSIZE, Prefix) != 0) {
+    // error handling
+    return;
+  }
+
+  if (strcat_s(Buf, BUFSIZE, Msg) != 0) {
+    // error handling
+    return;
+  }
+
+  if (strcat_s(Buf, BUFSIZE, Suffix) != 0) {
+    // error handling
+    return;
+  }
+
+  if (fputs(Buf, stderr) &lt; 0) {
+    // error handling
+    return;
+  }
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/unsafe-functions.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>bugprone-unused-local-non-trivial-variable</key>
+    <name>bugprone-unused-local-non-trivial-variable</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - bugprone-unused-local-non-trivial-variable</p>
+</div>
+<h1 id="bugprone-unused-local-non-trivial-variable">bugprone-unused-local-non-trivial-variable</h1>
+<p>Warns when a local non trivial variable is unused within a function. The following types of variables are excluded from this check:</p>
+<ul>
+<li>trivial and trivially copyable</li>
+<li>references and pointers</li>
+<li>exception variables in catch clauses</li>
+<li>static or thread local</li>
+<li>structured bindings</li>
+</ul>
+<p>This check can be configured to warn on all non-trivial variables by setting <span class="title-ref">IncludeTypes</span> to <span class="title-ref">.*</span>, and excluding specific types using <span class="title-ref">ExcludeTypes</span>.</p>
+<p>In the this example, <span class="title-ref">my_lock</span> would generate a warning that it is unused.</p>
+<pre class="c++"><code>std::mutex my_lock;
+// my_lock local variable is never used</code></pre>
+<p>In the next example, <span class="title-ref">future2</span> would generate a warning that it is unused.</p>
+<pre class="c++"><code>std::future&lt;MyObject&gt; future1;
+std::future&lt;MyObject&gt; future2;
+// ...
+MyObject foo = future1.get();
+// future2 is not used.</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IncludeTypes</p>
+<p>Semicolon-separated list of regular expressions matching types of variables to check. By default the following types are checked:</p>
+<ul>
+<li><span class="title-ref">::std::.*mutex</span></li>
+<li><span class="title-ref">::std::future</span></li>
+<li><span class="title-ref">::std::basic_string</span></li>
+<li><span class="title-ref">::std::basic_regex</span></li>
+<li><span class="title-ref">::std::basic_istringstream</span></li>
+<li><span class="title-ref">::std::basic_stringstream</span></li>
+<li><span class="title-ref">::std::bitset</span></li>
+<li><span class="title-ref">::std::filesystem::path</span></li>
+</ul>
+</div>
+<div class="option">
+<p>ExcludeTypes</p>
+<p>A semicolon-separated list of regular expressions matching types that are excluded from the <span class="title-ref">IncludeTypes</span> matches. By default it is an empty list.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/unused-local-non-trivial-variable.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>bugprone-unused-raii</key>
     <name>bugprone-unused-raii</name>
     <description>
@@ -3392,7 +4413,15 @@ public:
 <li><code>std::basic_string::empty()</code> and <code>std::vector::empty()</code>. Not using the return value often indicates that the programmer confused the function with <code>clear()</code>.</li>
 </ul>
 </div>
-<p><a href="../cert/err33-c.html">cert-err33-c</a> is an alias of this check that checks a fixed and large set of standard library functions.</p>
+<div class="option">
+<p>CheckedReturnTypes</p>
+<p>Semicolon-separated list of function return types to check. By default the following function return types are checked: <span class="title-ref">::std::error_code</span>, <span class="title-ref">::std::error_condition</span>, <span class="title-ref">::std::errc</span>, <span class="title-ref">::std::expected</span>, <span class="title-ref">::boost::system::error_code</span></p>
+</div>
+<div class="option">
+<p>AllowCastToVoid</p>
+<p>Controls whether casting return values to <code>void</code> is permitted. Default: <span class="title-ref">false</span>.</p>
+</div>
+<p><code class="interpreted-text" role="doc">cert-err33-c &lt;../cert/err33-c&gt;</code> is an alias of this check that checks a fixed and large set of standard library functions.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/unused-return-value.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -3545,7 +4574,7 @@ struct Derived : Base {
 
 </div>
 <h1 id="cert-con36-c">cert-con36-c</h1>
-<p>The cert-con36-c check is an alias, please see <a href="../bugprone/spuriously-wake-up-functions.html">bugprone-spuriously-wake-up-functions</a> for more information.</p>
+<p>The <span class="title-ref">cert-con36-c</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-spuriously-wake-up-functions &lt;../bugprone/spuriously-wake-up-functions&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/con36-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -3562,7 +4591,7 @@ struct Derived : Base {
 
 </div>
 <h1 id="cert-con54-cpp">cert-con54-cpp</h1>
-<p>The cert-con54-cpp check is an alias, please see <a href="../bugprone/spuriously-wake-up-functions.html">bugprone-spuriously-wake-up-functions</a> for more information.</p>
+<p>The <span class="title-ref">cert-con54-cpp</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-spuriously-wake-up-functions &lt;../bugprone/spuriously-wake-up-functions&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/con54-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -3579,7 +4608,7 @@ struct Derived : Base {
 
 </div>
 <h1 id="cert-dcl03-c">cert-dcl03-c</h1>
-<p>The cert-dcl03-c check is an alias, please see <a href="../misc/static-assert.html">misc-static-assert</a> for more information.</p>
+<p>The <span class="title-ref">cert-dcl03-c</span> check is an alias, please see <code class="interpreted-text" role="doc">misc-static-assert &lt;../misc/static-assert&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl03-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -3596,7 +4625,7 @@ struct Derived : Base {
 
 </div>
 <h1 id="cert-dcl16-c">cert-dcl16-c</h1>
-<p>The cert-dcl16-c check is an alias, please see <a href="../readability/uppercase-literal-suffix.html">readability-uppercase-literal-suffix</a> for more information.</p>
+<p>The <span class="title-ref">cert-dcl16-c</span> check is an alias, please see <code class="interpreted-text" role="doc">readability-uppercase-literal-suffix &lt;../readability/uppercase-literal-suffix&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl16-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -3610,6 +4639,12 @@ struct Derived : Base {
 <p>clang-tidy - cert-dcl21-cpp</p>
 </div>
 <h1 id="cert-dcl21-cpp">cert-dcl21-cpp</h1>
+<div class="note">
+<div class="title">
+<p>Note</p>
+</div>
+<p>This check is deprecated since it's no longer part of the CERT standard. It will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19.</p>
+</div>
 <p>This check flags postfix <code>operator++</code> and <code>operator--</code> declarations if the return type is not a const object. This also warns if the return type is a reference type.</p>
 <p>The object returned by a postfix increment or decrement operator is supposed to be a snapshot of the object's value prior to modification. With such an implementation, any modifications made to the resulting object from calling operator++(int) would be modifying a temporary object. Thus, such an implementation of a postfix increment or decrement operator should instead return a const object, prohibiting accidental mutation of a temporary object. Similarly, it is unexpected for the postfix operator to return a reference to its previous state, and any subsequent modifications would be operating on a stale object.</p>
 <p>This check corresponds to the CERT C++ Coding Standard recommendation DCL21-CPP. Overloaded postfix increment and decrement operators should return a const object. However, all of the CERT recommendations have been removed from public view, and so their justification for the behavior of this check requires an account on their wiki to view.</p>
@@ -3628,7 +4663,7 @@ struct Derived : Base {
 
 </div>
 <h1 id="cert-dcl37-c">cert-dcl37-c</h1>
-<p>The cert-dcl37-c check is an alias, please see <a href="../bugprone/reserved-identifier.html">bugprone-reserved-identifier</a> for more information.</p>
+<p>The <span class="title-ref">cert-dcl37-c</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-reserved-identifier &lt;../bugprone/reserved-identifier&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl37-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -3660,7 +4695,7 @@ struct Derived : Base {
 
 </div>
 <h1 id="cert-dcl51-cpp">cert-dcl51-cpp</h1>
-<p>The cert-dcl51-cpp check is an alias, please see <a href="../bugprone/reserved-identifier.html">bugprone-reserved-identifier</a> for more information.</p>
+<p>The <span class="title-ref">cert-dcl51-cpp</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-reserved-identifier &lt;../bugprone/reserved-identifier&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl51-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -3677,7 +4712,7 @@ struct Derived : Base {
 
 </div>
 <h1 id="cert-dcl54-cpp">cert-dcl54-cpp</h1>
-<p>The cert-dcl54-cpp check is an alias, please see <a href="../misc/new-delete-overloads.html">misc-new-delete-overloads</a> for more information.</p>
+<p>The <span class="title-ref">cert-dcl54-cpp</span> check is an alias, please see <code class="interpreted-text" role="doc">misc-new-delete-overloads &lt;../misc/new-delete-overloads&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl54-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -3743,7 +4778,7 @@ namespace std {
 
 </div>
 <h1 id="cert-dcl59-cpp">cert-dcl59-cpp</h1>
-<p>The cert-dcl59-cpp check is an alias, please see <a href="../google/build-namespaces.html">google-build-namespaces</a> for more information.</p>
+<p>The <span class="title-ref">cert-dcl59-cpp</span> check is an alias, please see <code class="interpreted-text" role="doc">google-build-namespaces &lt;../google/build-namespaces&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl59-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -3775,7 +4810,7 @@ namespace std {
 
 </div>
 <h1 id="cert-err09-cpp">cert-err09-cpp</h1>
-<p>The cert-err09-cpp check is an alias, please see <a href="../misc/throw-by-value-catch-by-reference.html">misc-throw-by-value-catch-by-reference</a> for more information.</p>
+<p>The <span class="title-ref">cert-err09-cpp</span> check is an alias, please see <code class="interpreted-text" role="doc">misc-throw-by-value-catch-by-reference &lt;../misc/throw-by-value-catch-by-reference&gt;</code> for more information.</p>
 <p>This check corresponds to the CERT C++ Coding Standard recommendation ERR09-CPP. Throw anonymous temporaries. However, all of the CERT recommendations have been removed from public view, and so their justification for the behavior of this check requires an account on their wiki to view.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/err09-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -3971,7 +5006,8 @@ namespace std {
 <li>wscanf()</li>
 <li>wscanf_s()</li>
 </ul>
-<p>This check is an alias of check <a href="../bugprone/unused-return-value.html">bugprone-unused-return-value</a> with a fixed set of functions.</p>
+<p>This check is an alias of check <code class="interpreted-text" role="doc">bugprone-unused-return-value &lt;../bugprone/unused-return-value&gt;</code> with a fixed set of functions.</p>
+<p>Suppressing issues by casting to <code>void</code> is enabled by default and can be disabled by setting <span class="title-ref">AllowCastToVoid</span> option to <code>false</code>.</p>
 <p>The check corresponds to a part of CERT C Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/c/ERR33-C.+Detect+and+handle+standard+library+errors">ERR33-C. Detect and handle standard library errors</a>. The list of checked functions is taken from the rule, with following exception:</p>
 <ul>
 <li>The check can not differentiate if a function is called with <code>NULL</code> argument. Therefore the following functions are not checked: <code>mblen</code>, <code>mbrlen</code>, <code>mbrtowc</code>, <code>mbtowc</code>, <code>wctomb</code>, <code>wctomb_s</code></li>
@@ -4064,7 +5100,7 @@ void func(const char *buff) {
 
 </div>
 <h1 id="cert-err61-cpp">cert-err61-cpp</h1>
-<p>The cert-err61-cpp check is an alias, please see <a href="../misc/throw-by-value-catch-by-reference.html">misc-throw-by-value-catch-by-reference</a> for more information.</p>
+<p>The <span class="title-ref">cert-err61-cpp</span> check is an alias, please see <code class="interpreted-text" role="doc">misc-throw-by-value-catch-by-reference &lt;../misc/throw-by-value-catch-by-reference&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/err61-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4078,7 +5114,7 @@ void func(const char *buff) {
       <![CDATA[<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/suspicious-memory-comparison.html">
 </div>
 <h1 id="cert-exp42-c">cert-exp42-c</h1>
-<p>The cert-exp42-c check is an alias, please see <a href="../bugprone/suspicious-memory-comparison.html">bugprone-suspicious-memory-comparison</a> for more information.</p>
+<p>The <span class="title-ref">cert-exp42-c</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-suspicious-memory-comparison &lt;../bugprone/suspicious-memory-comparison&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/exp42-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4095,7 +5131,7 @@ void func(const char *buff) {
 
 </div>
 <h1 id="cert-fio38-c">cert-fio38-c</h1>
-<p>The cert-fio38-c check is an alias, please see <a href="../misc/non-copyable-objects.html">misc-non-copyable-objects</a> for more information.</p>
+<p>The <span class="title-ref">cert-fio38-c</span> check is an alias, please see <code class="interpreted-text" role="doc">misc-non-copyable-objects &lt;../misc/non-copyable-objects&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/fio38-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4122,7 +5158,7 @@ void func(const char *buff) {
       <![CDATA[<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/suspicious-memory-comparison.html">
 </div>
 <h1 id="cert-flp37-c">cert-flp37-c</h1>
-<p>The cert-flp37-c check is an alias, please see <a href="../bugprone/suspicious-memory-comparison.html">bugprone-suspicious-memory-comparison</a> for more information.</p>
+<p>The <span class="title-ref">cert-flp37-c</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-suspicious-memory-comparison &lt;../bugprone/suspicious-memory-comparison&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/flp37-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4144,6 +5180,23 @@ void func(const char *buff) {
     <severity>MINOR</severity>
     </rule>
   <rule>
+    <key>cert-msc24-c</key>
+    <name>cert-msc24-c</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cert-msc24-c</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/unsafe-functions.html">
+
+</div>
+<h1 id="cert-msc24-c">cert-msc24-c</h1>
+<p>The <span class="title-ref">cert-msc24-c</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-unsafe-functions &lt;../bugprone/unsafe-functions&gt;</code> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/msc24-c.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>cert-msc30-c</key>
     <name>cert-msc30-c</name>
     <description>
@@ -4154,7 +5207,7 @@ void func(const char *buff) {
 
 </div>
 <h1 id="cert-msc30-c">cert-msc30-c</h1>
-<p>The cert-msc30-c check is an alias, please see <a href="../cert/msc50-cpp.html">cert-msc50-cpp</a> for more information.</p>
+<p>The <span class="title-ref">cert-msc30-c</span> check is an alias, please see <code class="interpreted-text" role="doc">cert-msc50-cpp &lt;../cert/msc50-cpp&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/msc30-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4171,9 +5224,26 @@ void func(const char *buff) {
 
 </div>
 <h1 id="cert-msc32-c">cert-msc32-c</h1>
-<p>The cert-msc32-c check is an alias, please see <a href="../cert/msc51-cpp.html">cert-msc51-cpp</a> for more information.</p>
+<p>The <span class="title-ref">cert-msc32-c</span> check is an alias, please see <code class="interpreted-text" role="doc">cert-msc51-cpp &lt;../cert/msc51-cpp&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/msc32-c.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>cert-msc33-c</key>
+    <name>cert-msc33-c</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cert-msc33-c</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/unsafe-functions.html">
+
+</div>
+<h1 id="cert-msc33-c">cert-msc33-c</h1>
+<p>The <span class="title-ref">cert-msc33-c</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-unsafe-functions &lt;../bugprone/unsafe-functions&gt;</code> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/msc33-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -4224,6 +5294,23 @@ void func(const char *buff) {
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>cert-msc54-cpp</key>
+    <name>cert-msc54-cpp</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cert-msc54-cpp</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/signal-handler.html">
+
+</div>
+<h1 id="cert-msc54-cpp">cert-msc54-cpp</h1>
+<p>The <span class="title-ref">cert-msc54-cpp</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-signal-handler &lt;../bugprone/signal-handler&gt;</code> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/msc54-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>cert-oop11-cpp</key>
     <name>cert-oop11-cpp</name>
     <description>
@@ -4234,7 +5321,7 @@ void func(const char *buff) {
 
 </div>
 <h1 id="cert-oop11-cpp">cert-oop11-cpp</h1>
-<p>The cert-oop11-cpp check is an alias, please see <a href="../performance/move-constructor-init.html">performance-move-constructor-init</a> for more information.</p>
+<p>The <span class="title-ref">cert-oop11-cpp check</span> is an alias, please see <code class="interpreted-text" role="doc">performance-move-constructor-init &lt;../performance/move-constructor-init&gt;</code> for more information.</p>
 <p>This check corresponds to the CERT C++ Coding Standard recommendation OOP11-CPP. Do not copy-initialize members or base classes from a move constructor. However, all of the CERT recommendations have been removed from public view, and so their justification for the behavior of this check requires an account on their wiki to view.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/oop11-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -4252,7 +5339,7 @@ void func(const char *buff) {
 
 </div>
 <h1 id="cert-oop54-cpp">cert-oop54-cpp</h1>
-<p>The cert-oop54-cpp check is an alias, please see <a href="../bugprone/unhandled-self-assignment.html">bugprone-unhandled-self-assignment</a> for more information.</p>
+<p>The <span class="title-ref">cert-oop54-cpp</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-unhandled-self-assignment &lt;../bugprone/unhandled-self-assignment&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/oop54-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4314,7 +5401,7 @@ void func(const char *buff) {
 
 </div>
 <h1 id="cert-pos44-c">cert-pos44-c</h1>
-<p>The cert-pos44-c check is an alias, please see <a href="../bugprone/bad-signal-to-kill-thread.html">bugprone-bad-signal-to-kill-thread</a> for more information.</p>
+<p>The <span class="title-ref">cert-pos44-c</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-bad-signal-to-kill-thread &lt;../bugprone/bad-signal-to-kill-thread&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/pos44-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4331,7 +5418,7 @@ void func(const char *buff) {
 
 </div>
 <h1 id="cert-pos47-c">cert-pos47-c</h1>
-<p>The cert-pos47-c check is an alias, please see <a href="../concurrency/thread-canceltype-asynchronous.html">concurrency-thread-canceltype-asynchronous</a> for more information.</p>
+<p>The <span class="title-ref">cert-pos47-c</span> check is an alias, please see <code class="interpreted-text" role="doc">concurrency-thread-canceltype-asynchronous &lt;../concurrency/thread-canceltype-asynchronous&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/pos47-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4348,7 +5435,7 @@ void func(const char *buff) {
 
 </div>
 <h1 id="cert-sig30-c">cert-sig30-c</h1>
-<p>The cert-sig30-c check is an alias, please see <a href="../bugprone/signal-handler.html">bugprone-signal-handler</a> for more information.</p>
+<p>The <span class="title-ref">cert-sig30-c</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-signal-handler &lt;../bugprone/signal-handler&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/sig30-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4365,9 +5452,27 @@ void func(const char *buff) {
 
 </div>
 <h1 id="cert-str34-c">cert-str34-c</h1>
-<p>The cert-str34-c check is an alias, please see <a href="../bugprone/signed-char-misuse.html">bugprone-signed-char-misuse</a> for more information.</p>
+<p>The <span class="title-ref">cert-str34-c</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-signed-char-misuse &lt;../bugprone/signed-char-misuse&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/str34-c.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-core.BitwiseShift</key>
+    <name>clang-analyzer-core.BitwiseShift</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - clang-analyzer-core.BitwiseShift</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-bitwiseshift">
+
+</div>
+<h1 id="clang-analyzer-core.bitwiseshift">clang-analyzer-core.BitwiseShift</h1>
+<p>Finds cases where bitwise shift operation causes undefined behaviour.</p>
+<p>The <span class="title-ref">clang-analyzer-core.BitwiseShift</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-bitwiseshift">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.BitwiseShift.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -4382,7 +5487,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-core.callandmessage">clang-analyzer-core.CallAndMessage</h1>
-<p>The clang-analyzer-core.CallAndMessage check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-callandmessage">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for logical errors for function calls and Objective-C message expressions (e.g., uninitialized arguments, null function pointers).</p>
+<p>The <span class="title-ref">clang-analyzer-core.CallAndMessage</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-callandmessage">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.CallAndMessage.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4399,7 +5505,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-core.dividezero">clang-analyzer-core.DivideZero</h1>
-<p>The clang-analyzer-core.DivideZero check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-dividezero">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for division by zero.</p>
+<p>The <span class="title-ref">clang-analyzer-core.DivideZero</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-dividezero">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.DivideZero.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4430,7 +5537,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-core.nonnullparamchecker">clang-analyzer-core.NonNullParamChecker</h1>
-<p>The clang-analyzer-core.NonNullParamChecker check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-nonnullparamchecker">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for null pointers passed as arguments to a function whose arguments are references or marked with the 'nonnull' attribute.</p>
+<p>The <span class="title-ref">clang-analyzer-core.NonNullParamChecker</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-nonnullparamchecker">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.NonNullParamChecker.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4447,7 +5555,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-core.nulldereference">clang-analyzer-core.NullDereference</h1>
-<p>The clang-analyzer-core.NullDereference check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-nulldereference">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for dereferences of null pointers.</p>
+<p>The <span class="title-ref">clang-analyzer-core.NullDereference</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-nulldereference">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.NullDereference.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4464,7 +5573,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-core.stackaddressescape">clang-analyzer-core.StackAddressEscape</h1>
-<p>The clang-analyzer-core.StackAddressEscape check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-stackaddressescape">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check that addresses to stack memory do not escape the function.</p>
+<p>The <span class="title-ref">clang-analyzer-core.StackAddressEscape</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-stackaddressescape">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.StackAddressEscape.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4481,7 +5591,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-core.undefinedbinaryoperatorresult">clang-analyzer-core.UndefinedBinaryOperatorResult</h1>
-<p>The clang-analyzer-core.UndefinedBinaryOperatorResult check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-undefinedbinaryoperatorresult">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for undefined results of binary operators.</p>
+<p>The <span class="title-ref">clang-analyzer-core.UndefinedBinaryOperatorResult</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-undefinedbinaryoperatorresult">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.UndefinedBinaryOperatorResult.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4498,7 +5609,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-core.uninitialized.arraysubscript">clang-analyzer-core.uninitialized.ArraySubscript</h1>
-<p>The clang-analyzer-core.uninitialized.ArraySubscript check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-arraysubscript">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for uninitialized values used as array subscripts.</p>
+<p>The <span class="title-ref">clang-analyzer-core.uninitialized.ArraySubscript</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-arraysubscript">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.uninitialized.ArraySubscript.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4515,7 +5627,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-core.uninitialized.assign">clang-analyzer-core.uninitialized.Assign</h1>
-<p>The clang-analyzer-core.uninitialized.Assign check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-assign">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for assigning uninitialized values.</p>
+<p>The <span class="title-ref">clang-analyzer-core.uninitialized.Assign</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-assign">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.uninitialized.Assign.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4532,7 +5645,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-core.uninitialized.branch">clang-analyzer-core.uninitialized.Branch</h1>
-<p>The clang-analyzer-core.uninitialized.Branch check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-branch">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for uninitialized values used as branch conditions.</p>
+<p>The <span class="title-ref">clang-analyzer-core.uninitialized.Branch</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-branch">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.uninitialized.Branch.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4545,10 +5659,32 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-core.uninitialized.CapturedBlockVariable</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-capturedblockvariable">
+
+</div>
 <h1 id="clang-analyzer-core.uninitialized.capturedblockvariable">clang-analyzer-core.uninitialized.CapturedBlockVariable</h1>
-<p>Check for blocks that capture uninitialized values</p>
+<p>Check for blocks that capture uninitialized values.</p>
+<p>The <span class="title-ref">clang-analyzer-core.uninitialized.CapturedBlockVariable</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-capturedblockvariable">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.uninitialized.CapturedBlockVariable.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-core.uninitialized.NewArraySize</key>
+    <name>clang-analyzer-core.uninitialized.NewArraySize</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - clang-analyzer-core.uninitialized.NewArraySize</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-newarraysize">
+
+</div>
+<h1 id="clang-analyzer-core.uninitialized.newarraysize">clang-analyzer-core.uninitialized.NewArraySize</h1>
+<p>Check if the size of the array in a new[] expression is undefined.</p>
+<p>The <span class="title-ref">clang-analyzer-core.uninitialized.NewArraySize</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-newarraysize">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.uninitialized.NewArraySize.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -4563,7 +5699,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-core.uninitialized.undefreturn">clang-analyzer-core.uninitialized.UndefReturn</h1>
-<p>The clang-analyzer-core.uninitialized.UndefReturn check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-undefreturn">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for uninitialized values being returned to the caller.</p>
+<p>The <span class="title-ref">clang-analyzer-core.uninitialized.UndefReturn</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-uninitialized-undefreturn">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.uninitialized.UndefReturn.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4580,7 +5717,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-core.vlasize">clang-analyzer-core.VLASize</h1>
-<p>The clang-analyzer-core.VLASize check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-vlasize">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for declarations of VLA of undefined or zero size.</p>
+<p>The <span class="title-ref">clang-analyzer-core.VLASize</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#core-vlasize">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.VLASize.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4593,8 +5731,12 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-cplusplus.InnerPointer</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-innerpointer">
+
+</div>
 <h1 id="clang-analyzer-cplusplus.innerpointer">clang-analyzer-cplusplus.InnerPointer</h1>
-<p>Check for inner pointers of C++ containers used after re/deallocation</p>
+<p>Check for inner pointers of C++ containers used after re/deallocation.</p>
+<p>The <span class="title-ref">clang-analyzer-cplusplus.InnerPointer</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-innerpointer">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.InnerPointer.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4607,11 +5749,9 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-cplusplus.Move</p>
 </div>
-<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-move">
-
-</div>
 <h1 id="clang-analyzer-cplusplus.move">clang-analyzer-cplusplus.Move</h1>
-<p>The clang-analyzer-cplusplus.Move check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-move">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Find use-after-move bugs in C++.</p>
+<p>The clang-analyzer-cplusplus.Move check is an alias of Clang Static Analyzer cplusplus.Move.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.Move.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4628,7 +5768,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-cplusplus.newdelete">clang-analyzer-cplusplus.NewDelete</h1>
-<p>The clang-analyzer-cplusplus.NewDelete check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdelete">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for double-free and use-after-free problems. Traces memory managed by new/delete.</p>
+<p>The <span class="title-ref">clang-analyzer-cplusplus.NewDelete</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdelete">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.NewDelete.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4645,9 +5786,61 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-cplusplus.newdeleteleaks">clang-analyzer-cplusplus.NewDeleteLeaks</h1>
-<p>The clang-analyzer-cplusplus.NewDeleteLeaks check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdeleteleaks">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for memory leaks. Traces memory managed by new/delete.</p>
+<p>The <span class="title-ref">clang-analyzer-cplusplus.NewDeleteLeaks</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-newdeleteleaks">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.NewDeleteLeaks.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-cplusplus.PlacementNew</key>
+    <name>clang-analyzer-cplusplus.PlacementNew</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - clang-analyzer-cplusplus.PlacementNew</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-placementnew">
+
+</div>
+<h1 id="clang-analyzer-cplusplus.placementnew">clang-analyzer-cplusplus.PlacementNew</h1>
+<p>Check if default placement new is provided with pointers to sufficient storage capacity.</p>
+<p>The <span class="title-ref">clang-analyzer-cplusplus.PlacementNew</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-placementnew">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.PlacementNew.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-cplusplus.PureVirtualCall</key>
+    <name>clang-analyzer-cplusplus.PureVirtualCall</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - clang-analyzer-cplusplus.PureVirtualCall</p>
+</div>
+<h1 id="clang-analyzer-cplusplus.purevirtualcall">clang-analyzer-cplusplus.PureVirtualCall</h1>
+<p>Check pure virtual function calls during construction/destruction.</p>
+<p>The clang-analyzer-cplusplus.PureVirtualCall check is an alias of Clang Static Analyzer cplusplus.PureVirtualCall.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.PureVirtualCall.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-cplusplus.StringChecker</key>
+    <name>clang-analyzer-cplusplus.StringChecker</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - clang-analyzer-cplusplus.StringChecker</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-stringchecker">
+
+</div>
+<h1 id="clang-analyzer-cplusplus.stringchecker">clang-analyzer-cplusplus.StringChecker</h1>
+<p>Checks C++ std::string bugs.</p>
+<p>The <span class="title-ref">clang-analyzer-cplusplus.StringChecker</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-stringchecker">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.StringChecker.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -4662,9 +5855,28 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-deadcode.deadstores">clang-analyzer-deadcode.DeadStores</h1>
-<p>The clang-analyzer-deadcode.DeadStores check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#deadcode-deadstores">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for values stored to variables that are never read afterwards.</p>
+<p>The <span class="title-ref">clang-analyzer-deadcode.DeadStores</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#deadcode-deadstores">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/deadcode.DeadStores.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-fuchsia.HandleChecker</key>
+    <name>clang-analyzer-fuchsia.HandleChecker</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - clang-analyzer-fuchsia.HandleChecker</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#fuchsia-handlechecker">
+
+</div>
+<h1 id="clang-analyzer-fuchsia.handlechecker">clang-analyzer-fuchsia.HandleChecker</h1>
+<p>A Checker that detect leaks related to Fuchsia handles.</p>
+<p>The <span class="title-ref">clang-analyzer-fuchsia.HandleChecker</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#fuchsia-handlechecker">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/fuchsia.HandleChecker.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -4679,7 +5891,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-nullability.nullabledereferenced">clang-analyzer-nullability.NullableDereferenced</h1>
-<p>The clang-analyzer-nullability.NullableDereferenced check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullabledereferenced">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warns when a nullable pointer is dereferenced.</p>
+<p>The <span class="title-ref">clang-analyzer-nullability.NullableDereferenced</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullabledereferenced">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/nullability.NullableDereferenced.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4696,7 +5909,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-nullability.nullablepassedtononnull">clang-analyzer-nullability.NullablePassedToNonnull</h1>
-<p>The clang-analyzer-nullability.NullablePassedToNonnull check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablepassedtononnull">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warns when a nullable pointer is passed to a pointer which has a _Nonnull type.</p>
+<p>The <span class="title-ref">clang-analyzer-nullability.NullablePassedToNonnull</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablepassedtononnull">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/nullability.NullablePassedToNonnull.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4709,8 +5923,12 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-nullability.NullableReturnedFromNonnull</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablereturnedfromnonnull">
+
+</div>
 <h1 id="clang-analyzer-nullability.nullablereturnedfromnonnull">clang-analyzer-nullability.NullableReturnedFromNonnull</h1>
 <p>Warns when a nullable pointer is returned from a function that has _Nonnull return type.</p>
+<p>The <span class="title-ref">clang-analyzer-nullability.NullableReturnedFromNonnull</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullablereturnedfromnonnull">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/nullability.NullableReturnedFromNonnull.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4727,7 +5945,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-nullability.nullpassedtononnull">clang-analyzer-nullability.NullPassedToNonnull</h1>
-<p>The clang-analyzer-nullability.NullPassedToNonnull check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullpassedtononnull">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warns when a null pointer is passed to a pointer which has a _Nonnull type.</p>
+<p>The <span class="title-ref">clang-analyzer-nullability.NullPassedToNonnull</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullpassedtononnull">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/nullability.NullPassedToNonnull.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4744,9 +5963,28 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-nullability.nullreturnedfromnonnull">clang-analyzer-nullability.NullReturnedFromNonnull</h1>
-<p>The clang-analyzer-nullability.NullReturnedFromNonnull check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullreturnedfromnonnull">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warns when a null pointer is returned from a function that has _Nonnull return type.</p>
+<p>The <span class="title-ref">clang-analyzer-nullability.NullReturnedFromNonnull</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#nullability-nullreturnedfromnonnull">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/nullability.NullReturnedFromNonnull.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-optin.core.EnumCastOutOfRange</key>
+    <name>clang-analyzer-optin.core.EnumCastOutOfRange</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - clang-analyzer-optin.core.EnumCastOutOfRange</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-enumcastoutofrange">
+
+</div>
+<h1 id="clang-analyzer-optin.core.enumcastoutofrange">clang-analyzer-optin.core.EnumCastOutOfRange</h1>
+<p>Check integer to enumeration casts for out of range values.</p>
+<p>The <span class="title-ref">clang-analyzer-optin.core.EnumCastOutOfRange</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-core-enumcastoutofrange">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.core.EnumCastOutOfRange.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -4761,7 +5999,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-optin.cplusplus.uninitializedobject">clang-analyzer-optin.cplusplus.UninitializedObject</h1>
-<p>The clang-analyzer-optin.cplusplus.UninitializedObject check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-uninitializedobject">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Reports uninitialized fields after object construction.</p>
+<p>The <span class="title-ref">clang-analyzer-optin.cplusplus.UninitializedObject</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-uninitializedobject">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.cplusplus.UninitializedObject.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4778,7 +6017,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-optin.cplusplus.virtualcall">clang-analyzer-optin.cplusplus.VirtualCall</h1>
-<p>The clang-analyzer-optin.cplusplus.VirtualCall check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-virtualcall">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check virtual function calls during construction/destruction.</p>
+<p>The <span class="title-ref">clang-analyzer-optin.cplusplus.VirtualCall</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-cplusplus-virtualcall">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.cplusplus.VirtualCall.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4795,7 +6035,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-optin.mpi.mpi-checker">clang-analyzer-optin.mpi.MPI-Checker</h1>
-<p>The clang-analyzer-optin.mpi.MPI-Checker check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-mpi-mpi-checker">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Checks MPI code.</p>
+<p>The <span class="title-ref">clang-analyzer-optin.mpi.MPI-Checker</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-mpi-mpi-checker">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.mpi.MPI-Checker.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4812,7 +6053,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-optin.osx.cocoa.localizability.emptylocalizationcontextchecker">clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker</h1>
-<p>The clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-emptylocalizationcontextchecker">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check that NSLocalizedString macros include a comment for context.</p>
+<p>The <span class="title-ref">clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-emptylocalizationcontextchecker">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.osx.cocoa.localizability.EmptyLocalizationContextChecker.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4829,7 +6071,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-optin.osx.cocoa.localizability.nonlocalizedstringchecker">clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker</h1>
-<p>The clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-nonlocalizedstringchecker">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warns about uses of non-localized NSStrings passed to UI methods expecting localized NSStrings.</p>
+<p>The <span class="title-ref">clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-osx-cocoa-localizability-nonlocalizedstringchecker">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.osx.cocoa.localizability.NonLocalizedStringChecker.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4843,7 +6086,8 @@ void func(const char *buff) {
 <p>clang-tidy - clang-analyzer-optin.osx.OSObjectCStyleCast</p>
 </div>
 <h1 id="clang-analyzer-optin.osx.osobjectcstylecast">clang-analyzer-optin.osx.OSObjectCStyleCast</h1>
-<p>Checker for C-style casts of OSObjects</p>
+<p>Checker for C-style casts of OSObjects.</p>
+<p>The clang-analyzer-optin.osx.OSObjectCStyleCast check is an alias of Clang Static Analyzer optin.osx.OSObjectCStyleCast.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.osx.OSObjectCStyleCast.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4856,8 +6100,12 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-optin.performance.GCDAntipattern</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-performance-gcdantipattern">
+
+</div>
 <h1 id="clang-analyzer-optin.performance.gcdantipattern">clang-analyzer-optin.performance.GCDAntipattern</h1>
-<p>Check for performance anti-patterns when using Grand Central Dispatch</p>
+<p>Check for performance anti-patterns when using Grand Central Dispatch.</p>
+<p>The <span class="title-ref">clang-analyzer-optin.performance.GCDAntipattern</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-performance-gcdantipattern">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.performance.GCDAntipattern.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4870,8 +6118,12 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-optin.performance.Padding</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-performance-padding">
+
+</div>
 <h1 id="clang-analyzer-optin.performance.padding">clang-analyzer-optin.performance.Padding</h1>
 <p>Check for excessively padded structs.</p>
+<p>The <span class="title-ref">clang-analyzer-optin.performance.Padding</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-performance-padding">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.performance.Padding.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4884,8 +6136,12 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-optin.portability.UnixAPI</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-portability-unixapi">
+
+</div>
 <h1 id="clang-analyzer-optin.portability.unixapi">clang-analyzer-optin.portability.UnixAPI</h1>
-<p>Finds implementation-defined behavior in UNIX/Posix functions</p>
+<p>Finds implementation-defined behavior in UNIX/Posix functions.</p>
+<p>The <span class="title-ref">clang-analyzer-optin.portability.UnixAPI</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-portability-unixapi">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.portability.UnixAPI.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4902,7 +6158,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.api">clang-analyzer-osx.API</h1>
-<p>The clang-analyzer-osx.API check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-api">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for proper uses of various Apple APIs.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.API</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-api">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.API.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4919,7 +6176,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.cocoa.atsync">clang-analyzer-osx.cocoa.AtSync</h1>
-<p>The clang-analyzer-osx.cocoa.AtSync check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-atsync">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for nil pointers used as mutexes for @synchronized.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.AtSync</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-atsync">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.AtSync.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4932,8 +6190,12 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-osx.cocoa.AutoreleaseWrite</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-autoreleasewrite">
+
+</div>
 <h1 id="clang-analyzer-osx.cocoa.autoreleasewrite">clang-analyzer-osx.cocoa.AutoreleaseWrite</h1>
-<p>Warn about potentially crashing writes to autoreleasing objects from different autoreleasing pools in Objective-C</p>
+<p>Warn about potentially crashing writes to autoreleasing objects from different autoreleasing pools in Objective-C.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.AutoreleaseWrite</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-autoreleasewrite">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.AutoreleaseWrite.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4950,7 +6212,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.cocoa.classrelease">clang-analyzer-osx.cocoa.ClassRelease</h1>
-<p>The clang-analyzer-osx.cocoa.ClassRelease check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-classrelease">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for sending 'retain', 'release', or 'autorelease' directly to a Class.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.ClassRelease</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-classrelease">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.ClassRelease.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4967,7 +6230,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.cocoa.dealloc">clang-analyzer-osx.cocoa.Dealloc</h1>
-<p>The clang-analyzer-osx.cocoa.Dealloc check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-dealloc">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn about Objective-C classes that lack a correct implementation of -dealloc.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.Dealloc</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-dealloc">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.Dealloc.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4984,7 +6248,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.cocoa.incompatiblemethodtypes">clang-analyzer-osx.cocoa.IncompatibleMethodTypes</h1>
-<p>The clang-analyzer-osx.cocoa.IncompatibleMethodTypes check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-incompatiblemethodtypes">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn about Objective-C method signatures with type incompatibilities.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.IncompatibleMethodTypes</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-incompatiblemethodtypes">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.IncompatibleMethodTypes.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -4997,8 +6262,12 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-osx.cocoa.Loops</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-loops">
+
+</div>
 <h1 id="clang-analyzer-osx.cocoa.loops">clang-analyzer-osx.cocoa.Loops</h1>
-<p>Improved modeling of loops using Cocoa collection types</p>
+<p>Improved modeling of loops using Cocoa collection types.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.Loops</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-loops">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.Loops.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5011,8 +6280,12 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-osx.cocoa.MissingSuperCall</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-missingsupercall">
+
+</div>
 <h1 id="clang-analyzer-osx.cocoa.missingsupercall">clang-analyzer-osx.cocoa.MissingSuperCall</h1>
-<p>Warn about Objective-C methods that lack a necessary call to super</p>
+<p>Warn about Objective-C methods that lack a necessary call to super.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.MissingSuperCall</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-missingsupercall">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.MissingSuperCall.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5029,7 +6302,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.cocoa.nilarg">clang-analyzer-osx.cocoa.NilArg</h1>
-<p>The clang-analyzer-osx.cocoa.NilArg check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nilarg">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for prohibited nil arguments to ObjC method calls.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.NilArg</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nilarg">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.NilArg.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5042,8 +6316,12 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-osx.cocoa.NonNilReturnValue</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nonnilreturnvalue">
+
+</div>
 <h1 id="clang-analyzer-osx.cocoa.nonnilreturnvalue">clang-analyzer-osx.cocoa.NonNilReturnValue</h1>
-<p>Model the APIs that are guaranteed to return a non-nil value</p>
+<p>Model the APIs that are guaranteed to return a non-nil value.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.NonNilReturnValue</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nonnilreturnvalue">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.NonNilReturnValue.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5060,7 +6338,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.cocoa.nsautoreleasepool">clang-analyzer-osx.cocoa.NSAutoreleasePool</h1>
-<p>The clang-analyzer-osx.cocoa.NSAutoreleasePool check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nsautoreleasepool">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn for suboptimal uses of NSAutoreleasePool in Objective-C GC mode.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.NSAutoreleasePool</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nsautoreleasepool">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.NSAutoreleasePool.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5077,7 +6356,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.cocoa.nserror">clang-analyzer-osx.cocoa.NSError</h1>
-<p>The clang-analyzer-osx.cocoa.NSError check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nserror">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check usage of NSError** parameters.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.NSError</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-nserror">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.NSError.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5094,7 +6374,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.cocoa.objcgenerics">clang-analyzer-osx.cocoa.ObjCGenerics</h1>
-<p>The clang-analyzer-osx.cocoa.ObjCGenerics check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-objcgenerics">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for type errors when using Objective-C generics.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.ObjCGenerics</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-objcgenerics">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.ObjCGenerics.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5111,7 +6392,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.cocoa.retaincount">clang-analyzer-osx.cocoa.RetainCount</h1>
-<p>The clang-analyzer-osx.cocoa.RetainCount check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-retaincount">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for leaks and improper reference count management.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.RetainCount</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-retaincount">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.RetainCount.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5124,8 +6406,12 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-osx.cocoa.RunLoopAutoreleaseLeak</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-runloopautoreleaseleak">
+
+</div>
 <h1 id="clang-analyzer-osx.cocoa.runloopautoreleaseleak">clang-analyzer-osx.cocoa.RunLoopAutoreleaseLeak</h1>
-<p>Check for leaked memory in autorelease pools that will never be drained</p>
+<p>Check for leaked memory in autorelease pools that will never be drained.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.RunLoopAutoreleaseLeak</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-runloopautoreleaseleak">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.RunLoopAutoreleaseLeak.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5142,7 +6428,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.cocoa.selfinit">clang-analyzer-osx.cocoa.SelfInit</h1>
-<p>The clang-analyzer-osx.cocoa.SelfInit check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-selfinit">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check that 'self' is properly initialized inside an initializer method.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.SelfInit</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-selfinit">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.SelfInit.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5159,7 +6446,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.cocoa.superdealloc">clang-analyzer-osx.cocoa.SuperDealloc</h1>
-<p>The clang-analyzer-osx.cocoa.SuperDealloc check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-superdealloc">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn about improper use of '[super dealloc]' in Objective-C.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.SuperDealloc</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-superdealloc">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.SuperDealloc.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5176,7 +6464,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.cocoa.unusedivars">clang-analyzer-osx.cocoa.UnusedIvars</h1>
-<p>The clang-analyzer-osx.cocoa.UnusedIvars check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-unusedivars">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn about private ivars that are never used.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.UnusedIvars</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-unusedivars">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.UnusedIvars.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5193,7 +6482,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.cocoa.variadicmethodtypes">clang-analyzer-osx.cocoa.VariadicMethodTypes</h1>
-<p>The clang-analyzer-osx.cocoa.VariadicMethodTypes check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-variadicmethodtypes">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for passing non-Objective-C types to variadic collection initialization methods that expect only Objective-C types.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.cocoa.VariadicMethodTypes</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-cocoa-variadicmethodtypes">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.cocoa.VariadicMethodTypes.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5210,7 +6500,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.corefoundation.cferror">clang-analyzer-osx.coreFoundation.CFError</h1>
-<p>The clang-analyzer-osx.coreFoundation.CFError check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cferror">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check usage of CFErrorRef* parameters.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.coreFoundation.CFError</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cferror">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFError.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5227,7 +6518,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.corefoundation.cfnumber">clang-analyzer-osx.coreFoundation.CFNumber</h1>
-<p>The clang-analyzer-osx.coreFoundation.CFNumber check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfnumber">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for proper uses of CFNumber APIs.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.coreFoundation.CFNumber</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfnumber">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFNumber.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5244,7 +6536,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.corefoundation.cfretainrelease">clang-analyzer-osx.coreFoundation.CFRetainRelease</h1>
-<p>The clang-analyzer-osx.coreFoundation.CFRetainRelease check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfretainrelease">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for null arguments to CFRetain/CFRelease/CFMakeCollectable.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.coreFoundation.CFRetainRelease</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-cfretainrelease">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.coreFoundation.CFRetainRelease.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5261,7 +6554,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.corefoundation.containers.outofbounds">clang-analyzer-osx.coreFoundation.containers.OutOfBounds</h1>
-<p>The clang-analyzer-osx.coreFoundation.containers.OutOfBounds check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-outofbounds">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Checks for index out-of-bounds when using 'CFArray' API.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.coreFoundation.containers.OutOfBounds</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-outofbounds">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.coreFoundation.containers.OutOfBounds.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5278,7 +6572,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.corefoundation.containers.pointersizedvalues">clang-analyzer-osx.coreFoundation.containers.PointerSizedValues</h1>
-<p>The clang-analyzer-osx.coreFoundation.containers.PointerSizedValues check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-pointersizedvalues">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warns if 'CFArray', 'CFDictionary', 'CFSet' are created with non-pointer-size values.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.coreFoundation.containers.PointerSizedValues</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-corefoundation-containers-pointersizedvalues">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.coreFoundation.containers.PointerSizedValues.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5292,7 +6587,8 @@ void func(const char *buff) {
 <p>clang-tidy - clang-analyzer-osx.MIG</p>
 </div>
 <h1 id="clang-analyzer-osx.mig">clang-analyzer-osx.MIG</h1>
-<p>Find violations of the Mach Interface Generator calling convention</p>
+<p>Find violations of the Mach Interface Generator calling convention.</p>
+<p>The clang-analyzer-osx.MIG check is an alias of Clang Static Analyzer osx.MIG.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.MIG.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5305,8 +6601,12 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-osx.NumberObjectConversion</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-numberobjectconversion">
+
+</div>
 <h1 id="clang-analyzer-osx.numberobjectconversion">clang-analyzer-osx.NumberObjectConversion</h1>
-<p>Check for erroneous conversions of objects representing numbers into numbers</p>
+<p>Check for erroneous conversions of objects representing numbers into numbers.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.NumberObjectConversion</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-numberobjectconversion">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.NumberObjectConversion.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5319,8 +6619,12 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-osx.ObjCProperty</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#osx-objcproperty">
+
+</div>
 <h1 id="clang-analyzer-osx.objcproperty">clang-analyzer-osx.ObjCProperty</h1>
-<p>Check for proper uses of Objective-C properties</p>
+<p>Check for proper uses of Objective-C properties.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.ObjCProperty</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-objcproperty">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.ObjCProperty.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5334,7 +6638,8 @@ void func(const char *buff) {
 <p>clang-tidy - clang-analyzer-osx.OSObjectRetainCount</p>
 </div>
 <h1 id="clang-analyzer-osx.osobjectretaincount">clang-analyzer-osx.OSObjectRetainCount</h1>
-<p>Check for leaks and improper reference count management for OSObject</p>
+<p>Check for leaks and improper reference count management for OSObject.</p>
+<p>The clang-analyzer-osx.OSObjectRetainCount check is an alias of Clang Static Analyzer osx.OSObjectRetainCount.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.OSObjectRetainCount.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5351,9 +6656,28 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-osx.seckeychainapi">clang-analyzer-osx.SecKeychainAPI</h1>
-<p>The clang-analyzer-osx.SecKeychainAPI check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-seckeychainapi">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for proper uses of Secure Keychain APIs.</p>
+<p>The <span class="title-ref">clang-analyzer-osx.SecKeychainAPI</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#osx-seckeychainapi">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/osx.SecKeychainAPI.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-security.cert.env.InvalidPtr</key>
+    <name>clang-analyzer-security.cert.env.InvalidPtr</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - clang-analyzer-security.cert.env.InvalidPtr</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-cert-env-invalidptr">
+
+</div>
+<h1 id="clang-analyzer-security.cert.env.invalidptr">clang-analyzer-security.cert.env.InvalidPtr</h1>
+<p>Finds usages of possibly invalidated pointers.</p>
+<p>The <span class="title-ref">clang-analyzer-security.cert.env.InvalidPtr</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-cert-env-invalidptr">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.cert.env.InvalidPtr.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -5368,7 +6692,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-security.floatloopcounter">clang-analyzer-security.FloatLoopCounter</h1>
-<p>The clang-analyzer-security.FloatLoopCounter check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-floatloopcounter">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn on using a floating point value as a loop counter (CERT: FLP30-C, FLP30-CPP).</p>
+<p>The <span class="title-ref">clang-analyzer-security.FloatLoopCounter</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-floatloopcounter">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.FloatLoopCounter.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5385,7 +6710,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-security.insecureapi.bcmp">clang-analyzer-security.insecureAPI.bcmp</h1>
-<p>The clang-analyzer-security.insecureAPI.bcmp check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcmp">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn on uses of the 'bcmp' function.</p>
+<p>The <span class="title-ref">clang-analyzer-security.insecureAPI.bcmp</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcmp">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.bcmp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5402,7 +6728,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-security.insecureapi.bcopy">clang-analyzer-security.insecureAPI.bcopy</h1>
-<p>The clang-analyzer-security.insecureAPI.bcopy check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcopy">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn on uses of the 'bcopy' function.</p>
+<p>The <span class="title-ref">clang-analyzer-security.insecureAPI.bcopy</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcopy">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.bcopy.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5419,9 +6746,25 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-security.insecureapi.bzero">clang-analyzer-security.insecureAPI.bzero</h1>
-<p>The clang-analyzer-security.insecureAPI.bzero check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bzero">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn on uses of the 'bzero' function.</p>
+<p>The <span class="title-ref">clang-analyzer-security.insecureAPI.bzero</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bzero">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.bzero.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-security.insecureAPI.decodeValueOfObjCType</key>
+    <name>clang-analyzer-security.insecureAPI.decodeValueOfObjCType</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - clang-analyzer-security.insecureAPI.decodeValueOfObjCType</p>
+</div>
+<h1 id="clang-analyzer-security.insecureapi.decodevalueofobjctype">clang-analyzer-security.insecureAPI.decodeValueOfObjCType</h1>
+<p>Warn on uses of the '-decodeValueOfObjCType:at:' method.</p>
+<p>The clang-analyzer-security.insecureAPI.decodeValueOfObjCType check is an alias of Clang Static Analyzer security.insecureAPI.decodeValueOfObjCType.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.decodeValueOfObjCType.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -5436,7 +6779,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-security.insecureapi.deprecatedorunsafebufferhandling">clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling</h1>
-<p>The clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-deprecatedorunsafebufferhandling">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn on uses of unsecure or deprecated buffer manipulating functions.</p>
+<p>The <span class="title-ref">clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-deprecatedorunsafebufferhandling">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.DeprecatedOrUnsafeBufferHandling.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5453,7 +6797,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-security.insecureapi.getpw">clang-analyzer-security.insecureAPI.getpw</h1>
-<p>The clang-analyzer-security.insecureAPI.getpw check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-getpw">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn on uses of the 'getpw' function.</p>
+<p>The <span class="title-ref">clang-analyzer-security.insecureAPI.getpw</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-getpw">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.getpw.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5470,7 +6815,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-security.insecureapi.gets">clang-analyzer-security.insecureAPI.gets</h1>
-<p>The clang-analyzer-security.insecureAPI.gets check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-gets">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn on uses of the 'gets' function.</p>
+<p>The <span class="title-ref">clang-analyzer-security.insecureAPI.gets</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-gets">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.gets.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5487,7 +6833,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-security.insecureapi.mkstemp">clang-analyzer-security.insecureAPI.mkstemp</h1>
-<p>The clang-analyzer-security.insecureAPI.mkstemp check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mkstemp">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn when 'mkstemp' is passed fewer than 6 X's in the format string.</p>
+<p>The <span class="title-ref">clang-analyzer-security.insecureAPI.mkstemp</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mkstemp">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.mkstemp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5504,7 +6851,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-security.insecureapi.mktemp">clang-analyzer-security.insecureAPI.mktemp</h1>
-<p>The clang-analyzer-security.insecureAPI.mktemp check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mktemp">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn on uses of the 'mktemp' function.</p>
+<p>The <span class="title-ref">clang-analyzer-security.insecureAPI.mktemp</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mktemp">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.mktemp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5521,7 +6869,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-security.insecureapi.rand">clang-analyzer-security.insecureAPI.rand</h1>
-<p>The clang-analyzer-security.insecureAPI.rand check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-rand">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn on uses of the 'rand', 'random', and related functions.</p>
+<p>The <span class="title-ref">clang-analyzer-security.insecureAPI.rand</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-rand">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.rand.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5538,7 +6887,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-security.insecureapi.strcpy">clang-analyzer-security.insecureAPI.strcpy</h1>
-<p>The clang-analyzer-security.insecureAPI.strcpy check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-strcpy">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn on uses of the 'strcpy' and 'strcat' functions.</p>
+<p>The <span class="title-ref">clang-analyzer-security.insecureAPI.strcpy</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-strcpy">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.strcpy.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5555,7 +6905,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-security.insecureapi.uncheckedreturn">clang-analyzer-security.insecureAPI.UncheckedReturn</h1>
-<p>The clang-analyzer-security.insecureAPI.UncheckedReturn check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-uncheckedreturn">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn on uses of functions whose return values must be always checked.</p>
+<p>The <span class="title-ref">clang-analyzer-security.insecureAPI.UncheckedReturn</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-uncheckedreturn">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.UncheckedReturn.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5572,7 +6923,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-security.insecureapi.vfork">clang-analyzer-security.insecureAPI.vfork</h1>
-<p>The clang-analyzer-security.insecureAPI.vfork check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-vfork">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Warn on uses of the 'vfork' function.</p>
+<p>The <span class="title-ref">clang-analyzer-security.insecureAPI.vfork</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-vfork">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.insecureAPI.vfork.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5589,7 +6941,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-unix.api">clang-analyzer-unix.API</h1>
-<p>The clang-analyzer-unix.API check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-api">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check calls to various UNIX/Posix functions.</p>
+<p>The <span class="title-ref">clang-analyzer-unix.API</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-api">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.API.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5606,7 +6959,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-unix.cstring.badsizearg">clang-analyzer-unix.cstring.BadSizeArg</h1>
-<p>The clang-analyzer-unix.cstring.BadSizeArg check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-badsizearg">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check the size argument passed into C string functions for common erroneous patterns.</p>
+<p>The <span class="title-ref">clang-analyzer-unix.cstring.BadSizeArg</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-badsizearg">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.cstring.BadSizeArg.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5623,9 +6977,28 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-unix.cstring.nullarg">clang-analyzer-unix.cstring.NullArg</h1>
-<p>The clang-analyzer-unix.cstring.NullArg check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-nullarg">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for null pointers being passed as arguments to C string functions.</p>
+<p>The <span class="title-ref">clang-analyzer-unix.cstring.NullArg</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-cstring-nullarg">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.cstring.NullArg.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-unix.Errno</key>
+    <name>clang-analyzer-unix.Errno</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - clang-analyzer-unix.Errno</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-errno">
+
+</div>
+<h1 id="clang-analyzer-unix.errno">clang-analyzer-unix.Errno</h1>
+<p>Check for improper use of 'errno'.</p>
+<p>The <span class="title-ref">clang-analyzer-unix.Errno</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-errno">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.Errno.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -5640,7 +7013,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-unix.malloc">clang-analyzer-unix.Malloc</h1>
-<p>The clang-analyzer-unix.Malloc check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-malloc">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for memory leaks, double free, and use-after-free problems. Traces memory managed by malloc()/free().</p>
+<p>The <span class="title-ref">clang-analyzer-unix.Malloc</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-malloc">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.Malloc.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5657,7 +7031,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-unix.mallocsizeof">clang-analyzer-unix.MallocSizeof</h1>
-<p>The clang-analyzer-unix.MallocSizeof check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-mallocsizeof">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for dubious malloc arguments involving sizeof.</p>
+<p>The <span class="title-ref">clang-analyzer-unix.MallocSizeof</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-mallocsizeof">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.MallocSizeof.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5674,9 +7049,28 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-unix.mismatcheddeallocator">clang-analyzer-unix.MismatchedDeallocator</h1>
-<p>The clang-analyzer-unix.MismatchedDeallocator check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-mismatcheddeallocator">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for mismatched deallocators.</p>
+<p>The <span class="title-ref">clang-analyzer-unix.MismatchedDeallocator</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-mismatcheddeallocator">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.MismatchedDeallocator.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-unix.StdCLibraryFunctions</key>
+    <name>clang-analyzer-unix.StdCLibraryFunctions</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - clang-analyzer-unix.StdCLibraryFunctions</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-stdclibraryfunctions">
+
+</div>
+<h1 id="clang-analyzer-unix.stdclibraryfunctions">clang-analyzer-unix.StdCLibraryFunctions</h1>
+<p>Check for invalid arguments of C standard library functions, and apply relations between arguments and return value.</p>
+<p>The <span class="title-ref">clang-analyzer-unix.StdCLibraryFunctions</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-stdclibraryfunctions">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.StdCLibraryFunctions.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -5691,7 +7085,8 @@ void func(const char *buff) {
 
 </div>
 <h1 id="clang-analyzer-unix.vfork">clang-analyzer-unix.Vfork</h1>
-<p>The clang-analyzer-unix.Vfork check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-vfork">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<p>Check for proper usage of vfork.</p>
+<p>The <span class="title-ref">clang-analyzer-unix.Vfork</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-vfork">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.Vfork.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5706,6 +7101,7 @@ void func(const char *buff) {
 </div>
 <h1 id="clang-analyzer-valist.copytoself">clang-analyzer-valist.CopyToSelf</h1>
 <p>Check for va_lists which are copied onto itself.</p>
+<p>The clang-analyzer-valist.CopyToSelf check is an alias of Clang Static Analyzer valist.CopyToSelf.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/valist.CopyToSelf.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5720,6 +7116,7 @@ void func(const char *buff) {
 </div>
 <h1 id="clang-analyzer-valist.uninitialized">clang-analyzer-valist.Uninitialized</h1>
 <p>Check for usages of uninitialized (or already released) va_lists.</p>
+<p>The clang-analyzer-valist.Uninitialized check is an alias of Clang Static Analyzer valist.Uninitialized.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/valist.Uninitialized.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5734,8 +7131,63 @@ void func(const char *buff) {
 </div>
 <h1 id="clang-analyzer-valist.unterminated">clang-analyzer-valist.Unterminated</h1>
 <p>Check for va_lists which are not released by a va_end call.</p>
+<p>The clang-analyzer-valist.Unterminated check is an alias of Clang Static Analyzer valist.Unterminated.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/valist.Unterminated.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-webkit.NoUncountedMemberChecker</key>
+    <name>clang-analyzer-webkit.NoUncountedMemberChecker</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - clang-analyzer-webkit.NoUncountedMemberChecker</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#webkit-nouncountedmemberchecker">
+
+</div>
+<h1 id="clang-analyzer-webkit.nouncountedmemberchecker">clang-analyzer-webkit.NoUncountedMemberChecker</h1>
+<p>Check for no uncounted member variables.</p>
+<p>The <span class="title-ref">clang-analyzer-webkit.NoUncountedMemberChecker</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#webkit-nouncountedmemberchecker">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/webkit.NoUncountedMemberChecker.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-webkit.RefCntblBaseVirtualDtor</key>
+    <name>clang-analyzer-webkit.RefCntblBaseVirtualDtor</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - clang-analyzer-webkit.RefCntblBaseVirtualDtor</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#webkit-refcntblbasevirtualdtor">
+
+</div>
+<h1 id="clang-analyzer-webkit.refcntblbasevirtualdtor">clang-analyzer-webkit.RefCntblBaseVirtualDtor</h1>
+<p>Check for any ref-countable base class having virtual destructor.</p>
+<p>The <span class="title-ref">clang-analyzer-webkit.RefCntblBaseVirtualDtor</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#webkit-refcntblbasevirtualdtor">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/webkit.RefCntblBaseVirtualDtor.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-webkit.UncountedLambdaCapturesChecker</key>
+    <name>clang-analyzer-webkit.UncountedLambdaCapturesChecker</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - clang-analyzer-webkit.UncountedLambdaCapturesChecker</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#webkit-uncountedlambdacaptureschecker">
+
+</div>
+<h1 id="clang-analyzer-webkit.uncountedlambdacaptureschecker">clang-analyzer-webkit.UncountedLambdaCapturesChecker</h1>
+<p>Check uncounted lambda captures.</p>
+<p>The <span class="title-ref">clang-analyzer-webkit.UncountedLambdaCapturesChecker</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#webkit-uncountedlambdacaptureschecker">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/webkit.UncountedLambdaCapturesChecker.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -5779,9 +7231,7 @@ sleep(1); // implementation may use SIGALRM</code></pre>
 </div>
 <h1 id="concurrency-thread-canceltype-asynchronous">concurrency-thread-canceltype-asynchronous</h1>
 <p>Finds <code>pthread_setcanceltype</code> function calls where a thread's cancellation type is set to asynchronous. Asynchronous cancellation type (<code>PTHREAD_CANCEL_ASYNCHRONOUS</code>) is generally unsafe, use type <code>PTHREAD_CANCEL_DEFERRED</code> instead which is the default. Even with deferred cancellation, a cancellation point in an asynchronous signal handler may still be acted upon and the effect is as if it was an asynchronous cancellation.</p>
-<blockquote>
-<p>pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &amp;oldtype);</p>
-</blockquote>
+<pre class="c++"><code>pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &amp;oldtype);</code></pre>
 <p>This check corresponds to the CERT C Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/c/POS47-C.+Do+not+use+threads+that+can+be+canceled+asynchronously">POS47-C. Do not use threads that can be canceled asynchronously</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/concurrency/thread-canceltype-asynchronous.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -5799,9 +7249,119 @@ sleep(1); // implementation may use SIGALRM</code></pre>
 
 </div>
 <h1 id="cppcoreguidelines-avoid-c-arrays">cppcoreguidelines-avoid-c-arrays</h1>
-<p>The cppcoreguidelines-avoid-c-arrays check is an alias, please see <a href="../modernize/avoid-c-arrays.html">modernize-avoid-c-arrays</a> for more information.</p>
+<p>The cppcoreguidelines-avoid-c-arrays check is an alias, please see <code class="interpreted-text" role="doc">modernize-avoid-c-arrays &lt;../modernize/avoid-c-arrays&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-c-arrays.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>cppcoreguidelines-avoid-capturing-lambda-coroutines</key>
+    <name>cppcoreguidelines-avoid-capturing-lambda-coroutines</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-avoid-capturing-lambda-coroutines</p>
+</div>
+<h1 id="cppcoreguidelines-avoid-capturing-lambda-coroutines">cppcoreguidelines-avoid-capturing-lambda-coroutines</h1>
+<p>Flags C++20 coroutine lambdas with non-empty capture lists that may cause use-after-free errors and suggests avoiding captures or ensuring the lambda closure object has a guaranteed lifetime.</p>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rcoro-capture">CP.51</a> from the C++ Core Guidelines.</p>
+<p>Using coroutine lambdas with non-empty capture lists can be risky, as capturing variables can lead to accessing freed memory after the first suspension point. This issue can occur even with refcounted smart pointers and copyable types. When a lambda expression creates a coroutine, it results in a closure object with storage, which is often on the stack and will eventually go out of scope. When the closure object goes out of scope, its captures also go out of scope. While normal lambdas finish executing before this happens, coroutine lambdas may resume from suspension after the closure object has been destructed, resulting in use-after-free memory access for all captures.</p>
+<p>Consider the following example:</p>
+<pre class="c++"><code>int value = get_value();
+std::shared_ptr&lt;Foo&gt; sharedFoo = get_foo();
+{
+    const auto lambda = [value, sharedFoo]() -&gt; std::future&lt;void&gt;
+    {
+        co_await something();
+        // &quot;sharedFoo&quot; and &quot;value&quot; have already been destroyed
+        // the &quot;shared&quot; pointer didn&#39;t accomplish anything
+    };
+    lambda();
+} // the lambda closure object has now gone out of scope</code></pre>
+<p>In this example, the lambda object is defined with two captures: value and <code>sharedFoo</code>. When <code>lambda()</code> is called, the lambda object is created on the stack, and the captures are copied into the closure object. When the coroutine is suspended, the lambda object goes out of scope, and the closure object is destroyed. When the coroutine is resumed, the captured variables may have been destroyed, resulting in use-after-free bugs.</p>
+<p>In conclusion, the use of coroutine lambdas with non-empty capture lists can lead to use-after-free errors when resuming the coroutine after the closure object has been destroyed. This check helps prevent such errors by flagging C++20 coroutine lambdas with non-empty capture lists and suggesting avoiding captures or ensuring the lambda closure object has a guaranteed lifetime.</p>
+<p>Following these guidelines can help ensure the safe and reliable use of coroutine lambdas in C++ code.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-capturing-lambda-coroutines.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>cppcoreguidelines-avoid-const-or-ref-data-members</key>
+    <name>cppcoreguidelines-avoid-const-or-ref-data-members</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-avoid-const-or-ref-data-members</p>
+</div>
+<h1 id="cppcoreguidelines-avoid-const-or-ref-data-members">cppcoreguidelines-avoid-const-or-ref-data-members</h1>
+<p>This check warns when structs or classes that are copyable or movable, and have const-qualified or reference (lvalue or rvalue) data members. Having such members is rarely useful, and makes the class only copy-constructible but not copy-assignable.</p>
+<p>Examples:</p>
+<pre class="c++"><code>// Bad, const-qualified member
+struct Const {
+  const int x;
+}
+
+// Good:
+class Foo {
+ public:
+  int get() const { return x; }
+ private:
+  int x;
+};
+
+// Bad, lvalue reference member
+struct Ref {
+  int&amp; x;
+};
+
+// Good:
+struct Foo {
+  int* x;
+  std::unique_ptr&lt;int&gt; x;
+  std::shared_ptr&lt;int&gt; x;
+  gsl::not_null&lt;int&gt; x;
+};
+
+// Bad, rvalue reference member
+struct RefRef {
+  int&amp;&amp; x;
+};</code></pre>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-constref">C.12</a> from the C++ Core Guidelines.</p>
+<p>Further reading: <a href="https://quuxplusone.github.io/blog/2022/01/23/dont-const-all-the-things/#data-members-never-const">Data members: Never const</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-const-or-ref-data-members.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>cppcoreguidelines-avoid-do-while</key>
+    <name>cppcoreguidelines-avoid-do-while</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-avoid-do-while</p>
+</div>
+<h1 id="cppcoreguidelines-avoid-do-while">cppcoreguidelines-avoid-do-while</h1>
+<p>Warns when using <code>do-while</code> loops. They are less readable than plain <code>while</code> loops, since the termination condition is at the end and the condition is not checked prior to the first iteration. This can lead to subtle bugs.</p>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-do">ES.75</a> from the C++ Core Guidelines.</p>
+<p>Examples:</p>
+<pre class="c++"><code>int x;
+do {
+    std::cin &gt;&gt; x;
+    // ...
+} while (x &lt; 0);</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>Ignore the check when analyzing macros. This is useful for safely defining function-like macros:</p>
+<pre class="c++"><code>#define FOO_BAR(x) \
+do { \
+  foo(x); \
+  bar(x); \
+} while(0)</code></pre>
+<p>Defaults to <span class="title-ref">false</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-do-while.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -5814,7 +7374,7 @@ sleep(1); // implementation may use SIGALRM</code></pre>
 </div>
 <h1 id="cppcoreguidelines-avoid-goto">cppcoreguidelines-avoid-goto</h1>
 <p>The usage of <code>goto</code> for control flow is error prone and should be replaced with looping constructs. Only forward jumps in nested loops are accepted.</p>
-<p>This check implements <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es76-avoid-goto">ES.76</a> from the CppCoreGuidelines and <a href="http://www.codingstandard.com/rule/6-3-1-ensure-that-the-labels-for-a-jump-statement-or-a-switch-condition-appear-later-in-the-same-or-an-enclosing-block/">6.3.1 from High Integrity C++</a>.</p>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es76-avoid-goto">ES.76</a> from the C++ Core Guidelines and <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements">6.3.1</a> from High Integrity C++ Coding Standard.</p>
 <p>For more information on why to avoid programming with <code>goto</code> you can read the famous paper <a href="https://www.cs.utexas.edu/users/EWD/ewd02xx/EWD215.PDF">A Case against the GO TO Statement.</a>.</p>
 <p>The check diagnoses <code>goto</code> for backward jumps in every language mode. These should be replaced with <span class="title-ref">C/C++</span> looping constructs.</p>
 <pre class="c++"><code>// Bad, handwritten for loop.
@@ -5857,7 +7417,7 @@ some_operation();</code></pre>
 
 </div>
 <h1 id="cppcoreguidelines-avoid-magic-numbers">cppcoreguidelines-avoid-magic-numbers</h1>
-<p>The cppcoreguidelines-avoid-magic-numbers check is an alias, please see <a href="../readability/magic-numbers.html">readability-magic-numbers</a> for more information.</p>
+<p>The cppcoreguidelines-avoid-magic-numbers check is an alias, please see <code class="interpreted-text" role="doc">readability-magic-numbers &lt;../readability/magic-numbers&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-magic-numbers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5871,7 +7431,7 @@ some_operation();</code></pre>
 <p>clang-tidy - cppcoreguidelines-avoid-non-const-global-variables</p>
 </div>
 <h1 id="cppcoreguidelines-avoid-non-const-global-variables">cppcoreguidelines-avoid-non-const-global-variables</h1>
-<p>Finds non-const global variables as described in <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-global">I.2 of C++ Core Guidelines</a> . As <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-global">R.6 of C++ Core Guidelines</a> is a duplicate of rule I.2 it also covers that rule.</p>
+<p>Finds non-const global variables as described in <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#i2-avoid-non-const-global-variables">I.2</a> of C++ Core Guidelines. As <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-global">R.6</a> of C++ Core Guidelines is a duplicate of rule <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#i2-avoid-non-const-global-variables">I.2</a> it also covers that rule.</p>
 <pre class="c++"><code>char a;  // Warns!
 const char b =  0;
 
@@ -5895,9 +7455,30 @@ protected:
 private:
     char h = 0;
 };</code></pre>
-<p>Variables: <code>a</code>, <code>c</code>, <code>c_ptr1</code>, <code>c_ptr2</code>, <code>c_const_ptr</code> and <code>c_reference</code>, will all generate warnings since they are either: a globally accessible variable and non-const, a pointer or reference providing global access to non-const data or both.</p>
+<p>The variables <code>a</code>, <code>c</code>, <code>c_ptr1</code>, <code>c_const_ptr</code> and <code>c_reference</code> will all generate warnings since they are either a non-const globally accessible variable, a pointer or a reference providing global access to non-const data or both.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-non-const-global-variables.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>cppcoreguidelines-avoid-reference-coroutine-parameters</key>
+    <name>cppcoreguidelines-avoid-reference-coroutine-parameters</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-avoid-reference-coroutine-parameters</p>
+</div>
+<h1 id="cppcoreguidelines-avoid-reference-coroutine-parameters">cppcoreguidelines-avoid-reference-coroutine-parameters</h1>
+<p>Warns when a coroutine accepts reference parameters. After a coroutine suspend point, references could be dangling and no longer valid. Instead, pass parameters as values.</p>
+<p>Examples:</p>
+<pre class="c++"><code>std::future&lt;int&gt; someCoroutine(int&amp; val) {
+  co_await ...;
+  // When the coroutine is resumed, &#39;val&#39; might no longer be valid.
+  if (val) ...
+}</code></pre>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rcoro-reference-parameters">CP.53</a> from the C++ Core Guidelines.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-reference-coroutine-parameters.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -5912,7 +7493,7 @@ private:
 
 </div>
 <h1 id="cppcoreguidelines-c-copy-assignment-signature">cppcoreguidelines-c-copy-assignment-signature</h1>
-<p>The cppcoreguidelines-c-copy-assignment-signature check is an alias, please see <a href="../misc/unconventional-assign-operator.html">misc-unconventional-assign-operator</a> for more information.</p>
+<p>The <span class="title-ref">cppcoreguidelines-c-copy-assignment-signature</span> check is an alias, please see <code class="interpreted-text" role="doc">misc-unconventional-assign-operator &lt;../misc/unconventional-assign-operator&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/c-copy-assignment-signature.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5929,7 +7510,7 @@ private:
 
 </div>
 <h1 id="cppcoreguidelines-explicit-virtual-functions">cppcoreguidelines-explicit-virtual-functions</h1>
-<p>The cppcoreguidelines-explicit-virtual-functions check is an alias, please see <a href="../modernize/use-override.html">modernize-use-override</a> for more information.</p>
+<p>The <span class="title-ref">cppcoreguidelines-explicit-virtual-functions</span> check is an alias, please see <code class="interpreted-text" role="doc">modernize-use-override &lt;../modernize/use-override&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/explicit-virtual-functions.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -5944,6 +7525,7 @@ private:
 </div>
 <h1 id="cppcoreguidelines-init-variables">cppcoreguidelines-init-variables</h1>
 <p>Checks whether there are local variables that are declared without an initial value. These may lead to unexpected behavior if there is a code path that reads the variable before assigning to it.</p>
+<p>This rule is part of the <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-init">Type safety (Type.5)</a> profile and <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-always">ES.20</a> from the C++ Core Guidelines.</p>
 <p>Only integers, booleans, floats, doubles and pointers are checked. The fix option initializes all detected values with the value of zero. An exception is float and double types, which are initialized to NaN.</p>
 <p>As an example a function that looks like this:</p>
 <pre class="c++"><code>void function() {
@@ -5997,11 +7579,28 @@ void function() {
 </div>
 <h1 id="cppcoreguidelines-interfaces-global-init">cppcoreguidelines-interfaces-global-init</h1>
 <p>This check flags initializers of globals that access extern objects, and therefore can lead to order-of-initialization problems.</p>
-<p>This rule is part of the "Interfaces" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-global-init">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-global-init</a></p>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Ri-global-init">I.22</a> from the C++ Core Guidelines.</p>
 <p>Note that currently this does not flag calls to non-constexpr functions, and therefore globals could still be accessed from functions themselves.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/interfaces-global-init.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
+    </rule>
+  <rule>
+    <key>cppcoreguidelines-macro-to-enum</key>
+    <name>cppcoreguidelines-macro-to-enum</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-macro-to-enum</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/macro-to-enum.html">
+
+</div>
+<h1 id="cppcoreguidelines-macro-to-enum">cppcoreguidelines-macro-to-enum</h1>
+<p>The cppcoreguidelines-macro-to-enum check is an alias, please see <code class="interpreted-text" role="doc">modernize-macro-to-enum &lt;../modernize/macro-to-enum&gt;</code> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/macro-to-enum.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>cppcoreguidelines-macro-usage</key>
@@ -6012,7 +7611,7 @@ void function() {
 </div>
 <h1 id="cppcoreguidelines-macro-usage">cppcoreguidelines-macro-usage</h1>
 <p>Finds macro usage that is considered problematic because better language constructs exist for the task.</p>
-<p>The relevant sections in the C++ Core Guidelines are <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es31-dont-use-macros-for-constants-or-functions">ES.31</a>, and <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es32-use-all_caps-for-all-macro-names">ES.32</a>.</p>
+<p>The relevant sections in the C++ Core Guidelines are <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es31-dont-use-macros-for-constants-or-functions">ES.31</a>, and <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es32-use-all_caps-for-all-macro-names">ES.32</a>.</p>
 <p>Examples:</p>
 <pre class="c++"><code>#define C 0
 #define F1(x, y) ((a) &gt; (b) ? (a) : (b))
@@ -6055,6 +7654,87 @@ test.cpp:3:9: warning: variadic macro &#39;F2&#39; used; consider using a &#39;c
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>cppcoreguidelines-misleading-capture-default-by-value</key>
+    <name>cppcoreguidelines-misleading-capture-default-by-value</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-misleading-capture-default-by-value</p>
+</div>
+<h1 id="cppcoreguidelines-misleading-capture-default-by-value">cppcoreguidelines-misleading-capture-default-by-value</h1>
+<p>Warns when lambda specify a by-value capture default and capture <code>this</code>.</p>
+<p>By-value capture defaults in member functions can be misleading about whether data members are captured by value or reference. This occurs because specifying the capture default <code>[=]</code> actually captures the <code>this</code> pointer by value, not the data members themselves. As a result, data members are still indirectly accessed via the captured <code>this</code> pointer, which essentially means they are being accessed by reference. Therefore, even when using <code>[=]</code>, data members are effectively captured by reference, which might not align with the user's expectations.</p>
+<p>Examples:</p>
+<pre class="c++"><code>struct AClass {
+  int member;
+  void misleadingLogic() {
+    int local = 0;
+    member = 0;
+    auto f = [=]() mutable {
+      local += 1;
+      member += 1;
+    };
+    f();
+    // Here, local is 0 but member is 1
+  }
+
+  void clearLogic() {
+    int local = 0;
+    member = 0;
+    auto f = [this, local]() mutable {
+      local += 1;
+      member += 1;
+    };
+    f();
+    // Here, local is 0 but member is 1
+  }
+};</code></pre>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f54-when-writing-a-lambda-that-captures-this-or-any-class-data-member-dont-use--default-capture">F.54</a> from the C++ Core Guidelines.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/misleading-capture-default-by-value.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>cppcoreguidelines-missing-std-forward</key>
+    <name>cppcoreguidelines-missing-std-forward</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-missing-std-forward</p>
+</div>
+<h1 id="cppcoreguidelines-missing-std-forward">cppcoreguidelines-missing-std-forward</h1>
+<p>Warns when a forwarding reference parameter is not forwarded inside the function body.</p>
+<p>Example:</p>
+<pre class="c++"><code>template &lt;class T&gt;
+void wrapper(T&amp;&amp; t) {
+  impl(std::forward&lt;T&gt;(t), 1, 2); // Correct
+}
+
+template &lt;class T&gt;
+void wrapper2(T&amp;&amp; t) {
+  impl(t, 1, 2); // Oops - should use std::forward&lt;T&gt;(t)
+}
+
+template &lt;class T&gt;
+void wrapper3(T&amp;&amp; t) {
+  impl(std::move(t), 1, 2); // Also buggy - should use std::forward&lt;T&gt;(t)
+}
+
+template &lt;class F&gt;
+void wrapper_function(F&amp;&amp; f) {
+  std::forward&lt;F&gt;(f)(1, 2); // Correct
+}
+
+template &lt;class F&gt;
+void wrapper_function2(F&amp;&amp; f) {
+  f(1, 2); // Incorrect - may not invoke the desired qualified function operator
+}</code></pre>
+<p>This check implements <a href="http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-forward">F.19</a> from the C++ Core Guidelines.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/missing-std-forward.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>cppcoreguidelines-narrowing-conversions</key>
     <name>cppcoreguidelines-narrowing-conversions</name>
     <description>
@@ -6063,8 +7743,7 @@ test.cpp:3:9: warning: variadic macro &#39;F2&#39; used; consider using a &#39;c
 </div>
 <h1 id="cppcoreguidelines-narrowing-conversions">cppcoreguidelines-narrowing-conversions</h1>
 <p>Checks for silent narrowing conversions, e.g: <code>int i = 0; i += 0.1;</code>. While the issue is obvious in this former example, it might not be so in the following: <code>void MyClass::f(double d) { int_member_ += d; }</code>.</p>
-<p>This rule is part of the "Expressions and statements" profile of the C++ Core Guidelines, corresponding to rule ES.46. See</p>
-<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es46-avoid-lossy-narrowing-truncating-arithmetic-conversions">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es46-avoid-lossy-narrowing-truncating-arithmetic-conversions</a>.</p>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es46-avoid-lossy-narrowing-truncating-arithmetic-conversions">ES.46</a> from the C++ Core Guidelines.</p>
 <dl>
 <dt>We enforce only part of the guideline, more specifically, we flag narrowing conversions from:</dt>
 <dd><ul>
@@ -6136,7 +7815,8 @@ test.cpp:3:9: warning: variadic macro &#39;F2&#39; used; consider using a &#39;c
 <p>clang-tidy - cppcoreguidelines-no-malloc</p>
 </div>
 <h1 id="cppcoreguidelines-no-malloc">cppcoreguidelines-no-malloc</h1>
-<p>This check handles C-Style memory management using <code>malloc()</code>, <code>realloc()</code>, <code>calloc()</code> and <code>free()</code>. It warns about its use and tries to suggest the use of an appropriate RAII object. Furthermore, it can be configured to check against a user-specified list of functions that are used for memory management (e.g. <code>posix_memalign()</code>). See <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-mallocfree">C++ Core Guidelines</a>.</p>
+<p>This check handles C-Style memory management using <code>malloc()</code>, <code>realloc()</code>, <code>calloc()</code> and <code>free()</code>. It warns about its use and tries to suggest the use of an appropriate RAII object. Furthermore, it can be configured to check against a user-specified list of functions that are used for memory management (e.g. <code>posix_memalign()</code>).</p>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-mallocfree">R.10</a> from the C++ Core Guidelines.</p>
 <p>There is no attempt made to provide fix-it hints, since manual resource management isn't easily transformed automatically into RAII.</p>
 <pre class="c++"><code>// Warns each of the following lines.
 // Containers like std::vector or std::string should be used.
@@ -6167,6 +7847,93 @@ struct some_struct* s = (struct some_struct*) malloc(sizeof(struct some_struct))
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>cppcoreguidelines-no-suspend-with-lock</key>
+    <name>cppcoreguidelines-no-suspend-with-lock</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-no-suspend-with-lock</p>
+</div>
+<h1 id="cppcoreguidelines-no-suspend-with-lock">cppcoreguidelines-no-suspend-with-lock</h1>
+<p>Flags coroutines that suspend while a lock guard is in scope at the suspension point.</p>
+<p>When a coroutine suspends, any mutexes held by the coroutine will remain locked until the coroutine resumes and eventually destructs the lock guard. This can lead to long periods with a mutex held and runs the risk of deadlock.</p>
+<p>Instead, locks should be released before suspending a coroutine.</p>
+<p>This check only checks suspending coroutines while a lock_guard is in scope; it does not consider manual locking or unlocking of mutexes, e.g., through calls to <code>std::mutex::lock()</code>.</p>
+<p>Examples:</p>
+<pre class="c++"><code>future bad_coro() {
+  std::lock_guard lock{mtx};
+  ++some_counter;
+  co_await something(); // Suspending while holding a mutex
+}
+
+future good_coro() {
+  {
+    std::lock_guard lock{mtx};
+    ++some_counter;
+  }
+  // Destroy the lock_guard to release the mutex before suspending the coroutine
+  co_await something(); // Suspending while holding a mutex
+}</code></pre>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rcoro-locks">CP.52</a> from the C++ Core Guidelines.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/no-suspend-with-lock.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>cppcoreguidelines-noexcept-destructor</key>
+    <name>cppcoreguidelines-noexcept-destructor</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-noexcept-destructor</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../performance/noexcept-destructor.html">
+
+</div>
+<h1 id="cppcoreguidelines-noexcept-destructor">cppcoreguidelines-noexcept-destructor</h1>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c37-make-destructors-noexcept">C.37</a> from the C++ Core Guidelines.</p>
+<p>The <span class="title-ref">cppcoreguidelines-noexcept-destructor</span> check is an alias, please see <code class="interpreted-text" role="doc">performance-noexcept-destructor &lt;../performance/noexcept-destructor&gt;</code> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/noexcept-destructor.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>cppcoreguidelines-noexcept-move-operations</key>
+    <name>cppcoreguidelines-noexcept-move-operations</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-noexcept-move-operations</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../performance/noexcept-move-constructor.html">
+
+</div>
+<h1 id="cppcoreguidelines-noexcept-move-operations">cppcoreguidelines-noexcept-move-operations</h1>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c66-make-move-operations-noexcept">C.66</a> from the C++ Core Guidelines.</p>
+<p>The <span class="title-ref">cppcoreguidelines-noexcept-move-operations</span> check is an alias, please see <code class="interpreted-text" role="doc">performance-noexcept-move-constructor &lt;../performance/noexcept-move-constructor&gt;</code> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/noexcept-move-operations.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>cppcoreguidelines-noexcept-swap</key>
+    <name>cppcoreguidelines-noexcept-swap</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-noexcept-swap</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../performance/noexcept-swap.html">
+
+</div>
+<h1 id="cppcoreguidelines-noexcept-swap">cppcoreguidelines-noexcept-swap</h1>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c83-for-value-like-types-consider-providing-a-noexcept-swap-function">C.83</a> , <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c84-a-swap-function-must-not-fail">C.84</a> and <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c85-make-swap-noexcept">C.85</a> from the C++ Core Guidelines.</p>
+<p>The <span class="title-ref">cppcoreguidelines-noexcept-swap check</span> is an alias, please see <code class="interpreted-text" role="doc">performance-noexcept-swap &lt;../performance/noexcept-swap&gt;</code> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/noexcept-swap.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>cppcoreguidelines-non-private-member-variables-in-classes</key>
     <name>cppcoreguidelines-non-private-member-variables-in-classes</name>
     <description>
@@ -6177,7 +7944,7 @@ struct some_struct* s = (struct some_struct*) malloc(sizeof(struct some_struct))
 
 </div>
 <h1 id="cppcoreguidelines-non-private-member-variables-in-classes">cppcoreguidelines-non-private-member-variables-in-classes</h1>
-<p>The cppcoreguidelines-non-private-member-variables-in-classes check is an alias, please see <a href="../misc/non-private-member-variables-in-classes.html">misc-non-private-member-variables-in-classes</a> for more information.</p>
+<p>The cppcoreguidelines-non-private-member-variables-in-classes check is an alias, please see <code class="interpreted-text" role="doc">misc-non-private-member-variables-in-classes &lt;../misc/non-private-member-variables-in-classes&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/non-private-member-variables-in-classes.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6192,9 +7959,9 @@ struct some_struct* s = (struct some_struct*) malloc(sizeof(struct some_struct))
 </div>
 <h1 id="cppcoreguidelines-owning-memory">cppcoreguidelines-owning-memory</h1>
 <p>This check implements the type-based semantics of <code>gsl::owner&lt;T*&gt;</code>, which allows static analysis on code, that uses raw pointers to handle resources like dynamic memory, but won't introduce RAII concepts.</p>
-<p>The relevant sections in the <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md">C++ Core Guidelines</a> are I.11, C.33, R.3 and GSL.Views The definition of a <code>gsl::owner&lt;T*&gt;</code> is straight forward</p>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#i11-never-transfer-ownership-by-a-raw-pointer-t-or-reference-t">I.11</a>, <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c33-if-a-class-has-an-owning-pointer-member-define-a-destructor">C.33</a>, <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r3-a-raw-pointer-a-t-is-non-owning">R.3</a> and <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#SS-views">GSL.Views</a> from the C++ Core Guidelines. The definition of a <code>gsl::owner&lt;T*&gt;</code> is straight forward</p>
 <pre class="c++"><code>namespace gsl { template &lt;typename T&gt; owner = T; }</code></pre>
-<p>It is therefore simple to introduce the owner even without using an implementation of the <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#gsl-guideline-support-library">Guideline Support Library</a>.</p>
+<p>It is therefore simple to introduce the owner even without using an implementation of the <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#S-gsl">Guideline Support Library</a>.</p>
 <p>All checks are purely type based and not (yet) flow sensitive.</p>
 <p>The following examples will demonstrate the correct and incorrect initializations of owners, assignment is handled the same way. Note that both <code>new</code> and <code>malloc()</code>-like resource functions are considered to produce resources.</p>
 <pre class="c++"><code>// Creating an owner with factory functions is checked.
@@ -6294,7 +8061,7 @@ private:
 // Code, that yields a false positive.
 OwnedValue&lt;gsl::owner&lt;int*&gt;&gt; Owner(new int(42)); // Type deduction yield T -&gt; int *
 // False positive, getValue returns int* and not gsl::owner&lt;int*&gt;
-gsl::owner&lt;int*&gt; OwnedInt = Owner.getValue(); </code></pre>
+gsl::owner&lt;int*&gt; OwnedInt = Owner.getValue();</code></pre>
 <p>Another limitation of the current implementation is only the type based checking. Suppose you have code like the following:</p>
 <pre class="c++"><code>// Two owners with assigned resources
 gsl::owner&lt;int*&gt; Owner1 = new int(42);
@@ -6316,10 +8083,16 @@ Owner1 = nullptr;</code></pre>
 </div>
 <h1 id="cppcoreguidelines-prefer-member-initializer">cppcoreguidelines-prefer-member-initializer</h1>
 <p>Finds member initializations in the constructor body which can be converted into member initializers of the constructor instead. This not only improves the readability of the code but also positively affects its performance. Class-member assignments inside a control statement or following the first control statement are ignored.</p>
-<p>This check implements <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c49-prefer-initialization-to-assignment-in-constructors">C.49</a> from the CppCoreGuidelines.</p>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c49-prefer-initialization-to-assignment-in-constructors">C.49</a> from the C++ Core Guidelines.</p>
 <p>If the language version is <span class="title-ref">C++ 11</span> or above, the constructor is the default constructor of the class, the field is not a bitfield (only in case of earlier language version than <span class="title-ref">C++ 20</span>), furthermore the assigned value is a literal, negated literal or <code>enum</code> constant then the preferred place of the initialization is at the class member declaration.</p>
-<p>This latter rule is <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c48-prefer-in-class-initializers-to-member-initializers-in-constructors-for-constant-initializers">C.48</a> from CppCoreGuidelines.</p>
-<p>Please note, that this check does not enforce this latter rule for initializations already implemented as member initializers. For that purpose see check <a href="../modernize/use-default-member-init.html">modernize-use-default-member-init</a>.</p>
+<p>This latter rule is <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c48-prefer-in-class-initializers-to-member-initializers-in-constructors-for-constant-initializers">C.48</a> from the C++ Core Guidelines.</p>
+<p>Please note, that this check does not enforce this latter rule for initializations already implemented as member initializers. For that purpose see check <code class="interpreted-text" role="doc">modernize-use-default-member-init &lt;../modernize/use-default-member-init&gt;</code>.</p>
+<div class="note">
+<div class="title">
+<p>Note</p>
+</div>
+<p>Enforcement of rule C.48 in this check is deprecated, to be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19 (only C.49 will be enforced by this check then). Please use <code class="interpreted-text" role="doc">cppcoreguidelines-use-default-member-init &lt;../cppcoreguidelines/use-default-member-init&gt;</code> to enforce rule C.48.</p>
+</div>
 <h2 id="example-1">Example 1</h2>
 <pre class="c++"><code>class C {
   int n;
@@ -6341,7 +8114,8 @@ public:
     if (dice())
       return;
     m = 1;
-  }</code></pre>
+  }
+};</code></pre>
 <h2 id="example-2">Example 2</h2>
 <pre class="c++"><code>class C {
   int n;
@@ -6362,7 +8136,9 @@ public:
 }</code></pre>
 <div class="option">
 <p>UseAssignment</p>
-<p>If this option is set to <span class="title-ref">true</span> (default is <span class="title-ref">false</span>), the check will initialize members with an assignment. In this case the fix of the first example looks like this:</p>
+<p>Note: this option is deprecated, to be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the <span class="title-ref">UseAssignment</span> option from <code class="interpreted-text" role="doc">cppcoreguidelines-use-default-member-init &lt;../cppcoreguidelines/use-default-member-init&gt;</code> instead.</p>
+<p>If this option is set to <span class="title-ref">true</span> (by default <span class="title-ref">UseAssignment</span> from <code class="interpreted-text" role="doc">modernize-use-default-member-init
+&lt;../modernize/use-default-member-init&gt;</code> will be used), the check will initialize members with an assignment. In this case the fix of the first example looks like this:</p>
 </div>
 <pre class="c++"><code>class C {
   int n = 1;
@@ -6389,7 +8165,7 @@ public:
 <h1 id="cppcoreguidelines-pro-bounds-array-to-pointer-decay">cppcoreguidelines-pro-bounds-array-to-pointer-decay</h1>
 <p>This check flags all array to pointer decays.</p>
 <p>Pointers should not be used as arrays. <code>span&lt;T&gt;</code> is a bounds-checked, safe alternative to using pointers to access arrays.</p>
-<p>This rule is part of the "Bounds safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-decay">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-decay</a>.</p>
+<p>This rule is part of the <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-bounds-decay">Bounds safety (Bounds 3)</a> profile from the C++ Core Guidelines.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-bounds-array-to-pointer-decay.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6404,7 +8180,7 @@ public:
 </div>
 <h1 id="cppcoreguidelines-pro-bounds-constant-array-index">cppcoreguidelines-pro-bounds-constant-array-index</h1>
 <p>This check flags all array subscript expressions on static arrays and <code>std::arrays</code> that either do not have a constant integer expression index or are out of bounds (for <code>std::array</code>). For out-of-bounds checking of static arrays, see the <span class="title-ref">-Warray-bounds</span> Clang diagnostic.</p>
-<p>This rule is part of the "Bounds safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-arrayindex">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-arrayindex</a>.</p>
+<p>This rule is part of the <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-bounds-arrayindex">Bounds safety (Bounds 2)</a> profile from the C++ Core Guidelines.</p>
 <p>Optionally, this check can generate fixes using <code>gsl::at</code> for indexing.</p>
 <h2 id="options">Options</h2>
 <div class="option">
@@ -6430,7 +8206,7 @@ public:
 <h1 id="cppcoreguidelines-pro-bounds-pointer-arithmetic">cppcoreguidelines-pro-bounds-pointer-arithmetic</h1>
 <p>This check flags all usage of pointer arithmetic, because it could lead to an invalid pointer. Subtraction of two pointers is not flagged by this check.</p>
 <p>Pointers should only refer to single objects, and pointer arithmetic is fragile and easy to get wrong. <code>span&lt;T&gt;</code> is a bounds-checked, safe type for accessing arrays of data.</p>
-<p>This rule is part of the "Bounds safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-arithmetic">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-bounds-arithmetic</a>.</p>
+<p>This rule is part of the <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-bounds-arithmetic">Bounds safety (Bounds 1)</a> profile from the C++ Core Guidelines.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-bounds-pointer-arithmetic.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6444,9 +8220,15 @@ public:
 <p>clang-tidy - cppcoreguidelines-pro-type-const-cast</p>
 </div>
 <h1 id="cppcoreguidelines-pro-type-const-cast">cppcoreguidelines-pro-type-const-cast</h1>
-<p>This check flags all uses of <code>const_cast</code> in C++ code.</p>
-<p>Modifying a variable that was declared const is undefined behavior, even with <code>const_cast</code>.</p>
-<p>This rule is part of the "Type safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-constcast">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-constcast</a>.</p>
+<p>Imposes limitations on the use of <code>const_cast</code> within C++ code. It depends on the <code class="interpreted-text" role="option">StrictMode</code> option setting to determine whether it should flag all instances of <code>const_cast</code> or only those that remove either <code>const</code> or <code>volatile</code> qualifier.</p>
+<p>Modifying a variable that has been declared as <code>const</code> in C++ is generally considered undefined behavior, and this remains true even when using <code>const_cast</code>. In C++, the <code>const</code> qualifier indicates that a variable is intended to be read-only, and the compiler enforces this by disallowing any attempts to change the value of that variable.</p>
+<p>Removing the <code>volatile</code> qualifier in C++ can have serious consequences. This qualifier indicates that a variable's value can change unpredictably, and removing it may lead to undefined behavior, optimization problems, and debugging challenges. It's essential to retain the <code>volatile</code> qualifier in situations where the variable's volatility is a crucial aspect of program correctness and reliability.</p>
+<p>This rule is part of the <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-constcast">Type safety (Type 3)</a> profile and <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es50-dont-cast-away-const">ES.50: Don't cast away const</a> rule from the C++ Core Guidelines.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>StrictMode</p>
+<p>When this setting is set to <span class="title-ref">true</span>, it means that any usage of <code>const_cast</code> is not allowed. On the other hand, when it's set to <span class="title-ref">false</span>, it permits casting to <code>const</code> or <code>volatile</code> types. Default value is <span class="title-ref">false</span>.</p>
+</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-const-cast.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6462,7 +8244,7 @@ public:
 <h1 id="cppcoreguidelines-pro-type-cstyle-cast">cppcoreguidelines-pro-type-cstyle-cast</h1>
 <p>This check flags all use of C-style casts that perform a <code>static_cast</code> downcast, <code>const_cast</code>, or <code>reinterpret_cast</code>.</p>
 <p>Use of these casts can violate type safety and cause the program to access a variable that is actually of type X to be accessed as if it were of an unrelated type Z. Note that a C-style <code>(T)expression</code> cast means to perform the first of the following that is possible: a <code>const_cast</code>, a <code>static_cast</code>, a <code>static_cast</code> followed by a <code>const_cast</code>, a <code>reinterpret_cast</code>, or a <code>reinterpret_cast</code> followed by a <code>const_cast</code>. This rule bans <code>(T)expression</code> only when used to perform an unsafe cast.</p>
-<p>This rule is part of the "Type safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-cstylecast">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-cstylecast</a>.</p>
+<p>This rule is part of the <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-cstylecast">Type safety (Type.4)</a> profile from the C++ Core Guidelines.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-cstyle-cast.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6489,7 +8271,7 @@ public:
 <p>UseAssignment</p>
 <p>If set to <span class="title-ref">true</span>, the check will provide fix-its with literal initializers ( <code>int i = 0;</code> ) instead of curly braces ( <code>int i{};</code> ).</p>
 </div>
-<p>This rule is part of the "Type safety" profile of the C++ Core Guidelines, corresponding to rule Type.6. See <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-memberinit">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-memberinit</a>.</p>
+<p>This rule is part of the <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-memberinit">Type safety (Type.6)</a> profile from the C++ Core Guidelines.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6505,7 +8287,7 @@ public:
 <h1 id="cppcoreguidelines-pro-type-reinterpret-cast">cppcoreguidelines-pro-type-reinterpret-cast</h1>
 <p>This check flags all uses of <code>reinterpret_cast</code> in C++ code.</p>
 <p>Use of these casts can violate type safety and cause the program to access a variable that is actually of type <code>X</code> to be accessed as if it were of an unrelated type <code>Z</code>.</p>
-<p>This rule is part of the "Type safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-reinterpretcast">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-reinterpretcast</a>.</p>
+<p>This rule is part of the <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-reinterpretcast">Type safety (Type.1.1)</a> profile from the C++ Core Guidelines.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-reinterpret-cast.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6521,7 +8303,12 @@ public:
 <h1 id="cppcoreguidelines-pro-type-static-cast-downcast">cppcoreguidelines-pro-type-static-cast-downcast</h1>
 <p>This check flags all usages of <code>static_cast</code>, where a base class is casted to a derived class. In those cases, a fix-it is provided to convert the cast to a <code>dynamic_cast</code>.</p>
 <p>Use of these casts can violate type safety and cause the program to access a variable that is actually of type <code>X</code> to be accessed as if it were of an unrelated type <code>Z</code>.</p>
-<p>This rule is part of the "Type safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-downcast">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-downcast</a>.</p>
+<p>This rule is part of the <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-downcast">Type safety (Type.2)</a> profile from the C++ Core Guidelines.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>StrictMode</p>
+<p>When set to <span class="title-ref">false</span>, no warnings are emitted for casts on non-polymorphic types. Default is <span class="title-ref">true</span>.</p>
+</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-static-cast-downcast.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6537,7 +8324,7 @@ public:
 <h1 id="cppcoreguidelines-pro-type-union-access">cppcoreguidelines-pro-type-union-access</h1>
 <p>This check flags all access to members of unions. Passing unions as a whole is not flagged.</p>
 <p>Reading from a union member assumes that member was the last one written, and writing to a union member assumes another member with a nontrivial destructor had its destructor called. This is fragile because it cannot generally be enforced to be safe in the language and so relies on programmer discipline to get it right.</p>
-<p>This rule is part of the "Type safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-unions">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-unions</a>.</p>
+<p>This rule is part of the <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-unions">Type safety (Type.7)</a> profile from the C++ Core Guidelines.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-union-access.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6552,11 +8339,75 @@ public:
 </div>
 <h1 id="cppcoreguidelines-pro-type-vararg">cppcoreguidelines-pro-type-vararg</h1>
 <p>This check flags all calls to c-style vararg functions and all use of <code>va_arg</code>.</p>
-<p>To allow for SFINAE use of vararg functions, a call is not flagged if a literal 0 is passed as the only vararg argument.</p>
+<p>To allow for SFINAE use of vararg functions, a call is not flagged if a literal 0 is passed as the only vararg argument or function is used in unevaluated context.</p>
 <p>Passing to varargs assumes the correct type will be read. This is fragile because it cannot generally be enforced to be safe in the language and so relies on programmer discipline to get it right.</p>
-<p>This rule is part of the "Type safety" profile of the C++ Core Guidelines, see <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-varargs">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-varargs</a>.</p>
+<p>This rule is part of the <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-varargs">Type safety (Type.8)</a> profile from the C++ Core Guidelines.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-vararg.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>cppcoreguidelines-rvalue-reference-param-not-moved</key>
+    <name>cppcoreguidelines-rvalue-reference-param-not-moved</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-rvalue-reference-param-not-moved</p>
+</div>
+<h1 id="cppcoreguidelines-rvalue-reference-param-not-moved">cppcoreguidelines-rvalue-reference-param-not-moved</h1>
+<p>Warns when an rvalue reference function parameter is never moved within the function body.</p>
+<p>Rvalue reference parameters indicate a parameter that should be moved with <code>std::move</code> from within the function body. Any such parameter that is never moved is confusing and potentially indicative of a buggy program.</p>
+<p>Example:</p>
+<pre class="c++"><code>void logic(std::string&amp;&amp; Input) {
+  std::string Copy(Input); // Oops - forgot to std::move
+}</code></pre>
+<p>Note that parameters that are unused and marked as such will not be diagnosed.</p>
+<p>Example:</p>
+<pre class="c++"><code>void conditional_use([[maybe_unused]] std::string&amp;&amp; Input) {
+  // No diagnostic here since Input is unused and marked as such
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>AllowPartialMove</p>
+<p>If set to <span class="title-ref">true</span>, the check accepts <code>std::move</code> calls containing any subexpression containing the parameter. CppCoreGuideline F.18 officially mandates that the parameter itself must be moved. Default is <span class="title-ref">false</span>.</p>
+<pre class="c++"><code>// &#39;p&#39; is flagged by this check if and only if AllowPartialMove is false
+void move_members_of(pair&lt;Obj, Obj&gt;&amp;&amp; p) {
+  pair&lt;Obj, Obj&gt; other;
+  other.first = std::move(p.first);
+  other.second = std::move(p.second);
+}
+
+// &#39;p&#39; is never flagged by this check
+void move_whole_pair(pair&lt;Obj, Obj&gt;&amp;&amp; p) {
+  pair&lt;Obj, Obj&gt; other = std::move(p);
+}</code></pre>
+</div>
+<div class="option">
+<p>IgnoreUnnamedParams</p>
+<p>If set to <span class="title-ref">true</span>, the check ignores unnamed rvalue reference parameters. Default is <span class="title-ref">false</span>.</p>
+</div>
+<div class="option">
+<p>IgnoreNonDeducedTemplateTypes</p>
+<p>If set to <span class="title-ref">true</span>, the check ignores non-deduced template type rvalue reference parameters. Default is <span class="title-ref">false</span>.</p>
+<pre class="c++"><code>template &lt;class T&gt;
+struct SomeClass {
+  // Below, &#39;T&#39; is not deduced and &#39;T&amp;&amp;&#39; is an rvalue reference type.
+  // This will be flagged if and only if IgnoreNonDeducedTemplateTypes is
+  // false. One suggested fix would be to specialize the class for &#39;T&#39; and
+  // &#39;T&amp;&#39; separately (e.g., see std::future), or allow only one of &#39;T&#39; or
+  // &#39;T&amp;&#39; instantiations of SomeClass (e.g., see std::optional).
+  SomeClass(T&amp;&amp; t) { }
+};
+
+// Never flagged, since &#39;T&#39; is a forwarding reference in a deduced context
+template &lt;class T&gt;
+void forwarding_ref(T&amp;&amp; t) {
+  T other = std::forward&lt;T&gt;(t);
+}</code></pre>
+</div>
+<p>This check implements <a href="http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f18-for-will-move-from-parameters-pass-by-x-and-stdmove-the-parameter">F.18</a> from the C++ Core Guidelines.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/rvalue-reference-param-not-moved.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -6578,7 +8429,7 @@ void use(B b) {  // Missing reference, intended?
 
 D d;
 use(d);  // Slice.</code></pre>
-<p>See the relevant C++ Core Guidelines sections for details: <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es63-dont-slice">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es63-dont-slice</a> <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c145-access-polymorphic-objects-through-pointers-and-references">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c145-access-polymorphic-objects-through-pointers-and-references</a></p>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es63-dont-slice">ES.63</a> and <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c145-access-polymorphic-objects-through-pointers-and-references">C.145</a> from the C++ Core Guidelines.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/slicing.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6594,14 +8445,23 @@ use(d);  // Slice.</code></pre>
 <p>The check finds classes where some but not all of the special member functions are defined.</p>
 <p>By default the compiler defines a copy constructor, copy assignment operator, move constructor, move assignment operator and destructor. The default can be suppressed by explicit user-definitions. The relationship between which functions will be suppressed by definitions of other functions is complicated and it is advised that all five are defaulted or explicitly defined.</p>
 <p>Note that defining a function with <code>= delete</code> is considered to be a definition.</p>
-<p>This rule is part of the "Constructors, assignments, and destructors" profile of the C++ Core Guidelines, corresponding to rule C.21. See</p>
-<p><a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all">https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all</a>.</p>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-five">C.21</a> from the C++ Core Guidelines.</p>
 <h2 id="options">Options</h2>
 <div class="option">
 <p>AllowSoleDefaultDtor</p>
-<p>When set to <span class="title-ref">true</span> (default is <span class="title-ref">false</span>), this check doesn't flag classes with a sole, explicitly defaulted destructor. An example for such a class is:</p>
-<pre class="c++"><code>struct A {
+<p>When set to <span class="title-ref">true</span> (default is <span class="title-ref">false</span>), this check will only trigger on destructors if they are defined and not defaulted.</p>
+<pre class="c++"><code>struct A { // This is fine.
   virtual ~A() = default;
+};
+
+struct B { // This is not fine.
+  ~B() {}
+};
+
+struct C {
+  // This is not checked, because the destructor might be defaulted in
+  // another translation unit.
+  ~C();
 };</code></pre>
 </div>
 <div class="option">
@@ -6628,6 +8488,24 @@ use(d);  // Slice.</code></pre>
     <severity>MINOR</severity>
     </rule>
   <rule>
+    <key>cppcoreguidelines-use-default-member-init</key>
+    <name>cppcoreguidelines-use-default-member-init</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - cppcoreguidelines-use-default-member-init</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/use-default-member-init.html">
+
+</div>
+<h1 id="cppcoreguidelines-use-default-member-init">cppcoreguidelines-use-default-member-init</h1>
+<p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-in-class-initializer">C.48</a> from the C++ Core Guidelines.</p>
+<p>The <span class="title-ref">cppcoreguidelines-use-default-member-init</span> check is an alias, please see <code class="interpreted-text" role="doc">modernize-use-default-member-init &lt;../modernize/use-default-member-init&gt;</code> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/use-default-member-init.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>cppcoreguidelines-virtual-class-destructor</key>
     <name>cppcoreguidelines-virtual-class-destructor</name>
     <description>
@@ -6636,7 +8514,7 @@ use(d);  // Slice.</code></pre>
 </div>
 <h1 id="cppcoreguidelines-virtual-class-destructor">cppcoreguidelines-virtual-class-destructor</h1>
 <p>Finds virtual classes whose destructor is neither public and virtual nor protected and non-virtual. A virtual class's destructor should be specified in one of these ways to prevent undefined behavior.</p>
-<p>This check implements <a href="http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-virtual">C.35</a> from the CppCoreGuidelines.</p>
+<p>This check implements <a href="http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-virtual">C.35</a> from the C++ Core Guidelines.</p>
 <p>Note that this check will diagnose a class with a virtual method regardless of whether the class is used as a base class or not.</p>
 <p>Fixes are available for user-declared and implicit destructors that are either public and non-virtual or protected and virtual. No fixes are offered for private destructors. There, the decision whether to make them private and virtual or protected and non-virtual depends on the use case and is thus left to the user.</p>
 <h2 id="example">Example</h2>
@@ -6719,7 +8597,7 @@ public:
 <p>A function call expression that uses a default argument will be diagnosed. Calling it without defaults will not cause a warning:</p>
 <pre class="c++"><code>foo();  // warning
 foo(0); // no warning</code></pre>
-<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
+<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en">https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en</a></p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/default-arguments-calls.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6737,7 +8615,7 @@ foo(0); // no warning</code></pre>
 <p>For example, the declaration:</p>
 <pre class="c++"><code>int foo(int value = 5) { return value; }</code></pre>
 <p>will cause a warning.</p>
-<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
+<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en">https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en</a></p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/default-arguments-declarations.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6754,7 +8632,7 @@ foo(0); // no warning</code></pre>
 
 </div>
 <h1 id="fuchsia-header-anon-namespaces">fuchsia-header-anon-namespaces</h1>
-<p>The fuchsia-header-anon-namespaces check is an alias, please see <a href="../google/build-namespaces.html">google-build-namespace</a> for more information.</p>
+<p>The fuchsia-header-anon-namespaces check is an alias, please see <code class="interpreted-text" role="doc">google-build-namespace &lt;../google/build-namespaces&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/header-anon-namespaces.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6798,7 +8676,7 @@ class Good_Child1 : public Interface_A, Interface_B {
   virtual int foo() override { return 0; }
   virtual int bar() override { return 0; }
 };</code></pre>
-<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
+<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en">https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en</a></p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/multiple-inheritance.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6818,7 +8696,7 @@ class Good_Child1 : public Interface_A, Interface_B {
 
 B &amp;operator=(const B &amp;Other);  // No warning
 B &amp;operator=(B &amp;&amp;Other) // No warning</code></pre>
-<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
+<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en">https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en</a></p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/overloaded-operator.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6845,8 +8723,8 @@ private:
 
 class C {
 public:
-  C(int Val) : Val(Val) {}
-  constexpr C() : Val(0) {}
+  constexpr C(int Val) : Val(Val) {}
+  C(int Val1, int Val2) : Val(Val1+Val2) {}
 
 private:
   int Val;
@@ -6861,8 +8739,8 @@ static C c2(0, 1);  // Warning, as constructor is not constexpr
 static int i;       // No warning, as it is trivial
 
 extern int get_i();
-static C(get_i())   // Warning, as the constructor is dynamically initialized</code></pre>
-<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
+static C c3(get_i());// Warning, as the constructor is dynamically initialized</code></pre>
+<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en">https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en</a></p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/statically-constructed-objects.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6894,7 +8772,7 @@ template &lt;typename T1, typename T2&gt;
 auto fn(const T1 &amp;lhs, const T2 &amp;rhs) -&gt; decltype(lhs + rhs) {
   return lhs + rhs;
 }</code></pre>
-<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
+<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en">https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en</a></p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/trailing-return.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6911,7 +8789,7 @@ auto fn(const T1 &amp;lhs, const T2 &amp;rhs) -&gt; decltype(lhs + rhs) {
 <p>Warns if classes are defined with virtual inheritance.</p>
 <p>For example, classes should not be defined with virtual inheritance:</p>
 <pre class="c++"><code>class B : public virtual A {};   // warning</code></pre>
-<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md">https://fuchsia.googlesource.com/zircon/+/master/docs/cxx.md</a></p>
+<p>See the features disallowed in Fuchsia at <a href="https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en">https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en</a></p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/fuchsia/virtual-inheritance.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6948,7 +8826,8 @@ auto fn(const T1 &amp;lhs, const T2 &amp;rhs) -&gt; decltype(lhs + rhs) {
 <h2 id="options">Options</h2>
 <div class="option">
 <p>HeaderFileExtensions</p>
-<p>A comma-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is "h,hh,hpp,hxx". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. e.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
+<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">HeaderFileExtensions</span>.</p>
+<p>A comma-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is "h,hh,hpp,hxx". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. E.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/build-namespaces.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -7044,7 +8923,8 @@ bool f() {
 <h2 id="options">Options</h2>
 <div class="option">
 <p>HeaderFileExtensions</p>
-<p>A comma-separated list of filename extensions of header files (the filename extensions should not contain "." prefix). Default is "h". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. e.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
+<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">HeaderFileExtensions</span>.</p>
+<p>A comma-separated list of filename extensions of header files (the filename extensions should not contain "." prefix). Default is "h". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. E.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/global-names-in-headers.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -7162,7 +9042,7 @@ bool *ABCIsNegative(int i) { return i &lt; 0; }</code></pre>
 <p>clang-tidy - google-readability-avoid-underscore-in-googletest-name</p>
 </div>
 <h1 id="google-readability-avoid-underscore-in-googletest-name">google-readability-avoid-underscore-in-googletest-name</h1>
-<p>Checks whether there are underscores in googletest test and test case names in test macros:</p>
+<p>Checks whether there are underscores in googletest test suite names and test names in test macros:</p>
 <ul>
 <li><code>TEST</code></li>
 <li><code>TEST_F</code></li>
@@ -7172,10 +9052,10 @@ bool *ABCIsNegative(int i) { return i &lt; 0; }</code></pre>
 </ul>
 <p>The <code>FRIEND_TEST</code> macro is not included.</p>
 <p>For example:</p>
-<pre class="c++"><code>TEST(TestCaseName, Illegal_TestName) {}
-TEST(Illegal_TestCaseName, TestName) {}</code></pre>
-<p>would trigger the check. <a href="https://google.github.io/googletest/faq.html#why-should-test-suite-names-and-test-names-not-contain-underscore">Underscores are not allowed</a> in test names nor test case names.</p>
-<p>The <code>DISABLED_</code> prefix, which may be used to <a href="https://google.github.io/googletest/advanced.html#temporarily-disabling-tests">disable individual tests</a>, is ignored when checking test names, but the rest of the rest of the test name is still checked.</p>
+<pre class="c++"><code>TEST(TestSuiteName, Illegal_TestName) {}
+TEST(Illegal_TestSuiteName, TestName) {}</code></pre>
+<p>would trigger the check. <a href="https://google.github.io/googletest/faq.html#why-should-test-suite-names-and-test-names-not-contain-underscore">Underscores are not allowed</a> in test suite name nor test names.</p>
+<p>The <code>DISABLED_</code> prefix, which may be used to <a href="https://google.github.io/googletest/advanced.html#temporarily-disabling-tests">disable test suites and individual tests</a>, is removed from the test suite name and test name before checking for underscores.</p>
 <p>This check does not propose any fixes.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/readability-avoid-underscore-in-googletest-name.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -7193,7 +9073,7 @@ TEST(Illegal_TestCaseName, TestName) {}</code></pre>
 
 </div>
 <h1 id="google-readability-braces-around-statements">google-readability-braces-around-statements</h1>
-<p>The google-readability-braces-around-statements check is an alias, please see <a href="../readability/braces-around-statements.html">readability-braces-around-statements</a> for more information.</p>
+<p>The <span class="title-ref">google-readability-braces-around-statements</span> check is an alias, please see <code class="interpreted-text" role="doc">readability-braces-around-statements &lt;../readability/braces-around-statements&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/readability-braces-around-statements.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7227,7 +9107,7 @@ TEST(Illegal_TestCaseName, TestName) {}</code></pre>
 
 </div>
 <h1 id="google-readability-function-size">google-readability-function-size</h1>
-<p>The google-readability-function-size check is an alias, please see <a href="../readability/function-size.html">readability-function-size</a> for more information.</p>
+<p>The <span class="title-ref">google-readability-function-size</span> check is an alias, please see <code class="interpreted-text" role="doc">readability-function-size &lt;../readability/function-size&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/readability-function-size.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7244,7 +9124,7 @@ TEST(Illegal_TestCaseName, TestName) {}</code></pre>
 
 </div>
 <h1 id="google-readability-namespace-comments">google-readability-namespace-comments</h1>
-<p>The google-readability-namespace-comments check is an alias, please see <a href="../llvm/namespace-comment.html">llvm-namespace-comment</a> for more information.</p>
+<p>The <span class="title-ref">google-readability-namespace-comments check</span> is an alias, please see <code class="interpreted-text" role="doc">llvm-namespace-comment &lt;../llvm/namespace-comment&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/readability-namespace-comments.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7361,7 +9241,7 @@ TYPED_TEST_SUITE(BarTest, BarTypes);</code></pre>
 
 </div>
 <h1 id="hicpp-avoid-c-arrays">hicpp-avoid-c-arrays</h1>
-<p>The hicpp-avoid-c-arrays check is an alias, please see <a href="../modernize/avoid-c-arrays.html">modernize-avoid-c-arrays</a> for more information.</p>
+<p>The hicpp-avoid-c-arrays check is an alias, please see <code class="interpreted-text" role="doc">modernize-avoid-c-arrays &lt;../modernize/avoid-c-arrays&gt;</code> for more information. It partly enforces the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-conversions">rule 4.1.1</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/avoid-c-arrays.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7374,9 +9254,11 @@ TYPED_TEST_SUITE(BarTest, BarTypes);</code></pre>
       <![CDATA[<div class="title">
 <p>clang-tidy - hicpp-avoid-goto</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=../cppcoreguidelines/avoid-goto.html">
+
+</div>
 <h1 id="hicpp-avoid-goto">hicpp-avoid-goto</h1>
-<p>The <span class="title-ref">hicpp-avoid-goto</span> check is an alias to <a href="../cppcoreguidelines/avoid-goto.html">cppcoreguidelines-avoid-goto</a>. Rule <a href="http://www.codingstandard.com/rule/6-3-1-ensure-that-the-labels-for-a-jump-statement-or-a-switch-condition-appear-later-in-the-same-or-an-enclosing-block/">6.3.1 High Integrity C++</a> requires that <code>goto</code> only skips parts of a block and is not used for other reasons.</p>
-<p>Both coding guidelines implement the same exception to the usage of <code>goto</code>.</p>
+<p>The <span class="title-ref">hicpp-avoid-goto</span> check is an alias, please see <code class="interpreted-text" role="doc">cppcoreguidelines-avoid-goto &lt;../cppcoreguidelines/avoid-goto&gt;</code> for more information. It enforces the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements">rule 6.3.1</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/avoid-goto.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7392,7 +9274,7 @@ TYPED_TEST_SUITE(BarTest, BarTypes);</code></pre>
 
 </div>
 <h1 id="hicpp-braces-around-statements">hicpp-braces-around-statements</h1>
-<p>The <span class="title-ref">hicpp-braces-around-statements</span> check is an alias, please see <a href="../readability/braces-around-statements.html">readability-braces-around-statements</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/6-1-1-enclose-the-body-of-a-selection-or-an-iteration-statement-in-a-compound-statement/">rule 6.1.1</a>.</p>
+<p>The <span class="title-ref">hicpp-braces-around-statements</span> check is an alias, please see <code class="interpreted-text" role="doc">readability-braces-around-statements &lt;../readability/braces-around-statements&gt;</code> for more information. It enforces the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements">rule 6.1.1</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/braces-around-statements.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7409,7 +9291,7 @@ TYPED_TEST_SUITE(BarTest, BarTypes);</code></pre>
 
 </div>
 <h1 id="hicpp-deprecated-headers">hicpp-deprecated-headers</h1>
-<p>The <span class="title-ref">hicpp-deprecated-headers</span> check is an alias, please see <a href="../modernize/deprecated-headers.html">modernize-deprecated-headers</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/1-3-3-do-not-use-the-c-standard-library-h-headers/">rule 1.3.3</a>.</p>
+<p>The <span class="title-ref">hicpp-deprecated-headers</span> check is an alias, please see <code class="interpreted-text" role="doc">modernize-deprecated-headers &lt;../modernize/deprecated-headers&gt;</code> for more information. It enforces the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/general">rule 1.3.3</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/deprecated-headers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7424,7 +9306,7 @@ TYPED_TEST_SUITE(BarTest, BarTypes);</code></pre>
 </div>
 <h1 id="hicpp-exception-baseclass">hicpp-exception-baseclass</h1>
 <p>Ensure that every value that in a <code>throw</code> expression is an instance of <code>std::exception</code>.</p>
-<p>This enforces <a href="http://www.codingstandard.com/section/15-1-throwing-an-exception/">rule 15.1</a> of the High Integrity C++ Coding Standard.</p>
+<p>This enforces <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard-exception-handling">rule 15.1</a> of the High Integrity C++ Coding Standard.</p>
 <pre class="c++"><code>class custom_exception {};
 
 void throwing() noexcept(false) {
@@ -7457,12 +9339,12 @@ void throwing2() noexcept(false) {
 
 </div>
 <h1 id="hicpp-explicit-conversions">hicpp-explicit-conversions</h1>
-<p>This check is an alias for <a href="../google/explicit-constructor.html">google-explicit-constructor</a>. Used to enforce parts of <a href="http://www.codingstandard.com/rule/5-4-1-only-use-casting-forms-static_cast-excl-void-dynamic_cast-or-explicit-constructor-call/">rule 5.4.1</a>. This check will enforce that constructors and conversion operators are marked <span class="title-ref">explicit</span>. Other forms of casting checks are implemented in other places. The following checks can be used to check for more forms of casting:</p>
+<p>This check is an alias for <code class="interpreted-text" role="doc">google-explicit-constructor &lt;../google/explicit-constructor&gt;</code>. Used to enforce parts of <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard-expressions">rule 5.4.1</a>. This check will enforce that constructors and conversion operators are marked <span class="title-ref">explicit</span>. Other forms of casting checks are implemented in other places. The following checks can be used to check for more forms of casting:</p>
 <ul>
-<li><a href="../cppcoreguidelines/pro-type-static-cast-downcast.html">cppcoreguidelines-pro-type-static-cast-downcast</a></li>
-<li><a href="../cppcoreguidelines/pro-type-reinterpret-cast.html">cppcoreguidelines-pro-type-reinterpret-cast</a></li>
-<li><a href="../cppcoreguidelines/pro-type-const-cast.html">cppcoreguidelines-pro-type-const-cast</a></li>
-<li><a href="../cppcoreguidelines/pro-type-cstyle-cast.html">cppcoreguidelines-pro-type-cstyle-cast</a></li>
+<li><code class="interpreted-text" role="doc">cppcoreguidelines-pro-type-static-cast-downcast &lt;../cppcoreguidelines/pro-type-static-cast-downcast&gt;</code></li>
+<li><code class="interpreted-text" role="doc">cppcoreguidelines-pro-type-reinterpret-cast &lt;../cppcoreguidelines/pro-type-reinterpret-cast&gt;</code></li>
+<li><code class="interpreted-text" role="doc">cppcoreguidelines-pro-type-const-cast &lt;../cppcoreguidelines/pro-type-const-cast&gt;</code></li>
+<li><code class="interpreted-text" role="doc">cppcoreguidelines-pro-type-cstyle-cast &lt;../cppcoreguidelines/pro-type-cstyle-cast&gt;</code></li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/explicit-conversions.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -7479,14 +9361,35 @@ void throwing2() noexcept(false) {
 
 </div>
 <h1 id="hicpp-function-size">hicpp-function-size</h1>
-<p>This check is an alias for <a href="../readability/function-size.html">readability-function-size</a>. Useful to enforce multiple sections on function complexity.</p>
+<p>This check is an alias for <code class="interpreted-text" role="doc">readability-function-size &lt;../readability/function-size&gt;</code>. Useful to enforce multiple sections on function complexity.</p>
 <ul>
-<li><a href="http://www.codingstandard.com/rule/8-2-2-do-not-declare-functions-with-an-excessive-number-of-parameters/">rule 8.2.2</a></li>
-<li><a href="http://www.codingstandard.com/rule/8-3-1-do-not-write-functions-with-an-excessive-mccabe-cyclomatic-complexity/">rule 8.3.1</a></li>
-<li><a href="http://www.codingstandard.com/rule/8-3-2-do-not-write-functions-with-a-high-static-program-path-count/">rule 8.3.2</a></li>
+<li><a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/definitions">rule 8.2.2</a></li>
+<li><a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/definitions">rule 8.3.1</a></li>
+<li><a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/definitions">rule 8.3.2</a></li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/function-size.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>hicpp-ignored-remove-result</key>
+    <name>hicpp-ignored-remove-result</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - hicpp-ignored-remove-result</p>
+</div>
+<h1 id="hicpp-ignored-remove-result">hicpp-ignored-remove-result</h1>
+<p>Ensure that the result of <code>std::remove</code>, <code>std::remove_if</code> and <code>std::unique</code> are not ignored according to <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-library">rule 17.5.1</a>.</p>
+<p>The mutating algorithms <code>std::remove</code>, <code>std::remove_if</code> and both overloads of <code>std::unique</code> operate by swapping or moving elements of the range they are operating over. On completion, they return an iterator to the last valid element. In the majority of cases the correct behavior is to use this result as the first operand in a call to <code>std::erase</code>.</p>
+<p>This check is a subset of <code class="interpreted-text" role="doc">bugprone-unused-return-value &lt;../bugprone/unused-return-value&gt;</code> and depending on used options it can be superfluous to enable both checks.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>AllowCastToVoid</p>
+<p>Controls whether casting return values to <code>void</code> is permitted. Default: <span class="title-ref">true</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/ignored-remove-result.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -7501,8 +9404,8 @@ void throwing2() noexcept(false) {
 
 </div>
 <h1 id="hicpp-invalid-access-moved">hicpp-invalid-access-moved</h1>
-<p>This check is an alias for <a href="../bugprone/use-after-move.html">bugprone-use-after-move</a>.</p>
-<p>Implements parts of the <a href="http://www.codingstandard.com/rule/8-4-1-do-not-access-an-invalid-object-or-an-object-with-indeterminate-value/">rule 8.4.1</a> to check if moved-from objects are accessed.</p>
+<p>This check is an alias for <code class="interpreted-text" role="doc">bugprone-use-after-move &lt;../bugprone/use-after-move&gt;</code>.</p>
+<p>Implements parts of the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/definitions">rule 8.4.1</a> to check if moved-from objects are accessed.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/invalid-access-moved.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7519,7 +9422,7 @@ void throwing2() noexcept(false) {
 
 </div>
 <h1 id="hicpp-member-init">hicpp-member-init</h1>
-<p>This check is an alias for <a href="../cppcoreguidelines/pro-type-member-init.html">cppcoreguidelines-pro-type-member-init</a>. Implements the check for <a href="http://www.codingstandard.com/rule/12-4-2-ensure-that-a-constructor-initializes-explicitly-all-base-classes-and-non-static-data-members/">rule 12.4.2</a> to initialize class members in the right order.</p>
+<p>This check is an alias for <code class="interpreted-text" role="doc">cppcoreguidelines-pro-type-member-init &lt;../cppcoreguidelines/pro-type-member-init&gt;</code>. Implements the check for <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/special-member-functions">rule 12.4.2</a> to initialize class members in the right order.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/member-init.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7535,7 +9438,7 @@ void throwing2() noexcept(false) {
 
 </div>
 <h1 id="hicpp-move-const-arg">hicpp-move-const-arg</h1>
-<p>The <span class="title-ref">hicpp-move-const-arg</span> check is an alias, please see <a href="../performance/move-const-arg.html">performance-move-const-arg</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/17-3-1-do-not-use-stdmove-on-objects-declared-with-const-or-const-type/">rule 17.3.1</a>.</p>
+<p>The <span class="title-ref">hicpp-move-const-arg</span> check is an alias, please see <code class="interpreted-text" role="doc">performance-move-const-arg &lt;../performance/move-const-arg&gt;</code> for more information. It enforces the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-library">rule 17.3.1</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/move-const-arg.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7549,7 +9452,7 @@ void throwing2() noexcept(false) {
 <p>clang-tidy - hicpp-multiway-paths-covered</p>
 </div>
 <h1 id="hicpp-multiway-paths-covered">hicpp-multiway-paths-covered</h1>
-<p>This check discovers situations where code paths are not fully-covered. It furthermore suggests using <code>if</code> instead of <code>switch</code> if the code will be more clear. The <a href="http://www.codingstandard.com/rule/6-1-2-explicitly-cover-all-paths-through-multi-way-selection-statements/">rule 6.1.2</a> and <a href="http://www.codingstandard.com/rule/6-1-4-ensure-that-a-switch-statement-has-at-least-two-case-labels-distinct-from-the-default-label/">rule 6.1.4</a> of the High Integrity C++ Coding Standard are enforced.</p>
+<p>This check discovers situations where code paths are not fully-covered. It furthermore suggests using <code>if</code> instead of <code>switch</code> if the code will be more clear. The <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements">rule 6.1.2</a> and <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements">rule 6.1.4</a> of the High Integrity C++ Coding Standard are enforced.</p>
 <p><code>if-else if</code> chains that miss a final <code>else</code> branch might lead to unexpected program execution and be the result of a logical error. If the missing <code>else</code> branch is intended you can leave it empty with a clarifying comment. This warning can be noisy on some code bases, so it is disabled by default.</p>
 <pre class="c++"><code>void f1() {
   int i = determineTheNumber();
@@ -7585,7 +9488,7 @@ void f3(enum Color c) {
   }
   // Other cases missing
 }</code></pre>
-<p>The <a href="http://www.codingstandard.com/rule/6-1-4-ensure-that-a-switch-statement-has-at-least-two-case-labels-distinct-from-the-default-label/">rule 6.1.4</a> requires every <code>switch</code> statement to have at least two <code>case</code> labels other than a <span class="title-ref">default</span> label. Otherwise, the <code>switch</code> could be better expressed with an <code>if</code> statement. Degenerated <code>switch</code> statements without any labels are caught as well.</p>
+<p>The <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements">rule 6.1.4</a> requires every <code>switch</code> statement to have at least two <code>case</code> labels other than a <span class="title-ref">default</span> label. Otherwise, the <code>switch</code> could be better expressed with an <code>if</code> statement. Degenerated <code>switch</code> statements without any labels are caught as well.</p>
 <pre class="c++"><code>// Degenerated switch that could be better written as `if`
 int i = 42;
 switch(i) {
@@ -7624,8 +9527,8 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-named-parameter">hicpp-named-parameter</h1>
-<p>This check is an alias for <a href="../readability/named-parameter.html">readability-named-parameter</a>.</p>
-<p>Implements <a href="http://www.codingstandard.com/rule/8-2-1-make-parameter-names-absent-or-identical-in-all-declarations/">rule 8.2.1</a>.</p>
+<p>This check is an alias for <code class="interpreted-text" role="doc">readability-named-parameter &lt;../readability/named-parameter&gt;</code>.</p>
+<p>Implements <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/definitions">rule 8.2.1</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/named-parameter.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7642,7 +9545,7 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-new-delete-operators">hicpp-new-delete-operators</h1>
-<p>This check is an alias for <a href="../misc/new-delete-overloads.html">misc-new-delete-overloads</a>. Implements <a href="http://www.codingstandard.com/section/12-3-free-store/">rule 12.3.1</a> to ensure the <span class="title-ref">new</span> and <span class="title-ref">delete</span> operators have the correct signature.</p>
+<p>This check is an alias for <code class="interpreted-text" role="doc">misc-new-delete-overloads &lt;../misc/new-delete-overloads&gt;</code>. Implements <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/special-member-functions">rule 12.3.1</a> to ensure the <span class="title-ref">new</span> and <span class="title-ref">delete</span> operators have the correct signature.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/new-delete-operators.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7659,7 +9562,7 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-no-array-decay">hicpp-no-array-decay</h1>
-<p>The <span class="title-ref">hicpp-no-array-decay</span> check is an alias, please see <a href="../cppcoreguidelines/pro-bounds-array-to-pointer-decay.html">cppcoreguidelines-pro-bounds-array-to-pointer-decay</a> for more information. It enforces the <a href="http://www.codingstandard.com/section/4-1-array-to-pointer-conversion/">rule 4.1.1</a>.</p>
+<p>The <span class="title-ref">hicpp-no-array-decay</span> check is an alias, please see <code class="interpreted-text" role="doc">cppcoreguidelines-pro-bounds-array-to-pointer-decay &lt;../cppcoreguidelines/pro-bounds-array-to-pointer-decay&gt;</code> for more information. It enforces the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-conversions">rule 4.1.1</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/no-array-decay.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7673,8 +9576,8 @@ switch(i) {}</code></pre>
 <p>clang-tidy - hicpp-no-assembler</p>
 </div>
 <h1 id="hicpp-no-assembler">hicpp-no-assembler</h1>
-<p>Check for assembler statements. No fix is offered.</p>
-<p>Inline assembler is forbidden by the <a href="http://www.codingstandard.com/section/7-5-the-asm-declaration/">High Integrity C++ Coding Standard</a> as it restricts the portability of code.</p>
+<p>Checks for assembler statements. Use of inline assembly should be avoided since it restricts the portability of the code.</p>
+<p>This enforces <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/declarations">rule 7.5.1</a> of the High Integrity C++ Coding Standard.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/no-assembler.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7691,7 +9594,7 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-no-malloc">hicpp-no-malloc</h1>
-<p>The <span class="title-ref">hicpp-no-malloc</span> check is an alias, please see <a href="../cppcoreguidelines/no-malloc.html">cppcoreguidelines-no-malloc</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/5-3-2-allocate-memory-using-new-and-release-it-using-delete/">rule 5.3.2</a>.</p>
+<p>The <span class="title-ref">hicpp-no-malloc</span> check is an alias, please see <code class="interpreted-text" role="doc">cppcoreguidelines-no-malloc &lt;../cppcoreguidelines/no-malloc&gt;</code> for more information. It enforces the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard-expressions">rule 5.3.2</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/no-malloc.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7708,7 +9611,8 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-noexcept-move">hicpp-noexcept-move</h1>
-<p>This check is an alias for <a href="../performance/noexcept-move-constructor.html">performance-noexcept-move-constructor</a>. Checks <a href="http://www.codingstandard.com/rule/12-5-4-declare-noexcept-the-move-constructor-and-move-assignment-operator">rule 12.5.4</a> to mark move assignment and move construction <span class="title-ref">noexcept</span>.</p>
+<p>This check is an alias for <code class="interpreted-text" role="doc">performance-noexcept-move-constructor
+&lt;../performance/noexcept-move-constructor&gt;</code>. Checks <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/special-member-functions">rule 12.5.4</a> to mark move assignment and move construction <span class="title-ref">noexcept</span>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/noexcept-move.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7722,7 +9626,7 @@ switch(i) {}</code></pre>
 </div>
 <h1 id="hicpp-signed-bitwise">hicpp-signed-bitwise</h1>
 <p>Finds uses of bitwise operations on signed integer types, which may lead to undefined or implementation defined behavior.</p>
-<p>The according rule is defined in the <a href="http://www.codingstandard.com/section/5-6-shift-operators/">High Integrity C++ Standard, Section 5.6.1</a>.</p>
+<p>The according rule is defined in the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard-expressions">High Integrity C++ Standard, Section 5.6.1</a>.</p>
 <h2 id="options">Options</h2>
 <div class="option">
 <p>IgnorePositiveIntegerLiterals</p>
@@ -7744,7 +9648,7 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-special-member-functions">hicpp-special-member-functions</h1>
-<p>This check is an alias for <a href="../cppcoreguidelines/special-member-functions.html">cppcoreguidelines-special-member-functions</a>. Checks that special member functions have the correct signature, according to <a href="http://www.codingstandard.com/rule/12-5-7-declare-assignment-operators-with-the-ref-qualifier/">rule 12.5.7</a>.</p>
+<p>This check is an alias for <code class="interpreted-text" role="doc">cppcoreguidelines-special-member-functions &lt;../cppcoreguidelines/special-member-functions&gt;</code>. Checks that special member functions have the correct signature, according to <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/special-member-functions">rule 12.5.7</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/special-member-functions.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7760,7 +9664,7 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-static-assert">hicpp-static-assert</h1>
-<p>The <span class="title-ref">hicpp-static-assert</span> check is an alias, please see <a href="../misc/static-assert.html">misc-static-assert</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/6-1-1-enclose-the-body-of-a-selection-or-an-iteration-statement-in-a-compound-statement/">rule 7.1.10</a>.</p>
+<p>The <span class="title-ref">hicpp-static-assert</span> check is an alias, please see <code class="interpreted-text" role="doc">misc-static-assert &lt;../misc/static-assert&gt;</code> for more information. It enforces the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/declarations">rule 7.1.10</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/static-assert.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7777,7 +9681,7 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-undelegated-constructor">hicpp-undelegated-constructor</h1>
-<p>This check is an alias for <a href="../bugprone/undelegated-constructor.html">bugprone-undelegated-constructor</a>. Partially implements <a href="http://www.codingstandard.com/rule/12-4-5-use-delegating-constructors-to-reduce-code-duplication/">rule 12.4.5</a> to find misplaced constructor calls inside a constructor.</p>
+<p>This check is an alias for <code class="interpreted-text" role="doc">bugprone-undelegated-constructor &lt;../bugprone/undelegated-constructor&gt;</code>. Partially implements <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/special-member-functions">rule 12.4.5</a> to find misplaced constructor calls inside a constructor.</p>
 <pre class="c++"><code>struct Ctor {
   Ctor();
   Ctor(int);
@@ -7807,7 +9711,8 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-uppercase-literal-suffix">hicpp-uppercase-literal-suffix</h1>
-<p>The hicpp-uppercase-literal-suffix check is an alias, please see <a href="../readability/uppercase-literal-suffix.html">readability-uppercase-literal-suffix</a> for more information.</p>
+<p>The hicpp-uppercase-literal-suffix check is an alias, please see <code class="interpreted-text" role="doc">readability-uppercase-literal-suffix &lt;../readability/uppercase-literal-suffix&gt;</code> for more information.</p>
+<p>Partially implements <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-conversions">rule 4.2.1</a> to ensure that the <code>U</code> suffix is writeln properly.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/uppercase-literal-suffix.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7824,7 +9729,7 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-use-auto">hicpp-use-auto</h1>
-<p>The <span class="title-ref">hicpp-use-auto</span> check is an alias, please see <a href="../modernize/use-auto.html">modernize-use-auto</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/7-1-8-use-auto-id-expr-when-declaring-a-variable-to-have-the-same-type-as-its-initializer-function-call/">rule 7.1.8</a>.</p>
+<p>The <span class="title-ref">hicpp-use-auto</span> check is an alias, please see <code class="interpreted-text" role="doc">modernize-use-auto &lt;../modernize/use-auto&gt;</code> for more information. It enforces the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/declarations">rule 7.1.8</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-auto.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7841,7 +9746,7 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-use-emplace">hicpp-use-emplace</h1>
-<p>The <span class="title-ref">hicpp-use-emplace</span> check is an alias, please see <a href="../modernize/use-emplace.html">modernize-use-emplace</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/17-4-2-use-api-calls-that-construct-objects-in-place/">rule 17.4.2</a>.</p>
+<p>The <span class="title-ref">hicpp-use-emplace</span> check is an alias, please see <code class="interpreted-text" role="doc">modernize-use-emplace &lt;../modernize/use-emplace&gt;</code> for more information. It enforces the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-library">rule 17.4.2</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-emplace.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7858,7 +9763,7 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-use-equals-default">hicpp-use-equals-default</h1>
-<p>This check is an alias for <a href="../modernize/use-equals-default.html">modernize-use-equals-default</a>. Implements <a href="http://www.codingstandard.com/rule/12-5-1-define-explicitly-default-or-delete-implicit-special-member-functions-of-concrete-classes/">rule 12.5.1</a> to explicitly default special member functions.</p>
+<p>This check is an alias for <code class="interpreted-text" role="doc">modernize-use-equals-default &lt;../modernize/use-equals-default&gt;</code>. Implements <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/special-member-functions">rule 12.5.1</a> to explicitly default special member functions.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-equals-default.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7875,7 +9780,7 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-use-equals-delete">hicpp-use-equals-delete</h1>
-<p>This check is an alias for <a href="../modernize/use-equals-delete.html">modernize-use-equals-delete</a>. Implements <a href="http://www.codingstandard.com/rule/12-5-1-define-explicitly-default-or-delete-implicit-special-member-functions-of-concrete-classes/">rule 12.5.1</a> to explicitly default or delete special member functions.</p>
+<p>This check is an alias for <code class="interpreted-text" role="doc">modernize-use-equals-delete &lt;../modernize/use-equals-delete&gt;</code>. Implements <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/special-member-functions">rule 12.5.1</a> to explicitly default or delete special member functions.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-equals-delete.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7892,7 +9797,7 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-use-noexcept">hicpp-use-noexcept</h1>
-<p>The <span class="title-ref">hicpp-use-noexcept</span> check is an alias, please see <a href="../modernize/use-noexcept.html">modernize-use-noexcept</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/1-3-5-do-not-use-throw-exception-specifications/">rule 1.3.5</a>.</p>
+<p>The <span class="title-ref">hicpp-use-noexcept</span> check is an alias, please see <code class="interpreted-text" role="doc">modernize-use-noexcept &lt;../modernize/use-noexcept&gt;</code> for more information. It enforces the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/general">rule 1.3.5</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-noexcept.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7909,7 +9814,7 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-use-nullptr">hicpp-use-nullptr</h1>
-<p>The <span class="title-ref">hicpp-use-nullptr</span> check is an alias, please see <a href="../modernize/use-nullptr.html">modernize-use-nullptr</a> for more information. It enforces the <a href="http://www.codingstandard.com/rule/2-5-3-use-nullptr-for-the-null-pointer-constant/">rule 2.5.3</a>.</p>
+<p>The <span class="title-ref">hicpp-use-nullptr</span> check is an alias, please see <code class="interpreted-text" role="doc">modernize-use-nullptr &lt;../modernize/use-nullptr&gt;</code> for more information. It enforces the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/lexical-conventions">rule 2.5.3</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-nullptr.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7926,7 +9831,7 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-use-override">hicpp-use-override</h1>
-<p>This check is an alias for <a href="../modernize/use-override.html">modernize-use-override</a>. Implements <a href="http://www.codingstandard.com/section/10-2-virtual-functions/">rule 10.2.1</a> to declare a virtual function <span class="title-ref">override</span> when overriding.</p>
+<p>This check is an alias for <code class="interpreted-text" role="doc">modernize-use-override &lt;../modernize/use-override&gt;</code>. Implements <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/derived-classes">rule 10.2.1</a> to declare a virtual function <span class="title-ref">override</span> when overriding.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/use-override.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7943,7 +9848,7 @@ switch(i) {}</code></pre>
 
 </div>
 <h1 id="hicpp-vararg">hicpp-vararg</h1>
-<p>The <span class="title-ref">hicpp-vararg</span> check is an alias, please see <a href="../cppcoreguidelines/pro-type-vararg.html">cppcoreguidelines-pro-type-vararg</a> for more information. It enforces the <a href="http://www.codingstandard.com/section/14-1-template-declarations/">rule 14.1.1</a>.</p>
+<p>The <span class="title-ref">hicpp-vararg</span> check is an alias, please see <code class="interpreted-text" role="doc">cppcoreguidelines-pro-type-vararg &lt;../cppcoreguidelines/pro-type-vararg&gt;</code> for more information. It enforces the <a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/templates">rule 14.1.1</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/hicpp/vararg.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -7983,7 +9888,7 @@ fn();</code></pre>
 
 </div>
 <h1 id="llvm-else-after-return">llvm-else-after-return</h1>
-<p>The llvm-else-after-return check is an alias, please see <a href="../readability/else-after-return.html">readability-else-after-return</a> for more information.</p>
+<p>The <span class="title-ref">llvm-else-after-return</span> check is an alias, please see <code class="interpreted-text" role="doc">readability-else-after-return &lt;../readability/else-after-return&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm/else-after-return.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -8001,6 +9906,7 @@ fn();</code></pre>
 <h2 id="options">Options</h2>
 <div class="option">
 <p>HeaderFileExtensions</p>
+<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">HeaderFileExtensions</span>.</p>
 <p>A comma-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is "h,hh,hpp,hxx". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. E.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
 </div>
 <h2>References</h2>
@@ -8128,7 +10034,7 @@ if (X.cast(y)) {}</code></pre>
 
 </div>
 <h1 id="llvm-qualified-auto">llvm-qualified-auto</h1>
-<p>The llvm-qualified-auto check is an alias, please see <a href="../readability/qualified-auto.html">readability-qualified-auto</a> for more information.</p>
+<p>The <span class="title-ref">llvm-qualified-auto check</span> is an alias, please see <code class="interpreted-text" role="doc">readability-qualified-auto &lt;../readability/qualified-auto&gt;</code> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm/qualified-auto.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -8161,11 +10067,15 @@ static std::string Moo = (Twine(&quot;bark&quot;) + &quot;bah&quot;).str();</cod
 <p>clang-tidy - llvmlibc-callee-namespace</p>
 </div>
 <h1 id="llvmlibc-callee-namespace">llvmlibc-callee-namespace</h1>
-<p>Checks all calls resolve to functions within <code>__llvm_libc</code> namespace.</p>
-<pre class="c++"><code>namespace __llvm_libc {
+<p>Checks all calls resolve to functions within correct namespace.</p>
+<pre class="c++"><code>// Implementation inside the LIBC_NAMESPACE namespace.
+// Correct if:
+// - LIBC_NAMESPACE is a macro
+// - LIBC_NAMESPACE expansion starts with `__llvm_libc`
+namespace LIBC_NAMESPACE {
 
 // Allow calls with the fully qualified name.
-__llvm_libc::strlen(&quot;hello&quot;);
+LIBC_NAMESPACE::strlen(&quot;hello&quot;);
 
 // Allow calls to compiler provided functions.
 (void)__builtin_abs(-1);
@@ -8176,7 +10086,7 @@ strlen(&quot;world&quot;);
 // Disallow calling into functions in the global namespace.
 ::strlen(&quot;!&quot;);
 
-} // namespace __llvm_libc</code></pre>
+} // namespace LIBC_NAMESPACE</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvmlibc/callee-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -8191,26 +10101,49 @@ strlen(&quot;world&quot;);
 </div>
 <h1 id="llvmlibc-implementation-in-namespace">llvmlibc-implementation-in-namespace</h1>
 <p>Checks that all declarations in the llvm-libc implementation are within the correct namespace.</p>
-<pre class="c++"><code>// Correct: implementation inside the correct namespace.
-namespace __llvm_libc {
+<pre class="c++"><code>// Implementation inside the LIBC_NAMESPACE namespace.
+// Correct if:
+// - LIBC_NAMESPACE is a macro
+// - LIBC_NAMESPACE expansion starts with `__llvm_libc`
+namespace LIBC_NAMESPACE {
     void LLVM_LIBC_ENTRYPOINT(strcpy)(char *dest, const char *src) {}
-    // Namespaces within __llvm_libc namespace are allowed.
-    namespace inner{
+    // Namespaces within LIBC_NAMESPACE namespace are allowed.
+    namespace inner {
         int localVar = 0;
     }
     // Functions with C linkage are allowed.
-    extern &quot;C&quot; void str_fuzz(){}
+    extern &quot;C&quot; void str_fuzz() {}
 }
 
-// Incorrect: implementation not in a namespace.
+// Incorrect: implementation not in the LIBC_NAMESPACE namespace.
 void LLVM_LIBC_ENTRYPOINT(strcpy)(char *dest, const char *src) {}
 
-// Incorrect: outer most namespace is not correct.
+// Incorrect: outer most namespace is not the LIBC_NAMESPACE macro.
 namespace something_else {
+    void LLVM_LIBC_ENTRYPOINT(strcpy)(char *dest, const char *src) {}
+}
+
+// Incorrect: outer most namespace expansion does not start with `__llvm_libc`.
+#define LIBC_NAMESPACE custom_namespace
+namespace LIBC_NAMESPACE {
     void LLVM_LIBC_ENTRYPOINT(strcpy)(char *dest, const char *src) {}
 }</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvmlibc/implementation-in-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>llvmlibc-inline-function-decl</key>
+    <name>llvmlibc-inline-function-decl</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - llvmlibc-inline-function-decl</p>
+</div>
+<h1 id="llvmlibc-inline-function-decl">llvmlibc-inline-function-decl</h1>
+<p>Checks that all implicitly and explicitly inline functions in header files are tagged with the <code>LIBC_INLINE</code> macro, except for functions implicit to classes or deleted functions. See the <a href="https://libc.llvm.org/dev/code_style.html">libc style guide</a> for more information about this macro.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvmlibc/inline-function-decl.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -8236,6 +10169,231 @@ namespace something_else {
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvmlibc/restrict-system-libc-headers.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>misc-confusable-identifiers</key>
+    <name>misc-confusable-identifiers</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - misc-confusable-identifiers</p>
+</div>
+<h1 id="misc-confusable-identifiers">misc-confusable-identifiers</h1>
+<p>Warn about confusable identifiers, i.e. identifiers that are visually close to each other, but use different Unicode characters. This detects a potential attack described in <a href="https://www.cve.org/CVERecord?id=CVE-2021-42574">CVE-2021-42574</a>.</p>
+<p>Example:</p>
+<pre class="text"><code>int fo; // Initial character is U+0066 (LATIN SMALL LETTER F).
+int fo; // Initial character is U+1D41F (MATHEMATICAL BOLD SMALL F) not U+0066 (LATIN SMALL LETTER F).</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/confusable-identifiers.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>misc-const-correctness</key>
+    <name>misc-const-correctness</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - misc-const-correctness</p>
+</div>
+<h1 id="misc-const-correctness">misc-const-correctness</h1>
+<p>This check implements detection of local variables which could be declared as <code>const</code> but are not. Declaring variables as <code>const</code> is required or recommended by many coding guidelines, such as: <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es25-declare-an-object-const-or-constexpr-unless-you-want-to-modify-its-value-later-on">ES.25</a> from the C++ Core Guidelines and <a href="https://www.autosar.org/fileadmin/standards/R22-11/AP/AUTOSAR_RS_CPP14Guidelines.pdf">AUTOSAR C++14 Rule A7-1-1 (6.7.1 Specifiers)</a>.</p>
+<p>Please note that this check's analysis is type-based only. Variables that are not modified but used to create a non-const handle that might escape the scope are not diagnosed as potential <code>const</code>.</p>
+<pre class="c++"><code>// Declare a variable, which is not ``const`` ...
+int i = 42;
+// but use it as read-only. This means that `i` can be declared ``const``.
+int result = i * i;       // Before transformation
+int const result = i * i; // After transformation</code></pre>
+<p>The check can analyze values, pointers and references but not (yet) pointees:</p>
+<pre class="c++"><code>// Normal values like built-ins or objects.
+int potential_const_int = 42;       // Before transformation
+int const potential_const_int = 42; // After transformation
+int copy_of_value = potential_const_int;
+
+MyClass could_be_const;       // Before transformation
+MyClass const could_be_const; // After transformation
+could_be_const.const_qualified_method();
+
+// References can be declared const as well.
+int &amp;reference_value = potential_const_int;       // Before transformation
+int const&amp; reference_value = potential_const_int; // After transformation
+int another_copy = reference_value;
+
+// The similar semantics of pointers are not (yet) analyzed.
+int *pointer_variable = &amp;potential_const_int; // _NO_ &#39;const int *pointer_variable&#39; suggestion.
+int last_copy = *pointer_variable;</code></pre>
+<p>The automatic code transformation is only applied to variables that are declared in single declarations. You may want to prepare your code base with <code class="interpreted-text" role="doc">readability-isolate-declaration &lt;../readability/isolate-declaration&gt;</code> first.</p>
+<p>Note that there is the check <code class="interpreted-text" role="doc">cppcoreguidelines-avoid-non-const-global-variables &lt;../cppcoreguidelines/avoid-non-const-global-variables&gt;</code> to enforce <code>const</code> correctness on all globals.</p>
+<h2 id="known-limitations">Known Limitations</h2>
+<p>The check does not run on <span class="title-ref">C</span> code.</p>
+<p>The check will not analyze templated variables or variables that are instantiation dependent. Different instantiations can result in different <code>const</code> correctness properties and in general it is not possible to find all instantiations of a template. The template might be used differently in an independent translation unit.</p>
+<p>Pointees can not be analyzed for constness yet. The following code shows this limitation.</p>
+<pre class="c++"><code>// Declare a variable that will not be modified.
+int constant_value = 42;
+
+// Declare a pointer to that variable, that does not modify either, but misses &#39;const&#39;.
+// Could be &#39;const int *pointer_to_constant = &amp;constant_value;&#39;
+int *pointer_to_constant = &amp;constant_value;
+
+// Usage:
+int result = 520 * 120 * (*pointer_to_constant);</code></pre>
+<p>This limitation affects the capability to add <code>const</code> to methods which is not possible, too.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>AnalyzeValues (default = true)</p>
+<p>Enable or disable the analysis of ordinary value variables, like <code>int i = 42;</code></p>
+<pre class="c++"><code>// Warning
+int i = 42;
+// No warning
+int const i = 42;
+
+// Warning
+int a[] = {42, 42, 42};
+// No warning
+int const a[] = {42, 42, 42};</code></pre>
+</div>
+<div class="option">
+<p>AnalyzeReferences (default = true)</p>
+<p>Enable or disable the analysis of reference variables, like <code>int &amp;ref = i;</code></p>
+<pre class="c++"><code>int i = 42;
+// Warning
+int&amp; ref = i;
+// No warning
+int const&amp; ref = i;</code></pre>
+</div>
+<div class="option">
+<p>WarnPointersAsValues (default = false)</p>
+<p>This option enables the suggestion for <code>const</code> of the pointer itself. Pointer values have two possibilities to be <code>const</code>, the pointer and the value pointing to.</p>
+<pre class="c++"><code>int value = 42;
+
+// Warning
+const int * pointer_variable = &amp;value;
+// No warning
+const int *const pointer_variable = &amp;value;</code></pre>
+</div>
+<div class="option">
+<p>TransformValues (default = true)</p>
+<p>Provides fixit-hints for value types that automatically add <code>const</code> if its a single declaration.</p>
+<pre class="c++"><code>// Before
+int value = 42;
+// After
+int const value = 42;
+
+// Before
+int a[] = {42, 42, 42};
+// After
+int const a[] = {42, 42, 42};
+
+// Result is modified later in its life-time. No diagnostic and fixit hint will be emitted.
+int result = value * 3;
+result -= 10;</code></pre>
+</div>
+<div class="option">
+<p>TransformReferences (default = true)</p>
+<p>Provides fixit-hints for reference types that automatically add <code>const</code> if its a single declaration.</p>
+<pre class="c++"><code>// This variable could still be a constant. But because there is a non-const reference to
+// it, it can not be transformed (yet).
+int value = 42;
+// The reference &#39;ref_value&#39; is not modified and can be made &#39;const int &amp;ref_value = value;&#39;
+// Before
+int &amp;ref_value = value;
+// After
+int const &amp;ref_value = value;
+
+// Result is modified later in its life-time. No diagnostic and fixit hint will be emitted.
+int result = ref_value * 3;
+result -= 10;</code></pre>
+</div>
+<div class="option">
+<p>TransformPointersAsValues (default = false)</p>
+<p>Provides fixit-hints for pointers if their pointee is not changed. This does not analyze if the value-pointed-to is unchanged!</p>
+<p>Requires 'WarnPointersAsValues' to be 'true'.</p>
+<pre class="c++"><code>int value = 42;
+
+// Before
+const int * pointer_variable = &amp;value;
+// After
+const int *const pointer_variable = &amp;value;
+
+// Before
+const int * a[] = {&amp;value, &amp;value};
+// After
+const int *const a[] = {&amp;value, &amp;value};
+
+// Before
+int *ptr_value = &amp;value;
+// After
+int *const ptr_value = &amp;value;
+
+int result = 100 * (*ptr_value); // Does not modify the pointer itself.
+// This modification of the pointee is still allowed and not diagnosed.
+*ptr_value = 0;
+
+// The following pointer may not become a &#39;int *const&#39;.
+int *changing_pointee = &amp;value;
+changing_pointee = &amp;result;</code></pre>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/const-correctness.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>misc-coroutine-hostile-raii</key>
+    <name>misc-coroutine-hostile-raii</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - misc-coroutine-hostile-raii</p>
+</div>
+<h1 id="misc-coroutine-hostile-raii">misc-coroutine-hostile-raii</h1>
+<p>Detects when objects of certain hostile RAII types persists across suspension points in a coroutine. Such hostile types include scoped-lockable types and types belonging to a configurable denylist.</p>
+<p>Some objects require that they be destroyed on the same thread that created them. Traditionally this requirement was often phrased as "must be a local variable", under the assumption that local variables always work this way. However this is incorrect with C++20 coroutines, since an intervening <code>co_await</code> may cause the coroutine to suspend and later be resumed on another thread.</p>
+<p>The lifetime of an object that requires being destroyed on the same thread must not encompass a <code>co_await</code> or <code>co_yield</code> point. If you create/destroy an object, you must do so without allowing the coroutine to suspend in the meantime.</p>
+<p>Following types are considered as hostile:</p>
+<blockquote>
+<ul>
+<li>Scoped-lockable types: A scoped-lockable object persisting across a suspension point is problematic as the lock held by this object could be unlocked by a different thread. This would be undefined behaviour. This includes all types annotated with the <code>scoped_lockable</code> attribute.</li>
+<li>Types belonging to a configurable denylist.</li>
+</ul>
+</blockquote>
+<pre class="c++"><code>// Call some async API while holding a lock.
+task coro() {
+  const std::lock_guard l(&amp;mu_);
+
+  // Oops! The async Bar function may finish on a different
+  // thread from the one that created the lock_guard (and called
+  // Mutex::Lock). After suspension, Mutex::Unlock will be called on the wrong thread.
+  co_await Bar();
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>RAIITypesList</p>
+<p>A semicolon-separated list of qualified types which should not be allowed to persist across suspension points. Eg: <code>my::lockable; a::b;::my::other::lockable;</code> The default value of this option is <span class="title-ref">"std::lock_guard;std::scoped_lock"</span>.</p>
+</div>
+<div class="option">
+<p>AllowedAwaitablesList</p>
+<p>A semicolon-separated list of qualified types of awaitables types which can be safely awaited while having hostile RAII objects in scope.</p>
+<p><code>co_await</code>-ing an expression of <code>awaitable</code> type is considered safe if the <code>awaitable</code> type is part of this list. RAII objects persisting across such a <code>co_await</code> expression are considered safe and hence are not flagged.</p>
+<p>Example usage:</p>
+<pre class="c++"><code>// Consider option AllowedAwaitablesList = &quot;safe_awaitable&quot;
+struct safe_awaitable {
+  bool await_ready() noexcept { return false; }
+  void await_suspend(std::coroutine_handle&lt;&gt;) noexcept {}
+  void await_resume() noexcept {}
+};
+auto wait() { return safe_awaitable{}; }
+
+task coro() {
+  // This persists across both the co_await&#39;s but is not flagged
+  // because the awaitable is considered safe to await on.
+  const std::lock_guard l(&amp;mu_);
+  co_await safe_awaitable{};
+  co_await wait();
+}</code></pre>
+<p>Eg: <code>my::safe::awaitable;other::awaitable</code> The default value of this option is empty string <span class="title-ref">""</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/coroutine-hostile-raii.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -8266,6 +10424,7 @@ static int b = 1;
 const int c = 1;
 const char* const str2 = &quot;foo&quot;;
 constexpr int k = 1;
+namespace { int x = 1; }
 
 // Warning: function definition.
 int g() {
@@ -8325,19 +10484,96 @@ constexpr int f10() { return 0; } // OK: constexpr function implies inline.
 // OK: C++14 variable templates are inline.
 template &lt;class T&gt;
 constexpr T pi = T(3.1415926L);</code></pre>
+<p>When <code class="interpreted-text" role="program">clang-tidy</code> is invoked with the <span class="title-ref">--fix-notes</span> option, this check provides fixes that automatically add the <code>inline</code> keyword to discovered functions. Please note that the addition of the <code>inline</code> keyword to variables is not currently supported by this check.</p>
 <h2 id="options">Options</h2>
 <div class="option">
 <p>HeaderFileExtensions</p>
+<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">HeaderFileExtensions</span>.</p>
 <p>A comma-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is "h,hh,hpp,hxx". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. E.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
 </div>
 <div class="option">
 <p>UseHeaderFileExtension</p>
+<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. The check will unconditionally use the global option <span class="title-ref">HeaderFileExtensions</span>.</p>
 <p>When <span class="title-ref">true</span>, the check will use the file extension to distinguish header files. Default is <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/definitions-in-headers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
+    </rule>
+  <rule>
+    <key>misc-header-include-cycle</key>
+    <name>misc-header-include-cycle</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - misc-header-include-cycle</p>
+</div>
+<h1 id="misc-header-include-cycle">misc-header-include-cycle</h1>
+<p>Check detects cyclic <code>#include</code> dependencies between user-defined headers.</p>
+<pre class="c++"><code>// Header A.hpp
+#pragma once
+#include &quot;B.hpp&quot;
+
+// Header B.hpp
+#pragma once
+#include &quot;C.hpp&quot;
+
+// Header C.hpp
+#pragma once
+#include &quot;A.hpp&quot;
+
+// Include chain: A-&gt;B-&gt;C-&gt;A</code></pre>
+<p>Header files are a crucial part of many C++ programs as they provide a way to organize declarations and definitions shared across multiple source files. However, header files can also create problems when they become entangled in complex dependency cycles. Such cycles can cause issues with compilation times, unnecessary rebuilds, and make it harder to understand the overall structure of the code.</p>
+<p>To address these issues, a check has been developed to detect cyclic dependencies between header files, also known as "include cycles". An include cycle occurs when a header file <span class="title-ref">A</span> includes header file <span class="title-ref">B</span>, and <span class="title-ref">B</span> (or any subsequent included header file) includes back header file <span class="title-ref">A</span>, resulting in a circular dependency cycle.</p>
+<p>This check operates at the preprocessor level and specifically analyzes user-defined headers and their dependencies. It focuses solely on detecting include cycles while disregarding other types or function dependencies. This specialized analysis helps identify and prevent issues related to header file organization.</p>
+<p>By detecting include cycles early in the development process, developers can identify and resolve these issues before they become more difficult and time-consuming to fix. This can lead to faster compile times, improved code quality, and a more maintainable codebase overall. Additionally, by ensuring that header files are organized in a way that avoids cyclic dependencies, developers can make their code easier to understand and modify over time.</p>
+<p>It's worth noting that only user-defined headers their dependencies are analyzed, System includes such as standard library headers and third-party library headers are excluded. System includes are usually well-designed and free of include cycles, and ignoring them helps to focus on potential issues within the project's own codebase. This limitation doesn't diminish the ability to detect <code>#include</code> cycles within the analyzed code.</p>
+<p>Developers should carefully review any warnings or feedback provided by this solution. While the analysis aims to identify and prevent include cycles, there may be situations where exceptions or modifications are necessary. It's important to exercise judgment and consider the specific context of the codebase when making adjustments.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoredFilesList</p>
+<p>Provides a way to exclude specific files/headers from the warnings raised by a check. This can be achieved by specifying a semicolon-separated list of regular expressions or filenames. This option can be used as an alternative to <code>//NOLINT</code> when using it is not possible. The default value of this option is an empty string, indicating that no files are ignored by default.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/header-include-cycle.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>misc-include-cleaner</key>
+    <name>misc-include-cleaner</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - misc-include-cleaner</p>
+</div>
+<h1 id="misc-include-cleaner">misc-include-cleaner</h1>
+<p>Checks for unused and missing includes. Generates findings only for the main file of a translation unit. Findings correspond to <a href="https://clangd.llvm.org/design/include-cleaner">https://clangd.llvm.org/design/include-cleaner</a>.</p>
+<p>Example:</p>
+<pre class="c++"><code>// foo.h
+class Foo{};
+// bar.h
+#include &quot;baz.h&quot;
+class Bar{};
+// baz.h
+class Baz{};
+// main.cc
+#include &quot;bar.h&quot; // OK: uses class Bar from bar.h
+#include &quot;foo.h&quot; // warning: unused include &quot;foo.h&quot;
+Bar bar;
+Baz baz; // warning: missing include &quot;baz.h&quot;</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreHeaders</p>
+<p>A semicolon-separated list of regexes to disable insertion/removal of header files that match this regex as a suffix. E.g., <span class="title-ref">foo/.*</span> disables insertion/removal for all headers under the directory <span class="title-ref">foo</span>. By default, no headers will be ignored.</p>
+</div>
+<div class="option">
+<p>DeduplicateFindings</p>
+<p>A boolean that controls whether the check should deduplicate findings for the same symbol. Defaults to <span class="title-ref">true</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>misc-misleading-bidirectional</key>
@@ -8589,6 +10825,7 @@ void f(const int_ptr ptr) {
 <li>The operator must always return <code>*this</code>.</li>
 </ul>
 </blockquote>
+<p>This check implements <a href="https://www.autosar.org/fileadmin/standards/R22-11/AP/AUTOSAR_RS_CPP14Guidelines.pdf">AUTOSAR C++14 Rule A13-2-1</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/unconventional-assign-operator.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -8662,6 +10899,10 @@ static void staticFunctionA() { /*some code that doesn&#39;t use `i`*/ }</code><
 <p>StrictMode</p>
 <p>When <span class="title-ref">false</span> (default value), the check will ignore trivially unused parameters, i.e. when the corresponding function has an empty body (and in case of constructors - no constructor initializers). When the function body is empty, an unused parameter is unlikely to be unnoticed by a human reader, and there's basically no place for a bug to hide.</p>
 </div>
+<div class="option">
+<p>IgnoreVirtual</p>
+<p>Determines whether virtual method parameters should be inspected. Set to <span class="title-ref">true</span> to ignore them. Default is <span class="title-ref">false</span>.</p>
+</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/unused-parameters.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -8676,11 +10917,56 @@ static void staticFunctionA() { /*some code that doesn&#39;t use `i`*/ }</code><
 </div>
 <h1 id="misc-unused-using-decls">misc-unused-using-decls</h1>
 <p>Finds unused <code>using</code> declarations.</p>
+<p>Unused <code>using</code><span class="title-ref"> declarations in header files will not be diagnosed since these using declarations are part of the header's public API. Allowed header file extensions can be configured via the `HeaderFileExtensions</span> option (see below).</p>
 <p>Example:</p>
-<pre class="c++"><code>namespace n { class C; }
+<pre class="c++"><code>// main.cpp
+namespace n { class C; }
 using n::C;  // Never actually used.</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>HeaderFileExtensions</p>
+<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">HeaderFileExtensions</span>.</p>
+<p>A semicolon-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is "h,hh,hpp,hxx". For extension-less header files, use an empty string or leave an empty string between "," if there are other filename extensions.</p>
+</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/unused-using-decls.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>misc-use-anonymous-namespace</key>
+    <name>misc-use-anonymous-namespace</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - misc-use-anonymous-namespace</p>
+</div>
+<h1 id="misc-use-anonymous-namespace">misc-use-anonymous-namespace</h1>
+<p>Finds instances of <code>static</code> functions or variables declared at global scope that could instead be moved into an anonymous namespace.</p>
+<p>Anonymous namespaces are the "superior alternative" according to the C++ Standard. <code>static</code> was proposed for deprecation, but later un-deprecated to keep C compatibility [1]. <code>static</code> is an overloaded term with different meanings in different contexts, so it can create confusion.</p>
+<p>The following uses of <code>static</code> will <em>not</em> be diagnosed:</p>
+<ul>
+<li>Functions or variables in header files, since anonymous namespaces in headers is considered an antipattern. Allowed header file extensions can be configured via the <span class="title-ref">HeaderFileExtensions</span> option (see below).</li>
+<li><code>const</code> or <code>constexpr</code> variables, since they already have implicit internal linkage in C++.</li>
+</ul>
+<p>Examples:</p>
+<pre class="c++"><code>// Bad
+static void foo();
+static int x;
+
+// Good
+namespace {
+  void foo();
+  int x;
+} // namespace</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>HeaderFileExtensions</p>
+<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">HeaderFileExtensions</span>.</p>
+<p>A semicolon-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is ";h;hh;hpp;hxx". For extension-less header files, using an empty string or leaving an empty string between ";" if there are other filename extensions.</p>
+</div>
+<p>[1] <a href="https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1012">Undeprecating static</a></p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/use-anonymous-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -8814,6 +11100,13 @@ namespace n7 {
 void t();
 }
 }
+}
+
+// in c++20
+namespace n8 {
+inline namespace n9 {
+void t();
+}
 }</code></pre>
 <p>Will be modified to:</p>
 <pre class="c++"><code>namespace n1::n2 {
@@ -8827,6 +11120,11 @@ void t();
 namespace n6::n7 {
 void t();
 }
+}
+
+// in c++20
+namespace n8::inline n9 {
+void t();
 }</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/concat-nested-namespaces.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -8992,7 +11290,19 @@ for (vector&lt;int&gt;::iterator it = v.begin(); it != v.end(); ++it)
   cout &lt;&lt; *it;
 
 // reasonable conversion
+for (vector&lt;int&gt;::iterator it = begin(v); it != end(v); ++it)
+  cout &lt;&lt; *it;
+
+// reasonable conversion
+for (vector&lt;int&gt;::iterator it = std::begin(v); it != std::end(v); ++it)
+  cout &lt;&lt; *it;
+
+// reasonable conversion
 for (int i = 0; i &lt; v.size(); ++i)
+  cout &lt;&lt; v[i];
+
+// reasonable conversion
+for (int i = 0; i &lt; size(v); ++i)
   cout &lt;&lt; v[i];</code></pre>
 <p>After applying the check with minimum confidence level set to <span class="title-ref">reasonable</span> (default):</p>
 <pre class="c++"><code>const int N = 5;
@@ -9108,6 +11418,64 @@ for (vector&lt;int&gt;::iterator it = vec.begin(), e = vec.end(); it != e; ++it)
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/loop-convert.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
+    </rule>
+  <rule>
+    <key>modernize-macro-to-enum</key>
+    <name>modernize-macro-to-enum</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - modernize-macro-to-enum</p>
+</div>
+<h1 id="modernize-macro-to-enum">modernize-macro-to-enum</h1>
+<p>Replaces groups of adjacent macros with an unscoped anonymous enum. Using an unscoped anonymous enum ensures that everywhere the macro token was used previously, the enumerator name may be safely used.</p>
+<p>This check can be used to enforce the C++ core guideline <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#enum1-prefer-enumerations-over-macros">Enum.1: Prefer enumerations over macros</a>, within the constraints outlined below.</p>
+<p>Potential macros for replacement must meet the following constraints:</p>
+<ul>
+<li>Macros must expand only to integral literal tokens or expressions of literal tokens. The expression may contain any of the unary operators <code>-</code>, <code>+</code>, <code>~</code> or <code>!</code>, any of the binary operators <code>,</code>, <code>-</code>, <code>+</code>, <code>*</code>, <code>/</code>, <code>%</code>, <code>&amp;</code>, <code>|</code>, <code>^</code>, <code>&lt;</code>, <code>&gt;</code>, <code>&lt;=</code>, <code>&gt;=</code>, <code>==</code>, <code>!=</code>, <code>||</code>, <code>&amp;&amp;</code>, <code>&lt;&lt;</code>, <code>&gt;&gt;</code> or <code>&lt;=&gt;</code>, the ternary operator <code>?:</code> and its <a href="https://gcc.gnu.org/onlinedocs/gcc/Conditionals.html">GNU extension</a>. Parenthesized expressions are also recognized. This recognizes most valid expressions. In particular, expressions with the <code>sizeof</code> operator are not recognized.</li>
+<li>Macros must be defined on sequential source file lines, or with only comment lines in between macro definitions.</li>
+<li>Macros must all be defined in the same source file.</li>
+<li>Macros must not be defined within a conditional compilation block. (Conditional include guards are exempt from this constraint.)</li>
+<li>Macros must not be defined adjacent to other preprocessor directives.</li>
+<li>Macros must not be used in any conditional preprocessing directive.</li>
+<li>Macros must not be used as arguments to other macros.</li>
+<li>Macros must not be undefined.</li>
+<li>Macros must be defined at the top-level, not inside any declaration or definition.</li>
+</ul>
+<p>Each cluster of macros meeting the above constraints is presumed to be a set of values suitable for replacement by an anonymous enum. From there, a developer can give the anonymous enum a name and continue refactoring to a scoped enum if desired. Comments on the same line as a macro definition or between subsequent macro definitions are preserved in the output. No formatting is assumed in the provided replacements, although clang-tidy can optionally format all fixes.</p>
+<div class="warning">
+<div class="title">
+<p>Warning</p>
+</div>
+<p>Initializing expressions are assumed to be valid initializers for an enum. C requires that enum values fit into an <code>int</code>, but this may not be the case for some accepted constant expressions. For instance <code>1 &lt;&lt; 40</code> will not fit into an <code>int</code> when the size of an <code>int</code> is 32 bits.</p>
+</div>
+<p>Examples:</p>
+<pre class="c++"><code>#define RED   0xFF0000
+#define GREEN 0x00FF00
+#define BLUE  0x0000FF
+
+#define TM_NONE (-1) // No method selected.
+#define TM_ONE 1    // Use tailored method one.
+#define TM_TWO 2    // Use tailored method two.  Method two
+                    // is preferable to method one.
+#define TM_THREE 3  // Use tailored method three.</code></pre>
+<p>becomes</p>
+<pre class="c++"><code>enum {
+RED = 0xFF0000,
+GREEN = 0x00FF00,
+BLUE = 0x0000FF
+};
+
+enum {
+TM_NONE = (-1), // No method selected.
+TM_ONE = 1,    // Use tailored method one.
+TM_TWO = 2,    // Use tailored method two.  Method two
+                    // is preferable to method one.
+TM_THREE = 3  // Use tailored method three.
+};</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/macro-to-enum.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>modernize-make-shared</key>
@@ -9346,6 +11714,14 @@ const char *const RegEx{R&quot;(\w\([a-z]\))&quot;};</code></pre>
 <p>The presence of any of the following escapes can cause the string to be converted to a raw string literal: <code>\\</code>, <code>\'</code>, <code>\"</code>, <code>\?</code>, and octal or hexadecimal escapes for printable ASCII characters.</p>
 <p>A string literal containing only escaped newlines is a common way of writing lines of text output. Introducing physical newlines with raw string literals in this case is likely to impede readability. These string literals are left unchanged.</p>
 <p>An escaped horizontal tab, form feed, or vertical tab prevents the string literal from being converted. The presence of a horizontal tab, form feed or vertical tab in source code is not visually obvious.</p>
+<div class="option">
+<p>DelimiterStem</p>
+<p>Custom delimiter to escape characters in raw string literals. It is used in the following construction: <code>R"stem_delimiter(contents)stem_delimiter"</code>. The default value is <span class="title-ref">lit</span>.</p>
+</div>
+<div class="option">
+<p>ReplaceShorterLiterals</p>
+<p>Controls replacing shorter non-raw string literals with longer raw string literals. Setting this option to <span class="title-ref">true</span> enables the replacement. The default value is <span class="title-ref">false</span> (shorter literals are not replaced).</p>
+</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/raw-string-literal.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -9575,6 +11951,38 @@ Foo bar() {
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>modernize-type-traits</key>
+    <name>modernize-type-traits</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - modernize-type-traits</p>
+</div>
+<h1 id="modernize-type-traits">modernize-type-traits</h1>
+<p>Converts standard library type traits of the form <code>traits&lt;...&gt;::type</code> and <code>traits&lt;...&gt;::value</code> into <code>traits_t&lt;...&gt;</code> and <code>traits_v&lt;...&gt;</code> respectively.</p>
+<p>For example:</p>
+<pre class="c++"><code>std::is_integral&lt;T&gt;::value
+std::is_same&lt;int, float&gt;::value
+typename std::add_const&lt;T&gt;::type
+std::make_signed&lt;unsigned&gt;::type</code></pre>
+<p>Would be converted into:</p>
+<pre class="c++"><code>std::is_integral_v&lt;T&gt;
+std::is_same_v&lt;int, float&gt;
+std::add_const_t&lt;T&gt;
+std::make_signed_t&lt;unsigned&gt;</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>If <span class="title-ref">true</span> don't diagnose traits defined in macros.</p>
+<p>Note: Fixes will never be emitted for code inside of macros.</p>
+<pre class="c++"><code>#define IS_SIGNED(T) std::is_signed&lt;T&gt;::value</code></pre>
+<p>Defaults to <span class="title-ref">false</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/type-traits.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>modernize-unary-static-assert</key>
     <name>modernize-unary-static-assert</name>
     <description>
@@ -9789,6 +12197,63 @@ bool x = p ? true : false;</code></pre>
     <severity>MINOR</severity>
     </rule>
   <rule>
+    <key>modernize-use-constraints</key>
+    <name>modernize-use-constraints</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - modernize-use-constraints</p>
+</div>
+<h1 id="modernize-use-constraints">modernize-use-constraints</h1>
+<p>Replace <code>std::enable_if</code> with C++20 requires clauses.</p>
+<p><code>std::enable_if</code> is a SFINAE mechanism for selecting the desired function or class template based on type traits or other requirements. <code>enable_if</code> changes the meta-arity of the template, and has other <a href="https://open-std.org/JTC1/SC22/WG21/docs/papers/2016/p0225r0.html">adverse side effects</a> in the code. C++20 introduces concepts and constraints as a cleaner language provided solution to achieve the same outcome.</p>
+<p>This check finds some common <code>std::enable_if</code> patterns that can be replaced by C++20 requires clauses. The tool can replace some of these patterns automatically, otherwise, the tool will emit a diagnostic without a replacement. The tool can detect the following <code>std::enable_if</code> patterns</p>
+<ol type="1">
+<li><code>std::enable_if</code> in the return type of a function</li>
+<li><code>std::enable_if</code> as the trailing template parameter for function templates</li>
+</ol>
+<p>Other uses, for example, in class templates for function parameters, are not currently supported by this tool. Other variants such as <code>boost::enable_if</code> are not currently supported by this tool.</p>
+<p>Below are some examples of code using <code>std::enable_if</code>.</p>
+<pre class="c++"><code>// enable_if in function return type
+template &lt;typename T&gt;
+std::enable_if_t&lt;T::some_trait, int&gt; only_if_t_has_the_trait() { ... }
+
+// enable_if in the trailing template parameter
+template &lt;typename T, std::enable_if_t&lt;T::some_trait, int&gt; = 0&gt;
+void another_version() { ... }
+
+template &lt;typename T&gt;
+typename std::enable_if&lt;T::some_value, Obj&gt;::type existing_constraint() requires (T::another_value) {
+  return Obj{};
+}
+
+template &lt;typename T, std::enable_if_t&lt;T::some_trait, int&gt; = 0&gt;
+struct my_class {};</code></pre>
+<p>The tool will replace the above code with,</p>
+<pre class="c++"><code>// warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
+template &lt;typename T&gt;
+int only_if_t_has_the_trait() requires T::some_trait { ... }
+
+// warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
+template &lt;typename T&gt;
+void another_version() requires T::some_trait { ... }
+
+// The tool will emit a diagnostic for the following, but will
+// not attempt to replace the code.
+// warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
+template &lt;typename T&gt;
+typename std::enable_if&lt;T::some_value, Obj&gt;::type existing_constraint() requires (T::another_value) {
+  return Obj{};
+}
+
+// The tool will not emit a diagnostic or attempt to replace the code.
+template &lt;typename T, std::enable_if_t&lt;T::some_trait, int&gt; = 0&gt;
+struct my_class {};</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-constraints.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>modernize-use-default-member-init</key>
     <name>modernize-use-default-member-init</name>
     <description>
@@ -9842,8 +12307,7 @@ struct A {
     <key>modernize-use-default</key>
     <name>modernize-use-default</name>
     <description>
-      <![CDATA[
-      <dl>
+      <![CDATA[<dl>
 <dt>orphan</dt>
 <dd>
 </dd>
@@ -9855,7 +12319,7 @@ struct A {
 
 </div>
 <h1 id="modernize-use-default">modernize-use-default</h1>
-<p>This check has been renamed to <a href="../modernize/use-equals-default.html">modernize-use-equals-default</a>.</p>
+<p>This check has been renamed to <code class="interpreted-text" role="doc">modernize-use-equals-default &lt;../modernize/use-equals-default&gt;</code>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-default.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -10002,7 +12466,7 @@ A::~A() = default;</code></pre>
 <h2 id="options">Options</h2>
 <div class="option">
 <p>IgnoreMacros</p>
-<p>If set to <span class="title-ref">true</span>, the check will not give warnings inside macros. Default is <span class="title-ref">true</span>.</p>
+<p>If set to <span class="title-ref">true</span>, the check will not give warnings inside macros and will ignore special members with bodies contain macros or preprocessor directives. Default is <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -10017,17 +12481,20 @@ A::~A() = default;</code></pre>
 <p>clang-tidy - modernize-use-equals-delete</p>
 </div>
 <h1 id="modernize-use-equals-delete">modernize-use-equals-delete</h1>
-<p>This check marks unimplemented private special member functions with <code>= delete</code>. To avoid false-positives, this check only applies in a translation unit that has all other member functions implemented.</p>
-<pre class="c++"><code>struct A {
-private:
+<p>Identifies unimplemented private special member functions, and recommends using <code>= delete</code> for them. Additionally, it recommends relocating any deleted member function from the <code>private</code> to the <code>public</code> section.</p>
+<p>Before the introduction of C++11, the primary method to effectively "erase" a particular function involved declaring it as <code>private</code> without providing a definition. This approach would result in either a compiler error (when attempting to call a private function) or a linker error (due to an undefined reference).</p>
+<p>However, subsequent to the advent of C++11, a more conventional approach emerged for achieving this purpose. It involves flagging functions as <code>= delete</code> and keeping them in the <code>public</code> section of the class.</p>
+<p>To prevent false positives, this check is only active within a translation unit where all other member functions have been implemented. The check will generate partial fixes by introducing <code>= delete</code>, but the user is responsible for manually relocating functions to the <code>public</code> section.</p>
+<pre class="c++"><code>// Example: bad
+class A {
+ private:
   A(const A&amp;);
   A&amp; operator=(const A&amp;);
 };
 
-// becomes
-
-struct A {
-private:
+// Example: good
+class A {
+ public:
   A(const A&amp;) = delete;
   A&amp; operator=(const A&amp;) = delete;
 };</code></pre>
@@ -10188,6 +12655,10 @@ int *ret_ptr() {
 }</code></pre>
 <h2 id="options">Options</h2>
 <div class="option">
+<p>IgnoredTypes</p>
+<p>Semicolon-separated list of regular expressions to match pointer types for which implicit casts will be ignored. Default value: <span class="title-ref">std::_CmpUnspecifiedParam::;^std::__cmp_cat::__unspec</span>.</p>
+</div>
+<div class="option">
 <p>NullMacros</p>
 <p>Comma-separated list of macro names that will be transformed along with <code>NULL</code>. By default this check will only replace the <code>NULL</code> macro and will skip any similar user-defined macros.</p>
 </div>
@@ -10231,6 +12702,10 @@ void assignment() {
 <p>If set to <span class="title-ref">true</span>, this check will not diagnose destructors. Default is <span class="title-ref">false</span>.</p>
 </div>
 <div class="option">
+<p>IgnoreTemplateInstantiations</p>
+<p>If set to <span class="title-ref">true</span>, instructs this check to ignore virtual function overrides that are part of template instantiations. Default is <span class="title-ref">false</span>.</p>
+</div>
+<div class="option">
 <p>AllowOverrideAndFinal</p>
 <p>If set to <span class="title-ref">true</span>, this check will not diagnose <code>override</code> as redundant with <code>final</code>. This is useful when code will be compiled by a compiler with warning/error checking flags requiring <code>override</code> explicitly on overridden members, such as <code>gcc -Wsuggest-override</code>/<code>gcc -Werror=suggest-override</code>. Default is <span class="title-ref">false</span>.</p>
 </div>
@@ -10250,6 +12725,159 @@ void assignment() {
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-override.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>modernize-use-starts-ends-with</key>
+    <name>modernize-use-starts-ends-with</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - modernize-use-starts-ends-with</p>
+</div>
+<h1 id="modernize-use-starts-ends-with">modernize-use-starts-ends-with</h1>
+<p>Checks whether a <code>find</code> or <code>rfind</code> result is compared with 0 and suggests replacing with <code>starts_with</code> when the method exists in the class. Notably, this will work with <code>std::string</code> and <code>std::string_view</code>.</p>
+<pre class="c++"><code>std::string s = &quot;...&quot;;
+if (s.find(&quot;prefix&quot;) == 0) { /* do something */ }
+if (s.rfind(&quot;prefix&quot;, 0) == 0) { /* do something */ }</code></pre>
+<p>becomes</p>
+<pre class="c++"><code>std::string s = &quot;...&quot;;
+if (s.starts_with(&quot;prefix&quot;)) { /* do something */ }
+if (s.starts_with(&quot;prefix&quot;)) { /* do something */ }</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-starts-ends-with.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>modernize-use-std-numbers</key>
+    <name>modernize-use-std-numbers</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - modernize-use-std-numbers</p>
+</div>
+<h1 id="modernize-use-std-numbers">modernize-use-std-numbers</h1>
+<p>Finds constants and function calls to math functions that can be replaced with C++20's mathematical constants from the <code>numbers</code> header and offers fix-it hints. Does not match the use of variables with that value, and instead, offers a replacement for the definition of those variables. Function calls that match the pattern of how the constant is calculated are matched and replaced with the <code>std::numbers</code> constant. The use of macros gets replaced with the corresponding <code>std::numbers</code> constant, instead of changing the macro definition.</p>
+<p>The following list of constants from the <code>numbers</code> header are supported:</p>
+<ul>
+<li><code>e</code></li>
+<li><code>log2e</code></li>
+<li><code>log10e</code></li>
+<li><code>pi</code></li>
+<li><code>inv_pi</code></li>
+<li><code>inv_sqrtpi</code></li>
+<li><code>ln2</code></li>
+<li><code>ln10</code></li>
+<li><code>sqrt2</code></li>
+<li><code>sqrt3</code></li>
+<li><code>inv_sqrt3</code></li>
+<li><code>egamma</code></li>
+<li><code>phi</code></li>
+</ul>
+<p>The list currently includes all constants as of C++20.</p>
+<p>The replacements use the type of the matched constant and can remove explicit casts, i.e., switching between <code>std::numbers::e</code>, <code>std::numbers::e_v&lt;float&gt;</code> and <code>std::numbers::e_v&lt;long double&gt;</code> where appropriate.</p>
+<pre class="c++"><code>double sqrt(double);
+double log2(double);
+void sink(auto&amp;&amp;) {}
+void floatSink(float);
+
+#define MY_PI 3.1415926
+
+void foo() {
+    const double Pi = 3.141592653589;           // const double Pi = std::numbers::pi
+    const auto Use = Pi / 2;                    // no match for Pi
+    static constexpr double Euler = 2.7182818;  // static constexpr double Euler = std::numbers::e;
+
+    log2(exp(1));                               // std::numbers::log2e;
+    log2(Euler);                                // std::numbers::log2e;
+    1 / sqrt(MY_PI);                            // std::numbers::inv_sqrtpi;
+    sink(MY_PI);                                // sink(std::numbers::pi);
+    floatSink(MY_PI);                           // floatSink(std::numbers::pi);
+    floatSink(static_cast&lt;float&gt;(MY_PI));       // floatSink(std::numbers::pi_v&lt;float&gt;);
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>DiffThreshold</p>
+<p>A floating point value that sets the detection threshold for when literals match a constant. A literal matches a constant if <code>abs(literal - constant) &lt; DiffThreshold</code> evaluates to <code>true</code>. Default is <span class="title-ref">0.001</span>.</p>
+</div>
+<div class="option">
+<p>IncludeStyle</p>
+<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-std-numbers.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>modernize-use-std-print</key>
+    <name>modernize-use-std-print</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - modernize-use-std-print</p>
+</div>
+<h1 id="modernize-use-std-print">modernize-use-std-print</h1>
+<p>Converts calls to <code>printf</code>, <code>fprintf</code>, <code>absl::PrintF</code> and <code>absl::FPrintf</code> to equivalent calls to C++23's <code>std::print</code> or <code>std::println</code> as appropriate, modifying the format string appropriately. The replaced and replacement functions can be customised by configuration options. Each argument that is the result of a call to <code>std::string::c_str()</code> and <code>std::string::data()</code> will have that now-unnecessary call removed in a similar manner to the <span class="title-ref">readability-redundant-string-cstr</span> check.</p>
+<p>In other words, it turns lines like:</p>
+<pre class="c++"><code>fprintf(stderr, &quot;The %s is %3d\n&quot;, description.c_str(), value);</code></pre>
+<p>into:</p>
+<pre class="c++"><code>std::println(stderr, &quot;The {} is {:3}&quot;, description, value);</code></pre>
+<p>If the <span class="title-ref">ReplacementPrintFunction</span> or <span class="title-ref">ReplacementPrintlnFunction</span> options are left, or assigned to their default values then this check is only enabled with <span class="title-ref">-std=c++23</span> or later.</p>
+<p>The check doesn't do a bad job, but it's not perfect. In particular:</p>
+<ul>
+<li>It assumes that the format string is correct for the arguments. If you get any warnings when compiling with <span class="title-ref">-Wformat</span> then misbehaviour is possible.</li>
+<li>At the point that the check runs, the AST contains a single <code>StringLiteral</code> for the format string and any macro expansion, token pasting, adjacent string literal concatenation and escaping has been handled. Although it's possible for the check to automatically put the escapes back, they may not be exactly as they were written (e.g. <code>"\x0a"</code> will become <code>"\n"</code> and <code>"ab" "cd"</code> will become <code>"abcd"</code>.) This is helpful since it means that the <code>PRIx</code> macros from <code>&lt;inttypes.h&gt;</code> are removed correctly.</li>
+<li>It supports field widths, precision, positional arguments, leading zeros, leading <code>+</code>, alignment and alternative forms.</li>
+<li>Use of any unsupported flags or specifiers will cause the entire statement to be left alone and a warning to be emitted. Particular unsupported features are:
+<ul>
+<li>The <code>%'</code> flag for thousands separators.</li>
+<li>The glibc extension <code>%m</code>.</li>
+</ul></li>
+<li><code>printf</code> and similar functions return the number of characters printed. <code>std::print</code> does not. This means that any invocations that use the return value will not be converted. Unfortunately this currently includes explicitly-casting to <code>void</code>. Deficiencies in this check mean that any invocations inside <code>GCC</code> compound statements cannot be converted even if the resulting value is not used.</li>
+</ul>
+<p>If conversion would be incomplete or unsafe then the entire invocation will be left unchanged.</p>
+<p>If the call is deemed suitable for conversion then:</p>
+<ul>
+<li><code>printf</code>, <code>fprintf</code>, <code>absl::PrintF</code>, <code>absl::FPrintF</code> and any functions specified by the <span class="title-ref">PrintfLikeFunctions</span> option or <span class="title-ref">FprintfLikeFunctions</span> are replaced with the function specified by the <span class="title-ref">ReplacementPrintlnFunction</span> option if the format string ends with <code>\n</code> or <span class="title-ref">ReplacementPrintFunction</span> otherwise.</li>
+<li>the format string is rewritten to use the <code>std::formatter</code> language. If a <code>\n</code> is found at the end of the format string not preceded by <code>r</code> then it is removed and <span class="title-ref">ReplacementPrintlnFunction</span> is used rather than <span class="title-ref">ReplacementPrintFunction</span>.</li>
+<li>any arguments that corresponded to <code>%p</code> specifiers that <code>std::formatter</code> wouldn't accept are wrapped in a <code>static_cast</code> to <code>const void *</code>.</li>
+<li>any arguments that corresponded to <code>%s</code> specifiers where the argument is of <code>signed char</code> or <code>unsigned char</code> type are wrapped in a <code>reinterpret_cast&lt;const char *&gt;</code>.</li>
+<li>any arguments where the format string and the parameter differ in signedness will be wrapped in an appropriate <code>static_cast</code> if <span class="title-ref">StrictMode</span> is enabled.</li>
+<li>any arguments that end in a call to <code>std::string::c_str()</code> or <code>std::string::data()</code> will have that call removed.</li>
+</ul>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>StrictMode</p>
+<p>When <span class="title-ref">true</span>, the check will add casts when converting from variadic functions like <code>printf</code> and printing signed or unsigned integer types (including fixed-width integer types from <code>&lt;cstdint&gt;</code>, <code>ptrdiff_t</code>, <code>size_t</code> and <code>ssize_t</code>) as the opposite signedness to ensure that the output matches that of <code>printf</code>. This does not apply when converting from non-variadic functions such as <code>absl::PrintF</code> and <code>fmt::printf</code>. For example, with <span class="title-ref">StrictMode</span> enabled:</p>
+<pre class="c++"><code>int i = -42;
+unsigned int u = 0xffffffff;
+printf(&quot;%d %u\n&quot;, i, u);</code></pre>
+<p>would be converted to:</p>
+<pre class="c++"><code>std::print(&quot;{} {}\n&quot;, static_cast&lt;unsigned int&gt;(i), static_cast&lt;int&gt;(u));</code></pre>
+<p>to ensure that the output will continue to be the unsigned representation of <span class="title-ref">-42</span> and the signed representation of <span class="title-ref">0xffffffff</span> (often <span class="title-ref">4294967254</span> and <span class="title-ref">-1</span> respectively.) When <span class="title-ref">false</span> (which is the default), these casts will not be added which may cause a change in the output.</p>
+</div>
+<div class="option">
+<p>PrintfLikeFunctions</p>
+<p>A semicolon-separated list of (fully qualified) extra function names to replace, with the requirement that the first parameter contains the printf-style format string and the arguments to be formatted follow immediately afterwards. If neither this option nor <span class="title-ref">FprintfLikeFunctions</span> are set then the default value for this option is <span class="title-ref">printf; absl::PrintF</span>, otherwise it is empty.</p>
+</div>
+<div class="option">
+<p>FprintfLikeFunctions</p>
+<p>A semicolon-separated list of (fully qualified) extra function names to replace, with the requirement that the first parameter is retained, the second parameter contains the printf-style format string and the arguments to be formatted follow immediately afterwards. If neither this option nor <span class="title-ref">PrintfLikeFunctions</span> are set then the default value for this option is <span class="title-ref">fprintf; absl::FPrintF</span>, otherwise it is empty.</p>
+</div>
+<div class="option">
+<p>ReplacementPrintFunction</p>
+<p>The function that will be used to replace <code>printf</code>, <code>fprintf</code> etc. during conversion rather than the default <code>std::print</code> when the originalformat string does not end with <code>\n</code>. It is expected that the function provides an interface that is compatible with <code>std::print</code>. A suitable candidate would be <code>fmt::print</code>.</p>
+</div>
+<div class="option">
+<p>ReplacementPrintlnFunction</p>
+<p>The function that will be used to replace <code>printf</code>, <code>fprintf</code> etc. during conversion rather than the default <code>std::println</code> when the original format string ends with <code>\n</code>. It is expected that the function provides an interface that is compatible with <code>std::println</code>. A suitable candidate would be <code>fmt::println</code>.</p>
+</div>
+<div class="option">
+<p>PrintHeader</p>
+<p>The header that must be included for the declaration of <span class="title-ref">ReplacementPrintFunction</span> so that a <code>#include</code> directive can be added if required. If <span class="title-ref">ReplacementPrintFunction</span> is <code>std::print</code> then this option will default to <code>&lt;print&gt;</code>, otherwise this option will default to nothing and no <code>#include</code> directive will be added.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-std-print.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -10416,11 +13044,19 @@ using MyPtrType = void (Class::*)() const;
 
 using R_t = struct { int a; };
 using R_p = R_t*;</code></pre>
+<p>The checker ignores <span class="title-ref">typedef</span> within <span class="title-ref">extern "C" { ... }</span> blocks.</p>
+<pre class="c++"><code>extern &quot;C&quot; {
+  typedef int InExternC; // Left intact.
+}</code></pre>
 <p>This check requires using C++11 or higher to run.</p>
 <h2 id="options">Options</h2>
 <div class="option">
 <p>IgnoreMacros</p>
 <p>If set to <span class="title-ref">true</span>, the check will not give warnings inside macros. Default is <span class="title-ref">true</span>.</p>
+</div>
+<div class="option">
+<p>IgnoreExternC</p>
+<p>If set to <span class="title-ref">true</span>, the check will not give warning inside <span class="title-ref">extern "C"`scope. Default is `false</span></p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-using.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -10484,7 +13120,7 @@ MPI_Send(&amp;buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);</code></pre>
 </div>
 <h1 id="objc-assert-equals">objc-assert-equals</h1>
 <p>Finds improper usages of <span class="title-ref">XCTAssertEqual</span> and <span class="title-ref">XCTAssertNotEqual</span> and replaces them with <span class="title-ref">XCTAssertEqualObjects</span> or <span class="title-ref">XCTAssertNotEqualObjects</span>.</p>
-<p>This makes tests less fragile, as many improperly rely on pointer equality for strings that have equal values. This assumption is not guarantted by the language.</p>
+<p>This makes tests less fragile, as many improperly rely on pointer equality for strings that have equal values. This assumption is not guaranteed by the language.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc/assert-equals.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -10563,6 +13199,80 @@ MPI_Send(&amp;buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);</code></pre>
 <p>Note that the check only verifies the presence of <code>-hash</code> in scenarios where its omission could result in unexpected behavior. The verification of the implementation of <code>-hash</code> is the responsibility of the developer, e.g., through the addition of unit tests to verify the implementation.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc/missing-hash.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>objc-nsdate-formatter</key>
+    <name>objc-nsdate-formatter</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - objc-nsdate-formatter</p>
+</div>
+<h1 id="objc-nsdate-formatter">objc-nsdate-formatter</h1>
+<p>When <code>NSDateFormatter</code> is used to convert an <code>NSDate</code> type to a <code>String</code> type, the user can specify a custom format string. Certain format specifiers are undesirable despite being legal. See <a href="http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns">http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns</a> for all legal date patterns.</p>
+<p>This checker reports as warnings the following string patterns in a date format specifier:</p>
+<ol>
+<li>yyyy + ww : Calendar year specified with week of a week year (unless YYYY is also specified).
+<ul>
+<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">yyyy-ww</span>;<br />
+Output string: <span class="title-ref">2014-01</span> (Wrong because it's not the first week of 2014)</div></li>
+<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">dd-MM-yyyy (ww-YYYY)</span>;<br />
+Output string: <span class="title-ref">29-12-2014 (01-2015)</span> (This is correct)</div></li>
+</ul></li>
+<li>F without ee/EE : Numeric day of week in a month without actual day.
+<ul>
+<li><div class="line-block"><strong>Example:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">F-MM</span>;<br />
+Output string: <span class="title-ref">5-12</span> (Wrong because it reads as <em>5th ___ of Dec</em> in English)</div></li>
+</ul></li>
+<li>F without MM : Numeric day of week in a month without month.
+<ul>
+<li><div class="line-block"><strong>Example:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">F-EE</span><br />
+Output string: <span class="title-ref">5-Mon</span> (Wrong because it reads as <em>5th Mon of ___</em> in English)</div></li>
+</ul></li>
+<li>WW without MM : Week of the month without the month.
+<ul>
+<li><div class="line-block"><strong>Example:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">WW-yyyy</span><br />
+Output string: <span class="title-ref">05-2014</span> (Wrong because it reads as <em>5th Week of ___</em> in English)</div></li>
+</ul></li>
+<li>YYYY + QQ : Week year specified with quarter of normal year (unless yyyy is also specified).
+<ul>
+<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-QQ</span><br />
+Output string: <span class="title-ref">2015-04</span> (Wrong because it's not the 4th quarter of 2015)</div></li>
+<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (QQ-yyyy)</span><br />
+Output string: <span class="title-ref">01-2015 (04-2014)</span> (This is correct)</div></li>
+</ul></li>
+<li>YYYY + MM : Week year specified with Month of a calendar year (unless yyyy is also specified).
+<ul>
+<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-MM</span><br />
+Output string: <span class="title-ref">2015-12</span> (Wrong because it's not the 12th month of 2015)</div></li>
+<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (MM-yyyy)</span><br />
+Output string: <span class="title-ref">01-2015 (12-2014)</span> (This is correct)</div></li>
+</ul></li>
+<li>YYYY + DD : Week year with day of a calendar year (unless yyyy is also specified).
+<ul>
+<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-DD</span><br />
+Output string: <span class="title-ref">2015-363</span> (Wrong because it's not the 363rd day of 2015)</div></li>
+<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (DD-yyyy)</span><br />
+Output string: <span class="title-ref">01-2015 (363-2014)</span> (This is correct)</div></li>
+</ul></li>
+<li>YYYY + WW : Week year with week of a calendar year (unless yyyy is also specified).
+<ul>
+<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-WW</span><br />
+Output string: <span class="title-ref">2015-05</span> (Wrong because it's not the 5th week of 2015)</div></li>
+<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (WW-MM-yyyy)</span><br />
+Output string: <span class="title-ref">01-2015 (05-12-2014)</span> (This is correct)</div></li>
+</ul></li>
+<li>YYYY + F : Week year with day of week in a calendar month (unless yyyy is also specified).
+<ul>
+<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-ww-F-EE</span><br />
+Output string: <span class="title-ref">2015-01-5-Mon</span> (Wrong because it's not the 5th Monday of January in 2015)</div></li>
+<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (F-EE-MM-yyyy)</span><br />
+Output string: <span class="title-ref">01-2015 (5-Mon-12-2014)</span> (This is correct)</div></li>
+</ul></li>
+</ol>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc/nsdate-formatter.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -10716,6 +13426,84 @@ void p0_3() {
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>performance-avoid-endl</key>
+    <name>performance-avoid-endl</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - performance-avoid-endl</p>
+</div>
+<h1 id="performance-avoid-endl">performance-avoid-endl</h1>
+<p>Checks for uses of <code>std::endl</code> on streams and suggests using the newline character <code>'\n'</code> instead.</p>
+<p>Rationale: Using <code>std::endl</code> on streams can be less efficient than using the newline character <code>'\n'</code> because <code>std::endl</code> performs two operations: it writes a newline character to the output stream and then flushes the stream buffer. Writing a single newline character using <code>'\n'</code> does not trigger a flush, which can improve performance. In addition, flushing the stream buffer can cause additional overhead when working with streams that are buffered.</p>
+<p>Example:</p>
+<p>Consider the following code:</p>
+<pre class="c++"><code>#include &lt;iostream&gt;
+
+int main() {
+  std::cout &lt;&lt; &quot;Hello&quot; &lt;&lt; std::endl;
+}</code></pre>
+<p>Which gets transformed into:</p>
+<pre class="c++"><code>#include &lt;iostream&gt;
+
+int main() {
+  std::cout &lt;&lt; &quot;Hello&quot; &lt;&lt; &#39;\n&#39;;
+}</code></pre>
+<p>This code writes a single newline character to the <code>std::cout</code> stream without flushing the stream buffer.</p>
+<p>Additionally, it is important to note that the standard C++ streams (like <code>std::cerr</code>, <code>std::wcerr</code>, <code>std::clog</code> and <code>std::wclog</code>) always flush after a write operation, unless <code>std::ios_base::sync_with_stdio</code> is set to <code>false</code>. regardless of whether <code>std::endl</code> or <code>'\n'</code> is used. Therefore, using <code>'\n'</code> with these streams will not result in any performance gain, but it is still recommended to use <code>'\n'</code> for consistency and readability.</p>
+<p>If you do need to flush the stream buffer, you can use <code>std::flush</code> explicitly like this:</p>
+<pre class="c++"><code>#include &lt;iostream&gt;
+
+int main() {
+  std::cout &lt;&lt; &quot;Hello\n&quot; &lt;&lt; std::flush;
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/avoid-endl.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>performance-enum-size</key>
+    <name>performance-enum-size</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - performance-enum-size</p>
+</div>
+<h1 id="performance-enum-size">performance-enum-size</h1>
+<p>Recommends the smallest possible underlying type for an <code>enum</code> or <code>enum</code> class based on the range of its enumerators. Analyzes the values of the enumerators in an <code>enum</code> or <code>enum</code> class, including signed values, to recommend the smallest possible underlying type that can represent all the values of the <code>enum</code>. The suggested underlying types are the integral types <code>std::uint8_t</code>, <code>std::uint16_t</code>, and <code>std::uint32_t</code> for unsigned types, and <code>std::int8_t</code>, <code>std::int16_t</code>, and <code>std::int32_t</code> for signed types. Using the suggested underlying types can help reduce the memory footprint of the program and improve performance in some cases.</p>
+<p>For example:</p>
+<pre class="c++"><code>// BEFORE
+enum Color {
+    RED = -1,
+    GREEN = 0,
+    BLUE = 1
+};
+
+std::optional&lt;Color&gt; color_opt;</code></pre>
+<p>The <span class="title-ref">Color</span> <code>enum</code> uses the default underlying type, which is <code>int</code> in this case, and its enumerators have values of -1, 0, and 1. Additionally, the <code>std::optional&lt;Color&gt;</code> object uses 8 bytes due to padding (platform dependent).</p>
+<pre class="c++"><code>// AFTER
+enum Color : std:int8_t {
+    RED = -1,
+    GREEN = 0,
+    BLUE = 1
+}
+
+std::optional&lt;Color&gt; color_opt;</code></pre>
+<p>In the revised version of the <span class="title-ref">Color</span> <code>enum</code>, the underlying type has been changed to <code>std::int8_t</code>. The enumerator <span class="title-ref">RED</span> has a value of -1, which can be represented by a signed 8-bit integer.</p>
+<p>By using a smaller underlying type, the memory footprint of the <span class="title-ref">Color</span> <code>enum</code> is reduced from 4 bytes to 1 byte. The revised version of the <code>std::optional&lt;Color&gt;</code> object would only require 2 bytes (due to lack of padding), since it contains a single byte for the <span class="title-ref">Color</span> <code>enum</code> and a single byte for the <code>bool</code> flag that indicates whether the optional value is set.</p>
+<p>Reducing the memory footprint of an <code>enum</code> can have significant benefits in terms of memory usage and cache performance. However, it's important to consider the trade-offs and potential impact on code readability and maintainability.</p>
+<p>Enums without enumerators (empty) are excluded from analysis.</p>
+<p>Requires C++11 or above. Does not provide auto-fixes.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>EnumIgnoreList</p>
+<p>Option is used to ignore certain enum types. It accepts a semicolon-separated list of (fully qualified) enum type names or regular expressions that match the enum type names. The default value is an empty string, which means no enums will be ignored.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/enum-size.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>performance-faster-string-find</key>
     <name>performance-faster-string-find</name>
     <description>
@@ -10773,8 +13561,7 @@ str.find(&#39;A&#39;);</code></pre>
     <key>performance-implicit-cast-in-loop</key>
     <name>performance-implicit-cast-in-loop</name>
     <description>
-      <![CDATA[
-      <dl>
+      <![CDATA[<dl>
 <dt>orphan</dt>
 <dd>
 </dd>
@@ -10786,7 +13573,8 @@ str.find(&#39;A&#39;);</code></pre>
 
 </div>
 <h1 id="performance-implicit-cast-in-loop">performance-implicit-cast-in-loop</h1>
-<p>This check has been renamed to <a href="../performance/implicit-conversion-in-loop.html">performance-implicit-conversion-in-loop</a>.</p>
+<p>This check has been renamed to <code class="interpreted-text" role="doc">performance-implicit-conversion-in-loop
+&lt;../performance/implicit-conversion-in-loop&gt;</code>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/implicit-cast-in-loop.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -11011,7 +13799,7 @@ StatusOr&lt;std::vector&lt;int&gt;&gt; NotCool() {
   const std::vector&lt;int&gt; obj = ...;
   return obj;  // calls `StatusOr::StatusOr(const std::vector&lt;int&gt;&amp;)`
 }</code></pre>
-<p>The former version (<code>Cool</code>) should be preferred over the latter (<code>Uncool</code>) as it will avoid allocations and potentially large memory copies.</p>
+<p>The former version (<code>Cool</code>) should be preferred over the latter (<code>NotCool</code>) as it will avoid allocations and potentially large memory copies.</p>
 <h2 id="semantics">Semantics</h2>
 <p>In the example above, <code>StatusOr::StatusOr(T&amp;&amp;)</code> have the same semantics as long as the copy and move constructors for <code>T</code> have the same semantics. Note that there is no guarantee that <code>S::S(T&amp;&amp;)</code> and <code>S::S(const T&amp;)</code> have the same semantics for any single <code>S</code>, so we're not providing automated fixes for this check, and judgement should be exerted when making the suggested changes.</p>
 <h2 id="wreturn-std-move">-Wreturn-std-move</h2>
@@ -11060,6 +13848,21 @@ tgt(char* maybe_underbiased_ptr) {
     <severity>MINOR</severity>
     </rule>
   <rule>
+    <key>performance-noexcept-destructor</key>
+    <name>performance-noexcept-destructor</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - performance-noexcept-destructor</p>
+</div>
+<h1 id="performance-noexcept-destructor">performance-noexcept-destructor</h1>
+<p>The check flags user-defined destructors marked with <code>noexcept(expr)</code> where <code>expr</code> evaluates to <code>false</code> (but is not a <code>false</code> literal itself).</p>
+<p>When a destructor is marked as <code>noexcept</code>, it assures the compiler that no exceptions will be thrown during the destruction of an object, which allows the compiler to perform certain optimizations such as omitting exception handling code.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/noexcept-destructor.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>performance-noexcept-move-constructor</key>
     <name>performance-noexcept-move-constructor</name>
     <description>
@@ -11073,6 +13876,21 @@ tgt(char* maybe_underbiased_ptr) {
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/noexcept-move-constructor.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
+    </rule>
+  <rule>
+    <key>performance-noexcept-swap</key>
+    <name>performance-noexcept-swap</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - performance-noexcept-swap</p>
+</div>
+<h1 id="performance-noexcept-swap">performance-noexcept-swap</h1>
+<p>The check flags user-defined swap and iter_swap functions not marked with <code>noexcept</code> or marked with <code>noexcept(expr)</code> where <code>expr</code> evaluates to <code>false</code> (but is not a <code>false</code> literal itself).</p>
+<p>When a swap or iter_swap function is marked as <code>noexcept</code>, it assures the compiler that no exceptions will be thrown during the swapping of two objects, which allows the compiler to perform certain optimizations such as omitting exception handling code.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/performance/noexcept-swap.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>performance-trivially-destructible</key>
@@ -11277,6 +14095,31 @@ vec_add(a, b);       // Power</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>portability-std-allocator-const</key>
+    <name>portability-std-allocator-const</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - portability-std-allocator-const</p>
+</div>
+<h1 id="portability-std-allocator-const">portability-std-allocator-const</h1>
+<p>Report use of <code>std::vector&lt;const T&gt;</code> (and similar containers of const elements). These are not allowed in standard C++, and should usually be <code>std::vector&lt;T&gt;</code> instead."</p>
+<p>Per C++ <code>[allocator.requirements.general]</code>: "T is any cv-unqualified object type", <code>std::allocator&lt;const T&gt;</code> is undefined. Many standard containers use <code>std::allocator</code> by default and therefore their <code>const T</code> instantiations are undefined.</p>
+<p>libc++ defines <code>std::allocator&lt;const T&gt;</code> as an extension which will be removed in the future.</p>
+<p>libstdc++ and MSVC do not support <code>std::allocator&lt;const T&gt;</code>:</p>
+<pre class="c++"><code>// libstdc++ has a better diagnostic since https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48101
+std::deque&lt;const int&gt; deque; // error: static assertion failed: std::deque must have a non-const, non-volatile value_type
+std::set&lt;const int&gt; set; // error: static assertion failed: std::set must have a non-const, non-volatile value_type
+std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::vector must have a non-const, non-volatile value_type
+
+// MSVC
+// error C2338: static_assert failed: &#39;The C++ Standard forbids containers of const elements because allocator&lt;const T&gt; is ill-formed.&#39;</code></pre>
+<p>Code bases only compiled with libc++ may accrue such undefined usage. This check finds such code and prevents backsliding while clean-up is ongoing.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/portability/std-allocator-const.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>readability-avoid-const-params-in-decls</key>
     <name>readability-avoid-const-params-in-decls</name>
     <description>
@@ -11298,6 +14141,84 @@ void f(const string&amp;);  // Good: const is not top level.</code></pre>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-const-params-in-decls.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
+    </rule>
+  <rule>
+    <key>readability-avoid-nested-conditional-operator</key>
+    <name>readability-avoid-nested-conditional-operator</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - readability-avoid-nested-conditional-operator</p>
+</div>
+<h1 id="readability-avoid-nested-conditional-operator">readability-avoid-nested-conditional-operator</h1>
+<p>Identifies instances of nested conditional operators in the code.</p>
+<p>Nested conditional operators, also known as ternary operators, can contribute to reduced code readability and comprehension. So they should be split as several statements and stored the intermediate results in temporary variable.</p>
+<p>Examples:</p>
+<pre class="c++"><code>int NestInConditional = (condition1 ? true1 : false1) ? true2 : false2;
+int NestInTrue = condition1 ? (condition2 ? true1 : false1) : false2;
+int NestInFalse = condition1 ? true1 : condition2 ? true2 : false1;</code></pre>
+<p>This check implements part of <a href="https://www.autosar.org/fileadmin/standards/R22-11/AP/AUTOSAR_RS_CPP14Guidelines.pdf">AUTOSAR C++14 Rule A5-16-1</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-nested-conditional-operator.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>readability-avoid-return-with-void-value</key>
+    <name>readability-avoid-return-with-void-value</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - readability-avoid-return-with-void-value</p>
+</div>
+<h1 id="readability-avoid-return-with-void-value">readability-avoid-return-with-void-value</h1>
+<p>Finds return statements with <code>void</code> values used within functions with <code>void</code> result types.</p>
+<p>A function with a <code>void</code> return type is intended to perform a task without producing a return value. Return statements with expressions could lead to confusion and may miscommunicate the function's intended behavior.</p>
+<p>Example:</p>
+<pre class=""><code>void g();
+void f() {
+    // ...
+    return g();
+}</code></pre>
+<p>In a long function body, the <code>return</code> statement suggests that the function returns a value. However, <code>return g();</code> is a combination of two statements that should be written as</p>
+<pre class=""><code>g();
+return;</code></pre>
+<p>to make clear that <code>g()</code> is called and immediately afterwards the function returns (nothing).</p>
+<p>In C, the same issue is detected by the compiler if the <code>-Wpedantic</code> mode is enabled.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>The value <span class="title-ref">false</span> specifies that return statements expanded from macros are not checked. The default value is <span class="title-ref">true</span>.</p>
+</div>
+<div class="option">
+<p>StrictMode</p>
+<p>The value <span class="title-ref">false</span> specifies that a direct return statement shall be excluded from the analysis if it is the only statement not contained in a block like <code>if (cond) return g();</code>. The default value is <span class="title-ref">true</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-return-with-void-value.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>readability-avoid-unconditional-preprocessor-if</key>
+    <name>readability-avoid-unconditional-preprocessor-if</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - readability-avoid-unconditional-preprocessor-if</p>
+</div>
+<h1 id="readability-avoid-unconditional-preprocessor-if">readability-avoid-unconditional-preprocessor-if</h1>
+<p>Finds code blocks that are constantly enabled or disabled in preprocessor directives by analyzing <code>#if</code> conditions, such as <code>#if 0</code> and <code>#if 1</code>, etc.</p>
+<pre class="c++"><code>#if 0
+    // some disabled code
+#endif
+
+#if 1
+   // some enabled code that can be disabled manually
+#endif</code></pre>
+<p>Unconditional preprocessor directives, such as <code>#if 0</code> for disabled code and <code>#if 1</code> for enabled code, can lead to dead code and always enabled code, respectively. Dead code can make understanding the codebase more difficult, hinder readability, and may be a sign of unfinished functionality or abandoned features. This can cause maintenance issues, confusion for future developers, and potential compilation problems.</p>
+<p>As a solution for both cases, consider using preprocessor macros or defines, like <code>#ifdef DEBUGGING_ENABLED</code>, to control code enabling or disabling. This approach provides better coordination and flexibility when working with different parts of the codebase. Alternatively, you can comment out the entire code using <code>/* */</code> block comments and add a hint, such as <code>@todo</code>, to indicate future actions.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-unconditional-preprocessor-if.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>readability-braces-around-statements</key>
@@ -11419,6 +14340,11 @@ const Clazz* foo();</code></pre>
 <h1 id="readability-container-data-pointer">readability-container-data-pointer</h1>
 <p>Finds cases where code could use <code>data()</code> rather than the address of the element at index 0 in a container. This pattern is commonly used to materialize a pointer to the backing data of a container. <code>std::vector</code> and <code>std::string</code> provide a <code>data()</code> accessor to retrieve the data pointer which should be preferred.</p>
 <p>This also ensures that in the case that the container is empty, the data pointer access does not perform an errant memory access.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoredContainers</p>
+<p>Semicolon-separated list of containers regexp for which this check won't be enforced. Default is <span class="title-ref">empty</span>.</p>
+</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/container-data-pointer.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -11432,12 +14358,17 @@ const Clazz* foo();</code></pre>
 <p>clang-tidy - readability-container-size-empty</p>
 </div>
 <h1 id="readability-container-size-empty">readability-container-size-empty</h1>
-<p>Checks whether a call to the <code>size()</code> method can be replaced with a call to <code>empty()</code>.</p>
-<p>The emptiness of a container should be checked using the <code>empty()</code> method instead of the <code>size()</code> method. It is not guaranteed that <code>size()</code> is a constant-time function, and it is generally more efficient and also shows clearer intent to use <code>empty()</code>. Furthermore some containers may implement the <code>empty()</code> method but not implement the <code>size()</code> method. Using <code>empty()</code> whenever possible makes it easier to switch to another container in the future.</p>
-<p>The check issues warning if a container has <code>size()</code> and <code>empty()</code> methods matching following signatures:</p>
+<p>Checks whether a call to the <code>size()</code>/<code>length()</code> method can be replaced with a call to <code>empty()</code>.</p>
+<p>The emptiness of a container should be checked using the <code>empty()</code> method instead of the <code>size()</code>/<code>length()</code> method. It is not guaranteed that <code>size()</code>/<code>length()</code> is a constant-time function, and it is generally more efficient and also shows clearer intent to use <code>empty()</code>. Furthermore some containers may implement the <code>empty()</code> method but not implement the <code>size()</code> or <code>length()</code> method. Using <code>empty()</code> whenever possible makes it easier to switch to another container in the future.</p>
+<p>The check issues warning if a container has <code>empty()</code> and <code>size()</code> or <code>length()</code> methods matching following signatures:</p>
 <pre class="c++"><code>size_type size() const;
+size_type length() const;
 bool empty() const;</code></pre>
 <p><span class="title-ref">size_type</span> can be any kind of integer type.</p>
+<div class="option">
+<p>ExcludedComparisonTypes</p>
+<p>A semicolon-separated list of class names for which the check will ignore comparisons of objects with default-constructed objects of the same type. If a class is listed here, the check will not suggest using <code>empty()</code> instead of such comparisons for objects of that class. Default value is: <span class="title-ref">::std::array</span>.</p>
+</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/container-size-empty.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -11453,7 +14384,7 @@ bool empty() const;</code></pre>
 <h1 id="readability-convert-member-functions-to-static">readability-convert-member-functions-to-static</h1>
 <p>Finds non-static member functions that can be made <code>static</code> because the functions don't use <code>this</code>.</p>
 <p>After applying modifications as suggested by the check, running the check again might find more opportunities to mark member functions <code>static</code>.</p>
-<p>After making a member function <code>static</code>, you might want to run the check <a href="../readability/static-accessed-through-instance.html">readability-static-accessed-through-instance</a> to replace calls like <code>Instance.method()</code> by <code>Class::method()</code>.</p>
+<p>After making a member function <code>static</code>, you might want to run the check <code class="interpreted-text" role="doc">readability-static-accessed-through-instance &lt;../readability/static-accessed-through-instance&gt;</code> to replace calls like <code>Instance.method()</code> by <code>Class::method()</code>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/convert-member-functions-to-static.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -11731,7 +14662,7 @@ if (p)
 <h2 id="options">Options</h2>
 <div class="option">
 <p>LineThreshold</p>
-<p>Flag functions exceeding this number of lines. The default is <span class="title-ref">-1</span> (ignore the number of lines).</p>
+<p>Flag functions exceeding this number of lines. The default is <span class="title-ref">none</span> (ignore the number of lines).</p>
 </div>
 <div class="option">
 <p>StatementThreshold</p>
@@ -11739,19 +14670,19 @@ if (p)
 </div>
 <div class="option">
 <p>BranchThreshold</p>
-<p>Flag functions exceeding this number of control statements. The default is <span class="title-ref">-1</span> (ignore the number of branches).</p>
+<p>Flag functions exceeding this number of control statements. The default is <span class="title-ref">none</span> (ignore the number of branches).</p>
 </div>
 <div class="option">
 <p>ParameterThreshold</p>
-<p>Flag functions that exceed a specified number of parameters. The default is <span class="title-ref">-1</span> (ignore the number of parameters).</p>
+<p>Flag functions that exceed a specified number of parameters. The default is <span class="title-ref">none</span> (ignore the number of parameters).</p>
 </div>
 <div class="option">
 <p>NestingThreshold</p>
-<p>Flag compound statements which create next nesting level after <span class="title-ref">NestingThreshold</span>. This may differ significantly from the expected value for macro-heavy code. The default is <span class="title-ref">-1</span> (ignore the nesting level).</p>
+<p>Flag compound statements which create next nesting level after <span class="title-ref">NestingThreshold</span>. This may differ significantly from the expected value for macro-heavy code. The default is <span class="title-ref">none</span> (ignore the nesting level).</p>
 </div>
 <div class="option">
 <p>VariableThreshold</p>
-<p>Flag functions exceeding this number of variables declared in the body. The default is <span class="title-ref">-1</span> (ignore the number of variables). Please note that function parameters and variables declared in lambdas, GNU Statement Expressions, and nested class inline functions are not counted.</p>
+<p>Flag functions exceeding this number of variables declared in the body. The default is <span class="title-ref">none</span> (ignore the number of variables). Please note that function parameters and variables declared in lambdas, GNU Statement Expressions, and nested class inline functions are not counted.</p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/function-size.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -11863,22 +14794,26 @@ catch (const std::exception&amp; e) {
 <li><code>CamelCase</code>,</li>
 <li><code>camel_Snake_Back</code>,</li>
 <li><code>Camel_Snake_Case</code>,</li>
-<li><code>aNy_CasE</code>.</li>
+<li><code>aNy_CasE</code>,</li>
+<li><code>Leading_upper_snake_case</code>.</li>
 </ul>
 </blockquote>
 <p>It also supports a fixed prefix and suffix that will be prepended or appended to the identifiers, regardless of the casing.</p>
 <p>Many configuration options are available, in order to be able to create different rules for different kinds of identifiers. In general, the rules are falling back to a more generic rule if the specific case is not configured.</p>
 <p>The naming of virtual methods is reported where they occur in the base class, but not where they are overridden, as it can't be fixed locally there. This also applies for pseudo-override patterns like CRTP.</p>
+<p><code>Leading_upper_snake_case</code> is a naming convention where the first word is capitalized followed by lower case word(s) seperated by underscore(s) '_'. Examples include: Cap_snake_case, Cobra_case, Foo_bar_baz, and Master_copy_8gb.</p>
 <h2 id="options">Options</h2>
 <p>The following options are described below:</p>
 <blockquote>
 <ul>
 <li><code class="interpreted-text" role="option">AbstractClassCase</code>, <code class="interpreted-text" role="option">AbstractClassPrefix</code>, <code class="interpreted-text" role="option">AbstractClassSuffix</code>, <code class="interpreted-text" role="option">AbstractClassIgnoredRegexp</code>, <code class="interpreted-text" role="option">AbstractClassHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">AggressiveDependentMemberLookup</code></li>
+<li><code class="interpreted-text" role="option">CheckAnonFieldInParent</code></li>
 <li><code class="interpreted-text" role="option">ClassCase</code>, <code class="interpreted-text" role="option">ClassPrefix</code>, <code class="interpreted-text" role="option">ClassSuffix</code>, <code class="interpreted-text" role="option">ClassIgnoredRegexp</code>, <code class="interpreted-text" role="option">ClassHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">ClassConstantCase</code>, <code class="interpreted-text" role="option">ClassConstantPrefix</code>, <code class="interpreted-text" role="option">ClassConstantSuffix</code>, <code class="interpreted-text" role="option">ClassConstantIgnoredRegexp</code>, <code class="interpreted-text" role="option">ClassConstantHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">ClassMemberCase</code>, <code class="interpreted-text" role="option">ClassMemberPrefix</code>, <code class="interpreted-text" role="option">ClassMemberSuffix</code>, <code class="interpreted-text" role="option">ClassMemberIgnoredRegexp</code>, <code class="interpreted-text" role="option">ClassMemberHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">ClassMethodCase</code>, <code class="interpreted-text" role="option">ClassMethodPrefix</code>, <code class="interpreted-text" role="option">ClassMethodSuffix</code>, <code class="interpreted-text" role="option">ClassMethodIgnoredRegexp</code></li>
+<li><code class="interpreted-text" role="option">ConceptCase</code>, <code class="interpreted-text" role="option">ConceptPrefix</code>, <code class="interpreted-text" role="option">ConceptSuffix</code>, <code class="interpreted-text" role="option">ConceptIgnoredRegexp</code></li>
 <li><code class="interpreted-text" role="option">ConstantCase</code>, <code class="interpreted-text" role="option">ConstantPrefix</code>, <code class="interpreted-text" role="option">ConstantSuffix</code>, <code class="interpreted-text" role="option">ConstantIgnoredRegexp</code>, <code class="interpreted-text" role="option">ConstantHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">ConstantMemberCase</code>, <code class="interpreted-text" role="option">ConstantMemberPrefix</code>, <code class="interpreted-text" role="option">ConstantMemberSuffix</code>, <code class="interpreted-text" role="option">ConstantMemberIgnoredRegexp</code>, <code class="interpreted-text" role="option">ConstantMemberHungarianPrefix</code></li>
 <li><code class="interpreted-text" role="option">ConstantParameterCase</code>, <code class="interpreted-text" role="option">ConstantParameterPrefix</code>, <code class="interpreted-text" role="option">ConstantParameterSuffix</code>, <code class="interpreted-text" role="option">ConstantParameterIgnoredRegexp</code>, <code class="interpreted-text" role="option">ConstantParameterHungarianPrefix</code></li>
@@ -12015,6 +14950,19 @@ struct Derived : Base&lt;T&gt; {
     this-&gt;bad_named_member = 0;
   }
 };</code></pre>
+<div class="option">
+<p>CheckAnonFieldInParent</p>
+<p>When set to <span class="title-ref">true</span>, fields in anonymous records (i.e. anonymous unions and structs) will be treated as names in the enclosing scope rather than public members of the anonymous record for the purpose of name checking.</p>
+</div>
+<p>For example:</p>
+<pre class="c++"><code>class Foo {
+private:
+  union {
+    int iv_;
+    float fv_;
+  };
+};</code></pre>
+<p>If <code class="interpreted-text" role="option">CheckAnonFieldInParent</code> is <span class="title-ref">false</span>, you may get warnings that <code>iv_</code> and <code>fv_</code> are not coherent to public member names, because <code>iv_</code> and <code>fv_</code> are public members of the anonymous union. When <code class="interpreted-text" role="option">CheckAnonFieldInParent</code> is <span class="title-ref">true</span>, <code>iv_</code> and <code>fv_</code> will be treated as private data members of <code>Foo</code> for the purpose of name checking and thus no warnings will be emitted.</p>
 <div class="option">
 <p>ClassCase</p>
 <p>When defined, the check will ensure class names conform to the selected casing.</p>
@@ -12172,6 +15120,35 @@ public:
 public:
   int pre_class_member_post();
 };</code></pre>
+<div class="option">
+<p>ConceptCase</p>
+<p>When defined, the check will ensure concept names conform to the selected casing.</p>
+</div>
+<div class="option">
+<p>ConceptPrefix</p>
+<p>When defined, the check will ensure concept names will add the prefixed with the given value (regardless of casing).</p>
+</div>
+<div class="option">
+<p>ConceptIgnoredRegexp</p>
+<p>Identifier naming checks won't be enforced for concept names matching this regular expression.</p>
+</div>
+<div class="option">
+<p>ConceptSuffix</p>
+<p>When defined, the check will ensure concept names will add the suffix with the given value (regardless of casing).</p>
+</div>
+<p>For example using values of:</p>
+<blockquote>
+<ul>
+<li>ConceptCase of <code>CamelCase</code></li>
+<li>ConceptPrefix of <code>Pre</code></li>
+<li>ConceptSuffix of <code>Post</code></li>
+</ul>
+</blockquote>
+<p>Identifies and/or transforms concept names as follows:</p>
+<p>Before:</p>
+<pre class="c++"><code>template&lt;typename T&gt; concept my_concept = requires (T t) { {t++}; };</code></pre>
+<p>After:</p>
+<pre class="c++"><code>template&lt;typename T&gt; concept PreMyConceptPost = requires (T t) { {t++}; };</code></pre>
 <div class="option">
 <p>ConstantCase</p>
 <p>When defined, the check will ensure constant names conform to the selected casing.</p>
@@ -13743,132 +16720,224 @@ public:
 <table>
 <thead>
 <tr class="header">
-<th>Primitive Types</th>
-<th>Microsoft data types</th>
+<th>Primitive Type</th>
+<th></th>
+<th></th>
+<th></th>
+<th>Microsoft Type</th>
+<th></th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
 <td><blockquote>
-<p>Type Prefix Type Prefix</p>
+<p>Type</p>
 </blockquote></td>
-<td>Type Prefix</td>
+<td>Prefix</td>
+<td>Type</td>
+<td>Prefix</td>
+<td>Type</td>
+<td>Prefix</td>
 </tr>
 <tr class="even">
-<td>================= ============== ====================== ==============</td>
-<td>=========== ==============</td>
+<td>=================</td>
+<td>==============</td>
+<td>======================</td>
+<td>==============</td>
+<td>==============</td>
+<td>==============</td>
 </tr>
 <tr class="odd">
-<td>int8_t i8 signed int si</td>
-<td>BOOL b</td>
+<td>int8_t</td>
+<td>i8</td>
+<td>signed int</td>
+<td>si</td>
+<td>BOOL</td>
+<td>b</td>
 </tr>
 <tr class="even">
-<td>int16_t i16 signed short ss</td>
-<td>BOOLEAN b</td>
+<td>int16_t</td>
+<td>i16</td>
+<td>signed short</td>
+<td>ss</td>
+<td>BOOLEAN</td>
+<td>b</td>
 </tr>
 <tr class="odd">
-<td>int32_t i32 signed short int ssi</td>
-<td>BYTE by</td>
+<td>int32_t</td>
+<td>i32</td>
+<td>signed short int</td>
+<td>ssi</td>
+<td>BYTE</td>
+<td>by</td>
 </tr>
 <tr class="even">
-<td>int64_t i64 signed long long int slli</td>
-<td>CHAR c</td>
+<td>int64_t</td>
+<td>i64</td>
+<td>signed long long int</td>
+<td>slli</td>
+<td>CHAR</td>
+<td>c</td>
 </tr>
 <tr class="odd">
-<td>uint8_t u8 signed long long sll</td>
-<td>UCHAR uc</td>
+<td>uint8_t</td>
+<td>u8</td>
+<td>signed long long</td>
+<td>sll</td>
+<td>UCHAR</td>
+<td>uc</td>
 </tr>
 <tr class="even">
-<td>uint16_t u16 signed long int sli</td>
-<td>SHORT s</td>
+<td>uint16_t</td>
+<td>u16</td>
+<td>signed long int</td>
+<td>sli</td>
+<td>SHORT</td>
+<td>s</td>
 </tr>
 <tr class="odd">
-<td>uint32_t u32 signed long sl</td>
-<td>USHORT us</td>
+<td>uint32_t</td>
+<td>u32</td>
+<td>signed long</td>
+<td>sl</td>
+<td>USHORT</td>
+<td>us</td>
 </tr>
 <tr class="even">
-<td>uint64_t u64 signed s</td>
-<td>WORD w</td>
+<td>uint64_t</td>
+<td>u64</td>
+<td>signed</td>
+<td>s</td>
+<td>WORD</td>
+<td>w</td>
 </tr>
 <tr class="odd">
-<td>char8_t c8 unsigned long long int ulli</td>
-<td>DWORD dw</td>
+<td>char8_t</td>
+<td>c8</td>
+<td>unsigned long long int</td>
+<td>ulli</td>
+<td>DWORD</td>
+<td>dw</td>
 </tr>
 <tr class="even">
-<td>char16_t c16 unsigned long long ull</td>
-<td>DWORD32 dw32</td>
+<td>char16_t</td>
+<td>c16</td>
+<td>unsigned long long</td>
+<td>ull</td>
+<td>DWORD32</td>
+<td>dw32</td>
 </tr>
 <tr class="odd">
-<td>char32_t c32 unsigned long int uli</td>
-<td>DWORD64 dw64</td>
+<td>char32_t</td>
+<td>c32</td>
+<td>unsigned long int</td>
+<td>uli</td>
+<td>DWORD64</td>
+<td>dw64</td>
 </tr>
 <tr class="even">
-<td>float f unsigned long ul</td>
-<td>LONG l</td>
+<td>float</td>
+<td>f</td>
+<td>unsigned long</td>
+<td>ul</td>
+<td>LONG</td>
+<td>l</td>
 </tr>
 <tr class="odd">
-<td>double d unsigned short int usi</td>
-<td>ULONG ul</td>
+<td>double</td>
+<td>d</td>
+<td>unsigned short int</td>
+<td>usi</td>
+<td>ULONG</td>
+<td>ul</td>
 </tr>
 <tr class="even">
-<td>char c unsigned short us</td>
-<td>ULONG32 ul32</td>
+<td>char</td>
+<td>c</td>
+<td>unsigned short</td>
+<td>us</td>
+<td>ULONG32</td>
+<td>ul32</td>
 </tr>
 <tr class="odd">
-<td>bool b unsigned int ui</td>
-<td>ULONG64 ul64</td>
+<td>bool</td>
+<td>b</td>
+<td>unsigned int</td>
+<td>ui</td>
+<td>ULONG64</td>
+<td>ul64</td>
 </tr>
 <tr class="even">
-<td>_Bool b unsigned u</td>
-<td>ULONGLONG ull</td>
+<td>_Bool</td>
+<td>b</td>
+<td>unsigned char</td>
+<td>uc</td>
+<td>ULONGLONG</td>
+<td>ull</td>
 </tr>
 <tr class="odd">
-<td>int i long long int lli</td>
-<td>HANDLE h</td>
+<td>int</td>
+<td>i</td>
+<td>unsigned</td>
+<td>u</td>
+<td>HANDLE</td>
+<td>h</td>
 </tr>
 <tr class="even">
-<td>size_t n long double ld</td>
-<td>INT i</td>
+<td>size_t</td>
+<td>n</td>
+<td>long long int</td>
+<td>lli</td>
+<td>INT</td>
+<td>i</td>
 </tr>
 <tr class="odd">
-<td>short s long long ll</td>
-<td>INT8 i8</td>
+<td>short</td>
+<td>s</td>
+<td>long double</td>
+<td>ld</td>
+<td>INT8</td>
+<td>i8</td>
 </tr>
 <tr class="even">
-<td>signed i long int li</td>
-<td>INT16 i16</td>
+<td>signed</td>
+<td>i</td>
+<td>long long</td>
+<td>ll</td>
+<td>INT16</td>
+<td>i16</td>
 </tr>
 <tr class="odd">
-<td>unsigned u long l</td>
-<td>INT32 i32</td>
+<td>unsigned</td>
+<td>u</td>
+<td>long int</td>
+<td>li</td>
+<td>INT32</td>
+<td>i32</td>
 </tr>
 <tr class="even">
-<td>long l ptrdiff_t p</td>
-<td>INT64 i64</td>
+<td>long</td>
+<td>l</td>
+<td>long</td>
+<td>l</td>
+<td>INT64</td>
+<td>i64</td>
 </tr>
 <tr class="odd">
-<td>long long ll</td>
-<td>UINT ui</td>
+<td>long long</td>
+<td>ll</td>
+<td>ptrdiff_t</td>
+<td>p</td>
+<td>UINT</td>
+<td>ui</td>
 </tr>
 <tr class="even">
-<td>unsigned long ul</td>
-<td>UINT8 u8</td>
-</tr>
-<tr class="odd">
-<td>long double ld</td>
-<td>UINT16 u16</td>
-</tr>
-<tr class="even">
-<td>ptrdiff_t p</td>
-<td>UINT32 u32</td>
-</tr>
-<tr class="odd">
-<td>wchar_t wc</td>
-<td>UINT64 u64</td>
-</tr>
-<tr class="even">
-<td><p>short int si short s</p></td>
-<td><p>PVOID p</p></td>
+<td><p>unsigned long long double ptrdiff_t wchar_t short int short</p></td>
+<td><p>ul ld p wc si s</p></td>
+<td><p>void</p></td>
+<td><p><em>none</em></p></td>
+<td><p>UINT8 UINT16 UINT32 UINT64 PVOID</p></td>
+<td><p>u8 u16 u32 u64 p</p></td>
 </tr>
 </tbody>
 </table>
@@ -13896,9 +16965,9 @@ public:
 <li><code class="interpreted-text" role="option">HungarianNotation.DerivedType.Array</code></li>
 <li><code class="interpreted-text" role="option">HungarianNotation.DerivedType.Pointer</code></li>
 <li><code class="interpreted-text" role="option">HungarianNotation.DerivedType.FunctionPointer</code></li>
-<li><code class="interpreted-text" role="option">HungarianNotation.CString.CharPrinter</code></li>
+<li><code class="interpreted-text" role="option">HungarianNotation.CString.CharPointer</code></li>
 <li><code class="interpreted-text" role="option">HungarianNotation.CString.CharArray</code></li>
-<li><code class="interpreted-text" role="option">HungarianNotation.CString.WideCharPrinter</code></li>
+<li><code class="interpreted-text" role="option">HungarianNotation.CString.WideCharPointer</code></li>
 <li><code class="interpreted-text" role="option">HungarianNotation.CString.WideCharArray</code></li>
 <li><code class="interpreted-text" role="option">HungarianNotation.PrimitiveType.*</code></li>
 <li><code class="interpreted-text" role="option">HungarianNotation.UserDefinedType.*</code></li>
@@ -13936,7 +17005,7 @@ void *pDataBuffer = NULL;
 typedef void (*FUNC_PTR)();
 FUNC_PTR fnFuncPtr = NULL;</code></pre>
 <div class="option">
-<p>HungarianNotation.CString.CharPrinter</p>
+<p>HungarianNotation.CString.CharPointer</p>
 <p>When defined, the check will ensure variable name will add the prefix with the given string. The default prefix is <span class="title-ref">sz</span>.</p>
 </div>
 <div class="option">
@@ -13944,7 +17013,7 @@ FUNC_PTR fnFuncPtr = NULL;</code></pre>
 <p>When defined, the check will ensure variable name will add the prefix with the given string. The default prefix is <span class="title-ref">sz</span>.</p>
 </div>
 <div class="option">
-<p>HungarianNotation.CString.WideCharPrinter</p>
+<p>HungarianNotation.CString.WideCharPointer</p>
 <p>When defined, the check will ensure variable name will add the prefix with the given string. The default prefix is <span class="title-ref">wsz</span>.</p>
 </div>
 <div class="option">
@@ -13952,20 +17021,22 @@ FUNC_PTR fnFuncPtr = NULL;</code></pre>
 <p>When defined, the check will ensure variable name will add the prefix with the given string. The default prefix is <span class="title-ref">wsz</span>.</p>
 </div>
 <p>Before:</p>
-<pre class="c++"><code>// CharPrinter
+<pre class="c++"><code>// CharPointer
 const char *NamePtr = &quot;Name&quot;;
 // CharArray
 const char NameArray[] = &quot;Name&quot;;
-// WideCharPrinter
+
+// WideCharPointer
 const wchar_t *WideNamePtr = L&quot;Name&quot;;
 // WideCharArray
 const wchar_t WideNameArray[] = L&quot;Name&quot;;</code></pre>
 <p>After:</p>
-<pre class="c++"><code>// CharPrinter
+<pre class="c++"><code>// CharPointer
 const char *szNamePtr = &quot;Name&quot;;
 // CharArray
 const char szNameArray[] = &quot;Name&quot;;
-// WideCharPrinter
+
+// WideCharPointer
 const wchar_t *wszWideNamePtr = L&quot;Name&quot;;
 // WideCharArray
 const wchar_t wszWideNameArray[] = L&quot;Name&quot;;</code></pre>
@@ -14012,8 +17083,7 @@ DWORD    dwValueDword = 0;</code></pre>
     <key>readability-implicit-bool-cast</key>
     <name>readability-implicit-bool-cast</name>
     <description>
-      <![CDATA[
-      <dl>
+      <![CDATA[<dl>
 <dt>orphan</dt>
 <dd>
 </dd>
@@ -14025,7 +17095,8 @@ DWORD    dwValueDword = 0;</code></pre>
 
 </div>
 <h1 id="readability-implicit-bool-cast">readability-implicit-bool-cast</h1>
-<p>This check has been renamed to <a href="../readability/implicit-bool-conversion.html">readability-implicit-bool-conversion</a>.</p>
+<p>This check has been renamed to <code class="interpreted-text" role="doc">readability-implicit-bool-conversion
+&lt;../readability/implicit-bool-conversion&gt;</code>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/implicit-bool-cast.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -14263,7 +17334,7 @@ void macros() {
 <blockquote>
 <ul>
 <li><a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-magic">Rule ES.45: Avoid "magic constants"; use symbolic constants in C++ Core Guidelines</a></li>
-<li><a href="http://www.codingstandard.com/rule/5-1-1-use-symbolic-names-instead-of-literal-values-in-code/">Rule 5.1.1 Use symbolic names instead of literal values in code in High Integrity C++</a></li>
+<li><a href="https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard-expressions">Rule 5.1.1 Use symbolic names instead of literal values in code in High Integrity C++</a></li>
 <li>Item 17 in "C++ Coding Standards: 101 Rules, Guidelines and Best Practices" by Herb Sutter and Andrei Alexandrescu</li>
 <li>Chapter 17 in "Clean Code - A handbook of agile software craftsmanship." by Robert C. Martin</li>
 <li>Rule 20701 in "TRAIN REAL TIME DATA PROTOCOL Coding Rules" by Armin-Hagen Weiss, Bombardier</li>
@@ -14271,7 +17342,17 @@ void macros() {
 </ul>
 </blockquote>
 <p>Examples of magic values:</p>
-<pre class="c++"><code>double circleArea = 3.1415926535 * radius * radius;
+<pre class="c++"><code>template&lt;typename T, size_t N&gt;
+struct CustomType {
+   T arr[N];
+};
+
+struct OtherType {
+   CustomType&lt;int, 30&gt; container;
+}
+CustomType&lt;int, 30&gt; values;
+
+double circleArea = 3.1415926535 * radius * radius;
 
 double totalCharge = 1.08 * itemPrice;
 
@@ -14283,7 +17364,20 @@ for (int mm = 1; mm &lt;= 12; ++mm) {
    std::cout &lt;&lt; month[mm] &lt;&lt; &#39;\n&#39;;
 }</code></pre>
 <p>Example with magic values refactored:</p>
-<pre class="c++"><code>double circleArea = M_PI * radius * radius;
+<pre class="c++"><code>template&lt;typename T, size_t N&gt;
+struct CustomType {
+   T arr[N];
+};
+
+const size_t NUMBER_OF_ELEMENTS = 30;
+using containerType = CustomType&lt;int, NUMBER_OF_ELEMENTS&gt;;
+
+struct OtherType {
+   containerType container;
+}
+containerType values;
+
+double circleArea = M_PI * radius * radius;
 
 const double TAX_RATE = 0.08;  // or make it variable and read from a file
 
@@ -14323,6 +17417,14 @@ for (int mm = 1; mm &lt;= MONTHS_IN_A_YEAR; ++mm) {
 <p>IgnoreBitFieldsWidths</p>
 <p>Boolean value indicating whether to accept magic numbers as bit field widths without warning. This is useful for example for register definitions which are generated from hardware specifications. Default value is <span class="title-ref">true</span>.</p>
 </div>
+<div class="option">
+<p>IgnoreTypeAliases</p>
+<p>Boolean value indicating whether to accept magic numbers in <code>typedef</code> or <code>using</code> declarations. Default value is <span class="title-ref">false</span>.</p>
+</div>
+<div class="option">
+<p>IgnoreUserDefinedLiterals</p>
+<p>Boolean value indicating whether to accept magic numbers in user-defined literals. Default value is <span class="title-ref">false</span>.</p>
+</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/magic-numbers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -14355,7 +17457,7 @@ for (int mm = 1; mm &lt;= MONTHS_IN_A_YEAR; ++mm) {
 <li>contain a <code>const_cast</code></li>
 <li>are templated or part of a class template</li>
 <li>have an empty body</li>
-<li>do not (implicitly) use <code>this</code> at all (see <a href="../readability/convert-member-functions-to-static.html">readability-convert-member-functions-to-static</a>).</li>
+<li>do not (implicitly) use <code>this</code> at all (see <code class="interpreted-text" role="doc">readability-convert-member-functions-to-static &lt;../readability/convert-member-functions-to-static&gt;</code>).</li>
 </ul>
 <p>The following real-world examples will be preserved by the check:</p>
 <pre class="c++"><code>class E1 {
@@ -14454,7 +17556,13 @@ if (cond1)
 <p>Find functions with unnamed arguments.</p>
 <p>The check implements the following rule originating in the Google C++ Style Guide:</p>
 <p><a href="https://google.github.io/styleguide/cppguide.html#Function_Declarations_and_Definitions">https://google.github.io/styleguide/cppguide.html#Function_Declarations_and_Definitions</a></p>
-<p>All parameters should be named, with identical names in the declaration and implementation.</p>
+<p>All parameters should have the same name in both the function declaration and definition. If a parameter is not utilized, its name can be commented out in a function definition.</p>
+<pre class="c++"><code>int doingSomething(int a, int b, int c);
+
+int doingSomething(int a, int b, int /*c*/) {
+    // Ok: the third param is not used
+    return a + b;
+}</code></pre>
 <p>Corresponding cpplint.py check name: <span class="title-ref">readability/function</span>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/named-parameter.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -14508,6 +17616,104 @@ void f4(int *p) {
 }</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/non-const-parameter.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>readability-operators-representation</key>
+    <name>readability-operators-representation</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - readability-operators-representation</p>
+</div>
+<h1 id="readability-operators-representation">readability-operators-representation</h1>
+<p>Enforces consistent token representation for invoked binary, unary and overloaded operators in C++ code. The check supports both traditional and alternative representations of operators, such as <code>&amp;&amp;</code> and <code>and</code>, <code>||</code> and <code>or</code>, and so on.</p>
+<p>In the realm of C++ programming, developers have the option to choose between two distinct representations for operators: traditional token representation and alternative token representation. Traditional tokens utilize symbols, such as <code>&amp;&amp;</code>, <code>||</code>, and <code>!</code>, while alternative tokens employ more descriptive words like <code>and</code>, <code>or</code>, and <code>not</code>.</p>
+<p>In the following mapping table, a comprehensive list of traditional and alternative tokens, along with their corresponding representations, is presented:</p>
+<table>
+<caption>Token Representation Mapping Table</caption>
+<thead>
+<tr class="header">
+<th>Traditional</th>
+<th>Alternative</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><code>&amp;&amp;</code></td>
+<td><code>and</code></td>
+</tr>
+<tr class="even">
+<td><code>&amp;=</code></td>
+<td><code>and_eq</code></td>
+</tr>
+<tr class="odd">
+<td><code>&amp;</code></td>
+<td><code>bitand</code></td>
+</tr>
+<tr class="even">
+<td><code>|</code></td>
+<td><code>bitor</code></td>
+</tr>
+<tr class="odd">
+<td><code>~</code></td>
+<td><code>compl</code></td>
+</tr>
+<tr class="even">
+<td><code>!</code></td>
+<td><code>not</code></td>
+</tr>
+<tr class="odd">
+<td><code>!=</code></td>
+<td><code>not_eq</code></td>
+</tr>
+<tr class="even">
+<td><code>||</code></td>
+<td><code>or</code></td>
+</tr>
+<tr class="odd">
+<td><code>|=</code></td>
+<td><code>or_eq</code></td>
+</tr>
+<tr class="even">
+<td><code>^</code></td>
+<td><code>xor</code></td>
+</tr>
+<tr class="odd">
+<td><code>^=</code></td>
+<td><code>xor_eq</code></td>
+</tr>
+</tbody>
+</table>
+<h2 id="example">Example</h2>
+<pre class="c++"><code>// Traditional Token Representation:
+
+if (!a||!b)
+{
+    // do something
+}
+
+// Alternative Token Representation:
+
+if (not a or not b)
+{
+    // do something
+}</code></pre>
+<h2 id="options">Options</h2>
+<p>Due to the distinct benefits and drawbacks of each representation, the default configuration doesn't enforce either. Explicit configuration is needed.</p>
+<p>To configure check to enforce Traditional Token Representation for all operators set options to <span class="title-ref">&amp;&amp;;&amp;=;&amp;;|;~;!;!=;||;|=;^;^=</span>.</p>
+<p>To configure check to enforce Alternative Token Representation for all operators set options to <span class="title-ref">and;and_eq;bitand;bitor;compl;not;not_eq;or;or_eq;xor;xor_eq</span>.</p>
+<p>Developers do not need to enforce all operators, and can mix the representations as desired by specifying a semicolon-separated list of both traditional and alternative tokens in the configuration, such as <span class="title-ref">and;||;not</span>.</p>
+<div class="option">
+<p>BinaryOperators</p>
+<p>This option allows you to specify a semicolon-separated list of binary operators for which you want to enforce specific token representation. The default value is empty string.</p>
+</div>
+<div class="option">
+<p>OverloadedOperators</p>
+<p>This option allows you to specify a semicolon-separated list of overloaded operators for which you want to enforce specific token representation. The default value is empty string.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/operators-representation.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -14605,6 +17811,33 @@ public:
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>readability-redundant-casting</key>
+    <name>readability-redundant-casting</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - readability-redundant-casting</p>
+</div>
+<h1 id="readability-redundant-casting">readability-redundant-casting</h1>
+<p>Detects explicit type casting operations that involve the same source and destination types, and subsequently recommend their removal. Covers a range of explicit casting operations, including <code>static_cast</code>, <code>const_cast</code>, C-style casts, and <code>reinterpret_cast</code>. Its primary objective is to enhance code readability and maintainability by eliminating unnecessary type casting.</p>
+<pre class="c++"><code>int value = 42;
+int result = static_cast&lt;int&gt;(value);</code></pre>
+<p>In this example, the <code>static_cast&lt;int&gt;(value)</code> is redundant, as it performs a cast from an <code>int</code> to another <code>int</code>.</p>
+<p>Casting operations involving constructor conversions, user-defined conversions, functional casts, type-dependent casts, casts between distinct type aliases that refer to the same underlying type, as well as bitfield-related casts and casts directly from lvalue to rvalue, are all disregarded by the check.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>If set to <span class="title-ref">true</span>, the check will not give warnings inside macros. Default is <span class="title-ref">true</span>.</p>
+</div>
+<div class="option">
+<p>IgnoreTypeAliases</p>
+<p>When set to <span class="title-ref">false</span>, the check will consider type aliases, and when set to <span class="title-ref">true</span>, it will resolve all type aliases and operate on the underlying types. Default is <span class="title-ref">false</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-casting.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>readability-redundant-control-flow</key>
     <name>readability-redundant-control-flow</name>
     <description>
@@ -14696,6 +17929,32 @@ int i = (*p)(10, 50);</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>readability-redundant-inline-specifier</key>
+    <name>readability-redundant-inline-specifier</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - readability-redundant-inline-specifier</p>
+</div>
+<h1 id="readability-redundant-inline-specifier">readability-redundant-inline-specifier</h1>
+<p>Detects redundant <code>inline</code> specifiers on function and variable declarations.</p>
+<p>Examples:</p>
+<pre class="c++"><code>constexpr inline void f() {}</code></pre>
+<p>In the example above the keyword <code>inline</code> is redundant since constexpr functions are implicitly inlined</p>
+<pre class="c++"><code>class MyClass {
+    inline void myMethod() {}
+};</code></pre>
+<p>In the example above the keyword <code>inline</code> is redundant since member functions defined entirely inside a class/struct/union definition are implicitly inlined.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>StrictMode</p>
+<p>If set to <span class="title-ref">true</span>, the check will also flag functions and variables that already have internal linkage as redundant.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-inline-specifier.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>readability-redundant-member-init</key>
     <name>readability-redundant-member-init</name>
     <description>
@@ -14705,13 +17964,14 @@ int i = (*p)(10, 50);</code></pre>
 <h1 id="readability-redundant-member-init">readability-redundant-member-init</h1>
 <p>Finds member initializations that are unnecessary because the same default constructor would be called if they were not present.</p>
 <h2 id="example">Example</h2>
-<pre class="c++"><code>// Explicitly initializing the member s is unnecessary.
+<pre class="c++"><code>// Explicitly initializing the member s and v is unnecessary.
 class Foo {
 public:
   Foo() : s() {}
 
 private:
   std::string s;
+  std::vector&lt;int&gt; v {};
 };</code></pre>
 <h2 id="options">Options</h2>
 <div class="option">
@@ -14817,6 +18077,11 @@ if (ptr.get() == nullptr) ... =&gt; if (ptr == nullptr) ...</code></pre>
 </div>
 <h1 id="readability-redundant-string-cstr">readability-redundant-string-cstr</h1>
 <p>Finds unnecessary calls to <code>std::string::c_str()</code> and <code>std::string::data()</code>.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>StringParameterFunctions</p>
+<p>A semicolon-separated list of (fully qualified) function/method/operator names, with the requirement that any parameter currently accepting a <code>const char*</code> input should also be able to accept <code>std::string</code> inputs, or proper overload candidates that can do so should exist. This can be used to configure functions such as <code>fmt::format</code>, <code>spdlog::logger::info</code>, or wrappers around these and similar functions. The default value is the empty string.</p>
+</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-string-cstr.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -14857,6 +18122,28 @@ std::string_view b;</code></pre>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-string-init.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>readability-reference-to-constructed-temporary</key>
+    <name>readability-reference-to-constructed-temporary</name>
+    <description>
+      <![CDATA[<div class="title">
+<p>clang-tidy - readability-reference-to-constructed-temporary</p>
+</div>
+<h1 id="readability-reference-to-constructed-temporary">readability-reference-to-constructed-temporary</h1>
+<p>Detects C++ code where a reference variable is used to extend the lifetime of a temporary object that has just been constructed.</p>
+<p>This construction is often the result of multiple code refactorings or a lack of developer knowledge, leading to confusion or subtle bugs. In most cases, what the developer really wanted to do is create a new variable rather than extending the lifetime of a temporary object.</p>
+<p>Examples of problematic code include:</p>
+<pre class="c++"><code>const std::string&amp; str(&quot;hello&quot;);
+
+struct Point { int x; int y; };
+const Point&amp; p = { 1, 2 };</code></pre>
+<p>In the first example, a <code>const std::string&amp;</code> reference variable <code>str</code> is assigned a temporary object created by the <code>std::string("hello")</code> constructor. In the second example, a <code>const Point&amp;</code> reference variable <code>p</code> is assigned an object that is constructed from an initializer list <code>{ 1, 2 }</code>. Both of these examples extend the lifetime of the temporary object to the lifetime of the reference variable, which can make it difficult to reason about and may lead to subtle bugs or misunderstanding.</p>
+<p>To avoid these issues, it is recommended to change the reference variable to a (<code>const</code>) value variable.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/reference-to-constructed-temporary.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -15039,6 +18326,10 @@ std::string_view b;</code></pre>
 </dl>
 <h2 id="options">Options</h2>
 <div class="option">
+<p>IgnoreMacros</p>
+<p>If <span class="title-ref">true</span>, ignore boolean expressions originating from expanded macros. Default is <span class="title-ref">false</span>.</p>
+</div>
+<div class="option">
 <p>ChainedConditionalReturn</p>
 <p>If <span class="title-ref">true</span>, conditional boolean return statements at the end of an <code>if/else if</code> chain will be transformed. Default is <span class="title-ref">false</span>.</p>
 </div>
@@ -15080,7 +18371,7 @@ char c = s.data()[i];  // char c = s[i];</code></pre>
 <h2 id="options">Options</h2>
 <div class="option">
 <p>Types</p>
-<p>The list of type(s) that triggers this check. Default is <span class="title-ref">::std::basic_string;::std::basic_string_view;::std::vector;::std::array</span></p>
+<p>The list of type(s) that triggers this check. Default is <span class="title-ref">::std::basic_string;::std::basic_string_view;::std::vector;::std::array;::std::span</span></p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/simplify-subscript-expr.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -15101,15 +18392,21 @@ char c = s.data()[i];  // char c = s[i];</code></pre>
 <pre class="c++"><code>struct C {
   static void foo();
   static int x;
+  enum { E1 };
+  enum E { E2 };
 };
 
 C *c1 = new C();
 c1-&gt;foo();
-c1-&gt;x;</code></pre>
+c1-&gt;x;
+c1-&gt;E1;
+c1-&gt;E2;</code></pre>
 <p>is changed to:</p>
 <pre class="c++"><code>C *c1 = new C();
 C::foo();
-C::x;</code></pre>
+C::x;
+C::E1;
+C::E2;</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/static-accessed-through-instance.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -15446,765 +18743,17 @@ Derived();             // and so temporary construction is okay</code></pre>
       </description>
     <type>BUG</type>
     </rule>
-  <rule>
-    <key>abseil-cleanup-ctad</key>
-    <name>abseil-cleanup-ctad</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - abseil-cleanup-ctad</p>
-</div>
-<h1 id="abseil-cleanup-ctad">abseil-cleanup-ctad</h1>
-<p>Suggests switching the initialization pattern of <code>absl::Cleanup</code> instances from the factory function to class template argument deduction (CTAD), in C++17 and higher.</p>
-<pre class="c++"><code>auto c1 = absl::MakeCleanup([] {});
-
-const auto c2 = absl::MakeCleanup(std::function&lt;void()&gt;([] {}));</code></pre>
-<p>becomes</p>
-<pre class="c++"><code>absl::Cleanup c1 = [] {};
-
-const absl::Cleanup c2 = std::function&lt;void()&gt;([] {});</code></pre>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/cleanup-ctad.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>bugprone-assignment-in-if-condition</key>
-    <name>bugprone-assignment-in-if-condition</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - bugprone-assignment-in-if-condition</p>
-</div>
-<h1 id="bugprone-assignment-in-if-condition">bugprone-assignment-in-if-condition</h1>
-<p>Finds assignments within conditions of <span class="title-ref">if</span> statements. Such assignments are bug-prone because they may have been intended as equality tests.</p>
-<p>This check finds all assignments within <span class="title-ref">if</span> conditions, including ones that are not flagged by <span class="title-ref">-Wparentheses</span> due to an extra set of parentheses, and including assignments that call an overloaded <span class="title-ref">operator=()</span>. The identified assignments violate <a href="https://barrgroup.com/embedded-systems/books/embedded-c-coding-standard/statement-rules/if-else-statements">BARR group "Rule 8.2.c"</a>.</p>
-<pre class="c++"><code>int f = 3;
-if(f = 4) { // This is identified by both `Wparentheses` and this check - should it have been: `if (f == 4)` ?
-  f = f + 1;
-}
-
-if((f == 5) || (f = 6)) { // the assignment here `(f = 6)` is identified by this check, but not by `-Wparentheses`. Should it have been `(f == 6)` ?
-  f = f + 2;
-}</code></pre>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/assignment-in-if-condition.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>bugprone-narrowing-conversions</key>
-    <name>bugprone-narrowing-conversions</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - bugprone-narrowing-conversions</p>
-</div>
-<div class="meta" data-http-equiv=refresh="5;URL=../cppcoreguidelines/narrowing-conversions.html">
-
-</div>
-<h1 id="bugprone-narrowing-conversions">bugprone-narrowing-conversions</h1>
-<p>The bugprone-narrowing-conversions check is an alias, please see <a href="../cppcoreguidelines/narrowing-conversions.html">cppcoreguidelines-narrowing-conversions</a> for more information.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/narrowing-conversions.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>bugprone-standalone-empty</key>
-    <name>bugprone-standalone-empty</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - bugprone-standalone-empty</p>
-</div>
-<h1 id="bugprone-standalone-empty">bugprone-standalone-empty</h1>
-<p>Warns when <span class="title-ref">empty()</span> is used on a range and the result is ignored. Suggests <span class="title-ref">clear()</span> if it is an existing member function.</p>
-<p>The <code>empty()</code> method on several common ranges returns a Boolean indicating whether or not the range is empty, but is often mistakenly interpreted as a way to clear the contents of a range. Some ranges offer a <code>clear()</code> method for this purpose. This check warns when a call to empty returns a result that is ignored, and suggests replacing it with a call to <code>clear()</code> if it is available as a member function of the range.</p>
-<p>For example, the following code could be used to indicate whether a range is empty or not, but the result is ignored:</p>
-<pre class="c++"><code>std::vector&lt;int&gt; v;
-...
-v.empty();</code></pre>
-<p>A call to <code>clear()</code> would appropriately clear the contents of the range:</p>
-<pre class="c++"><code>std::vector&lt;int&gt; v;
-...
-v.clear();</code></pre>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/standalone-empty.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>bugprone-suspicious-realloc-usage</key>
-    <name>bugprone-suspicious-realloc-usage</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - bugprone-suspicious-realloc-usage</p>
-</div>
-<h1 id="bugprone-suspicious-realloc-usage">bugprone-suspicious-realloc-usage</h1>
-<p>This check finds usages of <code>realloc</code> where the return value is assigned to the same expression as passed to the first argument: <code>p = realloc(p, size);</code> The problem with this construct is that if <code>realloc</code> fails it returns a null pointer but does not deallocate the original memory. If no other variable is pointing to it, the original memory block is not available any more for the program to use or free. In either case <code>p = realloc(p, size);</code> indicates bad coding style and can be replaced by <code>q = realloc(p, size);</code>.</p>
-<p>The pointer expression (used at <code>realloc</code>) can be a variable or a field member of a data structure, but can not contain function calls or unresolved types.</p>
-<p>In obvious cases when the pointer used at realloc is assigned to another variable before the <code>realloc</code> call, no warning is emitted. This happens only if a simple expression in form of <code>q = p</code> or <code>void *q = p</code> is found in the same function where <code>p = realloc(p, ...)</code> is found. The assignment has to be before the call to realloc (but otherwise at any place) in the same function. This suppression works only if <code>p</code> is a single variable.</p>
-<p>Examples:</p>
-<pre class="c++"><code>struct A {
-  void *p;
-};
-
-A &amp;getA();
-
-void foo(void *p, A *a, int new_size) {
-  p = realloc(p, new_size); // warning: &#39;p&#39; may be set to null if &#39;realloc&#39; fails, which may result in a leak of the original buffer
-  a-&gt;p = realloc(a-&gt;p, new_size); // warning: &#39;a-&gt;p&#39; may be set to null if &#39;realloc&#39; fails, which may result in a leak of the original buffer
-  getA().p = realloc(getA().p, new_size); // no warning
-}
-
-void foo1(void *p, int new_size) {
-  void *p1 = p;
-  p = realloc(p, new_size); // no warning
-}</code></pre>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-realloc-usage.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>bugprone-unchecked-optional-access</key>
-    <name>bugprone-unchecked-optional-access</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - bugprone-unchecked-optional-access</p>
-</div>
-<h1 id="bugprone-unchecked-optional-access">bugprone-unchecked-optional-access</h1>
-<p><em>Note</em>: This check uses a flow-sensitive static analysis to produce its results. Therefore, it may be more resource intensive (RAM, CPU) than the average clang-tidy check.</p>
-<p>This check identifies unsafe accesses to values contained in <code>std::optional&lt;T&gt;</code>, <code>absl::optional&lt;T&gt;</code>, or <code>base::Optional&lt;T&gt;</code> objects. Below we will refer to all these types collectively as <code>optional&lt;T&gt;</code>.</p>
-<p>An access to the value of an <code>optional&lt;T&gt;</code> occurs when one of its <code>value</code>, <code>operator*</code>, or <code>operator-&gt;</code> member functions is invoked. To align with common misconceptions, the check considers these member functions as equivalent, even though there are subtle differences related to exceptions versus undefined behavior. See go/optional-style-recommendations for more information on that topic.</p>
-<p>An access to the value of an <code>optional&lt;T&gt;</code> is considered safe if and only if code in the local scope (for example, a function body) ensures that the <code>optional&lt;T&gt;</code> has a value in all possible execution paths that can reach the access. That should happen either through an explicit check, using the <code>optional&lt;T&gt;::has_value</code> member function, or by constructing the <code>optional&lt;T&gt;</code> in a way that shows that it unambiguously holds a value (e.g using <code>std::make_optional</code> which always returns a populated <code>std::optional&lt;T&gt;</code>).</p>
-<p>Below we list some examples, starting with unsafe optional access patterns, followed by safe access patterns.</p>
-<h2 id="unsafe-access-patterns">Unsafe access patterns</h2>
-<h3 id="access-the-value-without-checking-if-it-exists">Access the value without checking if it exists</h3>
-<p>The check flags accesses to the value that are not locally guarded by existence check:</p>
-<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
-  use(*opt); // unsafe: it is unclear whether `opt` has a value.
-}</code></pre>
-<h3 id="access-the-value-in-the-wrong-branch">Access the value in the wrong branch</h3>
-<p>The check is aware of the state of an optional object in different branches of the code. For example:</p>
-<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
-  if (opt.has_value()) {
-  } else {
-    use(opt.value()); // unsafe: it is clear that `opt` does *not* have a value.
-  }
-}</code></pre>
-<h3 id="assume-a-function-result-to-be-stable">Assume a function result to be stable</h3>
-<p>The check is aware that function results might not be stable. That is, consecutive calls to the same function might return different values. For example:</p>
-<pre class="c++"><code>void f(Foo foo) {
-  if (foo.opt().has_value()) {
-    use(*foo.opt()); // unsafe: it is unclear whether `foo.opt()` has a value.
-  }
-}</code></pre>
-<h3 id="rely-on-invariants-of-uncommon-apis">Rely on invariants of uncommon APIs</h3>
-<p>The check is unaware of invariants of uncommon APIs. For example:</p>
-<pre class="c++"><code>void f(Foo foo) {
-  if (foo.HasProperty(&quot;bar&quot;)) {
-    use(*foo.GetProperty(&quot;bar&quot;)); // unsafe: it is unclear whether `foo.GetProperty(&quot;bar&quot;)` has a value.
-  }
-}</code></pre>
-<h3 id="check-if-a-value-exists-then-pass-the-optional-to-another-function">Check if a value exists, then pass the optional to another function</h3>
-<p>The check relies on local reasoning. The check and value access must both happen in the same function. An access is considered unsafe even if the caller of the function performing the access ensures that the optional has a value. For example:</p>
-<pre class="c++"><code>void g(std::optional&lt;int&gt; opt) {
-  use(*opt); // unsafe: it is unclear whether `opt` has a value.
-}
-
-void f(std::optional&lt;int&gt; opt) {
-  if (opt.has_value()) {
-    g(opt);
-  }
-}</code></pre>
-<h2 id="safe-access-patterns">Safe access patterns</h2>
-<h3 id="check-if-a-value-exists-then-access-the-value">Check if a value exists, then access the value</h3>
-<p>The check recognizes all straightforward ways for checking if a value exists and accessing the value contained in an optional object. For example:</p>
-<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
-  if (opt.has_value()) {
-    use(*opt);
-  }
-}</code></pre>
-<h3 id="check-if-a-value-exists-then-access-the-value-from-a-copy">Check if a value exists, then access the value from a copy</h3>
-<p>The criteria that the check uses is semantic, not syntactic. It recognizes when a copy of the optional object being accessed is known to have a value. For example:</p>
-<pre class="c++"><code>void f(std::optional&lt;int&gt; opt1) {
-  if (opt1.has_value()) {
-    std::optional&lt;int&gt; opt2 = opt1;
-    use(*opt2);
-  }
-}</code></pre>
-<h3 id="ensure-that-a-value-exists-using-common-macros">Ensure that a value exists using common macros</h3>
-<p>The check is aware of common macros like <code>CHECK</code>, <code>DCHECK</code>, and <code>ASSERT_THAT</code>. Those can be used to ensure that an optional object has a value. For example:</p>
-<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
-  DCHECK(opt.has_value());
-  use(*opt);
-}</code></pre>
-<h3 id="ensure-that-a-value-exists-then-access-the-value-in-a-correlated-branch">Ensure that a value exists, then access the value in a correlated branch</h3>
-<p>The check is aware of correlated branches in the code and can figure out when an optional object is ensured to have a value on all execution paths that lead to an access. For example:</p>
-<pre class="c++"><code>void f(std::optional&lt;int&gt; opt) {
-  bool safe = false;
-  if (opt.has_value() &amp;&amp; SomeOtherCondition()) {
-    safe = true;
-  }
-  // ... more code...
-  if (safe) {
-    use(*opt);
-  }
-}</code></pre>
-<h2 id="stabilize-function-results">Stabilize function results</h2>
-<p>Since function results are not assumed to be stable across calls, it is best to store the result of the function call in a local variable and use that variable to access the value. For example:</p>
-<pre class="c++"><code>void f(Foo foo) {
-  if (const auto&amp; foo_opt = foo.opt(); foo_opt.has_value()) {
-    use(*foo_opt);
-  }
-}</code></pre>
-<h2 id="do-not-rely-on-uncommon-api-invariants">Do not rely on uncommon-API invariants</h2>
-<p>When uncommon APIs guarantee that an optional has contents, do not rely on it --instead, check explicitly that the optional object has a value. For example:</p>
-<pre class="c++"><code>void f(Foo foo) {
-  if (const auto&amp; property = foo.GetProperty(&quot;bar&quot;)) {
-    use(*property);
-  }
-}</code></pre>
-<p>instead of the <span class="title-ref">HasProperty</span>, <span class="title-ref">GetProperty</span> pairing we saw above.</p>
-<h2 id="do-not-rely-on-caller-performed-checks">Do not rely on caller-performed checks</h2>
-<p>If you know that all of a function's callers have checked that an optional argument has a value, either change the function to take the value directly or check the optional again in the local scope of the callee. For example:</p>
-<pre class="c++"><code>void g(int val) {
-  use(val);
-}
-
-void f(std::optional&lt;int&gt; opt) {
-  if (opt.has_value()) {
-    g(*opt);
-  }
-}</code></pre>
-<p>and</p>
-<pre class="c++"><code>struct S {
-  std::optional&lt;int&gt; opt;
-  int x;
-};
-
-void g(const S &amp;s) {
-  if (s.opt.has_value() &amp;&amp; s.x &gt; 10) {
-    use(*s.opt);
-}
-
-void f(S s) {
-  if (s.opt.has_value()) {
-    g(s);
-  }
-}</code></pre>
-<h2 id="additional-notes">Additional notes</h2>
-<h3 id="aliases-created-via-using-declarations">Aliases created via <code>using</code> declarations</h3>
-<p>The check is aware of aliases of optional types that are created via <code>using</code> declarations. For example:</p>
-<pre class="c++"><code>using OptionalInt = std::optional&lt;int&gt;;
-
-void f(OptionalInt opt) {
-  use(opt.value()); // unsafe: it is unclear whether `opt` has a value.
-}</code></pre>
-<h3 id="lambdas">Lambdas</h3>
-<p>The check does not currently report unsafe optional accesses in lambdas. A future version will expand the scope to lambdas, following the rules outlined above. It is best to follow the same principles when using optionals in lambdas.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/unchecked-optional-access.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>cert-msc54-cpp</key>
-    <name>cert-msc54-cpp</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - cert-msc54-cpp</p>
-</div>
-<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/signal-handler.html">
-
-</div>
-<h1 id="cert-msc54-cpp">cert-msc54-cpp</h1>
-<p>The cert-msc54-cpp check is an alias, please see <a href="../bugprone/signal-handler.html">bugprone-signal-handler</a> for more information.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/msc54-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>cppcoreguidelines-avoid-const-or-ref-data-members</key>
-    <name>cppcoreguidelines-avoid-const-or-ref-data-members</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - cppcoreguidelines-avoid-const-or-ref-data-members</p>
-</div>
-<h1 id="cppcoreguidelines-avoid-const-or-ref-data-members">cppcoreguidelines-avoid-const-or-ref-data-members</h1>
-<p>This check warns when structs or classes have const-qualified or reference (lvalue or rvalue) data members. Having such members is rarely useful, and makes the class only copy-constructible but not copy-assignable.</p>
-<p>Examples:</p>
-<pre class="c++"><code>// Bad, const-qualified member
-struct Const {
-  const int x;
-}
-
-// Good:
-class Foo {
- public:
-  int get() const { return x; }
- private:
-  int x;
-};
-
-// Bad, lvalue reference member
-struct Ref {
-  int&amp; x;
-};
-
-// Good:
-struct Foo {
-  int* x;
-  std::unique_ptr&lt;int&gt; x;
-  std::shared_ptr&lt;int&gt; x;
-  gsl::not_null&lt;int&gt; x;
-};
-
-// Bad, rvalue reference member
-struct RefRef {
-  int&amp;&amp; x;
-};</code></pre>
-<p>The check implements <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c12-dont-make-data-members-const-or-references">rule C.12 of C++ Core Guidelines</a>.</p>
-<p>Further reading: <a href="https://quuxplusone.github.io/blog/2022/01/23/dont-const-all-the-things/#data-members-never-const">Data members: Never const</a>.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-const-or-ref-data-members.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>cppcoreguidelines-avoid-do-while</key>
-    <name>cppcoreguidelines-avoid-do-while</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - cppcoreguidelines-avoid-do-while</p>
-</div>
-<h1 id="cppcoreguidelines-avoid-do-while">cppcoreguidelines-avoid-do-while</h1>
-<p>Warns when using <code>do-while</code> loops. They are less readable than plain <code>while</code> loops, since the termination condition is at the end and the condition is not checked prior to the first iteration. This can lead to subtle bugs.</p>
-<p>The check implements <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Res-do">rule ES.75 of C++ Core Guidelines</a>.</p>
-<p>Examples:</p>
-<pre class="c++"><code>int x;
-do {
-    std::cin &gt;&gt; x;
-    // ...
-} while (x &lt; 0);</code></pre>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>IgnoreMacros</p>
-<p>Ignore the check when analyzing macros. This is useful for safely defining function-like macros:</p>
-<pre class="c++"><code>#define FOO_BAR(x) \
-do { \
-  foo(x); \
-  bar(x); \
-} while(0)</code></pre>
-<p>Defaults to <span class="title-ref">false</span>.</p>
-</div>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/avoid-do-while.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>cppcoreguidelines-macro-to-enum</key>
-    <name>cppcoreguidelines-macro-to-enum</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - cppcoreguidelines-macro-to-enum</p>
-</div>
-<div class="meta" data-http-equiv=refresh="5;URL=../modernize/macro-to-enum.html">
-
-</div>
-<h1 id="cppcoreguidelines-macro-to-enum">cppcoreguidelines-macro-to-enum</h1>
-<p>The cppcoreguidelines-macro-to-enum check is an alias, please see <code class="interpreted-text" role="doc">modernize-macro-to-enum &lt;../modernize/macro-to-enum&gt;</code> for more information.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/macro-to-enum.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>misc-confusable-identifiers</key>
-    <name>misc-confusable-identifiers</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - misc-confusable-identifiers</p>
-</div>
-<h1 id="misc-confusable-identifiers">misc-confusable-identifiers</h1>
-<p>Warn about confusable identifiers, i.e. identifiers that are visually close to each other, but use different Unicode characters. This detects a potential attack described in <a href="https://www.cve.org/CVERecord?id=CVE-2021-42574">CVE-2021-42574</a>.</p>
-<p>Example:</p>
-<pre class="text"><code>int fo; // Initial character is U+0066 (LATIN SMALL LETTER F).
-int fo; // Initial character is U+1D41F (MATHEMATICAL BOLD SMALL F) not U+0066 (LATIN SMALL LETTER F).</code></pre>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/confusable-identifiers.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>misc-const-correctness</key>
-    <name>misc-const-correctness</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - misc-const-correctness</p>
-</div>
-<h1 id="misc-const-correctness">misc-const-correctness</h1>
-<p>This check implements detection of local variables which could be declared as <code>const</code> but are not. Declaring variables as <code>const</code> is required or recommended by many coding guidelines, such as: <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es25-declare-an-object-const-or-constexpr-unless-you-want-to-modify-its-value-later-on">CppCoreGuidelines ES.25</a> and <a href="https://www.autosar.org/fileadmin/user_upload/standards/adaptive/17-03/AUTOSAR_RS_CPP14Guidelines.pdf">AUTOSAR C++14 Rule A7-1-1 (6.7.1 Specifiers)</a>.</p>
-<p>Please note that this check's analysis is type-based only. Variables that are not modified but used to create a non-const handle that might escape the scope are not diagnosed as potential <code>const</code>.</p>
-<pre class="c++"><code>// Declare a variable, which is not ``const`` ...
-int i = 42;
-// but use it as read-only. This means that `i` can be declared ``const``.
-int result = i * i;       // Before transformation
-int const result = i * i; // After transformation</code></pre>
-<p>The check can analyze values, pointers and references but not (yet) pointees:</p>
-<pre class="c++"><code>// Normal values like built-ins or objects.
-int potential_const_int = 42;       // Before transformation
-int const potential_const_int = 42; // After transformation
-int copy_of_value = potential_const_int;
-
-MyClass could_be_const;       // Before transformation
-MyClass const could_be_const; // After transformation
-could_be_const.const_qualified_method();
-
-// References can be declared const as well.
-int &amp;reference_value = potential_const_int;       // Before transformation
-int const&amp; reference_value = potential_const_int; // After transformation
-int another_copy = reference_value;
-
-// The similar semantics of pointers are not (yet) analyzed.
-int *pointer_variable = &amp;potential_const_int; // _NO_ &#39;const int *pointer_variable&#39; suggestion.
-int last_copy = *pointer_variable;</code></pre>
-<p>The automatic code transformation is only applied to variables that are declared in single declarations. You may want to prepare your code base with <a href="../readability/isolate-declaration.html">readability-isolate-declaration</a> first.</p>
-<p>Note that there is the check <a href="../cppcoreguidelines/avoid-non-const-global-variables.html">cppcoreguidelines-avoid-non-const-global-variables</a> to enforce <code>const</code> correctness on all globals.</p>
-<h2 id="known-limitations">Known Limitations</h2>
-<p>The check does not run on <span class="title-ref">C</span> code.</p>
-<p>The check will not analyze templated variables or variables that are instantiation dependent. Different instantiations can result in different <code>const</code> correctness properties and in general it is not possible to find all instantiations of a template. The template might be used differently in an independent translation unit.</p>
-<p>Pointees can not be analyzed for constness yet. The following code shows this limitation.</p>
-<pre class="c++"><code>// Declare a variable that will not be modified.
-int constant_value = 42;
-
-// Declare a pointer to that variable, that does not modify either, but misses &#39;const&#39;.
-// Could be &#39;const int *pointer_to_constant = &amp;constant_value;&#39;
-int *pointer_to_constant = &amp;constant_value;
-
-// Usage:
-int result = 520 * 120 * (*pointer_to_constant);</code></pre>
-<p>This limitation affects the capability to add <code>const</code> to methods which is not possible, too.</p>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>AnalyzeValues (default = true)</p>
-<p>Enable or disable the analysis of ordinary value variables, like <code>int i = 42;</code></p>
-<pre class="c++"><code>// Warning
-int i = 42;
-// No warning
-int const i = 42;
-
-// Warning
-int a[] = {42, 42, 42};
-// No warning
-int const a[] = {42, 42, 42};</code></pre>
-</div>
-<div class="option">
-<p>AnalyzeReferences (default = true)</p>
-<p>Enable or disable the analysis of reference variables, like <code>int &amp;ref = i;</code></p>
-<pre class="c++"><code>int i = 42;
-// Warning
-int&amp; ref = i;
-// No warning
-int const&amp; ref = i;</code></pre>
-</div>
-<div class="option">
-<p>WarnPointersAsValues (default = false)</p>
-<p>This option enables the suggestion for <code>const</code> of the pointer itself. Pointer values have two possibilities to be <code>const</code>, the pointer and the value pointing to.</p>
-<pre class="c++"><code>int value = 42;
-
-// Warning
-const int * pointer_variable = &amp;value;
-// No warning
-const int *const pointer_variable = &amp;value;</code></pre>
-</div>
-<div class="option">
-<p>TransformValues (default = true)</p>
-<p>Provides fixit-hints for value types that automatically add <code>const</code> if its a single declaration.</p>
-<pre class="c++"><code>// Before
-int value = 42;
-// After
-int const value = 42;
-
-// Before
-int a[] = {42, 42, 42};
-// After
-int const a[] = {42, 42, 42};
-
-// Result is modified later in its life-time. No diagnostic and fixit hint will be emitted.
-int result = value * 3;
-result -= 10;</code></pre>
-</div>
-<div class="option">
-<p>TransformReferences (default = true)</p>
-<p>Provides fixit-hints for reference types that automatically add <code>const</code> if its a single declaration.</p>
-<pre class="c++"><code>// This variable could still be a constant. But because there is a non-const reference to
-// it, it can not be transformed (yet).
-int value = 42;
-// The reference &#39;ref_value&#39; is not modified and can be made &#39;const int &amp;ref_value = value;&#39;
-// Before
-int &amp;ref_value = value;
-// After
-int const &amp;ref_value = value;
-
-// Result is modified later in its life-time. No diagnostic and fixit hint will be emitted.
-int result = ref_value * 3;
-result -= 10;</code></pre>
-</div>
-<div class="option">
-<p>TransformPointersAsValues (default = false)</p>
-<p>Provides fixit-hints for pointers if their pointee is not changed. This does not analyze if the value-pointed-to is unchanged!</p>
-<p>Requires 'WarnPointersAsValues' to be 'true'.</p>
-<pre class="c++"><code>int value = 42;
-
-// Before
-const int * pointer_variable = &amp;value;
-// After
-const int *const pointer_variable = &amp;value;
-
-// Before
-const int * a[] = {&amp;value, &amp;value};
-// After
-const int *const a[] = {&amp;value, &amp;value};
-
-// Before
-int *ptr_value = &amp;value;
-// After
-int *const ptr_value = &amp;value;
-
-int result = 100 * (*ptr_value); // Does not modify the pointer itself.
-// This modification of the pointee is still allowed and not diagnosed.
-*ptr_value = 0;
-
-// The following pointer may not become a &#39;int *const&#39;.
-int *changing_pointee = &amp;value;
-changing_pointee = &amp;result;</code></pre>
-</div>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/const-correctness.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>misc-use-anonymous-namespace</key>
-    <name>misc-use-anonymous-namespace</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - misc-use-anonymous-namespace</p>
-</div>
-<h1 id="misc-use-anonymous-namespace">misc-use-anonymous-namespace</h1>
-<p>Finds instances of <code>static</code> functions or variables declared at global scope that could instead be moved into an anonymous namespace.</p>
-<p>Anonymous namespaces are the "superior alternative" according to the C++ Standard. <code>static</code> was proposed for deprecation, but later un-deprecated to keep C compatibility [1]. <code>static</code> is an overloaded term with different meanings in different contexts, so it can create confusion.</p>
-<p>The following uses of <code>static</code> will <em>not</em> be diagnosed:</p>
-<ul>
-<li>Functions or variables in header files, since anonymous namespaces in headers is considered an antipattern. Allowed header file extensions can be configured via the <span class="title-ref">HeaderFileExtensions</span> option (see below).</li>
-<li><code>const</code> or <code>constexpr</code> variables, since they already have implicit internal linkage in C++.</li>
-</ul>
-<p>Examples:</p>
-<pre class="c++"><code>// Bad
-static void foo();
-static int x;
-
-// Good
-namespace {
-  void foo();
-  int x;
-} // namespace</code></pre>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>HeaderFileExtensions</p>
-<p>A semicolon-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is ";h;hh;hpp;hxx". For extension-less header files, using an empty string or leaving an empty string between ";" if there are other filename extensions.</p>
-</div>
-<p>[1] <a href="https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1012">Undeprecating static</a></p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/use-anonymous-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>modernize-macro-to-enum</key>
-    <name>modernize-macro-to-enum</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - modernize-macro-to-enum</p>
-</div>
-<h1 id="modernize-macro-to-enum">modernize-macro-to-enum</h1>
-<p>Replaces groups of adjacent macros with an unscoped anonymous enum. Using an unscoped anonymous enum ensures that everywhere the macro token was used previously, the enumerator name may be safely used.</p>
-<p>This check can be used to enforce the C++ core guideline <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#enum1-prefer-enumerations-over-macros">Enum.1: Prefer enumerations over macros</a>, within the constraints outlined below.</p>
-<p>Potential macros for replacement must meet the following constraints:</p>
-<ul>
-<li>Macros must expand only to integral literal tokens or expressions of literal tokens. The expression may contain any of the unary operators <code>-</code>, <code>+</code>, <code>~</code> or <code>!</code>, any of the binary operators <code>,</code>, <code>-</code>, <code>+</code>, <code>*</code>, <code>/</code>, <code>%</code>, <code>&amp;</code>, <code>|</code>, <code>^</code>, <code>&lt;</code>, <code>&gt;</code>, <code>&lt;=</code>, <code>&gt;=</code>, <code>==</code>, <code>!=</code>, <code>||</code>, <code>&amp;&amp;</code>, <code>&lt;&lt;</code>, <code>&gt;&gt;</code> or <code>&lt;=&gt;</code>, the ternary operator <code>?:</code> and its <a href="https://gcc.gnu.org/onlinedocs/gcc/Conditionals.html">GNU extension</a>. Parenthesized expressions are also recognized. This recognizes most valid expressions. In particular, expressions with the <code>sizeof</code> operator are not recognized.</li>
-<li>Macros must be defined on sequential source file lines, or with only comment lines in between macro definitions.</li>
-<li>Macros must all be defined in the same source file.</li>
-<li>Macros must not be defined within a conditional compilation block. (Conditional include guards are exempt from this constraint.)</li>
-<li>Macros must not be defined adjacent to other preprocessor directives.</li>
-<li>Macros must not be used in any conditional preprocessing directive.</li>
-<li>Macros must not be used as arguments to other macros.</li>
-<li>Macros must not be undefined.</li>
-<li>Macros must be defined at the top-level, not inside any declaration or definition.</li>
-</ul>
-<p>Each cluster of macros meeting the above constraints is presumed to be a set of values suitable for replacement by an anonymous enum. From there, a developer can give the anonymous enum a name and continue refactoring to a scoped enum if desired. Comments on the same line as a macro definition or between subsequent macro definitions are preserved in the output. No formatting is assumed in the provided replacements, although clang-tidy can optionally format all fixes.</p>
-<div class="warning">
-<div class="title">
-<p>Warning</p>
-</div>
-<p>Initializing expressions are assumed to be valid initializers for an enum. C requires that enum values fit into an <code>int</code>, but this may not be the case for some accepted constant expressions. For instance <code>1 &lt;&lt; 40</code> will not fit into an <code>int</code> when the size of an <code>int</code> is 32 bits.</p>
-</div>
-<p>Examples:</p>
-<pre class="c++"><code>#define RED   0xFF0000
-#define GREEN 0x00FF00
-#define BLUE  0x0000FF
-
-#define TM_NONE (-1) // No method selected.
-#define TM_ONE 1    // Use tailored method one.
-#define TM_TWO 2    // Use tailored method two.  Method two
-                    // is preferable to method one.
-#define TM_THREE 3  // Use tailored method three.</code></pre>
-<p>becomes</p>
-<pre class="c++"><code>enum {
-RED = 0xFF0000,
-GREEN = 0x00FF00,
-BLUE = 0x0000FF
-};
-
-enum {
-TM_NONE = (-1), // No method selected.
-TM_ONE = 1,    // Use tailored method one.
-TM_TWO = 2,    // Use tailored method two.  Method two
-                    // is preferable to method one.
-TM_THREE = 3  // Use tailored method three.
-};</code></pre>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/macro-to-enum.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>objc-nsdate-formatter</key>
-    <name>objc-nsdate-formatter</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - objc-nsdate-formatter</p>
-</div>
-<h1 id="objc-nsdate-formatter">objc-nsdate-formatter</h1>
-<p>When <code>NSDateFormatter</code> is used to convert an <code>NSDate</code> type to a <code>String</code> type, the user can specify a custom format string. Certain format specifiers are undesirable despite being legal. See <a href="http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns">http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns</a> for all legal date patterns.</p>
-<p>This checker reports as warnings the following string patterns in a date format specifier:</p>
-<ol>
-<li>yyyy + ww : Calendar year specified with week of a week year (unless YYYY is also specified).
-<ul>
-<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">yyyy-ww</span>;<br />
-Output string: <span class="title-ref">2014-01</span> (Wrong because it's not the first week of 2014)</div></li>
-<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">dd-MM-yyyy (ww-YYYY)</span>;<br />
-Output string: <span class="title-ref">29-12-2014 (01-2015)</span> (This is correct)</div></li>
-</ul></li>
-<li>F without ee/EE : Numeric day of week in a month without actual day.
-<ul>
-<li><div class="line-block"><strong>Example:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">F-MM</span>;<br />
-Output string: <span class="title-ref">5-12</span> (Wrong because it reads as <em>5th ___ of Dec</em> in English)</div></li>
-</ul></li>
-<li>F without MM : Numeric day of week in a month without month.
-<ul>
-<li><div class="line-block"><strong>Example:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">F-EE</span><br />
-Output string: <span class="title-ref">5-Mon</span> (Wrong because it reads as <em>5th Mon of ___</em> in English)</div></li>
-</ul></li>
-<li>WW without MM : Week of the month without the month.
-<ul>
-<li><div class="line-block"><strong>Example:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">WW-yyyy</span><br />
-Output string: <span class="title-ref">05-2014</span> (Wrong because it reads as <em>5th Week of ___</em> in English)</div></li>
-</ul></li>
-<li>YYYY + QQ : Week year specified with quarter of normal year (unless yyyy is also specified).
-<ul>
-<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-QQ</span><br />
-Output string: <span class="title-ref">2015-04</span> (Wrong because it's not the 4th quarter of 2015)</div></li>
-<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (QQ-yyyy)</span><br />
-Output string: <span class="title-ref">01-2015 (04-2014)</span> (This is correct)</div></li>
-</ul></li>
-<li>YYYY + MM : Week year specified with Month of a calendar year (unless yyyy is also specified).
-<ul>
-<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-MM</span><br />
-Output string: <span class="title-ref">2015-12</span> (Wrong because it's not the 12th month of 2015)</div></li>
-<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (MM-yyyy)</span><br />
-Output string: <span class="title-ref">01-2015 (12-2014)</span> (This is correct)</div></li>
-</ul></li>
-<li>YYYY + DD : Week year with day of a calendar year (unless yyyy is also specified).
-<ul>
-<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-DD</span><br />
-Output string: <span class="title-ref">2015-363</span> (Wrong because it's not the 363rd day of 2015)</div></li>
-<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (DD-yyyy)</span><br />
-Output string: <span class="title-ref">01-2015 (363-2014)</span> (This is correct)</div></li>
-</ul></li>
-<li>YYYY + WW : Week year with week of a calendar year (unless yyyy is also specified).
-<ul>
-<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-WW</span><br />
-Output string: <span class="title-ref">2015-05</span> (Wrong because it's not the 5th week of 2015)</div></li>
-<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (WW-MM-yyyy)</span><br />
-Output string: <span class="title-ref">01-2015 (05-12-2014)</span> (This is correct)</div></li>
-</ul></li>
-<li>YYYY + F : Week year with day of week in a calendar month (unless yyyy is also specified).
-<ul>
-<li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-ww-F-EE</span><br />
-Output string: <span class="title-ref">2015-01-5-Mon</span> (Wrong because it's not the 5th Monday of January in 2015)</div></li>
-<li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (F-EE-MM-yyyy)</span><br />
-Output string: <span class="title-ref">01-2015 (5-Mon-12-2014)</span> (This is correct)</div></li>
-</ul></li>
-</ol>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/objc/nsdate-formatter.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>portability-std-allocator-const</key>
-    <name>portability-std-allocator-const</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - portability-std-allocator-const</p>
-</div>
-<h1 id="portability-std-allocator-const">portability-std-allocator-const</h1>
-<p>Report use of <code>std::vector&lt;const T&gt;</code> (and similar containers of const elements). These are not allowed in standard C++, and should usually be <code>std::vector&lt;T&gt;</code> instead."</p>
-<p>Per C++ <code>[allocator.requirements.general]</code>: "T is any cv-unqualified object type", <code>std::allocator&lt;const T&gt;</code> is undefined. Many standard containers use <code>std::allocator</code> by default and therefore their <code>const T</code> instantiations are undefined.</p>
-<p>libc++ defines <code>std::allocator&lt;const T&gt;</code> as an extension which will be removed in the future.</p>
-<p>libstdc++ and MSVC do not support <code>std::allocator&lt;const T&gt;</code>:</p>
-<pre class="c++"><code>// libstdc++ has a better diagnostic since https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48101
-std::deque&lt;const int&gt; deque; // error: static assertion failed: std::deque must have a non-const, non-volatile value_type
-std::set&lt;const int&gt; set; // error: static assertion failed: std::set must have a non-const, non-volatile value_type
-std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::vector must have a non-const, non-volatile value_type
-
-// MSVC
-// error C2338: static_assert failed: &#39;The C++ Standard forbids containers of const elements because allocator&lt;const T&gt; is ill-formed.&#39;</code></pre>
-<p>Code bases only compiled with libc++ may accrue such undefined usage. This check finds such code and prevents backsliding while clean-up is ongoing.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/portability/std-allocator-const.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
 
   <!-- Clang Diagnostic Rules -->
 
-   <rule>
+  <rule>
     <key>clang-diagnostic-aix-compat</key>
     <name>clang-diagnostic-aix-compat</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: #pragma align(packed) may not be compatible with objects generated with AIX XL C/C++</li>
-<li>warning: requesting an alignment of 16 bytes or greater for struct members is not binary compatible with IBM XL C/C++ for AIX 16.1.0 and older</li>
+<li>warning: alignment of 16 bytes for a struct member is not binary compatible with IBM XL C/C++ for AIX 16.1.0 or older</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waix-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -16311,7 +18860,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: no avr-gcc installation can be found on the system, cannot link standard libraries</li>
 <li>warning: no avr-libc installation can be found on the system, cannot link standard libraries</li>
 <li>warning: no target microcontroller specified on command line, cannot link standard libraries, please pass -mmcu=&lt;mcu name&gt;</li>
 <li>warning: standard library not linked and so no interrupt vector table or compiler runtime routines will be linked</li>
@@ -16397,20 +18945,27 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: %select{values of type|enum values with underlying type}2 '%0' should not be used as format arguments; add an explicit cast to %1 instead</li>
 <li>warning: %select{void function|void method|constructor|destructor}1 %0 should not return a value</li>
 <li>warning: %select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++</li>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
 <li>warning: '%%n' specifier not supported on this platform</li>
 <li>warning: '%0' is not a valid object format flag</li>
 <li>warning: '%0' within '%1'</li>
 <li>warning: '%select{*|.*}0' specified field %select{width|precision}0 is missing a matching 'int' argument</li>
+<li>warning: '&amp;&amp;' of a value and its negation always evaluates to false</li>
 <li>warning: '&amp;&amp;' within '||'</li>
 <li>warning: '/*' within block comment</li>
 <li>warning: 'static' function %0 declared in header file should be declared 'static inline'</li>
 <li>warning: 'this' pointer cannot be null in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0</li>
+<li>warning: '||' of a value and its negation always evaluates to true</li>
 <li>warning: // comments are not allowed in this language</li>
 <li>warning: ISO C++ requires field designators to be specified in declaration order; field %1 will be initialized after field %0</li>
 <li>warning: add explicit braces to avoid dangling else</li>
 <li>warning: adding %0 to a string does not append to the string</li>
 <li>warning: all paths through this function will call itself</li>
 <li>warning: angle-bracketed include &lt;%0&gt; cannot be aliased to double-quoted include "%1"</li>
+<li>warning: argument %0 of type %1 with mismatched bound</li>
 <li>warning: array section %select{lower bound|length}0 is of type 'char'</li>
 <li>warning: array subscript is of type 'char'</li>
 <li>warning: assigning %select{field|instance variable}0 to itself</li>
@@ -16419,6 +18974,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: bitwise negation of a boolean expression%select{;| always evaluates to 'true';}0 did you mean logical negation?</li>
 <li>warning: bitwise or with non-zero value always evaluates to true</li>
 <li>warning: block pointer variable %0 is %select{uninitialized|null}1 when captured by block</li>
+<li>warning: call to undeclared function %0; ISO C99 and later do not support implicit function declarations</li>
+<li>warning: call to undeclared library function '%0' with type %1; ISO C99 and later do not support implicit function declarations</li>
 <li>warning: calling '%0' with a nonzero argument is unsafe</li>
 <li>warning: cannot mix positional and non-positional arguments in format string</li>
 <li>warning: case value not in enumerated type %0</li>
@@ -16442,10 +18999,10 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: escaped newline between */ characters at block comment end</li>
 <li>warning: expected 'ON' or 'OFF' or 'DEFAULT' in pragma</li>
 <li>warning: expected end of directive in pragma</li>
-<li>warning: explicitly assigning value of variable of type %0 to itself</li>
-<li>warning: explicitly assigning value of variable of type %0 to itself</li>
-<li>warning: explicitly moving variable of type %0 to itself</li>
-<li>warning: explicitly moving variable of type %0 to itself</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1</li>
+<li>warning: explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1</li>
+<li>warning: explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1</li>
 <li>warning: expression result unused</li>
 <li>warning: expression result unused; should this cast be to 'void'?</li>
 <li>warning: expression with side effects has no effect in an unevaluated context</li>
@@ -16470,7 +19027,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: ignoring temporary created by a constructor declared with %0 attribute</li>
 <li>warning: ignoring temporary created by a constructor declared with %0 attribute: %1</li>
 <li>warning: implicit declaration of function %0</li>
-<li>warning: implicit declaration of function %0 is invalid in C99</li>
 <li>warning: implicitly declaring library function '%0' with type %1</li>
 <li>warning: incomplete format specifier</li>
 <li>warning: initializer order does not match the declaration order</li>
@@ -16501,6 +19057,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: non-void function does not return a value in all control paths</li>
 <li>warning: non-void lambda does not return a value</li>
 <li>warning: non-void lambda does not return a value in all control paths</li>
+<li>warning: not packing field %0 as it is non-POD for the purposes of layout</li>
 <li>warning: null passed to a callee that requires a non-null argument</li>
 <li>warning: null returned from %select{function|method}0 that requires a non-null return value</li>
 <li>warning: object format flags cannot be used with '%0' conversion specifier</li>
@@ -16510,6 +19067,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: overflow converting case value to switch condition type (%0 to %1)</li>
 <li>warning: overlapping comparisons always evaluate to %select{false|true}0</li>
 <li>warning: overloaded operator %select{&gt;&gt;|&lt;&lt;}0 has higher precedence than comparison operator</li>
+<li>warning: parameter %0 was not declared, defaults to 'int'; ISO C99 and later do not support implicit int</li>
 <li>warning: position arguments in format strings start counting at 1 (not 0)</li>
 <li>warning: pragma STDC FENV_ROUND is not supported</li>
 <li>warning: pragma diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'</li>
@@ -16534,6 +19092,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: trigraph ends block comment</li>
 <li>warning: trigraph ignored</li>
 <li>warning: type specifier missing, defaults to 'int'</li>
+<li>warning: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int</li>
 <li>warning: unexpected token in pragma diagnostic</li>
 <li>warning: unknown pragma ignored</li>
 <li>warning: unknown pragma in STDC namespace</li>
@@ -16555,6 +19114,10 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: variable %0 is uninitialized when passed as a const reference argument here</li>
 <li>warning: variable %0 is uninitialized when used within its own initialization</li>
 <li>warning: variable %0 set but not used</li>
+<li>warning: variable length arrays in C++ are a Clang extension</li>
+<li>warning: variable length arrays in C++ are a Clang extension</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
 <li>warning: variable%select{s| %1|s %1 and %2|s %1, %2, and %3|s %1, %2, %3, and %4}0 used in loop condition not modified in loop body</li>
 <li>warning: zero field width in scanf format string is unused</li>
 </ul>
@@ -16624,7 +19187,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <ul>
 <li>warning: array argument is too small; %select{contains %0 elements|is of size %0}2, callee requires at least %1</li>
 <li>warning: array index %0 is before the beginning of the array</li>
-<li>warning: array index %0 is past the end of the array (which contains %1 element%s2)</li>
+<li>warning: array index %0 is past the end of the array (that has type %1%select{|, cast to %3}2)</li>
 <li>warning: array index %0 refers past the last possible element for an array in %1-bit address space containing %2-bit (%3-byte) elements (max possible %4 element%s5)</li>
 <li>warning: the pointer incremented by %0 refers past the last possible element for an array in %1-bit address space containing %2-bit (%3-byte) elements (max possible %4 element%s5)</li>
 </ul>
@@ -16640,10 +19203,23 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: the pointer decremented by %0 refers before the beginning of the array</li>
-<li>warning: the pointer incremented by %0 refers past the end of the array (that contains %1 element%s2)</li>
+<li>warning: the pointer incremented by %0 refers past the end of the array (that has type %1)</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warray-bounds-pointer-arithmetic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-array-parameter</key>
+    <name>clang-diagnostic-array-parameter</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: argument %0 of type %1 with mismatched bound</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warray-parameter" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -16682,6 +19258,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: %0 attribute argument '%1' not supported on a global variable</li>
 <li>warning: %0 attribute argument not supported: %1</li>
 <li>warning: %0 attribute can only be applied to instance variables or properties</li>
 <li>warning: %0 attribute ignored</li>
@@ -16690,29 +19267,33 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: %0 attribute ignored on inline function</li>
 <li>warning: %0 attribute ignored when parsing type</li>
 <li>warning: %0 attribute is deprecated and ignored in %1</li>
+<li>warning: %0 attribute is ignored because %1 is not a function pointer</li>
 <li>warning: %0 attribute is ignored because there exists no call expression inside the statement</li>
 <li>warning: %0 attribute isn't implemented by this Objective-C runtime</li>
-<li>warning: %0 attribute only applies to %1</li>
 <li>warning: %0 attribute only applies to %select{Objective-C object|pointer|pointer-to-CF-pointer|pointer/reference-to-OSObject-pointer}1 parameters</li>
 <li>warning: %0 attribute only applies to %select{functions|methods|properties}1 that return %select{an Objective-C object|a pointer|a non-retainable pointer}2</li>
-<li>warning: %0 attribute only applies to %select{functions|unions|variables and functions|functions and methods|functions, methods and blocks|functions, methods, and parameters|variables|variables and fields|variables, data members and tag types|types and namespaces|variables, functions and classes|kernel functions|non-K&amp;R-style functions}1</li>
 <li>warning: %0 attribute only applies to a pointer or reference (%1 is invalid)</li>
 <li>warning: %0 attribute only applies to return values that are pointers</li>
 <li>warning: %0 attribute only applies to return values that are pointers or references</li>
 <li>warning: %0 attribute only applies to%select{| constant}1 pointer arguments</li>
 <li>warning: %0 calling convention is not supported %select{for this target|on variadic function|on constructor/destructor|on builtin function}1</li>
 <li>warning: %0 currently has no effect on a using declaration</li>
+<li>warning: %0%select{ attribute|}1 only applies to %2</li>
+<li>warning: %0%select{ attribute|}1 only applies to %select{functions|unions|variables and functions|functions and methods|functions, methods and blocks|functions, methods, and parameters|variables|variables and fields|variables, data members and tag types|types and namespaces|variables, functions and classes|kernel functions|non-K&amp;R-style functions}2</li>
 <li>warning: %q0 redeclared inline; %1 attribute ignored</li>
 <li>warning: %select{MIPS|MSP430|RISC-V}0 'interrupt' attribute only applies to functions that have %select{no parameters|a 'void' return type}1</li>
 <li>warning: %select{alias|ifunc}1 will not be in section '%0' but in the same section as the %select{aliasee|resolver}2</li>
 <li>warning: %select{alias|ifunc}2 will always resolve to %0 even if weak definition of %1 is overridden</li>
 <li>warning: %select{alignment|size}0 of field %1 (%2 bits) does not match the %select{alignment|size}0 of the first field in transparent union; transparent_union attribute ignored</li>
-<li>warning: %select{unsupported|duplicate|unknown}0%select{| architecture| tune CPU}1 '%2' in the '%select{target|target_clones}3' attribute string; '%select{target|target_clones}3' attribute ignored</li>
+<li>warning: %select{unsupported|duplicate|unknown}0%select{| CPU| tune CPU}1 '%2' in the '%select{target|target_clones|target_version}3' attribute string; '%select{target|target_clones|target_version}3' attribute ignored</li>
 <li>warning: '%0' attribute cannot be specified on a definition</li>
 <li>warning: '%0' only applies to %select{function|pointer|Objective-C object or block pointer}1 types; type here is %2</li>
+<li>warning: '%select{pure|const}0' attribute on function returning 'void'; attribute ignored</li>
+<li>warning: '[[%select{nodiscard|gnu::warn_unused_result}0]]' attribute ignored when applied to a typedef; consider using '__attribute__((warn_unused_result))' or '[[clang::warn_unused_result]]' instead</li>
 <li>warning: '__clang__' is a predefined macro name, not an attribute scope specifier; did you mean '_Clang' instead?</li>
 <li>warning: 'abi_tag' attribute on %select{non-inline|anonymous}0 namespace ignored</li>
 <li>warning: 'cmse_nonsecure_entry' cannot be applied to functions with internal linkage</li>
+<li>warning: 'const' attribute imposes more restrictions; 'pure' attribute ignored</li>
 <li>warning: 'deprecated' attribute on anonymous namespace ignored</li>
 <li>warning: 'dllexport' attribute ignored on explicit instantiation definition</li>
 <li>warning: 'gnu_inline' attribute requires function to be marked 'inline', attribute ignored</li>
@@ -16742,8 +19323,9 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: attribute %0 ignored, because it is not attached to a declaration</li>
 <li>warning: attribute %0 is already applied</li>
 <li>warning: attribute %0 is already applied with different arguments</li>
-<li>warning: attribute %0 is ignored, place it after "%select{class|struct|interface|union|enum}1" to apply attribute to type declaration</li>
+<li>warning: attribute %0 is ignored, place it after "%select{class|struct|interface|union|enum|enum class|enum struct}1" to apply attribute to type declaration</li>
 <li>warning: attribute declaration must precede definition</li>
+<li>warning: attribute is ignored on this statement as it only applies to functions; use '%0' on statements</li>
 <li>warning: conflicting attributes %0 are ignored</li>
 <li>warning: direct attribute on property %0 ignored (not implemented by this Objective-C runtime)</li>
 <li>warning: first field of a transparent union cannot have %select{floating point|vector}0 type %1; transparent_union attribute ignored</li>
@@ -16753,9 +19335,11 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: import %select{module|name}0 (%1) does not match the import %select{module|name}0 (%2) of the previous declaration</li>
 <li>warning: import %select{module|name}0 cannot be applied to a function with a definition</li>
 <li>warning: inheritance model ignored on %select{primary template|partial specialization}0</li>
+<li>warning: maxclusterrank requires sm_90 or higher, CUDA arch provided: %0, ignoring %1 attribute</li>
 <li>warning: qualifiers after comma in declarator list are ignored</li>
 <li>warning: repeated RISC-V 'interrupt' attribute</li>
 <li>warning: requested alignment is less than minimum alignment of %1 for type %0</li>
+<li>warning: statement attribute %0 has higher precedence than function attribute '%select{always_inline|flatten|noinline}1'</li>
 <li>warning: template parameter of a function template with the 'sycl_kernel' attribute cannot be a non-type template parameter</li>
 <li>warning: transparent union definition must contain at least one field; transparent_union attribute ignored</li>
 <li>warning: transparent_union attribute can only be applied to a union definition; attribute ignored</li>
@@ -16921,6 +19505,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: %0</li>
+<li>warning: %0 (%1) exceeds limit (%2) in '%3'</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbackend-plugin" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -16946,7 +19531,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: call to %0 declared with 'warning' attribute: %1</li>
+<li>warning: call to '%0' declared with 'warning' attribute: %1</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wattribute-warning" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -17002,6 +19587,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: implicit truncation from %2 to a one-bit wide bit-field changes value from %0 to %1</li>
 <li>warning: implicit truncation from %2 to bit-field changes value from %0 to %1</li>
 </ul>
 <h2>References</h2>
@@ -17180,16 +19766,36 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c2x-extensions</key>
-    <name>clang-diagnostic-c2x-extensions</name>
+    <key>clang-diagnostic-c23-extensions</key>
+    <name>clang-diagnostic-c23-extensions</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: '_Static_assert' with no message is a C2x extension</li>
-<li>warning: omitting the parameter name in a function definition is a C2x extension</li>
+<li>warning: '_BitInt' suffix for literals is a C23 extension</li>
+<li>warning: '_Static_assert' with no message is a C23 extension</li>
+<li>warning: 'nullptr' is a C23 extension</li>
+<li>warning: [[]] attributes are a C23 extension</li>
+<li>warning: label at end of compound statement is a C23 extension</li>
+<li>warning: label followed by a declaration is a C23 extension</li>
+<li>warning: omitting the parameter name in a function definition is a C23 extension</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is a C23 extension</li>
+<li>warning: use of an empty initializer is a C23 extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc2x-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc23-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c23-compat</key>
+    <name>clang-diagnostic-c23-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' is a keyword in C23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc23-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -17228,6 +19834,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: %select{using this character in an identifier|starting an identifier with this character}0 is incompatible with C99</li>
+<li>warning: '%0' is a keyword in C99</li>
 <li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C89; this literal will %select{have type 'long long'|be ill-formed}0 in C99 onwards</li>
 <li>warning: unicode literals are incompatible with C99</li>
 </ul>
@@ -17255,32 +19862,52 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pre-c2x-compat</key>
-    <name>clang-diagnostic-pre-c2x-compat</name>
+    <key>clang-diagnostic-pre-c23-compat</key>
+    <name>clang-diagnostic-pre-c23-compat</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: '_BitInt' is incompatible with C standards before C2x</li>
-<li>warning: '_Static_assert' with no message is incompatible with C standards before C2x</li>
-<li>warning: digit separators are incompatible with C standards before C2x</li>
+<li>warning: #warning is incompatible with C standards before C23</li>
+<li>warning: '%0' is incompatible with C standards before C23</li>
+<li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
+<li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
+<li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
+<li>warning: [[]] attributes are incompatible with C standards before C23</li>
+<li>warning: digit separators are incompatible with C standards before C23</li>
+<li>warning: label at end of compound statement is incompatible with C standards before C23</li>
+<li>warning: label followed by a declaration is incompatible with C standards before C23</li>
+<li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
+<li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
+<li>warning: use of an empty initializer is incompatible with C standards before C23</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c23-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pre-c2x-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c2x-compat-pedantic</name>
+    <key>clang-diagnostic-pre-c23-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c23-compat-pedantic</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: '_BitInt' is incompatible with C standards before C2x</li>
-<li>warning: '_Static_assert' with no message is incompatible with C standards before C2x</li>
-<li>warning: digit separators are incompatible with C standards before C2x</li>
+<li>warning: #warning is incompatible with C standards before C23</li>
+<li>warning: '%0' is incompatible with C standards before C23</li>
+<li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
+<li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
+<li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
+<li>warning: [[]] attributes are incompatible with C standards before C23</li>
+<li>warning: digit separators are incompatible with C standards before C23</li>
+<li>warning: label at end of compound statement is incompatible with C standards before C23</li>
+<li>warning: label followed by a declaration is incompatible with C standards before C23</li>
+<li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
+<li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
+<li>warning: use of an empty initializer is incompatible with C standards before C23</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2x-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c23-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -17309,6 +19936,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: 'long long' is a C++11 extension</li>
 <li>warning: 'template' keyword outside of a template</li>
 <li>warning: 'typename' occurs outside of a template</li>
+<li>warning: [[]] attributes are a C++11 extension</li>
 <li>warning: alias declarations are a C++11 extension</li>
 <li>warning: befriending enumeration type %0 is a C++11 extension</li>
 <li>warning: commas at the end of enumerator lists are a C++11 extension</li>
@@ -17343,35 +19971,43 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
 <li>warning: '%0' is a keyword in C++11</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'auto' storage class specifier is redundant and incompatible with C++11</li>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
 <li>warning: constexpr if is incompatible with C++ standards before C++17</li>
 <li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: conversion from string literal to %0 is deprecated</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
 <li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
 <li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: digit separators are incompatible with C++ standards before C++14</li>
 <li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
 <li>warning: explicit instantiation cannot be 'inline'</li>
@@ -17391,31 +20027,37 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: inline variables are incompatible with C++ standards before C++17</li>
 <li>warning: integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
 <li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
 <li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
 <li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
 <li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
 <li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
 <li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
 <li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: unicode literals are incompatible with C++ standards before C++17</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: use of right-shift operator ('&gt;&gt;') in template argument will require parentheses in C++11</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
 <li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
@@ -17446,14 +20088,22 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
 <li>warning: '%0' is a keyword in C++11</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'auto' storage class specifier is redundant and incompatible with C++11</li>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
@@ -17461,24 +20111,25 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
 <li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
 <li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
@@ -17490,6 +20141,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: conversion from string literal to %0 is deprecated</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
@@ -17500,6 +20153,10 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: designated initializers are incompatible with C++ standards before C++20</li>
 <li>warning: digit separators are incompatible with C++ standards before C++14</li>
 <li>warning: digit separators are incompatible with C++ standards before C++14</li>
@@ -17533,6 +20190,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
 <li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
 <li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
@@ -17542,13 +20201,14 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
 <li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
 <li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
 <li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
 <li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
@@ -17559,8 +20219,11 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: return type deduction is incompatible with C++ standards before C++14</li>
 <li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
 <li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
 <li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
 <li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
 <li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
@@ -17569,6 +20232,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: unicode literals are incompatible with C++ standards before C++17</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
@@ -17578,6 +20243,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
@@ -17654,14 +20321,32 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <ul>
 <li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
 <li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
 <li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
 <li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
 <li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-narrowing" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++11-narrowing-const-reference</key>
+    <name>clang-diagnostic-c++11-narrowing-const-reference</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-narrowing-const-reference" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>CRITICAL</severity>
     </rule>
@@ -17770,27 +20455,34 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr if is incompatible with C++ standards before C++17</li>
 <li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
 <li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
 <li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
 <li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
 <li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
@@ -17799,22 +20491,26 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
 <li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
 <li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
 <li>warning: unicode literals are incompatible with C++ standards before C++17</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
 <li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
@@ -17830,31 +20526,39 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr if is incompatible with C++ standards before C++17</li>
@@ -17863,6 +20567,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
@@ -17873,6 +20579,10 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: designated initializers are incompatible with C++ standards before C++20</li>
 <li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
 <li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
@@ -17892,6 +20602,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: inline variables are incompatible with C++ standards before C++17</li>
 <li>warning: inline variables are incompatible with C++ standards before C++17</li>
 <li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
@@ -17902,8 +20614,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
 <li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
@@ -17912,18 +20624,24 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
 <li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
 <li>warning: unicode literals are incompatible with C++ standards before C++17</li>
 <li>warning: unicode literals are incompatible with C++ standards before C++17</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
@@ -17985,19 +20703,26 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
 <li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
 <li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
 <li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
@@ -18006,16 +20731,20 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
 <li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
 <li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
 <li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
 <li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
@@ -18044,31 +20773,45 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
 <li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
 <li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: designated initializers are incompatible with C++ standards before C++20</li>
 <li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
 <li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
@@ -18086,6 +20829,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
 <li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
 <li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
 <li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
@@ -18093,18 +20838,24 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
@@ -18123,6 +20874,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: aggregate initialization of type %0 from a parenthesized list of values is a C++20 extension</li>
+<li>warning: captured structured bindings are a C++20 extension</li>
 <li>warning: constexpr constructor that does not initialize all members is a C++20 extension</li>
 <li>warning: constexpr union constructor that does not initialize any member is a C++20 extension</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is a C++20 extension</li>
@@ -18136,6 +20889,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: initialized lambda pack captures are a C++20 extension</li>
 <li>warning: inline nested namespace definition is a C++20 extension</li>
 <li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is a C++20 extension</li>
+<li>warning: missing 'typename' prior to dependent type name %0%1; implicit 'typename' is a C++20 extension</li>
 <li>warning: range-based for loop initialization statements are a C++20 extension</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is a C++20 extension</li>
 <li>warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension</li>
@@ -18168,18 +20922,30 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: '%0' is a keyword in C++20</li>
 <li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
 <li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: taking address of non-addressable standard library function is incompatible with C++20</li>
 <li>warning: this expression will be parsed as explicit(bool) in C++20</li>
 <li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of implicit 'typename' is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-20-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -18192,23 +20958,45 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: '%0' is a keyword in C++20</li>
 <li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
 <li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: taking address of non-addressable standard library function is incompatible with C++20</li>
 <li>warning: this expression will be parsed as explicit(bool) in C++20</li>
 <li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of implicit 'typename' is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-20-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -18229,19 +21017,51 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++2b-extensions</key>
-    <name>clang-diagnostic-c++2b-extensions</name>
+    <key>clang-diagnostic-c++23-extensions</key>
+    <name>clang-diagnostic-c++23-extensions</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: 'size_t' suffix for literals is a C++2b extension</li>
-<li>warning: alias declaration in this context is a C++2b extension</li>
-<li>warning: an attribute specifier sequence in this position is a C++2b extension</li>
-<li>warning: consteval if is a C++2b extension</li>
-<li>warning: lambda without a parameter clause is a C++2b extension</li>
+<li>warning: %select{an attribute specifier sequence|%0}1 in this position is a C++23 extension</li>
+<li>warning: 'size_t' suffix for literals is a C++23 extension</li>
+<li>warning: alias declaration in this context is a C++23 extension</li>
+<li>warning: consteval if is a C++23 extension</li>
+<li>warning: declaring overloaded %0 as 'static' is a C++23 extension</li>
+<li>warning: definition of a %select{static|thread_local}1 variable in a constexpr %select{function|constructor}0 is a C++23 extension</li>
+<li>warning: label at end of compound statement is a C++23 extension</li>
+<li>warning: lambda without a parameter clause is a C++23 extension</li>
+<li>warning: static lambdas are a C++23 extension</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is a C++23 extension</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++23 extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2b-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++23-lambda-attributes</key>
+    <name>clang-diagnostic-c++23-lambda-attributes</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{an attribute specifier sequence|%0}1 in this position is a C++23 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-lambda-attributes" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++26-extensions</key>
+    <name>clang-diagnostic-c++26-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: placeholder variables are a C++2c extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-26-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -18251,15 +21071,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{anonymous struct|union}0 member %1 with a non-trivial %sub{select_special_member_kind}2 is incompatible with C++98</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{defaulted|deleted}0 function definitions are incompatible with C++98</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
 <li>warning: '%0' keyword is incompatible with C++98</li>
 <li>warning: '%0' type specifier is incompatible with C++98</li>
 <li>warning: '&lt;::' is treated as digraph '&lt;:' (aka '[') followed by ':' in C++98</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: 'alignas' is incompatible with C++98</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'auto' type specifier is incompatible with C++98</li>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
@@ -18267,25 +21091,27 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: 'decltype' type specifier is incompatible with C++98</li>
 <li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
 <li>warning: 'nullptr' is incompatible with C++98</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: 'static_assert' declarations are incompatible with C++98</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: C++11 attribute syntax is incompatible with C++98</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: [[]] attributes are incompatible with C++ standards before C++11</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: alias declarations are incompatible with C++98</li>
 <li>warning: alignof expressions are incompatible with C++98</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
 <li>warning: befriending %1 without '%select{struct|interface|union|class|enum}0' keyword is incompatible with C++98</li>
 <li>warning: befriending enumeration type %0 is incompatible with C++98</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: consecutive right angle brackets are incompatible with C++98 (use '&gt; &gt;')</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
 <li>warning: constexpr if is incompatible with C++ standards before C++17</li>
 <li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: constructor call from initializer list is incompatible with C++98</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
 <li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
@@ -18293,6 +21119,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
 <li>warning: default template arguments for a function template are incompatible with C++98</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: delegating constructors are incompatible with C++98</li>
 <li>warning: digit separators are incompatible with C++ standards before C++14</li>
 <li>warning: enumeration type in nested name specifier is incompatible with C++98</li>
@@ -18317,6 +21145,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: jump from switch statement to this case label is incompatible with C++98</li>
 <li>warning: jump from this %select{indirect|asm}0 goto statement to one of its possible targets is incompatible with C++98</li>
 <li>warning: jump from this goto statement to its label is incompatible with C++98</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: lambda expressions are incompatible with C++98</li>
 <li>warning: literal operators are incompatible with C++98</li>
 <li>warning: local type %0 as template argument is incompatible with C++98</li>
@@ -18330,7 +21159,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: non-type template argument referring to %select{function|object}0 %1 with internal linkage is incompatible with C++98</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
@@ -18347,7 +21176,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: scoped enumerations are incompatible with C++98</li>
 <li>warning: specifying character '%0' with a universal character name is incompatible with C++98</li>
 <li>warning: static data member %0 in union is incompatible with C++98</li>
-<li>warning: static_assert declarations are incompatible with C++98</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: substitution failure due to access control is incompatible with C++98</li>
 <li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
 <li>warning: trailing return types are incompatible with C++98</li>
@@ -18359,12 +21188,14 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: unnamed type as template argument is incompatible with C++98</li>
 <li>warning: use of 'template' keyword outside of a template is incompatible with C++98</li>
 <li>warning: use of 'typename' outside of a template is incompatible with C++98</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: use of non-static data member %0 in an unevaluated context is incompatible with C++98</li>
 <li>warning: use of null pointer as non-type template argument is incompatible with C++98</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
 <li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
@@ -18423,10 +21254,16 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: #line number greater than 32767 is incompatible with C++98</li>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{anonymous struct|union}0 member %1 with a non-trivial %sub{select_special_member_kind}2 is incompatible with C++98</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{defaulted|deleted}0 function definitions are incompatible with C++98</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
 <li>warning: %sub{select_initialized_entity_kind}1 of type %2 when binding a reference to a temporary would %select{invoke an inaccessible constructor|find no viable constructor|find ambiguous constructors|invoke a deleted constructor}0 in C++98</li>
@@ -18436,6 +21273,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: 'alignas' is incompatible with C++98</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'auto' type specifier is incompatible with C++98</li>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
@@ -18447,31 +21286,32 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
 <li>warning: 'long long' is incompatible with C++98</li>
 <li>warning: 'nullptr' is incompatible with C++98</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: 'static_assert' declarations are incompatible with C++98</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: C++11 attribute syntax is incompatible with C++98</li>
 <li>warning: C++98 requires newline at end of file</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: [[]] attributes are incompatible with C++ standards before C++11</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: alias declarations are incompatible with C++98</li>
 <li>warning: alignof expressions are incompatible with C++98</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
 <li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
 <li>warning: befriending %1 without '%select{struct|interface|union|class|enum}0' keyword is incompatible with C++98</li>
 <li>warning: befriending enumeration type %0 is incompatible with C++98</li>
 <li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
 <li>warning: cast between pointer-to-function and pointer-to-object is incompatible with C++98</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: commas at the end of enumerator lists are incompatible with C++98</li>
 <li>warning: consecutive right angle brackets are incompatible with C++98 (use '&gt; &gt;')</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
@@ -18483,6 +21323,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: constructor call from initializer list is incompatible with C++98</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
@@ -18495,6 +21337,10 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: default template arguments for a function template are incompatible with C++98</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: delegating constructors are incompatible with C++98</li>
 <li>warning: designated initializers are incompatible with C++ standards before C++20</li>
 <li>warning: digit separators are incompatible with C++ standards before C++14</li>
@@ -18537,6 +21383,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: jump from switch statement to this case label is incompatible with C++98</li>
 <li>warning: jump from this %select{indirect|asm}0 goto statement to one of its possible targets is incompatible with C++98</li>
 <li>warning: jump from this goto statement to its label is incompatible with C++98</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: lambda expressions are incompatible with C++98</li>
 <li>warning: literal operators are incompatible with C++98</li>
 <li>warning: local type %0 as template argument is incompatible with C++98</li>
@@ -18556,8 +21404,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
 <li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
@@ -18579,7 +21427,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: scoped enumerations are incompatible with C++98</li>
 <li>warning: specifying character '%0' with a universal character name is incompatible with C++98</li>
 <li>warning: static data member %0 in union is incompatible with C++98</li>
-<li>warning: static_assert declarations are incompatible with C++98</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: substitution failure due to access control is incompatible with C++98</li>
 <li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
 <li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
@@ -18595,6 +21444,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: unnamed type as template argument is incompatible with C++98</li>
 <li>warning: use of 'template' keyword outside of a template is incompatible with C++98</li>
 <li>warning: use of 'typename' outside of a template is incompatible with C++98</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
 <li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
@@ -18605,6 +21456,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
 <li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
@@ -18778,6 +21631,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
@@ -18816,6 +21670,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
@@ -18865,6 +21720,33 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-pre-c++23-compat</key>
+    <name>clang-diagnostic-pre-c++23-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-23-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-pre-c++2b-compat-pedantic</key>
     <name>clang-diagnostic-pre-c++2b-compat-pedantic</name>
     <description>
@@ -18878,6 +21760,59 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2b-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++23-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c++23-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-23-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++26-compat</key>
+    <name>clang-diagnostic-pre-c++26-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-26-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++26-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c++26-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-26-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -18919,9 +21854,23 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: cast %diff{from $ to $ |}0,1converts to incompatible function type</li>
+<li>warning: cast %diff{from $ to $ |}0,1converts to incompatible function type</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-function-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-cast-function-type-strict</key>
+    <name>clang-diagnostic-cast-function-type-strict</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: cast %diff{from $ to $ |}0,1converts to incompatible function type</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-function-type-strict" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -19106,6 +22055,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <ul>
 <li>warning: implicit conversion from %2 to %3 changes value from %0 to %1</li>
 <li>warning: implicit conversion from constant value %0 to 'BOOL'; the only well defined values for 'BOOL' are YES and NO</li>
+<li>warning: implicit truncation from %2 to a one-bit wide bit-field changes value from %0 to %1</li>
 <li>warning: implicit truncation from %2 to bit-field changes value from %0 to %1</li>
 </ul>
 <h2>References</h2>
@@ -19174,6 +22124,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: implicit conversion turns string literal into bool: %0 to %1</li>
 <li>warning: implicit conversion turns vector to scalar: %0 to %1</li>
 <li>warning: implicit conversion when assigning computation result loses floating-point precision: %0 to %1</li>
+<li>warning: implicit truncation from %2 to a one-bit wide bit-field changes value from %0 to %1</li>
 <li>warning: implicit truncation from %2 to bit-field changes value from %0 to %1</li>
 <li>warning: incompatible integer to pointer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
 <li>warning: incompatible pointer to integer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
@@ -19191,6 +22142,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-coro-non-aligned-allocation-function</key>
+    <name>clang-diagnostic-coro-non-aligned-allocation-function</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: under -fcoro-aligned-allocation, the non-aligned allocation function for the promise type %0 has higher precedence than the global aligned allocation function</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcoro-non-aligned-allocation-function" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -19202,8 +22166,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: %0 is required to declare the member 'unhandled_exception()' when exceptions are enabled</li>
 <li>warning: 'for co_await' belongs to CoroutineTS instead of C++20, which is deprecated</li>
 <li>warning: return type of 'coroutine_handle&lt;&gt;::address should be 'void*' (have %0) in order to get capability with existing async C API.</li>
-<li>warning: support for std::experimental::%0 will be removed in LLVM 15; use std::%0 instead</li>
 <li>warning: this coroutine may be split into pieces; not every piece is guaranteed to be inlined</li>
+<li>warning: under -fcoro-aligned-allocation, the non-aligned allocation function for the promise type %0 has higher precedence than the global aligned allocation function</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcoroutine" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -19294,6 +22258,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-dxil-validation</key>
+    <name>clang-diagnostic-dxil-validation</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: dxv not found. Resulting DXIL will not be validated or signed for use in release environments.</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdxil-validation" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-dangling</key>
     <name>clang-diagnostic-dangling</name>
     <description>
@@ -19306,10 +22283,10 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: binding reference member %0 to stack allocated %select{variable|parameter}2 %1</li>
 <li>warning: initializing pointer member %0 to point to a temporary object whose lifetime is shorter than the lifetime of the constructed object</li>
 <li>warning: initializing pointer member %0 with the stack address of %select{variable|parameter}2 %1</li>
+<li>warning: lifetime extension of %select{temporary|backing array of initializer list}0 created by aggregate initialization using a default member initializer is not yet supported; lifetime of %select{temporary|backing array}0 will end at the end of the full-expression</li>
 <li>warning: object backing the pointer will be destroyed at the end of the full-expression</li>
 <li>warning: returning %select{address of|reference to}0 local temporary object</li>
 <li>warning: returning address of label, which is local</li>
-<li>warning: sorry, lifetime extension of %select{temporary|backing array of initializer list}0 created by aggregate initialization using default member initializer is not supported; lifetime of %select{temporary|backing array}0 will end at the end of the full-expression</li>
 <li>warning: temporary bound to reference member of allocated object will be destroyed at the end of the full-expression</li>
 </ul>
 <h2>References</h2>
@@ -19498,29 +22475,33 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: %sub{select_arith_conv_kind}0 different enumeration types%diff{ ($ and $)|}1,2 is deprecated</li>
 <li>warning: %sub{select_arith_conv_kind}0 different enumeration types%diff{ ($ and $)|}1,2 is deprecated</li>
 <li>warning: '_ExtInt' is deprecated; use '_BitInt' instead</li>
+<li>warning: 'depend' clause for 'ordered' is deprecated; use 'doacross' instead</li>
 <li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
 <li>warning: -O4 is equivalent to -O3</li>
-<li>warning: -fconcepts-ts is deprecated - use '-std=c++20' for Concepts support</li>
 <li>warning: Use of 'long' with '__vector' is deprecated</li>
 <li>warning: access declarations are deprecated; use using declarations instead</li>
+<li>warning: applying attribute %0 to a declaration is deprecated; apply it to the type instead</li>
+<li>warning: argument '%0' is deprecated, %1</li>
 <li>warning: argument '%0' is deprecated, use '%1' instead</li>
+<li>warning: builtin %0 is deprecated; use %1 instead</li>
 <li>warning: comparison between two arrays is deprecated; to compare array addresses, use unary '+' to decay operands to pointers</li>
-<li>warning: compound assignment to object of volatile-qualified type %0 is deprecated</li>
 <li>warning: conversion from string literal to %0 is deprecated</li>
 <li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared copy %select{assignment operator|constructor}1</li>
 <li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared destructor</li>
 <li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided copy %select{assignment operator|constructor}1</li>
 <li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided destructor</li>
 <li>warning: dynamic exception specifications are deprecated</li>
+<li>warning: identifier %0 preceded by whitespace in a literal operator declaration is deprecated</li>
 <li>warning: implicit capture of 'this' with a capture default of '=' is deprecated</li>
 <li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
 <li>warning: macro %0 has been marked as deprecated%select{|: %2}1</li>
+<li>warning: minus(-) operator for reductions is deprecated; use + or user defined reduction instead</li>
 <li>warning: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated</li>
 <li>warning: property access is using %0 method which is deprecated</li>
 <li>warning: specifying 'uuid' as an ATL attribute is deprecated; use __declspec instead</li>
 <li>warning: specifying vector types with the 'mode' attribute is deprecated; use the 'vector_size' attribute instead</li>
-<li>warning: the '[[_Noreturn]]' attribute spelling is deprecated in C2x; use '[[noreturn]]' instead</li>
-<li>warning: top-level comma expression in array subscript is deprecated in C++20 and unsupported in C++2b</li>
+<li>warning: the '[[_Noreturn]]' attribute spelling is deprecated in C23; use '[[noreturn]]' instead</li>
+<li>warning: top-level comma expression in array subscript is deprecated in C++20 and unsupported in C++23</li>
 <li>warning: treating '%0' input as '%1' when in C++ mode, this behavior is deprecated</li>
 <li>warning: use of C-style parameters in Objective-C method declarations is deprecated</li>
 <li>warning: use of result of assignment to object of volatile-qualified type %0 is deprecated</li>
@@ -19565,11 +22546,25 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: applying attribute %0 to a declaration is deprecated; apply it to the type instead</li>
 <li>warning: specifying vector types with the 'mode' attribute is deprecated; use the 'vector_size' attribute instead</li>
-<li>warning: the '[[_Noreturn]]' attribute spelling is deprecated in C2x; use '[[noreturn]]' instead</li>
+<li>warning: the '[[_Noreturn]]' attribute spelling is deprecated in C23; use '[[noreturn]]' instead</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-attributes" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecated-builtins</key>
+    <name>clang-diagnostic-deprecated-builtins</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: builtin %0 is deprecated; use %1 instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-builtins" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -19579,7 +22574,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: top-level comma expression in array subscript is deprecated in C++20 and unsupported in C++2b</li>
+<li>warning: top-level comma expression in array subscript is deprecated in C++20 and unsupported in C++23</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-comma-subscript" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -19647,7 +22642,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: 'for co_await' belongs to CoroutineTS instead of C++20, which is deprecated</li>
-<li>warning: support for std::experimental::%0 will be removed in LLVM 15; use std::%0 instead</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-coroutine" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -19778,6 +22772,46 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-deprecated-literal-operator</key>
+    <name>clang-diagnostic-deprecated-literal-operator</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: identifier %0 preceded by whitespace in a literal operator declaration is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-literal-operator" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecated-module-dot-map</key>
+    <name>clang-diagnostic-deprecated-module-dot-map</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' as a module map name is deprecated, rename it to %select{module.modulemap|module.private.modulemap}1%select{| in the 'Modules' directory of the framework}2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-module-dot-map" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecated-non-prototype</key>
+    <name>clang-diagnostic-deprecated-non-prototype</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: a function %select{declaration|definition}0 without a prototype is deprecated in all versions of C %select{and is not supported in C23|and is treated as a zero-parameter prototype in C23, conflicting with a %select{previous|subsequent}2 %select{declaration|definition}3}1</li>
+<li>warning: passing arguments to %select{a function|%1}0 without a prototype is deprecated in all versions of C and is not supported in C23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-non-prototype" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-deprecated-objc-isa-usage</key>
     <name>clang-diagnostic-deprecated-objc-isa-usage</name>
     <description>
@@ -19805,6 +22839,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-deprecated-redundant-constexpr-static-def</key>
+    <name>clang-diagnostic-deprecated-redundant-constexpr-static-def</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-redundant-constexpr-static-def" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-deprecated-register</key>
     <name>clang-diagnostic-deprecated-register</name>
     <description>
@@ -19814,6 +22861,20 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-register" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecated-static-analyzer-flag</key>
+    <name>clang-diagnostic-deprecated-static-analyzer-flag</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: analyzer option '%0' is deprecated. This flag will be removed in %1, and passing this option will be an error.</li>
+<li>warning: analyzer option '%0' is deprecated. This flag will be removed in %1, and passing this option will be an error. Use '%2' instead.</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-static-analyzer-flag" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -19850,7 +22911,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: %select{decrement|increment}0 of object of volatile-qualified type %1 is deprecated</li>
-<li>warning: compound assignment to object of volatile-qualified type %0 is deprecated</li>
 <li>warning: use of result of assignment to object of volatile-qualified type %0 is deprecated</li>
 <li>warning: volatile qualifier in structured binding declaration is deprecated</li>
 <li>warning: volatile-qualified parameter type %0 is deprecated</li>
@@ -19920,8 +22980,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: '%select{\|@}0%1' command does not have a valid word argument</li>
 <li>warning: '%select{\|@}0%1' command does not terminate a verbatim text block</li>
+<li>warning: '%select{\|@}0%1' command has %plural{0:no|:%2}2 word argument%s2, expected %3</li>
 <li>warning: '%select{\|@}0%1' command used in a comment that is attached to a %select{function returning void|constructor|destructor|method returning void}2</li>
 <li>warning: '%select{\|@}0%1' command used in a comment that is not attached to a function or method declaration</li>
 <li>warning: '%select{\|@}0%select{classdesign|coclass|dependency|helper|helperclass|helps|instancesize|ownership|performance|security|superclass}1' command should not be used in a comment attached to a non-container declaration</li>
@@ -19938,6 +22998,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: duplicated command '%select{\|@}0%1'</li>
 <li>warning: empty paragraph passed to '%select{\|@}0%1' command</li>
 <li>warning: expected quoted string after equals sign</li>
+<li>warning: line splicing in Doxygen comments are not supported</li>
 <li>warning: not a Doxygen trailing comment</li>
 <li>warning: parameter '%0' is already documented</li>
 <li>warning: parameter '%0' not found in the function declaration</li>
@@ -20344,6 +23405,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: empty initialization statement of '%select{if|switch|range-based for}0' has no effect</li>
 <li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
 <li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
+<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
 <li>warning: method has no return type specified; defaults to 'id'</li>
 <li>warning: missing field %0 initializer</li>
 <li>warning: parameter %0 set but not used</li>
@@ -20356,7 +23418,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextra" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
-    <severity>INFO</severity>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-extra-semi</key>
@@ -20533,6 +23595,10 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <ul>
 <li>warning: %select{field width|precision}0 used with '%1' conversion specifier, resulting in undefined behavior</li>
 <li>warning: %select{values of type|enum values with underlying type}2 '%0' should not be used as format arguments; add an explicit cast to %1 instead</li>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
 <li>warning: '%%n' specifier not supported on this platform</li>
 <li>warning: '%0' is not a valid object format flag</li>
 <li>warning: '%select{*|.*}0' specified field %select{width|precision}0 is missing a matching 'int' argument</li>
@@ -20652,6 +23718,33 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-format-overflow</key>
+    <name>clang-diagnostic-format-overflow</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-overflow" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-format-overflow-non-kprintf</key>
+    <name>clang-diagnostic-format-overflow-non-kprintf</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-overflow-non-kprintf" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-format-pedantic</key>
     <name>clang-diagnostic-format-pedantic</name>
     <description>
@@ -20675,6 +23768,33 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-security" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-format-truncation</key>
+    <name>clang-diagnostic-format-truncation</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-truncation" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-format-truncation-non-kprintf</key>
+    <name>clang-diagnostic-format-truncation-non-kprintf</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-truncation-non-kprintf" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -20710,9 +23830,12 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
 <li>warning: '%0' may overflow; destination buffer in argument %1 has size %2, but the corresponding specifier may require size %3</li>
 <li>warning: '%0' size argument is too large; destination buffer has size %1, but size argument is %2</li>
-<li>warning: '%0' will always overflow; destination buffer has size %1, but format string expands to at least %2</li>
 <li>warning: '%0' will always overflow; destination buffer has size %1, but size argument is %2</li>
 <li>warning: '%0' will always overflow; destination buffer has size %1, but the source string has length %2 (including NUL byte)</li>
 </ul>
@@ -20836,6 +23959,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: body of cpu_dispatch function will be ignored</li>
 <li>warning: mixing 'target_clones' specifier mechanisms is permitted for GCC compatibility; use a comma separated sequence of string literals, or a string literal containing a comma-separated list of versions</li>
 <li>warning: version list contains duplicate entries</li>
+<li>warning: version list contains entries that don't impact code generation</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfunction-multiversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -20883,10 +24007,14 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: %select{struct|union}0 without named members is a GNU extension</li>
 <li>warning: '__auto_type' is a GNU extension</li>
 <li>warning: anonymous structs are a GNU extension</li>
+<li>warning: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension</li>
+<li>warning: arithmetic on%select{ a|}0 pointer%select{|s}0 to void is a GNU extension</li>
+<li>warning: arithmetic on%select{ a|}0 pointer%select{|s}0 to%select{ the|}2 function type%select{|s}2 %1%select{| and %3}2 is a GNU extension</li>
 <li>warning: binary integer literals are a GNU extension</li>
 <li>warning: cast to union type is a GNU extension</li>
 <li>warning: class member cannot be redeclared</li>
 <li>warning: complex integer types are a GNU extension</li>
+<li>warning: defining a type within '%select{__builtin_offsetof|offsetof}0' is a Clang extension</li>
 <li>warning: empty %select{struct|union}0 is a GNU extension</li>
 <li>warning: expression is not an %select{integer|integral}0 constant expression; folding it to a constant is a GNU extension</li>
 <li>warning: field %0 with variable sized type %1 not at the end of a struct or class is a GNU extension</li>
@@ -20900,18 +24028,24 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: must specify at least one argument for '...' parameter of variadic macro</li>
 <li>warning: redeclaration of already-defined enum %0 is a GNU extension</li>
 <li>warning: string literal operator templates are a GNU extension</li>
+<li>warning: subscript of a pointer to void is a GNU extension</li>
+<li>warning: this style of line directive is a GNU extension</li>
 <li>warning: token pasting of ',' and __VA_ARGS__ is a GNU extension</li>
 <li>warning: use of GNU 'missing =' extension in designator</li>
 <li>warning: use of GNU ?: conditional expression extension, omitting middle operand</li>
 <li>warning: use of GNU address-of-label extension</li>
 <li>warning: use of GNU array range extension</li>
 <li>warning: use of GNU case range extension</li>
-<li>warning: use of GNU empty initializer extension</li>
 <li>warning: use of GNU indirect-goto extension</li>
 <li>warning: use of GNU old-style field designator extension</li>
 <li>warning: use of GNU statement expression extension</li>
+<li>warning: use of GNU statement expression extension from macro expansion</li>
 <li>warning: variable length array folded to constant array as an extension</li>
 <li>warning: variable length arrays are a C99 feature</li>
+<li>warning: variable length arrays in C++ are a Clang extension</li>
+<li>warning: variable length arrays in C++ are a Clang extension</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
 <li>warning: zero size arrays are an extension</li>
 </ul>
 <h2>References</h2>
@@ -21148,6 +24282,60 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-gnu-line-marker</key>
+    <name>clang-diagnostic-gnu-line-marker</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: this style of line directive is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-line-marker" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-gnu-null-pointer-arithmetic</key>
+    <name>clang-diagnostic-gnu-null-pointer-arithmetic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-null-pointer-arithmetic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-gnu-offsetof-extensions</key>
+    <name>clang-diagnostic-gnu-offsetof-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: defining a type within '%select{__builtin_offsetof|offsetof}0' is a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-offsetof-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-gnu-pointer-arith</key>
+    <name>clang-diagnostic-gnu-pointer-arith</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: arithmetic on%select{ a|}0 pointer%select{|s}0 to void is a GNU extension</li>
+<li>warning: arithmetic on%select{ a|}0 pointer%select{|s}0 to%select{ the|}2 function type%select{|s}2 %1%select{| and %3}2 is a GNU extension</li>
+<li>warning: subscript of a pointer to void is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-pointer-arith" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-gnu-redeclared-enum</key>
     <name>clang-diagnostic-gnu-redeclared-enum</name>
     <description>
@@ -21167,9 +24355,23 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: use of GNU statement expression extension</li>
+<li>warning: use of GNU statement expression extension from macro expansion</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-statement-expression" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-gnu-statement-expression-from-macro-expansion</key>
+    <name>clang-diagnostic-gnu-statement-expression-from-macro-expansion</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: use of GNU statement expression extension from macro expansion</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-statement-expression-from-macro-expansion" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -21267,6 +24469,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: GCC does not allow the %0 attribute to be written on a type</li>
 <li>warning: GCC does not allow the 'cleanup' attribute argument to be anything other than a simple identifier</li>
 <li>warning: GCC does not allow variable declarations in for loop initializers before C99</li>
+<li>warning: GCC requires a function with the %0 attribute to be variadic</li>
 <li>warning: __final is a GNU extension, consider using C++11 final</li>
 </ul>
 <h2>References</h2>
@@ -21316,6 +24519,32 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-hip-omp-target-directives</key>
+    <name>clang-diagnostic-hip-omp-target-directives</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: HIP does not support OpenMP target directives; directive has been ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whip-omp-target-directives" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-hlsl-extensions</key>
+    <name>clang-diagnostic-hlsl-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: access specifiers are a clang HLSL extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whlsl-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-header-hygiene</key>
     <name>clang-diagnostic-header-hygiene</name>
     <description>
@@ -21334,6 +24563,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: %0 attribute argument '%1' not supported on a global variable</li>
 <li>warning: %0 attribute argument not supported: %1</li>
 <li>warning: %0 attribute can only be applied to instance variables or properties</li>
 <li>warning: %0 attribute ignored</li>
@@ -21342,29 +24572,33 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: %0 attribute ignored on inline function</li>
 <li>warning: %0 attribute ignored when parsing type</li>
 <li>warning: %0 attribute is deprecated and ignored in %1</li>
+<li>warning: %0 attribute is ignored because %1 is not a function pointer</li>
 <li>warning: %0 attribute is ignored because there exists no call expression inside the statement</li>
 <li>warning: %0 attribute isn't implemented by this Objective-C runtime</li>
-<li>warning: %0 attribute only applies to %1</li>
 <li>warning: %0 attribute only applies to %select{Objective-C object|pointer|pointer-to-CF-pointer|pointer/reference-to-OSObject-pointer}1 parameters</li>
 <li>warning: %0 attribute only applies to %select{functions|methods|properties}1 that return %select{an Objective-C object|a pointer|a non-retainable pointer}2</li>
-<li>warning: %0 attribute only applies to %select{functions|unions|variables and functions|functions and methods|functions, methods and blocks|functions, methods, and parameters|variables|variables and fields|variables, data members and tag types|types and namespaces|variables, functions and classes|kernel functions|non-K&amp;R-style functions}1</li>
 <li>warning: %0 attribute only applies to a pointer or reference (%1 is invalid)</li>
 <li>warning: %0 attribute only applies to return values that are pointers</li>
 <li>warning: %0 attribute only applies to return values that are pointers or references</li>
 <li>warning: %0 attribute only applies to%select{| constant}1 pointer arguments</li>
 <li>warning: %0 calling convention is not supported %select{for this target|on variadic function|on constructor/destructor|on builtin function}1</li>
 <li>warning: %0 currently has no effect on a using declaration</li>
+<li>warning: %0%select{ attribute|}1 only applies to %2</li>
+<li>warning: %0%select{ attribute|}1 only applies to %select{functions|unions|variables and functions|functions and methods|functions, methods and blocks|functions, methods, and parameters|variables|variables and fields|variables, data members and tag types|types and namespaces|variables, functions and classes|kernel functions|non-K&amp;R-style functions}2</li>
 <li>warning: %q0 redeclared inline; %1 attribute ignored</li>
 <li>warning: %select{MIPS|MSP430|RISC-V}0 'interrupt' attribute only applies to functions that have %select{no parameters|a 'void' return type}1</li>
 <li>warning: %select{alias|ifunc}1 will not be in section '%0' but in the same section as the %select{aliasee|resolver}2</li>
 <li>warning: %select{alias|ifunc}2 will always resolve to %0 even if weak definition of %1 is overridden</li>
 <li>warning: %select{alignment|size}0 of field %1 (%2 bits) does not match the %select{alignment|size}0 of the first field in transparent union; transparent_union attribute ignored</li>
-<li>warning: %select{unsupported|duplicate|unknown}0%select{| architecture| tune CPU}1 '%2' in the '%select{target|target_clones}3' attribute string; '%select{target|target_clones}3' attribute ignored</li>
+<li>warning: %select{unsupported|duplicate|unknown}0%select{| CPU| tune CPU}1 '%2' in the '%select{target|target_clones|target_version}3' attribute string; '%select{target|target_clones|target_version}3' attribute ignored</li>
 <li>warning: '%0' attribute cannot be specified on a definition</li>
 <li>warning: '%0' only applies to %select{function|pointer|Objective-C object or block pointer}1 types; type here is %2</li>
+<li>warning: '%select{pure|const}0' attribute on function returning 'void'; attribute ignored</li>
+<li>warning: '[[%select{nodiscard|gnu::warn_unused_result}0]]' attribute ignored when applied to a typedef; consider using '__attribute__((warn_unused_result))' or '[[clang::warn_unused_result]]' instead</li>
 <li>warning: '__clang__' is a predefined macro name, not an attribute scope specifier; did you mean '_Clang' instead?</li>
 <li>warning: 'abi_tag' attribute on %select{non-inline|anonymous}0 namespace ignored</li>
 <li>warning: 'cmse_nonsecure_entry' cannot be applied to functions with internal linkage</li>
+<li>warning: 'const' attribute imposes more restrictions; 'pure' attribute ignored</li>
 <li>warning: 'deprecated' attribute on anonymous namespace ignored</li>
 <li>warning: 'dllexport' attribute ignored on explicit instantiation definition</li>
 <li>warning: 'gnu_inline' attribute requires function to be marked 'inline', attribute ignored</li>
@@ -21394,8 +24628,9 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: attribute %0 ignored, because it is not attached to a declaration</li>
 <li>warning: attribute %0 is already applied</li>
 <li>warning: attribute %0 is already applied with different arguments</li>
-<li>warning: attribute %0 is ignored, place it after "%select{class|struct|interface|union|enum}1" to apply attribute to type declaration</li>
+<li>warning: attribute %0 is ignored, place it after "%select{class|struct|interface|union|enum|enum class|enum struct}1" to apply attribute to type declaration</li>
 <li>warning: attribute declaration must precede definition</li>
+<li>warning: attribute is ignored on this statement as it only applies to functions; use '%0' on statements</li>
 <li>warning: conflicting attributes %0 are ignored</li>
 <li>warning: direct attribute on property %0 ignored (not implemented by this Objective-C runtime)</li>
 <li>warning: first field of a transparent union cannot have %select{floating point|vector}0 type %1; transparent_union attribute ignored</li>
@@ -21405,9 +24640,11 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: import %select{module|name}0 (%1) does not match the import %select{module|name}0 (%2) of the previous declaration</li>
 <li>warning: import %select{module|name}0 cannot be applied to a function with a definition</li>
 <li>warning: inheritance model ignored on %select{primary template|partial specialization}0</li>
+<li>warning: maxclusterrank requires sm_90 or higher, CUDA arch provided: %0, ignoring %1 attribute</li>
 <li>warning: qualifiers after comma in declarator list are ignored</li>
 <li>warning: repeated RISC-V 'interrupt' attribute</li>
 <li>warning: requested alignment is less than minimum alignment of %1 for type %0</li>
+<li>warning: statement attribute %0 has higher precedence than function attribute '%select{always_inline|flatten|noinline}1'</li>
 <li>warning: template parameter of a function template with the 'sycl_kernel' attribute cannot be a non-type template parameter</li>
 <li>warning: transparent union definition must contain at least one field; transparent_union attribute ignored</li>
 <li>warning: transparent_union attribute can only be applied to a union definition; attribute ignored</li>
@@ -21416,6 +24653,20 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-attributes" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-ignored-gch</key>
+    <name>clang-diagnostic-ignored-gch</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: precompiled header '%0' was ignored because it is not a clang PCH file</li>
+<li>warning: precompiled header directory '%0' was ignored because it contains no clang PCH files</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-gch" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -21468,10 +24719,11 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: #pragma %0(pop, ...) failed: %1</li>
 <li>warning: #pragma options align=reset failed: %0</li>
 <li>warning: %0 is not a recognized builtin%select{|; consider including &lt;intrin.h&gt; to access non-builtin intrinsics}1</li>
+<li>warning: %select{value|type}0-dependent expression passed as an argument to debug command</li>
 <li>warning: '#pragma %0' is not supported on this target - ignored</li>
 <li>warning: '#pragma comment %0' ignored</li>
 <li>warning: '#pragma init_seg' is only supported when targeting a Microsoft environment</li>
-<li>warning: '#pragma optimize' is not supported</li>
+<li>warning: OpenCL extension %0 unknown or does not require pragma - ignoring</li>
 <li>warning: expected #pragma pack parameter to be '1', '2', '4', '8', or '16'</li>
 <li>warning: expected %select{'enable', 'disable', 'begin' or 'end'|'disable'}0 - ignoring</li>
 <li>warning: expected '#pragma unused' argument to be a variable name</li>
@@ -21489,6 +24741,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: expected non-wide string literal in '#pragma %0'</li>
 <li>warning: expected push, pop or a string literal for the section name in '#pragma %0' - ignored</li>
 <li>warning: expected string literal in '#pragma %0' - ignoring</li>
+<li>warning: expected string literal in 'clause %0' - ignoring</li>
 <li>warning: extra tokens at end of '#pragma %0' - ignored</li>
 <li>warning: incorrect use of #pragma clang force_cuda_host_device begin|end</li>
 <li>warning: incorrect use of '#pragma fenv_access (on|off)' - ignored</li>
@@ -21502,12 +24755,13 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: missing ':' or ')' after %0 - ignoring</li>
 <li>warning: missing argument to '#pragma %0'%select{|; expected %2}1</li>
 <li>warning: missing argument to debug command '%0'</li>
+<li>warning: missing debug command</li>
 <li>warning: only variables can be arguments to '#pragma unused'</li>
 <li>warning: pragma pop_macro could not pop '%0', no matching push_macro</li>
 <li>warning: undeclared variable %0 used as an argument for '#pragma unused'</li>
 <li>warning: unexpected argument '%0' to '#pragma %1'%select{|; expected %3}2</li>
+<li>warning: unexpected argument to debug command</li>
 <li>warning: unexpected debug command '%0'</li>
-<li>warning: unknown OpenCL extension %0 - ignoring</li>
 <li>warning: unknown action '%1' for '#pragma %0' - ignored</li>
 <li>warning: unknown action for '#pragma %0' - ignored</li>
 <li>warning: unknown module '%0'</li>
@@ -21554,10 +24808,13 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: call to undeclared function %0; ISO C99 and later do not support implicit function declarations</li>
+<li>warning: call to undeclared library function '%0' with type %1; ISO C99 and later do not support implicit function declarations</li>
 <li>warning: implicit declaration of function %0</li>
-<li>warning: implicit declaration of function %0 is invalid in C99</li>
 <li>warning: implicitly declaring library function '%0' with type %1</li>
+<li>warning: parameter %0 was not declared, defaults to 'int'; ISO C99 and later do not support implicit int</li>
 <li>warning: type specifier missing, defaults to 'int'</li>
+<li>warning: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int</li>
 <li>warning: use of unknown builtin %0</li>
 </ul>
 <h2>References</h2>
@@ -21668,8 +24925,9 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: call to undeclared function %0; ISO C99 and later do not support implicit function declarations</li>
+<li>warning: call to undeclared library function '%0' with type %1; ISO C99 and later do not support implicit function declarations</li>
 <li>warning: implicit declaration of function %0</li>
-<li>warning: implicit declaration of function %0 is invalid in C99</li>
 <li>warning: implicitly declaring library function '%0' with type %1</li>
 <li>warning: use of unknown builtin %0</li>
 </ul>
@@ -21684,12 +24942,14 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: parameter %0 was not declared, defaults to 'int'; ISO C99 and later do not support implicit int</li>
 <li>warning: type specifier missing, defaults to 'int'</li>
+<li>warning: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-int" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
-    <severity>INFO</severity>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-implicit-int-conversion</key>
@@ -21758,6 +25018,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-function-pointer-types" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-incompatible-ms-pragma-section</key>
+    <name>clang-diagnostic-incompatible-ms-pragma-section</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: `#pragma const_seg` for section %1 will not apply to %0 due to the presence of a %select{mutable field||non-trivial constructor|non-trivial destructor}2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-ms-pragma-section" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -21789,7 +25062,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-pointer-types" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
-    <severity>INFO</severity>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-incompatible-pointer-types-discards-qualifiers</key>
@@ -21900,11 +25173,12 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <ul>
 <li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
 <li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
+<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winitializer-overrides" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
-    <severity>INFO</severity>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-inline-namespace-reopened-noninline</key>
@@ -21931,7 +25205,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wint-conversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
-    <severity>INFO</severity>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-int-in-bool-context</key>
@@ -21980,7 +25254,10 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: feature flag '%0' is ignored since the feature is read only</li>
+<li>warning: feature flag '%0' must start with either '+' to enable the feature or '-' to disable it; flag ignored</li>
 <li>warning: ignoring extension '%0' because the '%1' architecture does not support it</li>
+<li>warning: mismatch between architecture and environment in target triple '%0'; did you mean '%1'?</li>
 <li>warning: missing plugin argument for plugin %0 in %1</li>
 <li>warning: missing plugin name in %0</li>
 <li>warning: no MCU device specified, but '-mhwmult' is set to 'auto', assuming no hardware multiply; use '-mmcu' to specify an MSP430 device, or '-mhwmult' to set the hardware multiply type explicitly</li>
@@ -22043,8 +25320,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: environment variable SCE_ORBIS_SDK_DIR is set, but points to invalid or nonexistent directory '%0'</li>
-<li>warning: unable to find %0 directory, expected to be in '%1'</li>
+<li>warning: unable to find %0 directory, expected to be in '%1' found via %2</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-or-nonexistent-directory" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -22165,6 +25441,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: floating-point comparison is always %select{true|false}0; constant cannot be represented exactly in type %1</li>
 <li>warning: magnitude of floating-point constant too large for type %0; maximum is %1</li>
 <li>warning: magnitude of floating-point constant too small for type %0; minimum is %1</li>
 </ul>
@@ -22415,6 +25692,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: exception specification in explicit instantiation does not match instantiated one</li>
 <li>warning: exception specification of '...' is a Microsoft extension</li>
 <li>warning: exception specification of overriding function is more lax than base version</li>
+<li>warning: expansion of predefined identifier '%0' to a string literal is a Microsoft extension</li>
 <li>warning: explicit constructor calls are a Microsoft extension</li>
 <li>warning: extra qualification on member %0</li>
 <li>warning: flexible array member %0 in a union is a Microsoft extension</li>
@@ -22422,6 +25700,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: forward references to 'enum' types are a Microsoft extension</li>
 <li>warning: function definition with pure-specifier is a Microsoft extension</li>
 <li>warning: implicit conversion between pointer-to-function and pointer-to-object is a Microsoft extension</li>
+<li>warning: initializing an array from a '%0' predefined identifier is a Microsoft extension</li>
 <li>warning: jump from this goto statement to its label is a Microsoft extension</li>
 <li>warning: non-type template argument containing a dereference operation is a Microsoft extension</li>
 <li>warning: pasting two '/' tokens into a '//' comment is a Microsoft extension</li>
@@ -22433,6 +25712,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: treating Ctrl-Z as end-of-file is a Microsoft extension</li>
 <li>warning: types declared in an anonymous %select{struct|union}0 are a Microsoft extension</li>
 <li>warning: union member %0 has reference type %1, which is a Microsoft extension</li>
+<li>warning: unqualified base initializer of class templates is a Microsoft extension</li>
 <li>warning: unqualified friend declaration referring to type outside of the nearest enclosing namespace is a Microsoft extension; add a nested name specifier</li>
 <li>warning: use of 'static_assert' without inclusion of &lt;assert.h&gt; is a Microsoft extension</li>
 <li>warning: use of member %0 before its declaration is a Microsoft extension</li>
@@ -22728,6 +26008,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-microsoft-init-from-predefined</key>
+    <name>clang-diagnostic-microsoft-init-from-predefined</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: initializing an array from a '%0' predefined identifier is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-init-from-predefined" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-microsoft-mutable-reference</key>
     <name>clang-diagnostic-microsoft-mutable-reference</name>
     <description>
@@ -22793,6 +26086,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-microsoft-string-literal-from-predefined</key>
+    <name>clang-diagnostic-microsoft-string-literal-from-predefined</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: expansion of predefined identifier '%0' to a string literal is a Microsoft extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-string-literal-from-predefined" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-microsoft-template</key>
     <name>clang-diagnostic-microsoft-template</name>
     <description>
@@ -22804,6 +26110,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: duplicate explicit instantiation of %0 ignored as a Microsoft extension</li>
 <li>warning: non-type template argument containing a dereference operation is a Microsoft extension</li>
 <li>warning: template argument for template type parameter must be a type; omitted 'typename' is a Microsoft extension</li>
+<li>warning: unqualified base initializer of class templates is a Microsoft extension</li>
 <li>warning: use of member %0 before its declaration is a Microsoft extension</li>
 <li>warning: use of member %0 found via unqualified lookup into dependent bases of class templates is a Microsoft extension</li>
 <li>warning: use of undeclared identifier %0; unqualified lookup into dependent bases of class template %1 is a Microsoft extension</li>
@@ -22876,6 +26183,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-void-pseudo-dtor" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-misexpect</key>
+    <name>clang-diagnostic-misexpect</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: Potential performance regression from use of __builtin_expect(): Annotation was correct on %0 of profiled executions.</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmisexpect" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -23084,6 +26404,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-module-include-translation</key>
+    <name>clang-diagnostic-module-include-translation</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>remark: treating #%select{include|import|include_next|__include_macros}0 as an import of module '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rmodule-include-translation" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-module-lock</key>
     <name>clang-diagnostic-module-lock</name>
     <description>
@@ -23126,17 +26459,24 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: %select{values of type|enum values with underlying type}2 '%0' should not be used as format arguments; add an explicit cast to %1 instead</li>
 <li>warning: %select{void function|void method|constructor|destructor}1 %0 should not return a value</li>
 <li>warning: %select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++</li>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
 <li>warning: '%%n' specifier not supported on this platform</li>
 <li>warning: '%0' is not a valid object format flag</li>
 <li>warning: '%select{*|.*}0' specified field %select{width|precision}0 is missing a matching 'int' argument</li>
+<li>warning: '&amp;&amp;' of a value and its negation always evaluates to false</li>
 <li>warning: '/*' within block comment</li>
 <li>warning: 'static' function %0 declared in header file should be declared 'static inline'</li>
 <li>warning: 'this' pointer cannot be null in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0</li>
+<li>warning: '||' of a value and its negation always evaluates to true</li>
 <li>warning: // comments are not allowed in this language</li>
 <li>warning: ISO C++ requires field designators to be specified in declaration order; field %1 will be initialized after field %0</li>
 <li>warning: adding %0 to a string does not append to the string</li>
 <li>warning: all paths through this function will call itself</li>
 <li>warning: angle-bracketed include &lt;%0&gt; cannot be aliased to double-quoted include "%1"</li>
+<li>warning: argument %0 of type %1 with mismatched bound</li>
 <li>warning: array section %select{lower bound|length}0 is of type 'char'</li>
 <li>warning: array subscript is of type 'char'</li>
 <li>warning: assigning %select{field|instance variable}0 to itself</li>
@@ -23145,6 +26485,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: bitwise negation of a boolean expression%select{;| always evaluates to 'true';}0 did you mean logical negation?</li>
 <li>warning: bitwise or with non-zero value always evaluates to true</li>
 <li>warning: block pointer variable %0 is %select{uninitialized|null}1 when captured by block</li>
+<li>warning: call to undeclared function %0; ISO C99 and later do not support implicit function declarations</li>
+<li>warning: call to undeclared library function '%0' with type %1; ISO C99 and later do not support implicit function declarations</li>
 <li>warning: calling '%0' with a nonzero argument is unsafe</li>
 <li>warning: cannot mix positional and non-positional arguments in format string</li>
 <li>warning: cast of type %0 to %1 is deprecated; use sel_getName instead</li>
@@ -23166,10 +26508,10 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: escaped newline between */ characters at block comment end</li>
 <li>warning: expected 'ON' or 'OFF' or 'DEFAULT' in pragma</li>
 <li>warning: expected end of directive in pragma</li>
-<li>warning: explicitly assigning value of variable of type %0 to itself</li>
-<li>warning: explicitly assigning value of variable of type %0 to itself</li>
-<li>warning: explicitly moving variable of type %0 to itself</li>
-<li>warning: explicitly moving variable of type %0 to itself</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1</li>
+<li>warning: explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1</li>
+<li>warning: explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1</li>
 <li>warning: expression result unused</li>
 <li>warning: expression result unused; should this cast be to 'void'?</li>
 <li>warning: expression with side effects has no effect in an unevaluated context</li>
@@ -23194,7 +26536,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: ignoring temporary created by a constructor declared with %0 attribute</li>
 <li>warning: ignoring temporary created by a constructor declared with %0 attribute: %1</li>
 <li>warning: implicit declaration of function %0</li>
-<li>warning: implicit declaration of function %0 is invalid in C99</li>
 <li>warning: implicitly declaring library function '%0' with type %1</li>
 <li>warning: incomplete format specifier</li>
 <li>warning: initializer order does not match the declaration order</li>
@@ -23227,6 +26568,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: null returned from %select{function|method}0 that requires a non-null return value</li>
 <li>warning: object format flags cannot be used with '%0' conversion specifier</li>
 <li>warning: overlapping comparisons always evaluate to %select{false|true}0</li>
+<li>warning: parameter %0 was not declared, defaults to 'int'; ISO C99 and later do not support implicit int</li>
 <li>warning: position arguments in format strings start counting at 1 (not 0)</li>
 <li>warning: pragma STDC FENV_ROUND is not supported</li>
 <li>warning: pragma diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'</li>
@@ -23250,6 +26592,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: trigraph ends block comment</li>
 <li>warning: trigraph ignored</li>
 <li>warning: type specifier missing, defaults to 'int'</li>
+<li>warning: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int</li>
 <li>warning: unexpected token in pragma diagnostic</li>
 <li>warning: unknown pragma ignored</li>
 <li>warning: unknown pragma in STDC namespace</li>
@@ -23284,7 +26627,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: explicitly moving variable of type %0 to itself</li>
+<li>warning: explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1</li>
 <li>warning: moving a local object in a return statement prevents copy elision</li>
 <li>warning: moving a temporary object prevents copy elision</li>
 <li>warning: redundant move in return statement</li>
@@ -23304,6 +26647,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmultichar" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-multi-gpu</key>
+    <name>clang-diagnostic-multi-gpu</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: multiple %0 architectures are detected: %1; only the first one is used for '%2'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmulti-gpu" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -23406,6 +26762,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: bit-field %0 is not wide enough to store all enumerators of %1</li>
 <li>warning: comparison of integers of different signs: %0 and %1</li>
 <li>warning: expression which evaluates to zero treated as a null pointer constant of type %0</li>
+<li>warning: floating-point comparison is always %select{true|false}0; constant cannot be represented exactly in type %1</li>
 <li>warning: higher order bits are zeroes after implicit conversion</li>
 <li>warning: implicit boolean conversion of Objective-C object literal always evaluates to true</li>
 <li>warning: implicit conversion changes signedness: %0 to %1</li>
@@ -23430,6 +26787,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: implicit conversion turns string literal into bool: %0 to %1</li>
 <li>warning: implicit conversion turns vector to scalar: %0 to %1</li>
 <li>warning: implicit conversion when assigning computation result loses floating-point precision: %0 to %1</li>
+<li>warning: implicit truncation from %2 to a one-bit wide bit-field changes value from %0 to %1</li>
 <li>warning: implicit truncation from %2 to bit-field changes value from %0 to %1</li>
 <li>warning: incompatible integer to pointer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
 <li>warning: incompatible pointer to integer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
@@ -23449,7 +26807,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnon-gcc" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
-    <severity>INFO</severity>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-non-literal-null-conversion</key>
@@ -24219,6 +27577,20 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-openacc</key>
+    <name>clang-diagnostic-openacc</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: OpenACC directives not yet implemented, pragma ignored</li>
+<li>warning: unexpected '#pragma acc ...' in program</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenacc" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-pedantic-core-features</key>
     <name>clang-diagnostic-pedantic-core-features</name>
     <description>
@@ -24257,6 +27629,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: '%0' is not a valid context property for the context selector '%1' and the context set '%2'; property ignored</li>
 <li>warning: '%0' is not a valid context selector for the context set '%1'; selector ignored</li>
 <li>warning: '%0' is not a valid context set in a `declare variant`; set ignored</li>
+<li>warning: 'ompx_attribute' clause only allows 'amdgpu_flat_work_group_size', 'amdgpu_waves_per_eu', and 'launch_bounds'; %0 is ignored</li>
 <li>warning: OpenMP loop iteration variable cannot have more than 64 bits size and will be narrowed</li>
 <li>warning: OpenMP offloading target '%0' is similar to target '%1' already specified; will be ignored</li>
 <li>warning: OpenMP only allows an ordered construct with the simd clause nested in a simd construct</li>
@@ -24267,14 +27640,18 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: allocator with the 'thread' trait access has unspecified behavior on '%0' directive</li>
 <li>warning: declaration is not declared in any declare target region</li>
 <li>warning: declaration marked as declare target after first use, it may lead to incorrect results</li>
+<li>warning: expected '#pragma omp end declare target' at end of file to match '#pragma omp %0'</li>
 <li>warning: expected '%0' after the %1; '%0' assumed</li>
 <li>warning: expected identifier or string literal describing a context %select{set|selector|property}0; %select{set|selector|property}0 skipped</li>
 <li>warning: initialization clause of OpenMP for loop is not in canonical form ('var = init' or 'T var = init')</li>
 <li>warning: interop type '%0' cannot be specified more than once</li>
 <li>warning: isa trait '%0' is not known to the current target; verify the spelling or consider restricting the context selector with the 'arch' selector further</li>
 <li>warning: more than one 'device_type' clause is specified</li>
+<li>warning: reserved locator 'omp_all_memory' cannot be specified more than once</li>
 <li>warning: score expressions in the OpenMP context selector need to be constant; %0 is not and will be ignored</li>
 <li>warning: specifying OpenMP directives with [[]] is an OpenMP 5.1 extension</li>
+<li>warning: target '%0' does not support exception handling; 'catch' block is ignored</li>
+<li>warning: target '%0' does not support exception handling; 'throw' is assumed to be never reached</li>
 <li>warning: the context %select{set|selector|property}0 '%1' was used already in the same 'omp declare variant' directive; %select{set|selector|property}0 ignored</li>
 <li>warning: the context property '%0' is not valid for the context selector '%1' and the context set '%2'; property ignored</li>
 <li>warning: the context selector '%0' in context set '%1' requires a context property defined in parentheses; selector ignored</li>
@@ -24320,6 +27697,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: expected identifier or string literal describing a context %select{set|selector|property}0; %select{set|selector|property}0 skipped</li>
 <li>warning: interop type '%0' cannot be specified more than once</li>
 <li>warning: more than one 'device_type' clause is specified</li>
+<li>warning: reserved locator 'omp_all_memory' cannot be specified more than once</li>
 <li>warning: the context %select{set|selector|property}0 '%1' was used already in the same 'omp declare variant' directive; %select{set|selector|property}0 ignored</li>
 <li>warning: the context property '%0' is not valid for the context selector '%1' and the context set '%2'; property ignored</li>
 <li>warning: the context selector '%0' in context set '%1' requires a context property defined in parentheses; selector ignored</li>
@@ -24330,6 +27708,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenmp-clauses" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-openmp-extensions</key>
+    <name>clang-diagnostic-openmp-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'ompx_attribute' clause only allows 'amdgpu_flat_work_group_size', 'amdgpu_waves_per_eu', and 'launch_bounds'; %0 is ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenmp-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -24390,6 +27781,20 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-openmp-target-exception</key>
+    <name>clang-diagnostic-openmp-target-exception</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: target '%0' does not support exception handling; 'catch' block is ignored</li>
+<li>warning: target '%0' does not support exception handling; 'throw' is assumed to be never reached</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenmp-target-exception" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-new-returns-null</key>
     <name>clang-diagnostic-new-returns-null</name>
     <description>
@@ -24409,16 +27814,22 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: %0 requires HVX, use -mhvx/-mhvx= to enable it</li>
+<li>warning: %0 requires debug info. Use %1 or debug options that enable debugger's stepping function; option ignored</li>
 <li>warning: '%0' does not support '-%1'; flag ignored</li>
 <li>warning: '%0' does not support '-moutline'; flag ignored</li>
-<li>warning: /JMC requires debug info. Use '/Zi', '/Z7' or other debug options; option ignored</li>
+<li>warning: -fjmc works only for ELF; option ignored</li>
+<li>warning: /arm64EC has been overridden by specified target: %0; option ignored</li>
+<li>warning: The warning option '-%0' is not supported</li>
+<li>warning: ignoring '%0' as it conflicts with that implied by '%1' (%2)</li>
 <li>warning: ignoring '%0' option as it cannot be used with %select{implicit usage of|}1 -mabicalls and the N64 ABI</li>
-<li>warning: ignoring '%0' option as it is not currently supported for offload arch '%1'. Use it with an offload arch containing '%2' instead</li>
+<li>warning: ignoring '%0' option as it is not currently supported for processor '%1'</li>
 <li>warning: ignoring '%0' option as it is not currently supported for target '%1'</li>
+<li>warning: ignoring '%0' option for offload arch '%1' as it is not currently supported there. Use it with an offload arch containing '%2' instead</li>
 <li>warning: ignoring '-mlong-calls' option as it is not currently supported with %select{|the implicit usage of }0-mabicalls</li>
 <li>warning: ignoring '-msmall-data-limit=' with -mcmodel=large for -fpic or RV64</li>
-<li>warning: option '%0' was ignored by the PS4 toolchain, using '-fPIC'</li>
+<li>warning: option '%0' was ignored by the %1 toolchain, using '-fPIC'</li>
 <li>warning: option '-ffine-grained-bitfield-accesses' cannot be enabled together with a sanitizer; flag ignored</li>
+<li>warning: the argument '%0' is not supported for option '%1'. Mapping to '%1%2'</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woption-ignored" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -24529,10 +27940,24 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: not packing field %0 as it is non-POD for the purposes of layout</li>
 <li>warning: packed attribute is unnecessary for %0</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpacked" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-packed-non-pod</key>
+    <name>clang-diagnostic-packed-non-pod</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: not packing field %0 as it is non-POD for the purposes of layout</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpacked-non-pod" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -24543,11 +27968,27 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: padding %select{struct|interface|class}0 %1 with %2 %select{byte|bit}3%s2 to align %4</li>
+<li>warning: padding %select{struct|interface|class}0 %1 with %2 %select{byte|bit}3%s2 to align %4</li>
 <li>warning: padding %select{struct|interface|class}0 %1 with %2 %select{byte|bit}3%s2 to align anonymous bit-field</li>
+<li>warning: padding %select{struct|interface|class}0 %1 with %2 %select{byte|bit}3%s2 to align anonymous field</li>
 <li>warning: padding size of %0 with %1 %select{byte|bit}2%s1 to alignment boundary</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpadded" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-padded-bitfield</key>
+    <name>clang-diagnostic-padded-bitfield</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: padding %select{struct|interface|class}0 %1 with %2 %select{byte|bit}3%s2 to align %4</li>
+<li>warning: padding %select{struct|interface|class}0 %1 with %2 %select{byte|bit}3%s2 to align anonymous bit-field</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpadded-bitfield" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -24779,10 +28220,11 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: #pragma warning expected a warning number</li>
 <li>warning: #pragma warning(push, level) requires a level between 0 and 4</li>
 <li>warning: %0 is not a recognized builtin%select{|; consider including &lt;intrin.h&gt; to access non-builtin intrinsics}1</li>
+<li>warning: %select{value|type}0-dependent expression passed as an argument to debug command</li>
 <li>warning: '#pragma %0' is not supported on this target - ignored</li>
 <li>warning: '#pragma comment %0' ignored</li>
 <li>warning: '#pragma init_seg' is only supported when targeting a Microsoft environment</li>
-<li>warning: '#pragma optimize' is not supported</li>
+<li>warning: OpenCL extension %0 unknown or does not require pragma - ignoring</li>
 <li>warning: Setting the floating point evaluation method to `source` on a target without SSE is not supported.</li>
 <li>warning: angle-bracketed include &lt;%0&gt; cannot be aliased to double-quoted include "%1"</li>
 <li>warning: double-quoted include "%0" cannot be aliased to angle-bracketed include &lt;%1&gt;</li>
@@ -24805,6 +28247,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: expected non-wide string literal in '#pragma %0'</li>
 <li>warning: expected push, pop or a string literal for the section name in '#pragma %0' - ignored</li>
 <li>warning: expected string literal in '#pragma %0' - ignoring</li>
+<li>warning: expected string literal in 'clause %0' - ignoring</li>
 <li>warning: extra tokens at end of '#pragma %0' - ignored</li>
 <li>warning: incorrect use of #pragma clang force_cuda_host_device begin|end</li>
 <li>warning: incorrect use of '#pragma fenv_access (on|off)' - ignored</li>
@@ -24818,6 +28261,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: missing ':' or ')' after %0 - ignoring</li>
 <li>warning: missing argument to '#pragma %0'%select{|; expected %2}1</li>
 <li>warning: missing argument to debug command '%0'</li>
+<li>warning: missing debug command</li>
 <li>warning: non-default #pragma pack value changes the alignment of struct or union members in the included file</li>
 <li>warning: only variables can be arguments to '#pragma unused'</li>
 <li>warning: pragma STDC FENV_ROUND is not supported</li>
@@ -24830,9 +28274,9 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: the current #pragma pack alignment value is modified in the included file</li>
 <li>warning: undeclared variable %0 used as an argument for '#pragma unused'</li>
 <li>warning: unexpected argument '%0' to '#pragma %1'%select{|; expected %3}2</li>
+<li>warning: unexpected argument to debug command</li>
 <li>warning: unexpected debug command '%0'</li>
 <li>warning: unexpected token in pragma diagnostic</li>
-<li>warning: unknown OpenCL extension %0 - ignoring</li>
 <li>warning: unknown action '%1' for '#pragma %0' - ignored</li>
 <li>warning: unknown action for '#pragma %0' - ignored</li>
 <li>warning: unknown module '%0'</li>
@@ -25027,6 +28471,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-read-only-types</key>
+    <name>clang-diagnostic-read-only-types</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: object of type %0 cannot be placed in read-only memory</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wread-only-types" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-redeclared-class-member</key>
     <name>clang-diagnostic-redeclared-class-member</name>
     <description>
@@ -25166,11 +28623,26 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: %0 is a reserved name for a module</li>
 <li>warning: identifier %0 is reserved because %select{&lt;ERROR&gt;|it starts with '_' at global scope|it starts with '_' and has C language linkage|it starts with '__'|it starts with '_' followed by a capital letter|it contains '__'}1</li>
 <li>warning: macro name is a reserved identifier</li>
+<li>warning: user-defined literal suffixes %select{&lt;ERROR&gt;|not starting with '_'|containing '__'}0 are reserved%select{; no literal will invoke this operator|}1</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreserved-identifier" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-reserved-module-identifier</key>
+    <name>clang-diagnostic-reserved-module-identifier</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is a reserved name for a module</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreserved-module-identifier" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -25356,8 +28828,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: assigning %select{field|instance variable}0 to itself</li>
-<li>warning: explicitly assigning value of variable of type %0 to itself</li>
-<li>warning: explicitly assigning value of variable of type %0 to itself</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wself-assign" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -25383,7 +28855,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: explicitly assigning value of variable of type %0 to itself</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wself-assign-overloaded" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -25396,7 +28868,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: explicitly moving variable of type %0 to itself</li>
+<li>warning: explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wself-move" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -25613,6 +29085,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-single-bit-bitfield-constant-conversion</key>
+    <name>clang-diagnostic-single-bit-bitfield-constant-conversion</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit truncation from %2 to a one-bit wide bit-field changes value from %0 to %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsingle-bit-bitfield-constant-conversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-sizeof-array-argument</key>
     <name>clang-diagnostic-sizeof-array-argument</name>
     <description>
@@ -25653,6 +29138,20 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-source-uses-openacc</key>
+    <name>clang-diagnostic-source-uses-openacc</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: OpenACC directives not yet implemented, pragma ignored</li>
+<li>warning: unexpected '#pragma acc ...' in program</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsource-uses-openacc" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-source-uses-openmp</key>
     <name>clang-diagnostic-source-uses-openmp</name>
     <description>
@@ -25661,6 +29160,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: '#pragma omp declare variant' cannot be applied for function after first usage; the original function might be used</li>
 <li>warning: '#pragma omp declare variant' cannot be applied to the function that was defined already; the original function might be used</li>
 <li>warning: OpenMP only allows an ordered construct with the simd clause nested in a simd construct</li>
+<li>warning: expected '#pragma omp end declare target' at end of file to match '#pragma omp %0'</li>
 <li>warning: isa trait '%0' is not known to the current target; verify the spelling or consider restricting the context selector with the 'arch' selector further</li>
 <li>warning: score expressions in the OpenMP context selector need to be constant; %0 is not and will be ignored</li>
 <li>warning: unexpected '#pragma omp ...' in program</li>
@@ -25722,6 +29222,21 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstatic-local-in-inline" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-strict-prototypes</key>
+    <name>clang-diagnostic-strict-prototypes</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: a %select{function|block}0 declaration without a prototype is deprecated %select{in all versions of C|}0</li>
+<li>warning: a function %select{declaration|definition}0 without a prototype is deprecated in all versions of C %select{and is not supported in C23|and is treated as a zero-parameter prototype in C23, conflicting with a %select{previous|subsequent}2 %select{declaration|definition}3}1</li>
+<li>warning: passing arguments to %select{a function|%1}0 without a prototype is deprecated in all versions of C and is not supported in C23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrict-prototypes" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -25916,6 +29431,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-switch-default</key>
+    <name>clang-diagnostic-switch-default</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'switch' missing 'default' label</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wswitch-default" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-switch-enum</key>
     <name>clang-diagnostic-switch-enum</name>
     <description>
@@ -25925,6 +29453,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wswitch-enum" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-sync-alignment</key>
+    <name>clang-diagnostic-sync-alignment</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: __sync builtin operation MUST have natural alignment (consider using __atomic).</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsync-alignment" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -25963,7 +29504,9 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <ul>
 <li>warning: %select{aligning a value|the result of checking whether a value is aligned}0 to 1 byte is %select{a no-op|always true}0</li>
 <li>warning: %select{self-|array }0comparison always evaluates to %select{a constant|true|false|'std::strong_ordering::equal'}1</li>
+<li>warning: '&amp;&amp;' of a value and its negation always evaluates to false</li>
 <li>warning: 'this' pointer cannot be null in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0</li>
+<li>warning: '||' of a value and its negation always evaluates to true</li>
 <li>warning: bitwise comparison always evaluates to %select{false|true}0</li>
 <li>warning: bitwise or with non-zero value always evaluates to true</li>
 <li>warning: comparison of %select{address of|function|array}0 '%1' %select{not |}2equal to a null pointer is always %select{true|false}2</li>
@@ -26011,6 +29554,20 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-constant-in-range-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-tautological-negation-compare</key>
+    <name>clang-diagnostic-tautological-negation-compare</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '&amp;&amp;' of a value and its negation always evaluates to false</li>
+<li>warning: '||' of a value and its negation always evaluates to true</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-negation-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -26181,6 +29738,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: passing variable %1 by reference requires holding %0 %select{'%2'|'%2' exclusively}3</li>
 <li>warning: releasing %0 '%1' that was not held</li>
 <li>warning: releasing %0 '%1' using %select{shared|exclusive}2 access, expected %select{shared|exclusive}3 access</li>
+<li>warning: returning the value that %1 points to by reference requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: returning variable %1 by reference requires holding %0 %select{'%2'|'%2' exclusively}3</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wthread-safety" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -26284,9 +29843,25 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <ul>
 <li>warning: passing the value that %1 points to by reference requires holding %0 %select{'%2'|'%2' exclusively}3</li>
 <li>warning: passing variable %1 by reference requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: returning the value that %1 points to by reference requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: returning variable %1 by reference requires holding %0 %select{'%2'|'%2' exclusively}3</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wthread-safety-reference" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-thread-safety-reference-return</key>
+    <name>clang-diagnostic-thread-safety-reference-return</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: returning the value that %1 points to by reference requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+<li>warning: returning variable %1 by reference requires holding %0 %select{'%2'|'%2' exclusively}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wthread-safety-reference-return" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -26505,8 +30080,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: \%0 used with no following hex digits; treating as '\' followed by identifier</li>
-<li>warning: empty delimited universal character name; treating as '\' 'u' '{' '}'</li>
-<li>warning: incomplete delimited universal character name; treating as '\' 'u' '{' identifier</li>
+<li>warning: empty delimited universal character name; treating as '\' '%0' '{' '}'</li>
+<li>warning: incomplete delimited universal character name; treating as '\' '%0' '{' identifier</li>
 <li>warning: incomplete universal character name; treating as '\' followed by identifier</li>
 <li>warning: universal character name refers to a surrogate character</li>
 <li>warning: universal character names are only valid in C99 or C++</li>
@@ -26597,6 +30172,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: joined argument treated as '%0'; did you mean '%1'?</li>
 <li>warning: unknown argument ignored in clang-cl '%0'; did you mean '%1'?</li>
 <li>warning: unknown argument ignored in clang-cl: '%0'</li>
 </ul>
@@ -26739,6 +30315,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: code will never be executed</li>
+<li>warning: due to lvalue conversion of the controlling expression, association of type %0 will never be selected because it is %select{of array type|qualified}1</li>
 <li>warning: fallthrough annotation in unreachable code</li>
 <li>warning: loop will run at most once (loop increment never executed)</li>
 </ul>
@@ -26756,6 +30333,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: 'break' will never be executed</li>
 <li>warning: 'return' will never be executed</li>
 <li>warning: code will never be executed</li>
+<li>warning: due to lvalue conversion of the controlling expression, association of type %0 will never be selected because it is %select{of array type|qualified}1</li>
 <li>warning: fallthrough annotation in unreachable code</li>
 <li>warning: loop will run at most once (loop increment never executed)</li>
 </ul>
@@ -26791,6 +30369,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-unreachable-code-generic-assoc</key>
+    <name>clang-diagnostic-unreachable-code-generic-assoc</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: due to lvalue conversion of the controlling expression, association of type %0 will never be selected because it is %select{of array type|qualified}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunreachable-code-generic-assoc" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-unreachable-code-loop-increment</key>
     <name>clang-diagnostic-unreachable-code-loop-increment</name>
     <description>
@@ -26817,6 +30408,20 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-unsafe-buffer-usage</key>
+    <name>clang-diagnostic-unsafe-buffer-usage</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is an %select{unsafe pointer used for buffer access|unsafe buffer that does not perform bounds checks}1</li>
+<li>warning: %select{unsafe pointer operation|unsafe pointer arithmetic|unsafe buffer access|function introduces unsafe buffer manipulation|unsafe invocation of span::data}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsafe-buffer-usage" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-unsequenced</key>
     <name>clang-diagnostic-unsequenced</name>
     <description>
@@ -26827,6 +30432,20 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsequenced" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unsupported-abi</key>
+    <name>clang-diagnostic-unsupported-abi</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0': selected processor lacks floating point registers</li>
+<li>warning: float ABI '%0' is not supported by current library</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-abi" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -26996,6 +30615,9 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: %0: '%1' input unused in cpp mode</li>
 <li>warning: %0: '%1' input unused%select{ when '%3' is present|}2</li>
 <li>warning: %0: previously preprocessed input%select{ unused when '%2' is present|}1</li>
+<li>warning: '%0' only applies to medium and large code models</li>
+<li>warning: '-x %0' after last input file has no effect</li>
+<li>warning: argument '%0' requires profile-guided optimization information</li>
 <li>warning: argument '%0' requires profile-guided optimization information</li>
 <li>warning: argument unused during compilation: '%0'</li>
 <li>warning: ignoring -fdiscard-value-names for LLVM Bitcode</li>
@@ -27267,7 +30889,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: user-defined literal suffixes not starting with '_' are reserved%select{; no literal will invoke this operator|}0</li>
+<li>warning: user-defined literal suffixes %select{&lt;ERROR&gt;|not starting with '_'|containing '__'}0 are reserved%select{; no literal will invoke this operator|}1</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wuser-defined-literals" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -27295,9 +30917,29 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <ul>
 <li>warning: variable length array used</li>
 <li>warning: variable length arrays are a C99 feature</li>
+<li>warning: variable length arrays in C++ are a Clang extension</li>
+<li>warning: variable length arrays in C++ are a Clang extension</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvla" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-vla-cxx-extension</key>
+    <name>clang-diagnostic-vla-cxx-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: variable length arrays in C++ are a Clang extension</li>
+<li>warning: variable length arrays in C++ are a Clang extension</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvla-cxx-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -27308,9 +30950,27 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: variable length arrays are a C99 feature</li>
+<li>warning: variable length arrays in C++ are a Clang extension</li>
+<li>warning: variable length arrays in C++ are a Clang extension</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvla-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-vla-extension-static-assert</key>
+    <name>clang-diagnostic-vla-extension-static-assert</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvla-extension-static-assert" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -27383,6 +31043,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvisibility" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-void-ptr-dereference</key>
+    <name>clang-diagnostic-void-ptr-dereference</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C does not allow indirection on operand of type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvoid-ptr-dereference" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -27469,25 +31142,366 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++98-c++11-compat</key>
-    <name>clang-diagnostic-c++98-c++11-compat</name>
+    <key>clang-diagnostic-slash-u-filename</key>
+    <name>clang-diagnostic-slash-u-filename</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
-<li>warning: digit separators are incompatible with C++ standards before C++14</li>
-<li>warning: generic lambdas are incompatible with C++11</li>
-<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
-<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
-<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
-<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+<li>warning: '/U%0' treated as the '/U' option</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wslash-u-filename" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-msvc-not-found</key>
+    <name>clang-diagnostic-msvc-not-found</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: unable to find a Visual Studio installation; try running Clang from a developer command prompt</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmsvc-not-found" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-darwin-sdk-settings</key>
+    <name>clang-diagnostic-darwin-sdk-settings</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: SDK settings were ignored as 'SDKSettings.json' could not be parsed</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdarwin-sdk-settings" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-stdlibcxx-not-found</key>
+    <name>clang-diagnostic-stdlibcxx-not-found</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: include path for libstdc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstdlibcxx-not-found" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-sarif-format-unstable</key>
+    <name>clang-diagnostic-sarif-format-unstable</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: diagnostic formatting in SARIF mode is currently unstable</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsarif-format-unstable" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-missing-multilib</key>
+    <name>clang-diagnostic-missing-multilib</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: no multilib found matching flags: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-multilib" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-android-unversioned-fallback</key>
+    <name>clang-diagnostic-android-unversioned-fallback</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: Using unversioned Android target directory %0 for target %1. Unversioned directories will not be used in Clang 19. Provide a versioned directory for the target version or lower instead.</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wandroid-unversioned-fallback" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-override-module</key>
+    <name>clang-diagnostic-override-module</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: overriding the module target triple with %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverride-module" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unable-to-open-stats-file</key>
+    <name>clang-diagnostic-unable-to-open-stats-file</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: unable to open statistics output file '%0': '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunable-to-open-stats-file" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-analyzer-incompatible-plugin</key>
+    <name>clang-diagnostic-analyzer-incompatible-plugin</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: checker plugin '%0' is not compatible with this version of the analyzer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wanalyzer-incompatible-plugin" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-div-by-zero</key>
+    <name>clang-diagnostic-div-by-zero</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{remainder|division}0 by zero is undefined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdiv-by-zero" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-module-file-config-mismatch</key>
+    <name>clang-diagnostic-module-file-config-mismatch</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: module file %0 cannot be loaded due to a configuration mismatch with the current compilation</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodule-file-config-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-eager-load-cxx-named-modules</key>
+    <name>clang-diagnostic-eager-load-cxx-named-modules</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: the form '-fmodule-file=&lt;BMI-path&gt;' is deprecated for standard C++ named modules;consider to use '-fmodule-file=&lt;module-name&gt;=&lt;BMI-path&gt;' instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#weager-load-cxx-named-modules" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-psabi</key>
+    <name>clang-diagnostic-psabi</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: AVX vector %select{return|argument}0 of type %1 without '%2' enabled changes the ABI</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpsabi" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-backslash-newline-escape</key>
+    <name>clang-diagnostic-backslash-newline-escape</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: backslash and newline separated by space</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbackslash-newline-escape" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-dollar-in-identifier-extension</key>
+    <name>clang-diagnostic-dollar-in-identifier-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '$' in identifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdollar-in-identifier-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-language-extension-token</key>
+    <name>clang-diagnostic-language-extension-token</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: extension used</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wlanguage-extension-token" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-invalid-utf8</key>
+    <name>clang-diagnostic-invalid-utf8</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: invalid UTF-8 in comment</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-utf8" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unicode-whitespace</key>
+    <name>clang-diagnostic-unicode-whitespace</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: treating Unicode character as whitespace</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-whitespace" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unicode-homoglyph</key>
+    <name>clang-diagnostic-unicode-homoglyph</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: treating Unicode character &lt;U+%0&gt; as an identifier character rather than as '%1' symbol</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-homoglyph" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unicode-zero-width</key>
+    <name>clang-diagnostic-unicode-zero-width</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: identifier contains Unicode character &lt;U+%0&gt; that is invisible in some environments</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-zero-width" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++1z-compat-mangling</key>
+    <name>clang-diagnostic-c++1z-compat-mangling</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat-mangling" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-mathematical-notation-identifier-extension</key>
+    <name>clang-diagnostic-mathematical-notation-identifier-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: mathematical notation character &lt;U+%0&gt; in an identifier is a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmathematical-notation-identifier-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-delimited-escape-sequence-extension</key>
+    <name>clang-diagnostic-delimited-escape-sequence-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{delimited|named}0 escape sequences are a %select{Clang|C++23}1 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdelimited-escape-sequence-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unknown-escape-sequence</key>
+    <name>clang-diagnostic-unknown-escape-sequence</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: unknown escape sequence '\%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-escape-sequence" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-invalid-unevaluated-string</key>
+    <name>clang-diagnostic-invalid-unevaluated-string</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: encoding prefix '%0' on an unevaluated string literal has no effect%select{| and is incompatible with c++2c}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-unevaluated-string" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-include-next-outside-header</key>
+    <name>clang-diagnostic-include-next-outside-header</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #include_next in primary source file; will search from start of include path</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winclude-next-outside-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-include-next-absolute-path</key>
+    <name>clang-diagnostic-include-next-absolute-path</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #include_next in file found relative to primary source file or found by absolute path; will search from start of include path</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winclude-next-absolute-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -27540,6 +31554,31 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-system-header-outside-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c2x-compat</key>
+    <name>clang-diagnostic-pre-c2x-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #warning is incompatible with C standards before C23</li>
+<li>warning: '%0' is incompatible with C standards before C23</li>
+<li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
+<li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
+<li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
+<li>warning: [[]] attributes are incompatible with C standards before C23</li>
+<li>warning: digit separators are incompatible with C standards before C23</li>
+<li>warning: label at end of compound statement is incompatible with C standards before C23</li>
+<li>warning: label followed by a declaration is incompatible with C standards before C23</li>
+<li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
+<li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
+<li>warning: use of an empty initializer is incompatible with C standards before C23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -27622,30 +31661,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++98-c++11-compat-pedantic</key>
-    <name>clang-diagnostic-c++98-c++11-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
-<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
-<li>warning: digit separators are incompatible with C++ standards before C++14</li>
-<li>warning: generic lambdas are incompatible with C++11</li>
-<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
-<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
-<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
-<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable templates are incompatible with C++ standards before C++14</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-embedded-directive</key>
     <name>clang-diagnostic-embedded-directive</name>
     <description>
@@ -27655,6 +31670,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wembedded-directive" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unknown-directives</key>
+    <name>clang-diagnostic-unknown-directives</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: invalid preprocessing directive%select{|, did you mean '#%1'?}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-directives" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -27685,6 +31713,31 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-pre-c2x-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c2x-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #warning is incompatible with C standards before C23</li>
+<li>warning: '%0' is incompatible with C standards before C23</li>
+<li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
+<li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
+<li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
+<li>warning: [[]] attributes are incompatible with C standards before C23</li>
+<li>warning: digit separators are incompatible with C standards before C23</li>
+<li>warning: label at end of compound statement is incompatible with C standards before C23</li>
+<li>warning: label followed by a declaration is incompatible with C standards before C23</li>
+<li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
+<li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
+<li>warning: use of an empty initializer is incompatible with C standards before C23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2x-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-private-header</key>
     <name>clang-diagnostic-private-header</name>
     <description>
@@ -27696,6 +31749,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprivate-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-include-angled-in-module-purview</key>
+    <name>clang-diagnostic-include-angled-in-module-purview</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '#include &lt;filename&gt;' attaches the declarations to the named module '%0', which is not usually intended; consider moving that directive before the module declaration</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winclude-angled-in-module-purview" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-header-guard</key>
@@ -27789,6 +31855,42 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-generic-type-extension</key>
+    <name>clang-diagnostic-generic-type-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: passing a type argument as the first operand to '_Generic' is a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgeneric-type-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++98-c++11-compat</key>
+    <name>clang-diagnostic-c++98-c++11-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-missing-selector-name</key>
     <name>clang-diagnostic-missing-selector-name</name>
     <description>
@@ -27798,35 +31900,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-selector-name" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++98-c++11-c++14-compat</key>
-    <name>clang-diagnostic-c++98-c++11-c++14-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
-<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
-<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
-<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
-<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
-<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
-<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
-<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
-<li>warning: inline variables are incompatible with C++ standards before C++17</li>
-<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
-<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
-<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
-<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
-<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
-<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -27901,7 +31974,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: ISO C++ does not allow an attribute list to appear here</li>
+<li>warning: ISO C++ does not allow %select{an attribute list|%0}1 to appear here</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcxx-attribute-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -27948,37 +32021,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</key>
-    <name>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
-<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
-<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
-<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
-<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
-<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
-<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
-<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
-<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
-<li>warning: hexadecimal floating literals are incompatible with C++ standards before C++17</li>
-<li>warning: inline variables are incompatible with C++ standards before C++17</li>
-<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
-<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
-<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
-<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
-<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
-<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-concepts-ts-compat</key>
     <name>clang-diagnostic-concepts-ts-compat</name>
     <description>
@@ -28001,6 +32043,30 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-enum" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++98-c++11-compat-pedantic</key>
+    <name>clang-diagnostic-c++98-c++11-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28040,6 +32106,32 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winterrupt-service-routine" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-auto-decl-extensions</key>
+    <name>clang-diagnostic-auto-decl-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: type inference of a declaration other than a plain identifier with optional trailing attributes is a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wauto-decl-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-excessive-regsave</key>
+    <name>clang-diagnostic-excessive-regsave</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{interrupt service routine|function with attribute 'no_caller_saved_registers'}0 should only call a function with attribute 'no_caller_saved_registers' or be compiled with '-mgeneral-regs-only'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexcessive-regsave" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28109,44 +32201,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat</key>
-    <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
-<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
-<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
-<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
-<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
-<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
-<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
-<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
-<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
-<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
-<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-strlcpy-strlcat-size</key>
     <name>clang-diagnostic-strlcpy-strlcat-size</name>
     <description>
@@ -28156,6 +32210,35 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrlcpy-strlcat-size" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++98-c++11-c++14-compat</key>
+    <name>clang-diagnostic-c++98-c++11-c++14-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28277,46 +32360,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</key>
-    <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
-<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
-<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
-<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
-<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: designated initializers are incompatible with C++ standards before C++20</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
-<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
-<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
-<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
-<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
-<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
-<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
-<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-atomic-property-with-user-defined-accessor</key>
     <name>clang-diagnostic-atomic-property-with-user-defined-accessor</name>
     <description>
@@ -28326,6 +32369,37 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-property-with-user-defined-accessor" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</key>
+    <name>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: hexadecimal floating literals are incompatible with C++ standards before C++17</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28434,6 +32508,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-invalid-static-assert-message</key>
+    <name>clang-diagnostic-invalid-static-assert-message</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: the message in this static assertion is not a constant expression</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-static-assert-message" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-redundant-consteval-if</key>
     <name>clang-diagnostic-redundant-consteval-if</name>
     <description>
@@ -28447,23 +32534,43 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++0x-narrowing</key>
-    <name>clang-diagnostic-c++0x-narrowing</name>
+    <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat</key>
+    <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
+<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
+<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
+<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
+<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-narrowing" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
-    <severity>CRITICAL</severity>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-weak-vtables</key>
@@ -28570,6 +32677,86 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-undefined-arm-streaming</key>
+    <name>clang-diagnostic-undefined-arm-streaming</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: builtin call has undefined behaviour when called from a %0 function</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-streaming" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-undefined-arm-za</key>
+    <name>clang-diagnostic-undefined-arm-za</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: builtin call is not valid when calling from a function without active ZA state</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-za" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</key>
+    <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
+<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: designated initializers are incompatible with C++ standards before C++20</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
+<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
+<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
+<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-undefined-arm-zt0</key>
+    <name>clang-diagnostic-undefined-arm-zt0</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: builtin call is not valid when calling from a function without active ZT0 state</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-zt0" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-vec-elem-size</key>
     <name>clang-diagnostic-vec-elem-size</name>
     <description>
@@ -28594,25 +32781,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-dictionary-duplicate-keys" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-narrowing</key>
-    <name>clang-diagnostic-narrowing</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnarrowing" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-alloca</key>
@@ -28706,6 +32874,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-pre-c++2c-compat</key>
+    <name>clang-diagnostic-pre-c++2c-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2c-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-invalid-initializer-from-system-header</key>
     <name>clang-diagnostic-invalid-initializer-from-system-header</name>
     <description>
@@ -28758,109 +32939,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-unsupported-availability-guard</key>
-    <name>clang-diagnostic-unsupported-availability-guard</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{@available|__builtin_available}0 does not guard availability here; use if (%select{@available|__builtin_available}0) instead</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-availability-guard" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++0x-compat</key>
-    <name>clang-diagnostic-c++0x-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
-<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
-<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
-<li>warning: '%0' is a keyword in C++11</li>
-<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
-<li>warning: 'auto' storage class specifier is redundant and incompatible with C++11</li>
-<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
-<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
-<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
-<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
-<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
-<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
-<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
-<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
-<li>warning: conversion from string literal to %0 is deprecated</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
-<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
-<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
-<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
-<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: digit separators are incompatible with C++ standards before C++14</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
-<li>warning: explicit instantiation cannot be 'inline'</li>
-<li>warning: explicit instantiation of %0 must occur at global scope</li>
-<li>warning: explicit instantiation of %0 not in a namespace enclosing %1</li>
-<li>warning: explicit instantiation of %q0 must occur in namespace %1</li>
-<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
-<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
-<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: generic lambdas are incompatible with C++11</li>
-<li>warning: identifier after literal will be treated as a reserved user-defined literal suffix in C++11</li>
-<li>warning: identifier after literal will be treated as a user-defined literal suffix in C++11</li>
-<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
-<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
-<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
-<li>warning: inline variables are incompatible with C++ standards before C++17</li>
-<li>warning: integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
-<li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
-<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
-<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
-<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
-<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
-<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
-<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
-<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
-<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
-<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
-<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
-<li>warning: use of right-shift operator ('&gt;&gt;') in template argument will require parentheses in C++11</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
-<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable templates are incompatible with C++ standards before C++14</li>
-<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-missing-prototype-for-cc</key>
     <name>clang-diagnostic-missing-prototype-for-cc</name>
     <description>
@@ -28870,6 +32948,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-prototype-for-cc" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unsupported-availability-guard</key>
+    <name>clang-diagnostic-unsupported-availability-guard</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{@available|__builtin_available}0 does not guard availability here; use if (%select{@available|__builtin_available}0) instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-availability-guard" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28926,6 +33017,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-pre-c++2c-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c++2c-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2c-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-attribute-packed-for-bitfield</key>
     <name>clang-diagnostic-attribute-packed-for-bitfield</name>
     <description>
@@ -28961,65 +33065,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-no-builtin-names" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++1z-compat</key>
-    <name>clang-diagnostic-c++1z-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
-<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
-<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
-<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
-<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
-<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
-<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
-<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
-<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
-<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
-<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
-<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
-<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
-<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
-<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-   <rule>
-    <key>clang-diagnostic-unqualified-std-cast-call</key>
-    <name>clang-diagnostic-unqualified-std-cast-call</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: unqualified call to %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunqualified-std-cast-call" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -29063,6 +33108,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-unqualified-std-cast-call</key>
+    <name>clang-diagnostic-unqualified-std-cast-call</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: unqualified call to '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunqualified-std-cast-call" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-invalid-partial-specialization</key>
     <name>clang-diagnostic-invalid-partial-specialization</name>
     <description>
@@ -29102,6 +33160,28 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++0x-narrowing</key>
+    <name>clang-diagnostic-c++0x-narrowing</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-narrowing" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-typename-missing</key>
     <name>clang-diagnostic-typename-missing</name>
     <description>
@@ -29124,43 +33204,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-prototypes" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-strict-prototypes</key>
-    <name>clang-diagnostic-strict-prototypes</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: this %select{function declaration is not|block declaration is not|old-style function definition is not preceded by}0 a prototype</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrict-prototypes" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++2a-compat</key>
-    <name>clang-diagnostic-c++2a-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%0' is a keyword in C++20</li>
-<li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
-<li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
-<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
-<li>warning: this expression will be parsed as explicit(bool) in C++20</li>
-<li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -29269,6 +33312,28 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-narrowing</key>
+    <name>clang-diagnostic-narrowing</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnarrowing" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-extern-initializer</key>
     <name>clang-diagnostic-extern-initializer</name>
     <description>
@@ -29291,35 +33356,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbraced-scalar-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++2a-compat-pedantic</key>
-    <name>clang-diagnostic-c++2a-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%0' is a keyword in C++20</li>
-<li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
-<li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
-<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
-<li>warning: this expression will be parsed as explicit(bool) in C++20</li>
-<li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -29376,6 +33412,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-atomic-access</key>
+    <name>clang-diagnostic-atomic-access</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: accessing a member of an atomic structure or union is undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-access" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-float-equal</key>
     <name>clang-diagnostic-float-equal</name>
     <description>
@@ -29413,6 +33462,110 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-count-negative" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++0x-compat</key>
+    <name>clang-diagnostic-c++0x-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: '%0' is a keyword in C++11</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'auto' storage class specifier is redundant and incompatible with C++11</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: conversion from string literal to %0 is deprecated</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
+<li>warning: explicit instantiation cannot be 'inline'</li>
+<li>warning: explicit instantiation of %0 must occur at global scope</li>
+<li>warning: explicit instantiation of %0 not in a namespace enclosing %1</li>
+<li>warning: explicit instantiation of %q0 must occur in namespace %1</li>
+<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
+<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: identifier after literal will be treated as a reserved user-defined literal suffix in C++11</li>
+<li>warning: identifier after literal will be treated as a user-defined literal suffix in C++11</li>
+<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
+<li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: use of right-shift operator ('&gt;&gt;') in template argument will require parentheses in C++11</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-shift-count-overflow</key>
@@ -29506,19 +33659,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>CRITICAL</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-void-ptr-dereference</key>
-    <name>clang-diagnostic-void-ptr-dereference</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ISO C++ does not allow indirection on operand of type %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvoid-ptr-dereference" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-address-of-packed-member</key>
     <name>clang-diagnostic-address-of-packed-member</name>
     <description>
@@ -29554,6 +33694,63 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-integer-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++1z-compat</key>
+    <name>clang-diagnostic-c++1z-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
+<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
+<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
+<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
+<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
+<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -29636,6 +33833,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-deprecate-lax-vec-conv-all</key>
+    <name>clang-diagnostic-deprecate-lax-vec-conv-all</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: Implicit conversion between vector types ('%0' and '%1') is deprecated. In the future, the behavior implied by '-fno-lax-vector-conversions' will be the default.</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecate-lax-vec-conv-all" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-jump-seh-finally</key>
     <name>clang-diagnostic-jump-seh-finally</name>
     <description>
@@ -29675,12 +33885,61 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++2a-compat</key>
+    <name>clang-diagnostic-c++2a-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: '%0' is a keyword in C++20</li>
+<li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: taking address of non-addressable standard library function is incompatible with C++20</li>
+<li>warning: this expression will be parsed as explicit(bool) in C++20</li>
+<li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of implicit 'typename' is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-incompatible-function-pointer-types-strict</key>
+    <name>clang-diagnostic-incompatible-function-pointer-types-strict</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: incompatible function pointer types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-function-pointer-types-strict" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-atomic-memory-ordering</key>
     <name>clang-diagnostic-atomic-memory-ordering</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: memory order argument to atomic operation is invalid</li>
+<li>warning: %select{|success |failure }0memory order argument to atomic operation is invalid</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-memory-ordering" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -29792,6 +34051,57 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++2a-compat-pedantic</key>
+    <name>clang-diagnostic-c++2a-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: '%0' is a keyword in C++20</li>
+<li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: taking address of non-addressable standard library function is incompatible with C++20</li>
+<li>warning: this expression will be parsed as explicit(bool) in C++20</li>
+<li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of implicit 'typename' is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-nested-anon-types</key>
     <name>clang-diagnostic-nested-anon-types</name>
     <description>
@@ -29840,6 +34150,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmultiple-move-vbase" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++23-default-comp-relaxed-constexpr</key>
+    <name>clang-diagnostic-c++23-default-comp-relaxed-constexpr</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is a C++23 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-default-comp-relaxed-constexpr" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -29909,6 +34232,21 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-return-local-addr</key>
+    <name>clang-diagnostic-return-local-addr</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{address of|reference to}0 stack memory associated with %select{local variable|parameter}2 %1 returned</li>
+<li>warning: returning %select{address of|reference to}0 local temporary object</li>
+<li>warning: returning address of label, which is local</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-local-addr" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-nonportable-vector-initialization</key>
     <name>clang-diagnostic-nonportable-vector-initialization</name>
     <description>
@@ -29961,6 +34299,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-unaligned-qualifier-implicit-cast</key>
+    <name>clang-diagnostic-unaligned-qualifier-implicit-cast</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit cast from type %0 to type %1 drops __unaligned qualifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunaligned-qualifier-implicit-cast" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-module-import-in-extern-c</key>
     <name>clang-diagnostic-module-import-in-extern-c</name>
     <description>
@@ -29996,6 +34347,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexport-using-directive" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-experimental-header-units</key>
+    <name>clang-diagnostic-experimental-header-units</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: the implementation of header units is in an experimental phase</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexperimental-header-units" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -30059,11 +34423,12 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <ul>
 <li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
 <li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
+<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverride-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
-    <severity>INFO</severity>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-effc++</key>
@@ -30079,6 +34444,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-c2x-compat</key>
+    <name>clang-diagnostic-c2x-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' is a keyword in C23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc2x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-sequence-point</key>
     <name>clang-diagnostic-sequence-point</name>
     <description>
@@ -30089,34 +34467,6 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsequence-point" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-deprecated-copy-dtor</key>
-    <name>clang-diagnostic-deprecated-copy-dtor</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared destructor</li>
-<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided destructor</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-copy-dtor" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-partial-availability</key>
-    <name>clang-diagnostic-partial-availability</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0 is only available on %1 %2 or newer</li>
-<li>warning: %0 is only available on %1 %2 or newer</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpartial-availability" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -30169,6 +34519,10 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: %select{values of type|enum values with underlying type}2 '%0' should not be used as format arguments; add an explicit cast to %1 instead</li>
 <li>warning: %select{void function|void method|constructor|destructor}1 %0 should not return a value</li>
 <li>warning: %select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++</li>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
 <li>warning: '%%n' specifier not supported on this platform</li>
 <li>warning: '%0' is not a valid object format flag</li>
 <li>warning: '%0' qualifier on function type %1 has no effect</li>
@@ -30177,11 +34531,13 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: '%0' type qualifier%s1 on return type %plural{1:has|:have}1 no effect</li>
 <li>warning: '%0' within '%1'</li>
 <li>warning: '%select{*|.*}0' specified field %select{width|precision}0 is missing a matching 'int' argument</li>
+<li>warning: '&amp;&amp;' of a value and its negation always evaluates to false</li>
 <li>warning: '&amp;&amp;' within '||'</li>
 <li>warning: '-fuse-ld=' taking a path is deprecated; use '--ld-path=' instead</li>
 <li>warning: '/*' within block comment</li>
 <li>warning: 'static' function %0 declared in header file should be declared 'static inline'</li>
 <li>warning: 'this' pointer cannot be null in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0</li>
+<li>warning: '||' of a value and its negation always evaluates to true</li>
 <li>warning: // comments are not allowed in this language</li>
 <li>warning: ARC %select{unused|__unsafe_unretained|__strong|__weak|__autoreleasing}0 lifetime qualifier on return type is ignored</li>
 <li>warning: ISO C++ requires field designators to be specified in declaration order; field %1 will be initialized after field %0</li>
@@ -30189,6 +34545,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: adding %0 to a string does not append to the string</li>
 <li>warning: all paths through this function will call itself</li>
 <li>warning: angle-bracketed include &lt;%0&gt; cannot be aliased to double-quoted include "%1"</li>
+<li>warning: argument %0 of type %1 with mismatched bound</li>
 <li>warning: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension</li>
 <li>warning: array section %select{lower bound|length}0 is of type 'char'</li>
 <li>warning: array subscript is of type 'char'</li>
@@ -30199,6 +34556,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: bitwise or with non-zero value always evaluates to true</li>
 <li>warning: block pointer variable %0 is %select{uninitialized|null}1 when captured by block</li>
 <li>warning: call to function without interrupt attribute could clobber interruptee's VFP registers</li>
+<li>warning: call to undeclared function %0; ISO C99 and later do not support implicit function declarations</li>
+<li>warning: call to undeclared library function '%0' with type %1; ISO C99 and later do not support implicit function declarations</li>
 <li>warning: calling '%0' with a nonzero argument is unsafe</li>
 <li>warning: cannot mix positional and non-positional arguments in format string</li>
 <li>warning: case value not in enumerated type %0</li>
@@ -30226,10 +34585,10 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: escaped newline between */ characters at block comment end</li>
 <li>warning: expected 'ON' or 'OFF' or 'DEFAULT' in pragma</li>
 <li>warning: expected end of directive in pragma</li>
-<li>warning: explicitly assigning value of variable of type %0 to itself</li>
-<li>warning: explicitly assigning value of variable of type %0 to itself</li>
-<li>warning: explicitly moving variable of type %0 to itself</li>
-<li>warning: explicitly moving variable of type %0 to itself</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1</li>
+<li>warning: explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1</li>
+<li>warning: explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1</li>
 <li>warning: expression result unused</li>
 <li>warning: expression result unused; should this cast be to 'void'?</li>
 <li>warning: expression with side effects has no effect in an unevaluated context</li>
@@ -30254,9 +34613,9 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: ignoring temporary created by a constructor declared with %0 attribute</li>
 <li>warning: ignoring temporary created by a constructor declared with %0 attribute: %1</li>
 <li>warning: implicit declaration of function %0</li>
-<li>warning: implicit declaration of function %0 is invalid in C99</li>
 <li>warning: implicitly declaring library function '%0' with type %1</li>
 <li>warning: incomplete format specifier</li>
+<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
 <li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
 <li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
 <li>warning: initializer order does not match the declaration order</li>
@@ -30289,6 +34648,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: non-void function does not return a value in all control paths</li>
 <li>warning: non-void lambda does not return a value</li>
 <li>warning: non-void lambda does not return a value in all control paths</li>
+<li>warning: not packing field %0 as it is non-POD for the purposes of layout</li>
 <li>warning: null passed to a callee that requires a non-null argument</li>
 <li>warning: null returned from %select{function|method}0 that requires a non-null return value</li>
 <li>warning: object format flags cannot be used with '%0' conversion specifier</li>
@@ -30299,6 +34659,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: overlapping comparisons always evaluate to %select{false|true}0</li>
 <li>warning: overloaded operator %select{&gt;&gt;|&lt;&lt;}0 has higher precedence than comparison operator</li>
 <li>warning: parameter %0 set but not used</li>
+<li>warning: parameter %0 was not declared, defaults to 'int'; ISO C99 and later do not support implicit int</li>
 <li>warning: performing pointer arithmetic on a null pointer has undefined behavior%select{| if the offset is nonzero}0</li>
 <li>warning: performing pointer subtraction with a null pointer %select{has|may have}0 undefined behavior</li>
 <li>warning: position arguments in format strings start counting at 1 (not 0)</li>
@@ -30327,6 +34688,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: trigraph ends block comment</li>
 <li>warning: trigraph ignored</li>
 <li>warning: type specifier missing, defaults to 'int'</li>
+<li>warning: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int</li>
 <li>warning: unexpected token in pragma diagnostic</li>
 <li>warning: unknown pragma ignored</li>
 <li>warning: unknown pragma in STDC namespace</li>
@@ -30349,6 +34711,10 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: variable %0 is uninitialized when passed as a const reference argument here</li>
 <li>warning: variable %0 is uninitialized when used within its own initialization</li>
 <li>warning: variable %0 set but not used</li>
+<li>warning: variable length arrays in C++ are a Clang extension</li>
+<li>warning: variable length arrays in C++ are a Clang extension</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
 <li>warning: variable%select{s| %1|s %1 and %2|s %1, %2, and %3|s %1, %2, %3, and %4}0 used in loop condition not modified in loop body</li>
 <li>warning: zero field width in scanf format string is unused</li>
 </ul>
@@ -30442,7 +34808,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wint-conversions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
-    <severity>INFO</severity>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-vector-conversions</key>
@@ -30482,6 +34848,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: 'long long' is a C++11 extension</li>
 <li>warning: 'template' keyword outside of a template</li>
 <li>warning: 'typename' occurs outside of a template</li>
+<li>warning: [[]] attributes are a C++11 extension</li>
 <li>warning: alias declarations are a C++11 extension</li>
 <li>warning: befriending enumeration type %0 is a C++11 extension</li>
 <li>warning: commas at the end of enumerator lists are a C++11 extension</li>
@@ -30507,6 +34874,20 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecated-copy-dtor</key>
+    <name>clang-diagnostic-deprecated-copy-dtor</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared destructor</li>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided destructor</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-copy-dtor" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -30567,6 +34948,8 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: aggregate initialization of type %0 from a parenthesized list of values is a C++20 extension</li>
+<li>warning: captured structured bindings are a C++20 extension</li>
 <li>warning: constexpr constructor that does not initialize all members is a C++20 extension</li>
 <li>warning: constexpr union constructor that does not initialize any member is a C++20 extension</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is a C++20 extension</li>
@@ -30580,7 +34963,7 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <li>warning: initialized lambda pack captures are a C++20 extension</li>
 <li>warning: inline nested namespace definition is a C++20 extension</li>
 <li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is a C++20 extension</li>
-<li>warning: member using declaration naming a non-member enumerator is a C++20 extension</li>
+<li>warning: missing 'typename' prior to dependent type name %0%1; implicit 'typename' is a C++20 extension</li>
 <li>warning: range-based for loop initialization statements are a C++20 extension</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is a C++20 extension</li>
 <li>warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension</li>
@@ -30591,6 +34974,63 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++2b-extensions</key>
+    <name>clang-diagnostic-c++2b-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{an attribute specifier sequence|%0}1 in this position is a C++23 extension</li>
+<li>warning: 'size_t' suffix for literals is a C++23 extension</li>
+<li>warning: alias declaration in this context is a C++23 extension</li>
+<li>warning: consteval if is a C++23 extension</li>
+<li>warning: declaring overloaded %0 as 'static' is a C++23 extension</li>
+<li>warning: definition of a %select{static|thread_local}1 variable in a constexpr %select{function|constructor}0 is a C++23 extension</li>
+<li>warning: label at end of compound statement is a C++23 extension</li>
+<li>warning: lambda without a parameter clause is a C++23 extension</li>
+<li>warning: static lambdas are a C++23 extension</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is a C++23 extension</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++23 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2b-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++2c-extensions</key>
+    <name>clang-diagnostic-c++2c-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: placeholder variables are a C++2c extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2c-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c2x-extensions</key>
+    <name>clang-diagnostic-c2x-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '_BitInt' suffix for literals is a C23 extension</li>
+<li>warning: '_Static_assert' with no message is a C23 extension</li>
+<li>warning: 'nullptr' is a C23 extension</li>
+<li>warning: [[]] attributes are a C23 extension</li>
+<li>warning: label at end of compound statement is a C23 extension</li>
+<li>warning: label followed by a declaration is a C23 extension</li>
+<li>warning: omitting the parameter name in a function definition is a C23 extension</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is a C23 extension</li>
+<li>warning: use of an empty initializer is a C23 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc2x-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -30648,6 +35088,20 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-partial-availability</key>
+    <name>clang-diagnostic-partial-availability</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is only available on %1 %2 or newer</li>
+<li>warning: %0 is only available on %1 %2 or newer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpartial-availability" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-fixed-point-overflow</key>
     <name>clang-diagnostic-fixed-point-overflow</name>
     <description>
@@ -30659,6 +35113,19 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfixed-point-overflow" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-enum-constexpr-conversion</key>
+    <name>clang-diagnostic-enum-constexpr-conversion</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: integer value %0 is outside the valid range of values [%1, %2] for the enumeration type %3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wenum-constexpr-conversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-constant-evaluated</key>
@@ -30687,12 +35154,25 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-nan-infinity-disabled</key>
+    <name>clang-diagnostic-nan-infinity-disabled</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: use of %select{infinity|NaN}0%select{| via a macro}1 is undefined behavior due to the currently enabled floating-point options</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnan-infinity-disabled" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-stack-protector</key>
     <name>clang-diagnostic-stack-protector</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: Unable to protect inline asm that clobbers stack pointer against stack clash</li>
+<li>warning: unable to protect inline asm that clobbers stack pointer against stack clash</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstack-protector" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -30705,10 +35185,101 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: Speculative load hardening does not protect functions with asm goto</li>
+<li>warning: speculative load hardening does not protect functions with asm goto</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wslh-asm-goto" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-objc-duplicate-category-definition</key>
+    <name>clang-diagnostic-objc-duplicate-category-definition</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: duplicate definition of category %1 on interface %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-duplicate-category-definition" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-invalid-feature-combination</key>
+    <name>clang-diagnostic-invalid-feature-combination</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: invalid feature combination: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-feature-combination" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-knl-knm-isa-support-removed</key>
+    <name>clang-diagnostic-knl-knm-isa-support-removed</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: KNL, KNM related Intel Xeon Phi CPU's specific ISA's supports will be removed in LLVM 19.</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wknl-knm-isa-support-removed" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-sloc-usage</key>
+    <name>clang-diagnostic-sloc-usage</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>remark: source manager location address space usage:</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rsloc-usage" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-apinotes</key>
+    <name>clang-diagnostic-apinotes</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wapinotes" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-nonportable-private-apinotes-path</key>
+    <name>clang-diagnostic-nonportable-private-apinotes-path</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: private API notes file for module '%0' should be named '%0_private.apinotes', not '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-private-apinotes-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-nonportable-private-system-apinotes-path</key>
+    <name>clang-diagnostic-nonportable-private-system-apinotes-path</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: private API notes file for module '%0' should be named '%0_private.apinotes', not '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-private-system-apinotes-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -30726,15 +35297,15 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-unsupported-abi</key>
-    <name>clang-diagnostic-unsupported-abi</name>
+    <key>clang-diagnostic-overriding-option</key>
+    <name>clang-diagnostic-overriding-option</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: float ABI '%0' is not supported by current library</li>
+<li>warning: overriding '%0' option with '%1'</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-abi" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverriding-option" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -30778,25 +35349,12 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-div-by-zero</key>
-    <name>clang-diagnostic-div-by-zero</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{remainder|division}0 by zero is undefined</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdiv-by-zero" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-debug-compression-unavailable</key>
     <name>clang-diagnostic-debug-compression-unavailable</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: cannot compress debug sections (zlib not installed)</li>
+<li>warning: cannot compress debug sections (%0 not enabled)</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdebug-compression-unavailable" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -30804,262 +35362,15 @@ std::vector&lt;int* const&gt; vector; // error: static assertion failed: std::ve
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-slash-u-filename</key>
-    <name>clang-diagnostic-slash-u-filename</name>
+    <key>clang-diagnostic-delayed-template-parsing-in-cxx20</key>
+    <name>clang-diagnostic-delayed-template-parsing-in-cxx20</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: '/U%0' treated as the '/U' option</li>
+<li>warning: -fdelayed-template-parsing is deprecated after C++20</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wslash-u-filename" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-msvc-not-found</key>
-    <name>clang-diagnostic-msvc-not-found</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: unable to find a Visual Studio installation; try running Clang from a developer command prompt</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmsvc-not-found" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-darwin-sdk-settings</key>
-    <name>clang-diagnostic-darwin-sdk-settings</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: SDK settings were ignored as 'SDKSettings.json' could not be parsed</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdarwin-sdk-settings" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-stdlibcxx-not-found</key>
-    <name>clang-diagnostic-stdlibcxx-not-found</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: include path for libstdc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstdlibcxx-not-found" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-override-module</key>
-    <name>clang-diagnostic-override-module</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: overriding the module target triple with %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverride-module" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unable-to-open-stats-file</key>
-    <name>clang-diagnostic-unable-to-open-stats-file</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: unable to open statistics output file '%0': '%1'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunable-to-open-stats-file" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-analyzer-incompatible-plugin</key>
-    <name>clang-diagnostic-analyzer-incompatible-plugin</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: checker plugin '%0' is not compatible with this version of the analyzer</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wanalyzer-incompatible-plugin" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-module-file-config-mismatch</key>
-    <name>clang-diagnostic-module-file-config-mismatch</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: module file %0 cannot be loaded due to a configuration mismatch with the current compilation</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodule-file-config-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-psabi</key>
-    <name>clang-diagnostic-psabi</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: AVX vector %select{return|argument}0 of type %1 without '%2' enabled changes the ABI</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpsabi" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++1z-compat-mangling</key>
-    <name>clang-diagnostic-c++1z-compat-mangling</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat-mangling" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-backslash-newline-escape</key>
-    <name>clang-diagnostic-backslash-newline-escape</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: backslash and newline separated by space</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbackslash-newline-escape" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-dollar-in-identifier-extension</key>
-    <name>clang-diagnostic-dollar-in-identifier-extension</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '$' in identifier</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdollar-in-identifier-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-language-extension-token</key>
-    <name>clang-diagnostic-language-extension-token</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: extension used</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wlanguage-extension-token" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unicode-whitespace</key>
-    <name>clang-diagnostic-unicode-whitespace</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: treating Unicode character as whitespace</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-whitespace" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unicode-homoglyph</key>
-    <name>clang-diagnostic-unicode-homoglyph</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: treating Unicode character &lt;U+%0&gt; as identifier character rather than as '%1' symbol</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-homoglyph" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unicode-zero-width</key>
-    <name>clang-diagnostic-unicode-zero-width</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: identifier contains Unicode character &lt;U+%0&gt; that is invisible in some environments</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-zero-width" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-delimited-escape-sequence-extension</key>
-    <name>clang-diagnostic-delimited-escape-sequence-extension</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: delimited escape sequences are a Clang extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdelimited-escape-sequence-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unknown-escape-sequence</key>
-    <name>clang-diagnostic-unknown-escape-sequence</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: unknown escape sequence '\%0'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-escape-sequence" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-include-next-outside-header</key>
-    <name>clang-diagnostic-include-next-outside-header</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #include_next in primary source file; will search from start of include path</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winclude-next-outside-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-include-next-absolute-path</key>
-    <name>clang-diagnostic-include-next-absolute-path</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #include_next in file found relative to primary source file or found by absolute path; will search from start of include path</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winclude-next-absolute-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdelayed-template-parsing-in-cxx20" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangsa/CxxClangSARuleRepositoryTest.java
@@ -37,7 +37,7 @@ class CxxClangSARuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxClangSARuleRepository.KEY);
-    assertThat(repo.rules()).hasSize(93);
+    assertThat(repo.rules()).hasSize(98);
   }
 
 }

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
@@ -36,7 +36,7 @@ class CxxClangTidyRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxClangTidyRuleRepository.KEY);
-    assertThat(repo.rules()).hasSize(1355);
+    assertThat(repo.rules()).hasSize(1511);
   }
 
 }

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -361,7 +361,7 @@ def rstfiles_to_rules_xml(directory, fix_urls):
 
 def contains_required_fields(entry_value):
     FIELDS = ["!name", "!anonymous", "!superclasses",
-              "Class", "DefaultSeverity", "Text"]
+              "Class", "DefaultSeverity", "Summary"]
     for field in FIELDS:
         if field not in entry_value:
             return False
@@ -502,11 +502,11 @@ def calculate_rule_type_and_severity(diagnostics):
 def generate_description(diag_group_name, diagnostics):
     html_lines = ["<p>Diagnostic text:</p>", "<ul>"]
     all_diagnostics_are_remarks = True
-    for diagnostic in sorted(diagnostics, key=lambda k: k['Text']):
+    for diagnostic in sorted(diagnostics, key=lambda k: k['Summary']):
         diag_class = diagnostic["Class"]["def"]
         all_diagnostics_are_remarks = all_diagnostics_are_remarks and (
             diag_class == "CLASS_REMARK")
-        diag_text = diagnostic["Text"]
+        diag_text = diagnostic["Summary"]
         diag_class_printable = DIAG_CLASS[diag_class]["printable"]
         diag_text_escaped = html.escape(diag_text, quote=False)
         html_lines.append("<li>%s: %s</li>" %

--- a/cxx-sensors/src/tools/clangtidy_createrules.pyproj
+++ b/cxx-sensors/src/tools/clangtidy_createrules.pyproj
@@ -1,0 +1,39 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>46164d90-7249-4216-b115-b99d1420d74c</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <StartupFile>clangtidy_createrules.py</StartupFile>
+    <SearchPath>
+    </SearchPath>
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <Name>clangtidy_createrules</Name>
+    <RootNamespace>clangtidy_createrules</RootNamespace>
+    <LaunchProvider>Standard Python launcher</LaunchProvider>
+    <CommandLineArguments>diagnostics "C:\Development\git\sonar-cxx\cxx-sensors\src\tools\diagnostic.json" &gt; "C:\Development\git\sonar-cxx\cxx-sensors\src\tools\diagnostic_new.xml"</CommandLineArguments>
+    <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="clangtidy_createrules.py" />
+    <Compile Include="utils_createrules.py" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
+  <!-- Uncomment the CoreCompile target to enable the Build command in
+       Visual Studio and specify your pre- and post-build commands in
+       the BeforeBuild and AfterBuild targets below. -->
+  <!--<Target Name="CoreCompile" />-->
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+</Project>

--- a/cxx-sensors/src/tools/clangtidy_createrules.sln
+++ b/cxx-sensors/src/tools/clangtidy_createrules.sln
@@ -1,0 +1,23 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31911.196
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "clangtidy_createrules", "clangtidy_createrules.pyproj", "{46164D90-7249-4216-B115-B99D1420D74C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{46164D90-7249-4216-B115-B99D1420D74C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{46164D90-7249-4216-B115-B99D1420D74C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C4A6BDFE-BF78-40A6-B31B-19D9B6E2BBC2}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
- use tag llvmorg-19-init
- new ClangTidy rules:
  - bugprone-casting-through-void
  - bugprone-chained-comparison
  - bugprone-compare-pointer-to-member-virtual-function
  - bugprone-empty-catch
  - bugprone-inc-dec-in-conditions
  - bugprone-incorrect-enable-if
  - bugprone-multi-level-implicit-pointer-conversion
  - bugprone-multiple-new-in-one-expression
  - bugprone-non-zero-enum-to-bool-conversion
  - bugprone-optional-value-conversion
  - bugprone-switch-missing-default-case
  - bugprone-unique-ptr-array-mismatch
  - bugprone-unsafe-functions
  - bugprone-unused-local-non-trivial-variable
  - cert-msc24-c
  - cert-msc33-c
  - clang-analyzer-core.BitwiseShift
  - clang-analyzer-core.uninitialized.NewArraySize
  - clang-analyzer-cplusplus.PlacementNew
  - clang-analyzer-cplusplus.PureVirtualCall
  - clang-analyzer-cplusplus.StringChecker
  - clang-analyzer-fuchsia.HandleChecker
  - clang-analyzer-optin.core.EnumCastOutOfRange
  - clang-analyzer-security.cert.env.InvalidPtr
  - clang-analyzer-security.insecureAPI.decodeValueOfObjCType
  - clang-analyzer-unix.Errno
  - clang-analyzer-unix.StdCLibraryFunctions
  - clang-analyzer-webkit.NoUncountedMemberChecker
  - clang-analyzer-webkit.RefCntblBaseVirtualDtor
  - clang-analyzer-webkit.UncountedLambdaCapturesChecker
  - clang-diagnostic-android-unversioned-fallback
  - clang-diagnostic-apinotes
  - clang-diagnostic-array-parameter
  - clang-diagnostic-atomic-access
  - clang-diagnostic-auto-decl-extensions
  - clang-diagnostic-c++11-narrowing-const-reference
  - clang-diagnostic-c++23-default-comp-relaxed-constexpr
  - clang-diagnostic-c++23-extensions
  - clang-diagnostic-c++23-lambda-attributes
  - clang-diagnostic-c++26-extensions
  - clang-diagnostic-c++2c-extensions
  - clang-diagnostic-c23-compat
  - clang-diagnostic-c23-extensions
  - clang-diagnostic-c2x-compat
  - clang-diagnostic-cast-function-type-strict
  - clang-diagnostic-coro-non-aligned-allocation-function
  - clang-diagnostic-delayed-template-parsing-in-cxx20
  - clang-diagnostic-deprecate-lax-vec-conv-all
  - clang-diagnostic-deprecated-builtins
  - clang-diagnostic-deprecated-literal-operator
  - clang-diagnostic-deprecated-module-dot-map
  - clang-diagnostic-deprecated-non-prototype
  - clang-diagnostic-deprecated-redundant-constexpr-static-def
  - clang-diagnostic-deprecated-static-analyzer-flag
  - clang-diagnostic-dxil-validation
  - clang-diagnostic-eager-load-cxx-named-modules
  - clang-diagnostic-enum-constexpr-conversion
  - clang-diagnostic-excessive-regsave
  - clang-diagnostic-experimental-header-units
  - clang-diagnostic-format-overflow
  - clang-diagnostic-format-overflow-non-kprintf
  - clang-diagnostic-format-truncation
  - clang-diagnostic-format-truncation-non-kprintf
  - clang-diagnostic-generic-type-extension
  - clang-diagnostic-gnu-line-marker
  - clang-diagnostic-gnu-null-pointer-arithmetic
  - clang-diagnostic-gnu-offsetof-extensions
  - clang-diagnostic-gnu-pointer-arith
  - clang-diagnostic-gnu-statement-expression-from-macro-expansion
  - clang-diagnostic-hip-omp-target-directives
  - clang-diagnostic-hlsl-extensions
  - clang-diagnostic-ignored-gch
  - clang-diagnostic-include-angled-in-module-purview
  - clang-diagnostic-incompatible-function-pointer-types-strict
  - clang-diagnostic-incompatible-ms-pragma-section
  - clang-diagnostic-invalid-feature-combination
  - clang-diagnostic-invalid-static-assert-message
  - clang-diagnostic-invalid-unevaluated-string
  - clang-diagnostic-invalid-utf8
  - clang-diagnostic-knl-knm-isa-support-removed
  - clang-diagnostic-mathematical-notation-identifier-extension
  - clang-diagnostic-microsoft-init-from-predefined
  - clang-diagnostic-microsoft-string-literal-from-predefined
  - clang-diagnostic-misexpect
  - clang-diagnostic-missing-multilib
  - clang-diagnostic-module-include-translation
  - clang-diagnostic-multi-gpu
  - clang-diagnostic-nan-infinity-disabled
  - clang-diagnostic-nonportable-private-apinotes-path
  - clang-diagnostic-nonportable-private-system-apinotes-path
  - clang-diagnostic-objc-duplicate-category-definition
  - clang-diagnostic-openacc
  - clang-diagnostic-openmp-extensions
  - clang-diagnostic-openmp-target-exception
  - clang-diagnostic-overriding-option
  - clang-diagnostic-packed-non-pod
  - clang-diagnostic-padded-bitfield
  - clang-diagnostic-pre-c++23-compat
  - clang-diagnostic-pre-c++23-compat-pedantic
  - clang-diagnostic-pre-c++26-compat
  - clang-diagnostic-pre-c++26-compat-pedantic
  - clang-diagnostic-pre-c++2c-compat
  - clang-diagnostic-pre-c++2c-compat-pedantic
  - clang-diagnostic-pre-c23-compat
  - clang-diagnostic-pre-c23-compat-pedantic
  - clang-diagnostic-read-only-types
  - clang-diagnostic-reserved-module-identifier
  - clang-diagnostic-return-local-addr
  - clang-diagnostic-sarif-format-unstable
  - clang-diagnostic-single-bit-bitfield-constant-conversion
  - clang-diagnostic-sloc-usage
  - clang-diagnostic-source-uses-openacc
  - clang-diagnostic-switch-default
  - clang-diagnostic-sync-alignment
  - clang-diagnostic-tautological-negation-compare
  - clang-diagnostic-thread-safety-reference-return
  - clang-diagnostic-unaligned-qualifier-implicit-cast
  - clang-diagnostic-undefined-arm-streaming
  - clang-diagnostic-undefined-arm-za
  - clang-diagnostic-undefined-arm-zt0
  - clang-diagnostic-unknown-directives
  - clang-diagnostic-unreachable-code-generic-assoc
  - clang-diagnostic-unsafe-buffer-usage
  - clang-diagnostic-vla-cxx-extension
  - clang-diagnostic-vla-extension-static-assert
  - cppcoreguidelines-avoid-capturing-lambda-coroutines
  - cppcoreguidelines-avoid-do-while
  - cppcoreguidelines-avoid-reference-coroutine-parameters
  - cppcoreguidelines-misleading-capture-default-by-value
  - cppcoreguidelines-missing-std-forward
  - cppcoreguidelines-no-suspend-with-lock
  - cppcoreguidelines-noexcept-destructor
  - cppcoreguidelines-noexcept-move-operations
  - cppcoreguidelines-noexcept-swap
  - cppcoreguidelines-rvalue-reference-param-not-moved
  - cppcoreguidelines-use-default-member-init
  - hicpp-ignored-remove-result
  - llvmlibc-inline-function-decl
  - misc-coroutine-hostile-raii
  - misc-header-include-cycle
  - misc-include-cleaner
  - modernize-type-traits
  - modernize-use-constraints
  - modernize-use-starts-ends-with
  - modernize-use-std-numbers
  - modernize-use-std-print
  - performance-avoid-endl
  - performance-enum-size
  - performance-noexcept-destructor
  - performance-noexcept-swap
  - readability-avoid-nested-conditional-operator
  - readability-avoid-return-with-void-value
  - readability-avoid-unconditional-preprocessor-if
  - readability-operators-representation
  - readability-redundant-casting
  - readability-redundant-inline-specifier
  - readability-reference-to-constructed-temporary
- new Clang Static Analyzer rules
  - BitwiseShift
  - EnumCastOutOfRange
  - security.cert.env.InvalidPtr
  - unix.Errno
  - unix.StdCLibraryFunctions
- add VisualStudio project for development/debugging
- diagnostic.json: using name 'Summary' instead of 'Text' for description

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2640)
<!-- Reviewable:end -->
