### PR TITLE
Support correct repository (description) for CustomCxxRulesDefinition

### DIFF
--- a/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxSquidSensor.java
+++ b/sonar-cxx-plugin/src/main/java/org/sonar/plugins/cxx/CxxSquidSensor.java
@@ -477,7 +477,7 @@ public class CxxSquidSensor implements ProjectSensor {
 
         RuleKey ruleKey = checks.ruleKey((SquidAstVisitor<Grammar>) message.getCheck());
         if (ruleKey != null) {
-          var newIssue = context.newIssue().forRule(RuleKey.of(CheckList.REPOSITORY_KEY, ruleKey.rule()));
+          var newIssue = context.newIssue().forRule(RuleKey.of(ruleKey.repository(), ruleKey.rule()));
           var location = newIssue.newLocation()
             .on(inputFile)
             .at(inputFile.selectLine(line))


### PR DESCRIPTION
`CxxSquidSensor.saveViolations` was always using `CheckList.REPOSITORY_KEY` (repository key=cxx) to create new issues. In case a `CustomCxxRulesDefinition` was using a different repository key this was not taken into account.

The fix is related to #2642.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2644)
<!-- Reviewable:end -->
