### PR TITLE
Cppcheck 2.14.0 support

### DIFF
--- a/cxx-sensors/src/main/resources/cppcheck.xml
+++ b/cxx-sensors/src/main/resources/cppcheck.xml
@@ -8056,6 +8056,61 @@ Pointer arithmetic overflow.
     </description>
     <severity>MINOR</severity>
     </rule>
+  <!-- ########### New in Cppcheck 2.14.0 ########### -->
+  <rule>
+    <key>eraseIteratorOutOfBounds</key>
+    <name>Calling function 'erase()' on the iterator 'iter' which is out of bounds</name>
+    <description><![CDATA[
+        <p>
+  Calling function 'erase()' on the iterator 'iter' which is out of
+  bounds.
+  </p>
+  <h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/628.html" target="_blank">CWE-628</a></p>
+        ]]></description>
+    <tag>cwe</tag>
+    <type>BUG</type>
+    <remediationFunction>CONSTANT_ISSUE</remediationFunction>
+    <remediationFunctionBaseEffort>5min</remediationFunctionBaseEffort>
+    </rule>
+  <rule>
+    <key>eraseIteratorOutOfBoundsCond</key>
+    <name>Either the condition 'x' is redundant or function 'erase()' is called on the iterator 'iter' which is out of bounds</name>
+    <description><![CDATA[
+        <p>
+  Either the condition 'x' is redundant or function 'erase()' is called
+  on the iterator 'iter' which is out of bounds.
+  </p>
+  <h2>References</h2>
+  <p><a href="https://cwe.mitre.org/data/definitions/628.html" target="_blank">CWE-628</a></p>
+        ]]></description>
+    <tag>cwe</tag>
+    <severity>MINOR</severity>
+    <type>BUG</type>
+    <remediationFunction>CONSTANT_ISSUE</remediationFunction>
+    <remediationFunctionBaseEffort>5min</remediationFunctionBaseEffort>
+    </rule>
+  <rule>
+    <key>returnByReference</key>
+    <name>Function 'func()' should return member 'var' by const reference</name>
+    <description><![CDATA[
+        Function 'func()' should return member 'var' by const reference.
+        ]]></description>
+    <severity>MINOR</severity>
+    <type>BUG</type>
+    <remediationFunction>CONSTANT_ISSUE</remediationFunction>
+    <remediationFunctionBaseEffort>5min</remediationFunctionBaseEffort>
+    </rule>
+  <rule>
+    <key>uselessOverride</key>
+    <name>The function '' overrides a function in a base class but just delegates back to the base class</name>
+    <description><![CDATA[
+        The function '' overrides a function in a base class but just delegates back to the base class.
+        ]]></description>
+    <severity>MINOR</severity>
+    <remediationFunction>CONSTANT_ISSUE</remediationFunction>
+    <remediationFunctionBaseEffort>5min</remediationFunctionBaseEffort>
+    </rule>  
   <!-- ########### Internal Cppcheck errors (not in errorlist) ########### -->
   <rule>
     <key>internalAstError</key>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/cppcheck/CxxCppCheckRuleRepositoryTest.java
@@ -37,7 +37,7 @@ class CxxCppCheckRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxCppCheckRuleRepository.KEY);
-    assertThat(repo.rules()).hasSize(681);
+    assertThat(repo.rules()).hasSize(685);
   }
 
 }


### PR DESCRIPTION
- https://sourceforge.net/p/cppcheck/news/2024/04/cppcheck-2140/
- new rules:
  - eraseIteratorOutOfBounds
  - eraseIteratorOutOfBoundsCond
  - returnByReference
  - uselessOverride
- close #2668

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2677)
<!-- Reviewable:end -->
