### PR TITLE
Visual Studio 2022 v17.9 warnings support

### DIFF
--- a/cxx-sensors/src/main/resources/compiler-vc.xml
+++ b/cxx-sensors/src/main/resources/compiler-vc.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  C and C++ rules from
+  * last update: VC2022 V17.9
+-->
 <rules>
   <rule>
     <key>CustomRuleTemplate</key>
@@ -94,15 +98,15 @@
   </rule>
   <rule>
     <key>C1257</key>
-    <name>C1257: 'Plugin-name': Initialization Failure</name>
+    <name>C1257: 'plugin-name': Initialization Failure</name>
     <description>
       <![CDATA[
 <p>The Code Analysis tool reports this error when there's an internal error in the plugin, not in the code being analyzed.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c1257?view=msvc-170" target="_blank">C1257</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C1258</key>
     <name>C1258: Failed to save XML Log file 'filename'</name>
@@ -111,9 +115,9 @@
 <p>The Code Analysis tool reports this error when there's an internal error in the plugin, not in the code being analyzed.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c1258?view=msvc-170" target="_blank">C1258</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C1259</key>
     <name>C1259: A fatal error was issued by a plugin</name>
@@ -122,9 +126,9 @@
 <p>The Code Analysis tool reports this error when there's an internal error in the plugin, not in the code being analyzed.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c1259?view=msvc-170" target="_blank">C1259</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C1260</key>
     <name>C1260: The plugins 'plugin-1' and 'plugin-2' share the same id</name>
@@ -139,7 +143,7 @@
   </rule>
   <rule>
     <key>C4001</key>
-    <name>C4001: nonstandard extension 'single line comment' was used</name>
+    <name>C4001: Nonstandard extension 'single line comment' was used</name>
     <description>
       <![CDATA[
 <p>Single-line comments are standard in C++ and standard in C starting with C99.
@@ -151,7 +155,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4002</key>
-    <name>C4002: too many actual parameters for macro 'identifier'</name>
+    <name>C4002: Too many arguments for function-like macro invocation 'identifier'</name>
     <description>
       <![CDATA[
 <p>The number of actual parameters in the macro exceeds the number of formal parameters in the macro definition. The preprocessor collects the extra parameters but ignores them during macro expansion.</p>
@@ -162,7 +166,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4003</key>
-    <name>C4003: not enough actual parameters for macro 'identifier'</name>
+    <name>C4003: Not enough arguments for function-like macro invocation 'identifier'</name>
     <description>
       <![CDATA[
 <p>The number of formal parameters in the macro definition exceeds the number of actual parameters in the macro. Macro expansion substitutes empty text for the missing parameters.</p>
@@ -173,7 +177,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4005</key>
-    <name>C4005: 'identifier' : macro redefinition</name>
+    <name>C4005: 'identifier': macro redefinition</name>
     <description>
       <![CDATA[
 <p>The macro identifier is defined twice. The compiler uses the second macro definition.</p>
@@ -195,10 +199,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4007</key>
-    <name>C4007: 'function' : must be 'attribute'</name>
+    <name>C4007: 'function': must be 'attribute'</name>
     <description>
       <![CDATA[
-<p>A required attribute for a function is not explicitly stated. For example, the function <strong>main</strong> must have the <strong><code>__cdecl</code></strong> attribute. The compiler forces the attribute.</p>
+<p>A required attribute for a function isn't explicitly stated. For example, the function <code>main</code> must have the <code>__cdecl</code> attribute. The compiler forces the attribute.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4007?view=msvc-170" target="_blank">C4007</a></p>]]>
     </description>
@@ -206,7 +210,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4008</key>
-    <name>C4008: 'identifier' : 'attribute' attribute ignored</name>
+    <name>C4008: 'identifier': 'attribute' attribute ignored</name>
     <description>
       <![CDATA[
 <p>The compiler ignored the <strong><code>__fastcall</code></strong>, <strong><code>static</code></strong>, or <strong><code>inline</code></strong> attribute for a function (level 3 warning) or data (level 2 warning).</p>
@@ -239,7 +243,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4015</key>
-    <name>C4015: 'identifier' : type of bit field must be integral</name>
+    <name>C4015: 'identifier': type of bit field must be integral</name>
     <description>
       <![CDATA[
 <p>The bit field is not declared as an integer type. The compiler assumes the base type of the bit field to be unsigned. Bit fields must be declared as unsigned integer types.</p>
@@ -250,7 +254,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4018</key>
-    <name>C4018: 'token' : signed/unsigned mismatch</name>
+    <name>C4018: 'token': signed/unsigned mismatch</name>
     <description>
       <![CDATA[
 <p>Using the <em>token</em> operator to compare <strong><code>signed</code></strong> and <strong><code>unsigned</code></strong> numbers required the compiler to convert the <strong><code>signed</code></strong> value to <strong><code>unsigned</code></strong>.</p>
@@ -261,10 +265,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4019</key>
-    <name>C4019: empty statement at global scope</name>
+    <name>C4019: Empty statement at global scope</name>
     <description>
       <![CDATA[
-<p>A semicolon at global scope is not preceded by a statement.</p>
+<p>A semicolon at global scope isn't preceded by a statement.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4019?view=msvc-170" target="_blank">C4019</a></p>]]>
     </description>
@@ -272,7 +276,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4020</key>
-    <name>C4020: 'function' : too many actual parameters</name>
+    <name>C4020: 'function': too many actual parameters</name>
     <description>
       <![CDATA[
 <p>The number of actual parameters in a function call exceeds the number of formal parameters in the function prototype or definition. The compiler passes the extra actual parameters according to the calling convention of the function.</p>
@@ -283,7 +287,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4022</key>
-    <name>C4022: 'function' : pointer mismatch for actual parameter 'number'</name>
+    <name>C4022: 'function': pointer mismatch for actual parameter 'number'</name>
     <description>
       <![CDATA[
 <p>The pointer type of the actual parameter differs from the pointer type of the corresponding formal parameter. The actual parameter is passed without change.</p>
@@ -294,7 +298,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4023</key>
-    <name>C4023: 'symbol' : based pointer passed to unprototyped function : parameter number</name>
+    <name>C4023: 'symbol': based pointer passed to unprototyped function : parameter number</name>
     <description>
       <![CDATA[
 <p>Passing a based pointer to an unprototyped function causes the pointer to be normalized, with unpredictable results.</p>
@@ -305,7 +309,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4024</key>
-    <name>C4024: 'function' : different types for formal and actual parameter 'number'</name>
+    <name>C4024: 'function': different types for formal and actual parameter 'number'</name>
     <description>
       <![CDATA[
 <p>Corresponding formal and actual parameters have different types. The compiler passes the actual parameter without change. The receiving function converts the parameter type to the type expected.</p>
@@ -316,7 +320,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4025</key>
-    <name>C4025: 'number' : based pointer passed to function with variable arguments: parameter number</name>
+    <name>C4025: 'number': based pointer passed to function with variable arguments: parameter number</name>
     <description>
       <![CDATA[
 <p>Passing a based pointer to a function with variable arguments causes the pointer to be normalized, with unpredictable results. Do not pass based pointers to functions with variable arguments.</p>
@@ -327,7 +331,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4026</key>
-    <name>C4026: function declared with formal parameter list</name>
+    <name>C4026: Function declared with formal parameter list</name>
     <description>
       <![CDATA[
 <p>The function declaration has formal parameters, but the function definition does not. Subsequent calls to this function assume that the function takes no parameters.</p>
@@ -338,7 +342,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4027</key>
-    <name>C4027: function declared without formal parameter list</name>
+    <name>C4027: Function declared without formal parameter list</name>
     <description>
       <![CDATA[
 <p>The function declaration had no formal parameters, but there are formal parameters in the function definition or actual parameters in a call.</p>
@@ -349,7 +353,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4028</key>
-    <name>C4028: formal parameter 'number' different from declaration</name>
+    <name>C4028: Formal parameter 'number' different from declaration</name>
     <description>
       <![CDATA[
 <p>The type of the formal parameter does not agree with the corresponding parameter in the declaration. The type in the original declaration is used.</p>
@@ -360,7 +364,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4029</key>
-    <name>C4029: declared formal parameter list different from definition</name>
+    <name>C4029: Declared formal parameter list different from definition</name>
     <description>
       <![CDATA[
 <p>Formal parameter types in the function declaration do not agree with those in the function definition. The compiler uses the parameter list from the definition.</p>
@@ -371,7 +375,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4030</key>
-    <name>C4030: first formal parameter list longer than the second list</name>
+    <name>C4030: First formal parameter list longer than the second list</name>
     <description>
       <![CDATA[
 <p>A function was redeclared with different formal parameters. The compiler uses the formal parameters given in the first declaration.</p>
@@ -382,7 +386,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4031</key>
-    <name>C4031: second formal parameter list longer than the first list</name>
+    <name>C4031: Second formal parameter list longer than the first list</name>
     <description>
       <![CDATA[
 <p>A function is redeclared with different formal parameters. The compiler uses the formal parameters given in the first declaration.</p>
@@ -393,7 +397,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4032</key>
-    <name>C4032: formal parameter 'number' has different type when promoted</name>
+    <name>C4032: Formal parameter 'number' has different type when promoted</name>
     <description>
       <![CDATA[
 <p>The parameter type is not compatible, through default promotions, with the type in a previous declaration.</p>
@@ -426,7 +430,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4036</key>
-    <name>C4036: unnamed 'type' as actual parameter</name>
+    <name>C4036: Unnamed 'type' as actual parameter</name>
     <description>
       <![CDATA[
 <p>No type name is given for a structure, union, enumeration, or class used as an actual parameter. If you are using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/zg-generate-function-prototypes?view=msvc-170">/Zg</a> to generate function prototypes, the compiler issues this warning and comments out the formal parameter in the generated prototype.</p>
@@ -437,7 +441,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4038</key>
-    <name>C4038: 'modifier' : illegal ambient class modifier</name>
+    <name>C4038: 'modifier': illegal ambient class modifier</name>
     <description>
       <![CDATA[
 <p>This modifier cannot be used for classes with <strong><code>dllimport</code></strong> or <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=msvc-170">dllexport</a> attributes.</p>
@@ -448,7 +452,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4041</key>
-    <name>C4041: compiler limit : terminating browser output</name>
+    <name>C4041: Compiler limit: terminating browser output</name>
     <description>
       <![CDATA[
 <p>Browser information exceeded the compiler limit.</p>
@@ -459,7 +463,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4042</key>
-    <name>C4042: 'identifier' : has bad storage class</name>
+    <name>C4042: 'identifier': has bad storage class</name>
     <description>
       <![CDATA[
 <p>The specified storage class cannot be used with this identifier in this context. The compiler uses the default storage class instead.</p>
@@ -470,7 +474,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4045</key>
-    <name>C4045: 'array' : array bounds overflow</name>
+    <name>C4045: 'array': array bounds overflow</name>
     <description>
       <![CDATA[
 <p>The array has too many initializers. Extra initializers are ignored.</p>
@@ -481,7 +485,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4047</key>
-    <name>C4047: 'operator' : 'identifier1' differs in levels of indirection from 'identifier2'</name>
+    <name>C4047: 'operator': 'identifier1' differs in levels of indirection from 'identifier2'</name>
     <description>
       <![CDATA[
 <p>A pointer can point to a variable (one level of indirection), to another pointer that points to a variable (two levels of indirection), and so on.</p>
@@ -492,7 +496,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4048</key>
-    <name>C4048: different declared array subscripts : 'identifier1' and 'identifier2'</name>
+    <name>C4048: Different declared array subscripts: 'identifier1' and 'identifier2'</name>
     <description>
       <![CDATA[
 <p>An expression involves pointers to arrays of different size. The pointers are used without conversion.</p>
@@ -503,7 +507,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4049</key>
-    <name>C4049: compiler limit : terminating line number emission</name>
+    <name>C4049: Compiler limit: terminating line number emission</name>
     <description>
       <![CDATA[
 <p>The file contains more than 16,777,215 (2<sup>24</sup>-1) source lines. The compiler stops numbering at 16,777,215.</p>
@@ -514,7 +518,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4051</key>
-    <name>C4051: type conversion; possible loss of data</name>
+    <name>C4051: Type conversion; possible loss of data</name>
     <description>
       <![CDATA[
 <p>An expression contains two data items with different base types. Converting one type causes the data item to be truncated.</p>
@@ -525,10 +529,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4052</key>
-    <name>C4052: function declarations different; one contains variable arguments</name>
+    <name>C4052: Function declarations different; one contains variable arguments</name>
     <description>
       <![CDATA[
-<p>One declaration of the function does not contain variable arguments. It is ignored.</p>
+<p>One declaration of the function doesn't contain variable arguments. The empty declaration is ignored.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4052?view=msvc-170" target="_blank">C4052</a></p>]]>
     </description>
@@ -536,7 +540,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4053</key>
-    <name>C4053: one void operand for '?:'</name>
+    <name>C4053: One void operand for '?:'</name>
     <description>
       <![CDATA[
 <p>The <code>?:</code> operator is given an expression of type <strong><code>void</code></strong>. The value of the <strong><code>void</code></strong> operand is undefined.</p>
@@ -547,7 +551,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4055</key>
-    <name>C4055: 'conversion' : from data pointer 'type1' to function pointer 'type2'</name>
+    <name>C4055: 'conversion': from data pointer 'type1' to function pointer 'type2'</name>
     <description>
       <![CDATA[
 <p><strong>Obsolete:</strong> This warning is not generated by Visual Studio 2017 and later versions.</p>
@@ -558,7 +562,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4056</key>
-    <name>C4056: overflow in floating point constant arithmetic</name>
+    <name>C4056: Overflow in floating point constant arithmetic</name>
     <description>
       <![CDATA[
 <p>Floating-point constant arithmetic generates a result that exceeds the maximum allowable value.</p>
@@ -569,7 +573,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4057</key>
-    <name>C4057: 'operator' : 'identifier1' indirection to slightly different base types from 'identifier2'</name>
+    <name>C4057: 'operator': 'identifier1' indirection to slightly different base types from 'identifier2'</name>
     <description>
       <![CDATA[
 <p>Two pointer expressions refer to different base types. The expressions are used without conversion.</p>
@@ -580,10 +584,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4061</key>
-    <name>C4061: enumerator 'identifier' in switch of enum 'enumeration' is not explicitly handled by a case label</name>
+    <name>C4061: Enumerator 'identifier' in switch of enum 'enumeration' is not explicitly handled by a case label</name>
     <description>
       <![CDATA[
-<p>The specified enumerator <em>identifier</em> has no associated handler in a <strong><code>switch</code></strong> statement that has a <strong><code>default</code></strong> case. The missing case might be an oversight, or it may not be an issue. It may depend on whether the enumerator is handled by the default case or not. For a related warning on unused enumerators in <strong><code>switch</code></strong> statements that have no <strong><code>default</code></strong> case, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4062?view=msvc-170">C4062</a>.</p>
+<p>The specified enumerator <em>identifier</em> has no associated handler in a <code>switch</code> statement that has a <code>default</code> case. The missing case might be an oversight, or it may not be an issue. Whether the missing <code>case</code> is an issue in practice depends on if the default case handles the enumerator. For a related warning on unused enumerators in <code>switch</code> statements that have no <code>default</code> case, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4062?view=msvc-170">C4062</a>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4061?view=msvc-170" target="_blank">C4061</a></p>]]>
     </description>
@@ -591,10 +595,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4062</key>
-    <name>C4062: enumerator 'identifier' in switch of enum 'enumeration' is not handled</name>
+    <name>C4062: Enumerator 'identifier' in switch of enum 'enumeration' is not handled</name>
     <description>
       <![CDATA[
-<p>The enumerator <em>identifier</em> has no associated <code>case</code> handler in a <strong><code>switch</code></strong> statement, and there's no <strong><code>default</code></strong> label that can catch it. The missing case may be an oversight, and is a potential error in your code. For a related warning on unused enumerators in <strong><code>switch</code></strong> statements that have a <strong><code>default</code></strong> case, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4061?view=msvc-170">C4061</a>.</p>
+<p>The enumerator <em>identifier</em> doesn't have a <code>case</code> handler associated with it in a <strong><code>switch</code></strong> statement, and there's no <strong><code>default</code></strong> label that can catch it. The missing case may be an oversight, and is a potential error in your code. For a related warning on unused enumerators in <strong><code>switch</code></strong> statements that have a <strong><code>default</code></strong> case, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4061?view=msvc-170">C4061</a>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4062?view=msvc-170" target="_blank">C4062</a></p>]]>
     </description>
@@ -602,7 +606,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4066</key>
-    <name>C4066: characters beyond first in wide-character constant ignored</name>
+    <name>C4066: Characters beyond first in wide-character constant ignored</name>
     <description>
       <![CDATA[
 <p>The compiler processes only the first character of a wide-character constant.</p>
@@ -613,7 +617,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4067</key>
-    <name>C4067: unexpected tokens following preprocessor directive - expected a newline</name>
+    <name>C4067: Unexpected tokens following preprocessor directive - expected a newline</name>
     <description>
       <![CDATA[
 <p>The compiler found and ignored extra characters following a preprocessor directive. This can be caused by any unexpected characters, though a common cause is a stray semicolon after the directive. Comments do not cause this warning. The <strong>/Za</strong> compiler option enables this warning for more preprocessor directives than the default setting.</p>
@@ -624,7 +628,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4068</key>
-    <name>C4068: unknown pragma</name>
+    <name>C4068: Unknown pragma</name>
     <description>
       <![CDATA[
 <p>The compiler ignored an unrecognized <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/pragma-directives-and-the-pragma-keyword?view=msvc-170">pragma</a>. Be sure the <strong>pragma</strong> is allowed by the compiler you are using.</p>
@@ -635,7 +639,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4073</key>
-    <name>C4073: initializers put in library initialization area</name>
+    <name>C4073: Initializers put in library initialization area</name>
     <description>
       <![CDATA[
 <p>Only third-party library developers should use the library initialization area, which is specified by <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/init-seg?view=msvc-170">#pragma init_seg</a>.</p>
@@ -646,7 +650,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4074</key>
-    <name>C4074: initializers put in compiler reserved initialization area</name>
+    <name>C4074: Initializers put in compiler reserved initialization area</name>
     <description>
       <![CDATA[
 <p>The compiler initialization area, which is specified by <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/init-seg?view=msvc-170">#pragma init_seg</a>, is reserved by Microsoft. Code in this area may be executed before initialization of the C run-time library.</p>
@@ -657,7 +661,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4075</key>
-    <name>C4075: initializers put in unrecognized initialization area</name>
+    <name>C4075: Initializers put in unrecognized initialization area</name>
     <description>
       <![CDATA[
 <p>A <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/init-seg?view=msvc-170">#pragma init_seg</a> uses an unrecognized section name. The compiler ignores the <strong>pragma</strong> command.</p>
@@ -668,7 +672,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4076</key>
-    <name>C4076: 'type modifier' : can not be used with type 'typename'</name>
+    <name>C4076: 'type modifier': can not be used with type 'typename'</name>
     <description>
       <![CDATA[
 <p>A type modifier, whether it is <strong><code>signed</code></strong> or <strong><code>unsigned</code></strong>, cannot be used with a non-integer type. <em>type modifier</em> is ignored.</p>
@@ -679,7 +683,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4077</key>
-    <name>C4077: unknown check_stack option</name>
+    <name>C4077: Unknown check_stack option</name>
     <description>
       <![CDATA[
 <p>The old form of the <strong>check_stack</strong> pragma is used with an unknown argument. The argument must be <code>+</code>, <code>-</code>, <code>(on)</code>, <code>(off)</code>, or empty.</p>
@@ -690,7 +694,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4079</key>
-    <name>C4079: unexpected token 'token'</name>
+    <name>C4079: Unexpected token 'token'</name>
     <description>
       <![CDATA[
 <p>An unexpected separator token occurs in a pragma argument list. The remainder of the pragma was ignored.</p>
@@ -701,7 +705,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4080</key>
-    <name>C4080: expected identifier for segment name; found 'symbol'</name>
+    <name>C4080: Expected identifier for segment name; found 'symbol'</name>
     <description>
       <![CDATA[
 <p>The name of the segment in <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/alloc-text?view=msvc-170">#pragma alloc_text</a> must be a string or an identifier. The compiler ignores the pragma if a valid identifier is not found.</p>
@@ -712,7 +716,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4081</key>
-    <name>C4081: expected 'token1'; found 'token2'</name>
+    <name>C4081: Expected 'token1'; found 'token2'</name>
     <description>
       <![CDATA[
 <p>The compiler expected a different token in this context.</p>
@@ -723,7 +727,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4083</key>
-    <name>C4083: expected 'token'; found identifier 'identifier'</name>
+    <name>C4083: Expected 'token'; found identifier 'identifier'</name>
     <description>
       <![CDATA[
 <p>An identifier occurs in the wrong place in a <strong>#pragma</strong> statement.</p>
@@ -734,7 +738,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4085</key>
-    <name>C4085: expected pragma parameter to be 'on' or 'off'</name>
+    <name>C4085: Expected pragma parameter to be 'on' or 'off'</name>
     <description>
       <![CDATA[
 <p>The pragma requires an <strong>on</strong> or <strong>off</strong> parameter. The pragma is ignored.</p>
@@ -745,7 +749,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4086</key>
-    <name>C4086: expected pragma parameter to be '1', '2', '4', '8', or '16'</name>
+    <name>C4086: Expected pragma parameter to be '1', '2', '4', '8', or '16'</name>
     <description>
       <![CDATA[
 <p>The pragma parameter does not have the required value (1, 2, 4, 8, or 16).</p>
@@ -756,7 +760,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4087</key>
-    <name>C4087: 'function' : declared with 'void' parameter list</name>
+    <name>C4087: 'function': declared with 'void' parameter list</name>
     <description>
       <![CDATA[
 <p>The function declaration has no formal parameters, but the function call has actual parameters. Extra parameters are passed according to the calling convention of the function.</p>
@@ -767,7 +771,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4088</key>
-    <name>C4088: 'function' : pointer mismatch in actual parameter 'number', formal parameter 'number'</name>
+    <name>C4088: 'function': pointer mismatch in actual parameter 'number', formal parameter 'number'</name>
     <description>
       <![CDATA[
 <p>The corresponding formal and actual parameters have a different level of indirection. The actual parameter is passed without change. The called function interprets its value as a pointer.</p>
@@ -778,7 +782,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4089</key>
-    <name>C4089: 'function' : different types in actual parameter 'number', formal parameter 'number'</name>
+    <name>C4089: 'function': different types in actual parameter 'number', formal parameter 'number'</name>
     <description>
       <![CDATA[
 <p>The corresponding formal and actual parameters have different types. The actual parameter is passed without change. The function casts the actual parameter to the type specified in the function definition.</p>
@@ -789,7 +793,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4090</key>
-    <name>C4090: 'operation' : different 'modifier' qualifiers</name>
+    <name>C4090: 'operation': different 'modifier' qualifiers</name>
     <description>
       <![CDATA[
 <p>A variable used in an operation is defined with a specified modifier that prevents it from being modified without detection by the compiler. The expression is compiled without modification.</p>
@@ -800,10 +804,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4091</key>
-    <name>C4091: 'keyword' : ignored on left of 'type' when no variable is declared</name>
+    <name>C4091: 'keyword': ignored on left of 'type' when no variable is declared</name>
     <description>
       <![CDATA[
-<p>The compiler detected a situation where the user probably intended a variable to be declared, but the compiler was not able to declare the variable.</p>
+<p>The compiler detected a situation where the user probably intended a variable to be declared, but the compiler wasn't able to declare the variable.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4091?view=msvc-170" target="_blank">C4091</a></p>]]>
     </description>
@@ -822,7 +826,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4094</key>
-    <name>C4094: untagged 'token' declared no symbols</name>
+    <name>C4094: Untagged 'token' declared no symbols</name>
     <description>
       <![CDATA[
 <p>The compiler detected an empty declaration using an untagged structure, union, or class. The declaration is ignored.</p>
@@ -844,7 +848,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4097</key>
-    <name>C4097: expected pragma parameter to be 'restore' or 'off'</name>
+    <name>C4097: Expected pragma parameter to be 'restore' or 'off'</name>
     <description>
       <![CDATA[
 <p>A pragma was passed an invalid value.</p>
@@ -855,7 +859,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4098</key>
-    <name>C4098: 'function' : void function returning a value</name>
+    <name>C4098: 'function': void function returning a value</name>
     <description>
       <![CDATA[
 <p>A function declared with return type <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/void-cpp?view=msvc-170">void</a> has a <strong><code>return</code></strong> statement that returns a value. The compiler assumes the function returns a value of type <strong><code>int</code></strong>.</p>
@@ -866,7 +870,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4099</key>
-    <name>C4099: 'identifier' : type name first seen using 'objecttype1' now seen using 'objecttype2'</name>
+    <name>C4099: 'identifier': type name first seen using 'objecttype1' now seen using 'objecttype2'</name>
     <description>
       <![CDATA[
 <p>An object declared as a structure is defined as a class, or an object declared as a class is defined as a structure. The compiler uses the type given in the definition.</p>
@@ -877,7 +881,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4100</key>
-    <name>C4100: 'identifier' : unreferenced formal parameter</name>
+    <name>C4100: 'identifier': unreferenced formal parameter</name>
     <description>
       <![CDATA[
 <p>The formal parameter is not referenced in the body of the function. The unreferenced parameter is ignored.</p>
@@ -888,7 +892,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4101</key>
-    <name>C4101: 'identifier' : unreferenced local variable</name>
+    <name>C4101: 'identifier': unreferenced local variable</name>
     <description>
       <![CDATA[
 <p>The local variable is never used.</p>
@@ -899,7 +903,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4102</key>
-    <name>C4102: 'label' : unreferenced label</name>
+    <name>C4102: 'label': unreferenced label</name>
     <description>
       <![CDATA[
 <p>The label is defined but never referenced. The compiler ignores the label.</p>
@@ -910,7 +914,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4103</key>
-    <name>C4103: 'filename' : alignment changed after including header, may be due to missing #pragma pack(pop)</name>
+    <name>C4103: 'filename': alignment changed after including header, may be due to missing #pragma pack(pop)</name>
     <description>
       <![CDATA[
 <p>Packing affects the layout of classes, and commonly, if packing changes across header files, there can be problems.</p>
@@ -921,7 +925,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4109</key>
-    <name>C4109: unexpected identifier 'identifier'</name>
+    <name>C4109: Unexpected identifier 'identifier'</name>
     <description>
       <![CDATA[
 <p>The pragma containing the unexpected identifier is ignored.</p>
@@ -932,7 +936,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4112</key>
-    <name>C4112: #line requires an integer between 1 and number</name>
+    <name>C4112: #line requires an integer between 1 and 'line_count'</name>
     <description>
       <![CDATA[
 <p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-line-directive-c-cpp?view=msvc-170">#line</a> directive specifies an integer parameter that is outside the allowable range.</p>
@@ -954,7 +958,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4114</key>
-    <name>C4114: same type qualifier used more than once</name>
+    <name>C4114: Same type qualifier used more than once</name>
     <description>
       <![CDATA[
 <p>A type declaration or definition uses a type qualifier (<strong><code>const</code></strong>, <strong><code>volatile</code></strong>, <strong><code>signed</code></strong>, or <strong><code>unsigned</code></strong>) more than once. This causes a warning with Microsoft extensions (/Ze) and an error under ANSI compatibility (/Za).</p>
@@ -965,7 +969,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4115</key>
-    <name>C4115: 'type' : named type definition in parentheses</name>
+    <name>C4115: 'type': named type definition in parentheses</name>
     <description>
       <![CDATA[
 <p>The given symbol is used to define a structure, union, or enumerated type inside a parenthetical expression. The scope of the definition may be unexpected.</p>
@@ -976,7 +980,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4116</key>
-    <name>C4116: unnamed type definition in parentheses</name>
+    <name>C4116: Unnamed type definition in parentheses</name>
     <description>
       <![CDATA[
 <p>A structure, union, or enumerated type with no name is defined in a parenthetical expression. The type definition is meaningless.</p>
@@ -987,7 +991,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4117</key>
-    <name>C4117: macro name 'name' is reserved; 'Command' ignored</name>
+    <name>C4117: Macro name 'name' is reserved; 'Command' ignored</name>
     <description>
       <![CDATA[
 <p>macro name 'name' is reserved; 'Command' ignored.</p>
@@ -998,7 +1002,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4119</key>
-    <name>C4119: different bases 'base1' and 'base2' specified</name>
+    <name>C4119: Different bases 'base1' and 'base2' specified</name>
     <description>
       <![CDATA[
 <p>Two based pointers are incompatible because they have different bases. The compiler cannot convert between them.</p>
@@ -1009,7 +1013,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4120</key>
-    <name>C4120: based/unbased mismatch</name>
+    <name>C4120: Based/unbased mismatch</name>
     <description>
       <![CDATA[
 <p>The compiler cannot convert between the two pointers because one is based and the other is not.</p>
@@ -1020,7 +1024,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4121</key>
-    <name>C4121: 'symbol' : alignment of a member was sensitive to packing</name>
+    <name>C4121: 'symbol': alignment of a member was sensitive to packing</name>
     <description>
       <![CDATA[
 <p>The compiler added padding to align a structure member on the packing boundary but the packing value is less than the member's size.</p>
@@ -1031,7 +1035,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4122</key>
-    <name>C4122: 'function' : alloc_text applicable only to functions with C linkage</name>
+    <name>C4122: 'function': alloc_text applicable only to functions with C linkage</name>
     <description>
       <![CDATA[
 <p>The <strong>alloc_text</strong> pragma applies only to functions declared with <strong>extern c</strong>. It cannot be used with external C++ functions.</p>
@@ -1053,7 +1057,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4125</key>
-    <name>C4125: decimal digit terminates octal escape sequence</name>
+    <name>C4125: Decimal digit terminates octal escape sequence</name>
     <description>
       <![CDATA[
 <p>The compiler evaluates the octal number without the decimal digit and assumes the decimal digit is a character.</p>
@@ -1064,7 +1068,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4127</key>
-    <name>C4127: conditional expression is constant</name>
+    <name>C4127: Conditional expression is constant</name>
     <description>
       <![CDATA[
 <p>The controlling expression of an <strong><code>if</code></strong> statement or <strong><code>while</code></strong> loop evaluates to a constant. Because of their common idiomatic usage, beginning in Visual Studio 2015 update 3, trivial constants such as 1 or <strong><code>true</code></strong> do not trigger the warning, unless they are the result of an operation in an expression.</p>
@@ -1075,7 +1079,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4129</key>
-    <name>C4129: 'character' : unrecognized character escape sequence</name>
+    <name>C4129: 'character': unrecognized character escape sequence</name>
     <description>
       <![CDATA[
 <p>The <code>character</code> following a backslash (\) in a character or string constant is not recognized as a valid escape sequence. The backslash is ignored and not printed. The character following the backslash is printed.</p>
@@ -1086,7 +1090,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4130</key>
-    <name>C4130: 'operator' : logical operation on address of string constant</name>
+    <name>C4130: 'operator': logical operation on address of string constant</name>
     <description>
       <![CDATA[
 <p>Using the operator with the address of a string literal produces unexpected code.</p>
@@ -1097,7 +1101,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4131</key>
-    <name>C4131: 'function' : uses old-style declarator</name>
+    <name>C4131: 'function': uses old-style declarator</name>
     <description>
       <![CDATA[
 <p>The specified function declaration is not in prototype form.</p>
@@ -1108,7 +1112,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4132</key>
-    <name>C4132: 'object' : const object should be initialized</name>
+    <name>C4132: 'object': const object should be initialized</name>
     <description>
       <![CDATA[
 <p>The constant is not initialized. The value of a symbol with the <strong><code>const</code></strong> attribute cannot be changed after its definition, it should be given an initialization value.</p>
@@ -1119,10 +1123,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4133</key>
-    <name>C4133: 'type' : incompatible types - from 'type1' to 'type2'</name>
+    <name>C4133: 'expression': incompatible types - from 'type1' to 'type2'</name>
     <description>
       <![CDATA[
-<p>This warning can be caused by trying to subtract two pointers of different types.</p>
+<p>This warning is emitted when incompatible types are used in an expression. For example, doing arithmetic operations such as subtraction with different pointer types.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4133?view=msvc-170" target="_blank">C4133</a></p>]]>
     </description>
@@ -1141,10 +1145,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4141</key>
-    <name>C4141: 'modifier' : used more than once</name>
+    <name>C4141: 'modifier': used more than once</name>
     <description>
       <![CDATA[
-<p>'modifier' : used more than once.</p>
+<p>'modifier': used more than once.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4141?view=msvc-170" target="_blank">C4141</a></p>]]>
     </description>
@@ -1152,7 +1156,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4142</key>
-    <name>C4142: benign redefinition of type</name>
+    <name>C4142: Benign redefinition of type</name>
     <description>
       <![CDATA[
 <p>A type is redefined in a manner that has no effect on the generated code.</p>
@@ -1163,7 +1167,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4143</key>
-    <name>C4143: pragma 'same_seg' not supported</name>
+    <name>C4143: Pragma 'same_seg' not supported</name>
     <description>
       <![CDATA[
 <p>The <strong>#pragma same_seg</strong> is no longer supported. Use the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/based-pointers-cpp?view=msvc-170">__based</a> keyword instead.</p>
@@ -1174,7 +1178,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4144</key>
-    <name>C4144: 'expression' : relational expression as switch expression</name>
+    <name>C4144: 'expression': relational expression as switch expression</name>
     <description>
       <![CDATA[
 <p>The specified relational expression was used as the control expression of a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/switch-statement-cpp?view=msvc-170">switch</a> statement. The associated case statements will be offered Boolean values.</p>
@@ -1185,7 +1189,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4145</key>
-    <name>C4145: 'expression1' : relational expression as switch expression; possible confusion with 'expression2'</name>
+    <name>C4145: 'expression1': relational expression as switch expression; possible confusion with 'expression2'</name>
     <description>
       <![CDATA[
 <p>A <strong><code>switch</code></strong> statement uses a relational expression as its control expression, which results in a Boolean value for the <strong><code>case</code></strong> statements. Did you mean <em>expression2</em>?</p>
@@ -1196,7 +1200,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4146</key>
-    <name>C4146: unary minus operator applied to unsigned type, result still unsigned</name>
+    <name>C4146: Unary minus operator applied to unsigned type, result still unsigned</name>
     <description>
       <![CDATA[
 <p>Unsigned types can hold only non-negative values, so unary minus (negation) usually doesn't make sense when applied to an unsigned type. Both the operand and the result are non-negative.</p>
@@ -1207,10 +1211,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4150</key>
-    <name>C4150: deletion of pointer to incomplete type 'type'; no destructor called</name>
+    <name>C4150: Deletion of pointer to incomplete type 'type'; no destructor called</name>
     <description>
       <![CDATA[
-<p>The <strong><code>delete</code></strong> operator is called to delete a type that was declared but not defined, so the compiler cannot find a destructor.</p>
+<p>The <code>delete</code> operator is called to delete a type that was declared but not defined. The compiler can't find the destructor to call because the definition isn't in the same translation unit as the <code>delete</code>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4150?view=msvc-170" target="_blank">C4150</a></p>]]>
     </description>
@@ -1218,7 +1222,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4152</key>
-    <name>C4152: non standard extension, function/data ptr conversion in expression</name>
+    <name>C4152: Non standard extension, function/data ptr conversion in expression</name>
     <description>
       <![CDATA[
 <p>A function pointer is converted to or from a data pointer. This conversion is allowed under Microsoft extensions (/Ze) but not under ANSI C.</p>
@@ -1229,7 +1233,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4153</key>
-    <name>C4153: function/data pointer conversion in expression</name>
+    <name>C4153: Function/data pointer conversion in expression</name>
     <description>
       <![CDATA[
 <p>A function pointer is converted to or from a data pointer. This conversion is allowed under Microsoft extensions (/Ze) but not under ANSI C.</p>
@@ -1240,7 +1244,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4154</key>
-    <name>C4154: deletion of an array expression; conversion to pointer supplied</name>
+    <name>C4154: Deletion of an array expression; conversion to pointer supplied</name>
     <description>
       <![CDATA[
 <p>You cannot use <strong><code>delete</code></strong> on an array, so the compiler converts the array to a pointer.</p>
@@ -1251,7 +1255,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4155</key>
-    <name>C4155: deletion of an array expression without using the array form of 'delete'</name>
+    <name>C4155: Deletion of an array expression without using the array form of 'delete'</name>
     <description>
       <![CDATA[
 <p>The array form of <strong><code>delete</code></strong> should be used to delete an array. This warning occurs only under ANSI-compatibility (/Za).</p>
@@ -1262,7 +1266,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4156</key>
-    <name>C4156: deletion of an array expression without using the array form of 'delete'; array form substituted</name>
+    <name>C4156: Deletion of an array expression without using the array form of 'delete'; array form substituted</name>
     <description>
       <![CDATA[
 <p>The non-array form of <strong><code>delete</code></strong> cannot delete an array. The compiler translated <strong><code>delete</code></strong> to the array form.</p>
@@ -1273,7 +1277,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4157</key>
-    <name>C4157: pragma was ignored by C compiler</name>
+    <name>C4157: Pragma was ignored by C compiler</name>
     <description>
       <![CDATA[
 <p>Only the C++ compiler recognizes <strong>init_seg()</strong>.</p>
@@ -1284,7 +1288,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4158</key>
-    <name>C4158: assuming #pragma pointers_to_members(full_generality, inheritance)</name>
+    <name>C4158: Assuming #pragma pointers_to_members(full_generality, inheritance)</name>
     <description>
       <![CDATA[
 <p>A <code>#pragma pointers_to_members( single | multiple | virtual )</code> was issued without an accompanying <code>#pragma pointers_to_members(full_generality)</code>.</p>
@@ -1295,7 +1299,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4159</key>
-    <name>C4159: #pragma pragma(pop,...) : has popped previously pushed identifier 'identifier'</name>
+    <name>C4159: #pragma pragma(pop,...): has popped previously pushed identifier 'identifier'</name>
     <description>
       <![CDATA[
 <p>Your source code contains a <strong>push</strong> instruction with an identifier for a pragma followed by a <strong>pop</strong> instruction without an identifier. As a result, <em>identifier</em> is popped, and subsequent uses of <em>identifier</em> may cause unexpected behavior.</p>
@@ -1306,7 +1310,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4160</key>
-    <name>C4160: #pragma (pop,...) : did not find previously pushed identifier 'identifier'</name>
+    <name>C4160: #pragma (pop,...): did not find previously pushed identifier 'identifier'</name>
     <description>
       <![CDATA[
 <p>A pragma statement in your source code tries to pop an identifier that has not been pushed. To avoid this warning, be sure that the identifier being popped has been properly pushed.</p>
@@ -1317,7 +1321,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4161</key>
-    <name>C4161: #pragma pragma(pop...) : more pops than pushes</name>
+    <name>C4161: #pragma pragma(pop...): more pops than pushes</name>
     <description>
       <![CDATA[
 <p>Because your source code contains one more pop than pushes for pragma <em>pragma</em>, the stack may not behave as you expect. To avoid the warning, be sure that the number of pops does not exceed the number of pushes.</p>
@@ -1328,7 +1332,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4162</key>
-    <name>C4162: 'identifier' : no function with C linkage found</name>
+    <name>C4162: 'identifier': no function with C linkage found</name>
     <description>
       <![CDATA[
 <p>A function with C linkage is declared but cannot be found.</p>
@@ -1339,7 +1343,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4163</key>
-    <name>C4163: 'identifier' : not available as an intrinsic function</name>
+    <name>C4163: 'identifier': not available as an intrinsic function</name>
     <description>
       <![CDATA[
 <p>The specified function cannot be used as an <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/intrinsic?view=msvc-170">intrinsic</a> function. The compiler ignores the invalid function name.</p>
@@ -1350,7 +1354,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4164</key>
-    <name>C4164: 'identifier' : intrinsic function not declared</name>
+    <name>C4164: 'identifier': intrinsic function not declared</name>
     <description>
       <![CDATA[
 <p>The specified intrinsic function is not declared; you may need to #include the appropriate header file.</p>
@@ -1364,7 +1368,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4165: 'HRESULT' is being converted to 'bool'</name>
     <description>
       <![CDATA[
-<p>When using an HRESULT in an <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/if-else-statement-cpp?view=msvc-170">if</a> statement, the HRESULT will be converted to a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/bool-cpp?view=msvc-170">bool</a> unless you explicitly test for the variable as an HRESULT. This warning is off by default.</p>
+<p>When an <code>HRESULT</code> is used in an <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/if-else-statement-cpp?view=msvc-170"><code>if</code></a> statement, the <code>HRESULT</code> is converted to a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/bool-cpp?view=msvc-170"><code>bool</code></a> unless you explicitly test for the variable as an <code>HRESULT</code>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4165?view=msvc-170" target="_blank">C4165</a></p>]]>
     </description>
@@ -1372,7 +1376,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4166</key>
-    <name>C4166: illegal calling convention for constructor/destructor</name>
+    <name>C4166: Illegal calling convention for constructor/destructor</name>
     <description>
       <![CDATA[
 <p>Constructors and destructors cannot have calling conventions other than the default for the platform (except when you explicitly specify <strong>__clrcall</strong>).</p>
@@ -1383,7 +1387,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4167</key>
-    <name>C4167: function : only available as an intrinsic function</name>
+    <name>C4167: 'function': only available as an intrinsic function</name>
     <description>
       <![CDATA[
 <p>The <strong>#pragma function</strong> tries to force the compiler to use a conventional call to a function that must be used in intrinsic form. The pragma is ignored.</p>
@@ -1394,7 +1398,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4168</key>
-    <name>C4168: compiler limit : out of debugger types, delete program database 'database' and rebuild</name>
+    <name>C4168: Compiler limit: out of debugger types, delete program database 'database' and rebuild</name>
     <description>
       <![CDATA[
 <p>The program database file must be rebuilt to accommodate all types in the program.</p>
@@ -1405,7 +1409,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4172</key>
-    <name>C4172: returning address of local variable or temporary</name>
+    <name>C4172: Returning address of local variable or temporary</name>
     <description>
       <![CDATA[
 <p>A function returns the address of a local variable or temporary object. Local variables and temporary objects are destroyed when a function returns, so the address returned is not valid.</p>
@@ -1416,10 +1420,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4174</key>
-    <name>C4174: 'name' : not available as a #pragma component</name>
+    <name>C4174: 'name': not available as a #pragma component</name>
     <description>
       <![CDATA[
-<p>'name' : not available as a #pragma component.</p>
+<p>'name': not available as a #pragma component.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4174?view=msvc-170" target="_blank">C4174</a></p>]]>
     </description>
@@ -1427,7 +1431,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4175</key>
-    <name>C4175: #pragma component(browser, on) : browser info must initially be specified on the command line</name>
+    <name>C4175: #pragma component(browser, on): browser info must initially be specified on the command line</name>
     <description>
       <![CDATA[
 <p>To use <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/component?view=msvc-170">component</a> pragma, you must generate browse information during compilation (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/fr-fr-create-dot-sbr-file?view=msvc-170">/FR</a>).</p>
@@ -1438,7 +1442,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4176</key>
-    <name>C4176: 'subcomponent' : unknown subcomponent for #pragma component browser</name>
+    <name>C4176: 'subcomponent': unknown subcomponent for #pragma component browser</name>
     <description>
       <![CDATA[
 <p>The <strong>component</strong> pragma contains an invalid subcomponent. To exclude references to a particular name, you must use the <strong>references</strong> option before the name.</p>
@@ -1460,7 +1464,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4178</key>
-    <name>C4178: case constant 'constant' too big for the type of the switch expression</name>
+    <name>C4178: Case constant 'constant' too big for the type of the switch expression</name>
     <description>
       <![CDATA[
 <p>A case constant in a <strong><code>switch</code></strong> expression does not fit in the type to which it is assigned.</p>
@@ -1471,7 +1475,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4179</key>
-    <name>C4179: '//*' : parsed as '/' and '/*': confusion with standard '//' comments</name>
+    <name>C4179: '//*': parsed as '/' and '/*': confusion with standard '//' comments</name>
     <description>
       <![CDATA[
 <p>In standard C89, <strong><code>//*</code></strong> is an incorrect comment delimiter. Use <strong><code>/*</code></strong> under <strong><code>/Za</code></strong> instead.</p>
@@ -1482,7 +1486,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4180</key>
-    <name>C4180: qualifier applied to function type has no meaning; ignored</name>
+    <name>C4180: Qualifier applied to function type has no meaning; ignored</name>
     <description>
       <![CDATA[
 <p>A qualifier, such as <strong><code>const</code></strong>, is applied to a function type defined by <strong><code>typedef</code></strong>.</p>
@@ -1515,7 +1519,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4185</key>
-    <name>C4185: ignoring unknown #import attribute 'attribute'</name>
+    <name>C4185: Ignoring unknown #import attribute 'attribute'</name>
     <description>
       <![CDATA[
 <p>The attribute is not a valid attribute of <code>#import</code>. It is ignored.</p>
@@ -1548,7 +1552,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4189</key>
-    <name>C4189: 'identifier' : local variable is initialized but not referenced</name>
+    <name>C4189: 'identifier': local variable is initialized but not referenced</name>
     <description>
       <![CDATA[
 <p>A variable is declared and initialized but not used.</p>
@@ -1570,7 +1574,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4191</key>
-    <name>C4191: 'operator/operation' : unsafe conversion from 'type of expression' to 'type required'</name>
+    <name>C4191: 'operator/operation': unsafe conversion from 'type of expression' to 'type required'</name>
     <description>
       <![CDATA[
 <p>Several operations involving function pointers are considered unsafe.</p>
@@ -1581,7 +1585,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4192</key>
-    <name>C4192: automatically excluding 'name' while importing type library 'library'</name>
+    <name>C4192: Automatically excluding 'name' while importing type library 'library'</name>
     <description>
       <![CDATA[
 <p>A <code>#import</code> library contains an item, <em>name</em>, that is also defined in the Win32 system headers. Due to limitations of type libraries, names such as <strong>IUnknown</strong> or GUID are often defined in a type library, duplicating the definition from the system headers. <code>#import</code> will detect these items and refuse to incorporate them in the .tlh and .tli header files.</p>
@@ -1592,7 +1596,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4197</key>
-    <name>C4197: 'type' : top-level volatile in cast is ignored</name>
+    <name>C4197: 'type': top-level volatile in cast is ignored</name>
     <description>
       <![CDATA[
 <p>The compiler detected a cast to an r-value type which is qualified with <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/volatile-cpp?view=msvc-170">volatile</a>, or a cast of an r-value type to some type that is qualified with volatile. According to the C standard (6.5.3), properties associated with qualified types are meaningful only for l-value expressions.</p>
@@ -1603,7 +1607,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4200</key>
-    <name>C4200: nonstandard extension used : zero-sized array in struct/union</name>
+    <name>C4200: Nonstandard extension used: zero-sized array in struct/union</name>
     <description>
       <![CDATA[
 <p>Indicates that a structure or union contains an array that has zero size.</p>
@@ -1614,7 +1618,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4201</key>
-    <name>C4201: nonstandard extension used : nameless struct/union</name>
+    <name>C4201: Nonstandard extension used: nameless struct/union</name>
     <description>
       <![CDATA[
 <p>Under Microsoft extensions (/Ze), you can specify a structure without a declarator as members of another structure or union. These structures generate an error under ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>).</p>
@@ -1625,7 +1629,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4202</key>
-    <name>C4202: nonstandard extension used : '...': prototype parameter in name list illegal</name>
+    <name>C4202: Nonstandard extension used: '...': prototype parameter in name list illegal</name>
     <description>
       <![CDATA[
 <p>An old-style function definition contains variable arguments. These definitions generate an error under ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>).</p>
@@ -1636,7 +1640,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4204</key>
-    <name>C4204: nonstandard extension used : non-constant aggregate initializer</name>
+    <name>C4204: Nonstandard extension used: non-constant aggregate initializer</name>
     <description>
       <![CDATA[
 <p>With Microsoft extensions (/Ze), you can initialize aggregate types (arrays, structures, unions, and classes) with values that are not constants.</p>
@@ -1647,7 +1651,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4205</key>
-    <name>C4205: nonstandard extension used : static function declaration in function scope</name>
+    <name>C4205: Nonstandard extension used: static function declaration in function scope</name>
     <description>
       <![CDATA[
 <p>With Microsoft extensions (/Ze), <strong><code>static</code></strong> functions can be declared inside another function. The function is given global scope.</p>
@@ -1658,7 +1662,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4206</key>
-    <name>C4206: nonstandard extension used : translation unit is empty</name>
+    <name>C4206: Nonstandard extension used: translation unit is empty</name>
     <description>
       <![CDATA[
 <p>The file was empty after preprocessing.</p>
@@ -1669,7 +1673,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4207</key>
-    <name>C4207: nonstandard extension used : extended initializer form</name>
+    <name>C4207: Nonstandard extension used: extended initializer form</name>
     <description>
       <![CDATA[
 <p>With Microsoft extensions (/Ze), you can initialize an unsized array of <strong><code>char</code></strong> using a string within braces.</p>
@@ -1680,7 +1684,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4208</key>
-    <name>C4208: nonstandard extension used : delete [exp] - exp evaluated but ignored</name>
+    <name>C4208: Nonstandard extension used: delete [exp] - exp evaluated but ignored</name>
     <description>
       <![CDATA[
 <p>With Microsoft extensions (/Ze), you can delete an array using a value within brackets with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/delete-operator-cpp?view=msvc-170">delete operator</a>. The value is ignored.</p>
@@ -1691,7 +1695,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4210</key>
-    <name>C4210: nonstandard extension used : function given file scope</name>
+    <name>C4210: nonstandard extension used: function given file scope</name>
     <description>
       <![CDATA[
 <p>With the default Microsoft extensions (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Ze</a>), function declarations have file scope.</p>
@@ -1702,7 +1706,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4211</key>
-    <name>C4211: nonstandard extension used : redefined extern to static</name>
+    <name>C4211: Nonstandard extension used: redefined extern to static</name>
     <description>
       <![CDATA[
 <p>With the default Microsoft extensions (/Ze), you can redefine an <strong><code>extern</code></strong> identifier as <strong><code>static</code></strong>.</p>
@@ -1713,7 +1717,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4212</key>
-    <name>C4212: nonstandard extension used : function declaration used ellipsis</name>
+    <name>C4212: Nonstandard extension used: function declaration used ellipsis</name>
     <description>
       <![CDATA[
 <p>The function prototype has a variable number of arguments. The function definition does not.</p>
@@ -1724,7 +1728,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4213</key>
-    <name>C4213: nonstandard extension used : cast on l-value</name>
+    <name>C4213: Nonstandard extension used: cast on l-value</name>
     <description>
       <![CDATA[
 <p>With the default Microsoft extensions (/Ze), you can use casts on the left side of an assignment statement.</p>
@@ -1735,7 +1739,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4214</key>
-    <name>C4214: nonstandard extension used : bit field types other than int</name>
+    <name>C4214: Nonstandard extension used: bit field types other than int</name>
     <description>
       <![CDATA[
 <p>With the default Microsoft extensions (/Ze), bitfield structure members can be of any integer type.</p>
@@ -1746,7 +1750,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4215</key>
-    <name>C4215: nonstandard extension used : long float</name>
+    <name>C4215: Nonstandard extension used: long float</name>
     <description>
       <![CDATA[
 <p>The default Microsoft extensions (/Ze) treat <strong>long float</strong> as <strong><code>double</code></strong>. ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>) does not. Use <strong><code>double</code></strong> to maintain compatibility.</p>
@@ -1757,7 +1761,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4216</key>
-    <name>C4216: nonstandard extension used : float long</name>
+    <name>C4216: Nonstandard extension used: float long</name>
     <description>
       <![CDATA[
 <p>The default Microsoft extensions (/Ze) treat <strong>float long</strong> as <strong><code>double</code></strong>. ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>) does not. Use <strong><code>double</code></strong> to maintain compatibility.</p>
@@ -1768,10 +1772,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4218</key>
-    <name>C4218: nonstandard extension used : must specify at least a storage class or a type</name>
+    <name>C4218: Nonstandard extension used: must specify at least a storage class or a type</name>
     <description>
       <![CDATA[
-<p>With the default Microsoft extensions (/Ze), you can declare a variable without specifying a type or storage class. The default type is <strong><code>int</code></strong>.</p>
+<p>With the default Microsoft extensions (<code>/Ze</code>), you can declare a variable without specifying a type or storage class. The default type is <strong><code>int</code></strong>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4218?view=msvc-170" target="_blank">C4218</a></p>]]>
     </description>
@@ -1790,7 +1794,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4221</key>
-    <name>C4221: nonstandard extension used : 'identifier' : cannot be initialized using address of automatic variable</name>
+    <name>C4221: Nonstandard extension used: 'identifier' : cannot be initialized using address of automatic variable</name>
     <description>
       <![CDATA[
 <p>With the default Microsoft extensions (/Ze), you can initialize an aggregate type (<strong>array</strong>, <strong><code>struct</code></strong>, or <strong><code>union</code></strong>) with the address of a local (automatic) variable.</p>
@@ -1801,10 +1805,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4223</key>
-    <name>C4223: nonstandard extension used : non-lvalue array converted to pointer</name>
+    <name>C4223: Nonstandard extension used: non-lvalue array converted to pointer</name>
     <description>
       <![CDATA[
-<p>In standard C, you cannot convert a non-lvalue array to a pointer. With the default Microsoft extensions (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Ze</a>), you can.</p>
+<p>In standard C, you can't convert a nonlvalue array to a pointer. With the default Microsoft extensions (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170"><code>/Ze</code></a>), you can.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-1-and-4-c4223?view=msvc-170" target="_blank">C4223</a></p>]]>
     </description>
@@ -1812,7 +1816,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4224</key>
-    <name>C4224: nonstandard extension used : formal parameter 'identifier' was previously defined as a type</name>
+    <name>C4224: Nonstandard extension used: formal parameter 'identifier' was previously defined as a type</name>
     <description>
       <![CDATA[
 <p>The identifier was previously used as a <strong><code>typedef</code></strong>. This causes a warning under ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>).</p>
@@ -1823,7 +1827,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4226</key>
-    <name>C4226: nonstandard extension used : 'keyword' is an obsolete keyword</name>
+    <name>C4226: Nonstandard extension used: 'keyword' is an obsolete keyword</name>
     <description>
       <![CDATA[
 <p>The current version of Visual C++ does not use this keyword.</p>
@@ -1834,7 +1838,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4227</key>
-    <name>C4227: anachronism used : qualifiers on reference are ignored</name>
+    <name>C4227: Anachronism used: qualifiers on reference are ignored</name>
     <description>
       <![CDATA[
 <p>Using qualifiers like <strong><code>const</code></strong> or <strong><code>volatile</code></strong> with C++ references is an outdated practice.</p>
@@ -1845,7 +1849,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4228</key>
-    <name>C4228: nonstandard extension used : qualifiers after comma in declarator list are ignored</name>
+    <name>C4228: Nonstandard extension used: qualifiers after comma in declarator list are ignored</name>
     <description>
       <![CDATA[
 <p>Use of qualifiers like <strong><code>const</code></strong> or <strong><code>volatile</code></strong> after a comma when declaring variables is a Microsoft extension (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Ze</a>).</p>
@@ -1856,7 +1860,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4229</key>
-    <name>C4229: anachronism used : modifiers on data are ignored</name>
+    <name>C4229: Anachronism used: modifiers on data are ignored</name>
     <description>
       <![CDATA[
 <p>Using a Microsoft modifier such as <strong><code>__cdecl</code></strong> on a data declaration is an outdated practice.</p>
@@ -1867,7 +1871,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4230</key>
-    <name>C4230: anachronism used : modifiers/qualifiers interspersed; qualifier ignored</name>
+    <name>C4230: Anachronism used: modifiers/qualifiers interspersed; qualifier ignored</name>
     <description>
       <![CDATA[
 <p>Using a qualifier before a Microsoft modifier such as <strong><code>__cdecl</code></strong> is an outdated practice.</p>
@@ -1878,7 +1882,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4232</key>
-    <name>C4232: nonstandard extension used : 'identifier' : address of dllimport 'dllimport' is not static, identity not guaranteed</name>
+    <name>C4232: Nonstandard extension used: 'identifier' : address of dllimport 'dllimport' is not static, identity not guaranteed</name>
     <description>
       <![CDATA[
 <p>Under Microsoft extensions (/Ze), you can give a nonstatic value as the address of a function declared with the <strong><code>dllimport</code></strong> modifier. Under ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>), this causes an error.</p>
@@ -1889,7 +1893,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4233</key>
-    <name>C4233: nonstandard extension used : 'keyword' keyword only supported in C++, not C</name>
+    <name>C4233: Nonstandard extension used: 'keyword' keyword only supported in C++, not C</name>
     <description>
       <![CDATA[
 <p>The compiler compiled your source code as C rather than C++, and you used a keyword that is only valid in C++. The compiler compiles your source file as C if the extension of the source file is .c or you use <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/tc-tp-tc-tp-specify-source-file-type?view=msvc-170">/Tc</a>.</p>
@@ -1900,7 +1904,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4234</key>
-    <name>C4234: nonstandard extension used: 'keyword' keyword reserved for future use</name>
+    <name>C4234: Nonstandard extension used: 'keyword' keyword reserved for future use</name>
     <description>
       <![CDATA[
 <p>The compiler does not yet implement the keyword you used.</p>
@@ -1911,10 +1915,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4235</key>
-    <name>C4235: nonstandard extension used : 'keyword' keyword not supported on this architecture</name>
+    <name>C4235: Nonstandard extension used: 'keyword' keyword not supported on this architecture</name>
     <description>
       <![CDATA[
-<p>The compiler does not support the keyword you used.</p>
+<p>The compiler doesn't support the keyword you used on the architecture your build is targeting.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4235?view=msvc-170" target="_blank">C4235</a></p>]]>
     </description>
@@ -1933,7 +1937,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4238</key>
-    <name>C4238: nonstandard extension used : class rvalue used as lvalue</name>
+    <name>C4238: Nonstandard extension used: class rvalue used as lvalue</name>
     <description>
       <![CDATA[
 <p>For compatibility with previous versions of Visual C++, Microsoft extensions (<strong>/Ze</strong>) allow you to use a class type as an rvalue in a context that implicitly or explicitly takes its address. In some cases, such as the example below, this can be dangerous.</p>
@@ -1944,7 +1948,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4239</key>
-    <name>C4239: nonstandard extension used : 'token' : conversion from 'type' to 'type'</name>
+    <name>C4239: Nonstandard extension used: 'token' : conversion from 'type' to 'type'</name>
     <description>
       <![CDATA[
 <p>This type conversion is not allowed by the C++ standard, but it is permitted here as an extension. This warning is always followed by at least one line of explanation describing the language rule being violated.</p>
@@ -1955,7 +1959,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4240</key>
-    <name>C4240: nonstandard extension used : access to 'classname' now defined to be 'access specifier', previously it was defined to be 'access specifier'</name>
+    <name>C4240: Nonstandard extension used: access to 'classname' now defined to be 'access specifier', previously it was defined to be 'access specifier'</name>
     <description>
       <![CDATA[
 <p>Under ANSI compatibility (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>), you cannot change the access to a nested class. Under the default Microsoft extensions (/Ze), you can, with this warning.</p>
@@ -1966,7 +1970,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4242</key>
-    <name>C4242: 'identifier' : conversion from 'type1' to 'type2', possible loss of data</name>
+    <name>C4242: 'identifier': conversion from 'type1' to 'type2', possible loss of data</name>
     <description>
       <![CDATA[
 <p>The types are different. Type conversion may result in loss of data. The compiler makes the type conversion.</p>
@@ -1991,7 +1995,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4244: 'conversion' conversion from 'type1' to 'type2', possible loss of data</name>
     <description>
       <![CDATA[
-<p>An integer type is converted to a smaller integer type. This is a level-4 warning if <em>type1</em> is <strong><code>int</code></strong> and <em>type2</em> is smaller than <strong><code>int</code></strong>. Otherwise, it is a level 3 (assigned a value of type <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/int8-int16-int32-int64?view=msvc-170">__int64</a> to a variable of type <strong><code>unsigned int</code></strong>). A possible loss of data may have occurred.</p>
+<p>An integer type is converted to a smaller integer type.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244?view=msvc-170" target="_blank">C4244</a></p>]]>
     </description>
@@ -1999,7 +2003,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4245</key>
-    <name>C4245: 'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch</name>
+    <name>C4245: 'conversion': conversion from 'type1' to 'type2', signed/unsigned mismatch</name>
     <description>
       <![CDATA[
 <p>You tried to convert a <strong><code>signed const</code></strong> type that has a negative value to an <strong><code>unsigned</code></strong> type.</p>
@@ -2010,7 +2014,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4250</key>
-    <name>C4250: 'class1' : inherits 'class2::member' via dominance</name>
+    <name>C4250: 'class1': inherits 'class2::member' via dominance</name>
     <description>
       <![CDATA[
 <p>Two or more members have the same name. The one in <code>class2</code> is inherited because it is a base class for the other classes that contained this member.</p>
@@ -2021,10 +2025,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4251</key>
-    <name>C4251: 'type' : class 'type1' needs to have dll-interface to be used by clients of class 'type2'</name>
+    <name>C4251: 'type': class 'type1' needs to have dll-interface to be used by clients of class 'type2'</name>
     <description>
       <![CDATA[
-<p>To minimize the possibility of data corruption when exporting a class declared as <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=msvc-170"><code>__declspec(dllexport)</code></a>.</p>
+<p>This warning happens if a class is marked with <code>__declspec(dllexport)</code> or <code>__declspec(dllimport)</code> and a nonstatic data member that is a member of the class or a member of one of its base classes, has a type that is a class type that isn't marked with <code>__declspec(dllexport)</code> or <code>__declspec(dllimport)</code>. See <a data-linktype="self-bookmark" href="#example">Example</a>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251?view=msvc-170" target="_blank">C4251</a></p>]]>
     </description>
@@ -2032,7 +2036,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4254</key>
-    <name>C4254: 'operator' : conversion from 'type1' to 'type2', possible loss of data</name>
+    <name>C4254: 'operator': conversion from 'type1':'field_bits' to 'type2':'field_bits', possible loss of data</name>
     <description>
       <![CDATA[
 <p>A larger bit field was assigned to a smaller bit field. There could be a loss of data.</p>
@@ -2043,10 +2047,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4255</key>
-    <name>C4255: 'function' : no function prototype given: converting '()' to '(void)'</name>
+    <name>C4255: 'function': no function prototype given: converting '()' to '(void)'</name>
     <description>
       <![CDATA[
-<p>The compiler did not find an explicit list of arguments to a function. This warning is for the C compiler only.</p>
+<p>The compiler didn't find an explicit list of arguments to a function. This warning is for the C compiler only.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4255?view=msvc-170" target="_blank">C4255</a></p>]]>
     </description>
@@ -2065,7 +2069,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4258</key>
-    <name>C4258: 'variable' : definition from the for loop is ignored; the definition from the enclosing scope is used"</name>
+    <name>C4258: 'variable': definition from the for loop is ignored; the definition from the enclosing scope is used"</name>
     <description>
       <![CDATA[
 <p>Under <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Ze</a> and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/zc-forscope-force-conformance-in-for-loop-scope?view=msvc-170">/Zc:forScope</a>, variables defined in a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/for-statement-cpp?view=msvc-170">for</a> loop go out of scope after the <strong><code>for</code></strong> loop ends. This warning occurs if a variable with the same name as the loop variable, but defined in the enclosing loop, is used again in the scope containing the <strong><code>for</code></strong> loop.</p>
@@ -2076,10 +2080,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4263</key>
-    <name>C4263: 'function' : member function does not override any base class virtual member function</name>
+    <name>C4263: 'function': member function does not override any base class virtual member function</name>
     <description>
       <![CDATA[
-<p>A class function definition has the same name as a virtual function in a base class but not the same number or type of arguments. This effectively hides the virtual function in the base class.</p>
+<p>A class function definition has the same name as a virtual function in a base class but not the same number or type of arguments. This pattern effectively hides the virtual function in the base class.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4263?view=msvc-170" target="_blank">C4263</a></p>]]>
     </description>
@@ -2087,7 +2091,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4264</key>
-    <name>C4264: 'virtual_function' : no override available for virtual member function from base 'class'; function is hidden</name>
+    <name>C4264: 'virtual_function': no override available for virtual member function from base 'class'; function is hidden</name>
     <description>
       <![CDATA[
 <p>C4264 is always generated after <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4263?view=msvc-170">C4263</a>.</p>
@@ -2098,7 +2102,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4265</key>
-    <name>C4265: 'class' : class has virtual functions, but destructor is not virtual</name>
+    <name>C4265: 'classname': class has virtual functions, but its non-trivial destructor is not virtual</name>
     <description>
       <![CDATA[
 <p>When a class has virtual functions but a nonvirtual destructor, objects of the type might not be destroyed properly when the class is destroyed through a base class pointer.</p>
@@ -2109,10 +2113,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4266</key>
-    <name>C4266: 'function' : no override available for virtual member function from base 'type'; function is hidden</name>
+    <name>C4266: 'function': no override available for virtual member function from base 'type'; function is hidden</name>
     <description>
       <![CDATA[
-<p>A derived class did not override all overloads of a virtual function.</p>
+<p>A derived class didn't override all overloads of a virtual function.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4266?view=msvc-170" target="_blank">C4266</a></p>]]>
     </description>
@@ -2120,7 +2124,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4267</key>
-    <name>C4267: 'var' : conversion from 'size_t' to 'type', possible loss of data</name>
+    <name>C4267: 'var': conversion from 'size_t' to 'type', possible loss of data</name>
     <description>
       <![CDATA[
 <p>The compiler detected a conversion from <code>size_t</code> to a smaller type.</p>
@@ -2131,7 +2135,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4268</key>
-    <name>C4268: 'identifier' : 'const' static/global data initialized with compiler generated default constructor fills the object with zeros</name>
+    <name>C4268: 'identifier': 'const' static/global data initialized with compiler generated default constructor fills the object with zeros</name>
     <description>
       <![CDATA[
 <p>A <strong><code>const</code></strong> global or static instance of a non-trivial class is initialized with a compiler-generated default constructor.</p>
@@ -2142,7 +2146,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4269</key>
-    <name>C4269: 'identifier' : 'const' automatic data initialized with compiler generated default constructor produces unreliable results</name>
+    <name>C4269: 'identifier': 'const' automatic data initialized with compiler generated default constructor produces unreliable results</name>
     <description>
       <![CDATA[
 <p>A <strong><code>const</code></strong> automatic instance of a non-trivial class is initialized with a compiler-generated default constructor.</p>
@@ -2153,7 +2157,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4272</key>
-    <name>C4272: 'function' : is marked __declspec(dllimport); must specify native calling convention when importing a function</name>
+    <name>C4272: 'function': is marked __declspec(dllimport); must specify native calling convention when importing a function</name>
     <description>
       <![CDATA[
 <p>It is an error to export a function marked with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/clrcall?view=msvc-170">__clrcall</a> calling convention, and the compiler issues this warning if you attempt to import a function marked <code>__clrcall</code>.</p>
@@ -2164,7 +2168,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4273</key>
-    <name>C4273: 'function' : inconsistent DLL linkage</name>
+    <name>C4273: 'function': inconsistent DLL linkage</name>
     <description>
       <![CDATA[
 <p>Two definitions in a file differ in their use of <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=msvc-170"><code>dllimport</code></a>.</p>
@@ -2186,7 +2190,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4275</key>
-    <name>C4275: non - DLL-interface class 'class_1' used as base for DLL-interface class 'class_2'</name>
+    <name>C4275: Non-DLL-interface class 'class_1' used as base for DLL-interface class 'class_2'</name>
     <description>
       <![CDATA[
 <p>An exported class was derived from a class that wasn't exported.</p>
@@ -2197,7 +2201,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4276</key>
-    <name>C4276: 'function' : no prototype provided; assumed no parameters</name>
+    <name>C4276: 'function': no prototype provided; assumed no parameters</name>
     <description>
       <![CDATA[
 <p>When you take the address of a function with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/stdcall?view=msvc-170">__stdcall</a> calling convention, you must give a prototype so the compiler can create the function's decorated name. Since <em>function</em> has no prototype, the compiler, when creating the decorated name, assumes the function has no parameters.</p>
@@ -2211,8 +2215,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4278: 'identifier': identifier in type library 'tlb' is already a macro</name>
     <description>
       <![CDATA[
-<p>Identifier in type library 'tlb' is already a macro; use the 'rename' qualifier.</p>
-<p>When using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170">#import</a>, an identifier in the typelib you are importing is attempting to declare an identifier <em>identifier</em>. However, this is already a valid symbol.</p>
+<p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170"><code>#import</code></a> is attempting to import an identifier into the translation unit. However, there's already a symbol with that name. Use the <code>#import</code> <strong>rename</strong> attribute to assign an alias to the symbol in the type library.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4278?view=msvc-170" target="_blank">C4278</a></p>]]>
     </description>
@@ -2242,10 +2245,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4282</key>
-    <name>C4282: then through type 'type'</name>
+    <name>C4282: 'operator -&gt;' recursion occurred through type 'type': then through type 'type'</name>
     <description>
       <![CDATA[
-<p>This continuation of warning C4281shows that <strong>operator-&gt;</strong> calls itself through <code>type</code>.</p>
+<p>This continuation of warning C4281 shows that <strong>operator-&gt;</strong> calls itself through <code>type</code>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4282?view=msvc-170" target="_blank">C4282</a></p>]]>
     </description>
@@ -2253,7 +2256,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4283</key>
-    <name>C4283: and through type 'type'</name>
+    <name>C4283: 'operator -&gt;' recursion occurred through type 'type': and through type 'type'</name>
     <description>
       <![CDATA[
 <p>This continuation of warning <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4281?view=msvc-170">C4281</a> shows that <strong>operator-&gt;</strong> calls itself through <code>type</code>.</p>
@@ -2264,7 +2267,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4285</key>
-    <name>C4285: return type for 'identifier::operator -&gt;' is recursive if applied using infix notation</name>
+    <name>C4285: Return type for 'identifier::operator -&gt;' is recursive if applied using infix notation</name>
     <description>
       <![CDATA[
 <p>The specified <strong>operator-&gt;()</strong> function cannot return the type for which it is defined or a reference to the type for which it is defined.</p>
@@ -2275,7 +2278,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4286</key>
-    <name>C4286: 'type1' : is caught by base class ('type2') on line number</name>
+    <name>C4286: 'type1': is caught by base class ('type2') on line number</name>
     <description>
       <![CDATA[
 <p>The specified exception type is handled by a previous handler. The type for the second catch is derived from the type of the first. Exceptions for a base class catch exceptions for a derived class.</p>
@@ -2286,7 +2289,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4287</key>
-    <name>C4287: 'operator' : unsigned/negative constant mismatch</name>
+    <name>C4287: 'operator': unsigned/negative constant mismatch</name>
     <description>
       <![CDATA[
 <p>An unsigned variable was used in an operation with a negative number.</p>
@@ -2297,7 +2300,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4288</key>
-    <name>C4288: nonstandard extension used</name>
+    <name>C4288: Nonstandard extension used</name>
     <description>
       <![CDATA[
 <p>When compiling with <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170"><code>/Ze</code></a> and <strong>/Zc:forscope-</strong>, a variable declared in a <strong><code>for</code></strong> loop was used after the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/for-statement-cpp?view=msvc-170">for</a>-loop scope. A Microsoft extension to the C++ language allows this variable to remain in scope, and C4288 reminds you that the first declaration of the variable is not used.</p>
@@ -2308,10 +2311,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4289</key>
-    <name>C4289: nonstandard extension used : 'var' : loop control variable declared in the for-loop is used outside the for-loop scope</name>
+    <name>C4289: Nonstandard extension used: 'var' : loop control variable declared in the for-loop is used outside the for-loop scope</name>
     <description>
       <![CDATA[
-<p>When compiling with <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Ze</a> and <strong>/Zc:forScope-</strong>, a variable declared in a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/for-statement-cpp?view=msvc-170">for</a> loop was used after the <strong><code>for</code></strong>-loop scope.</p>
+<p>When <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Ze</a> and <strong>/Zc:forScope-</strong> are used in a build, a variable declared in a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/for-statement-cpp?view=msvc-170"><code>for</code></a> loop was used after the <strong><code>for</code></strong>-loop scope.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4289?view=msvc-170" target="_blank">C4289</a></p>]]>
     </description>
@@ -2330,7 +2333,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4291</key>
-    <name>C4291: 'declaration' : no matching operator delete found; memory will not be freed if initialization throws an exception</name>
+    <name>C4291: 'declaration': no matching operator delete found; memory will not be freed if initialization throws an exception</name>
     <description>
       <![CDATA[
 <p>A placement <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/new-operator-cpp?view=msvc-170">new</a> is used for which there is no placement <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/delete-operator-cpp?view=msvc-170">delete</a>.</p>
@@ -2341,7 +2344,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4293</key>
-    <name>C4293: 'operator' : shift count negative or too big, undefined behavior</name>
+    <name>C4293: 'operator': shift count negative or too big, undefined behavior</name>
     <description>
       <![CDATA[
 <p>If a shift count is negative or too large, the behavior of the resulting image is undefined.</p>
@@ -2352,7 +2355,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4295</key>
-    <name>C4295: 'array' : array is too small to include a terminating null character</name>
+    <name>C4295: 'array': array is too small to include a terminating null character</name>
     <description>
       <![CDATA[
 <p>An array was initialized but the last character in the array is not a null; accessing the array as a string may produce unexpected results.</p>
@@ -2363,7 +2366,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4296</key>
-    <name>C4296: 'operator' : expression is always false</name>
+    <name>C4296: 'operator': expression is always false</name>
     <description>
       <![CDATA[
 <p>An unsigned variable was used in a comparison operation with zero.</p>
@@ -2374,7 +2377,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4297</key>
-    <name>C4297: 'function' : function assumed not to throw an exception but does</name>
+    <name>C4297: 'function': function assumed not to throw an exception but does</name>
     <description>
       <![CDATA[
 <p>A function declaration contains a (possibly implicit) <strong><code>noexcept</code></strong> specifier, an empty <strong><code>throw</code></strong> exception specifier, or a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/nothrow-cpp?view=msvc-170">__declspec(nothrow)</a> attribute, and the definition contains one or more <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/try-throw-and-catch-statements-cpp?view=msvc-170">throw</a> statements. To resolve C4297, do not attempt to throw exceptions in functions that are declared <code>__declspec(nothrow)</code>, <code>noexcept(true)</code> or <code>throw()</code>. Alternatively, remove the <strong><code>noexcept</code></strong>, <code>throw()</code>, or <code>__declspec(nothrow)</code> specification.</p>
@@ -2385,7 +2388,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4302</key>
-    <name>C4302: 'conversion' : truncation from 'type 1' to 'type 2'</name>
+    <name>C4302: 'conversion': truncation from 'type 1' to 'type 2'</name>
     <description>
       <![CDATA[
 <p>The compiler detected a conversion from a larger type to a smaller type. Information may be lost.</p>
@@ -2396,7 +2399,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4305</key>
-    <name>C4305: 'context' : truncation from 'type1' to 'type2'</name>
+    <name>C4305: 'conversion': truncation from 'type1' to 'type2'</name>
     <description>
       <![CDATA[
 <p>This warning is issued when a value is converted to a smaller type in an initialization or as a constructor argument, resulting in a loss of information.</p>
@@ -2407,10 +2410,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4306</key>
-    <name>C4306: 'identifier' : conversion from 'type1' to 'type2' of greater size</name>
+    <name>C4306: 'conversion': conversion from 'type1' to 'type2' of greater size</name>
     <description>
       <![CDATA[
-<p>The identifier is type cast to a larger pointer. The unfilled high bits of the new type will be zero-filled.</p>
+<p>The identifier is type cast to a larger pointer. The unfilled high bits of the new type are zero-filled.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4306?view=msvc-170" target="_blank">C4306</a></p>]]>
     </description>
@@ -2418,7 +2421,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4307</key>
-    <name>C4307: 'operator' : integral constant overflow</name>
+    <name>C4307: 'operator': signed integral constant overflow</name>
     <description>
       <![CDATA[
 <p>The operator is used in an expression that results in an integer constant overflowing the space allocated for it. You may need to use a larger type for the constant. A <strong><code>signed int</code></strong> holds a smaller value than an <strong><code>unsigned int</code></strong> because the <strong><code>signed int</code></strong> uses one bit to represent the sign.</p>
@@ -2429,7 +2432,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4308</key>
-    <name>C4308: negative integral constant converted to unsigned type</name>
+    <name>C4308: Negative integral constant converted to unsigned type</name>
     <description>
       <![CDATA[
 <p>An expression converts a negative integer constant to an unsigned type. The result of the expression is probably meaningless.</p>
@@ -2440,7 +2443,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4309</key>
-    <name>C4309: 'conversion' : truncation of constant value</name>
+    <name>C4309: 'conversion': truncation of constant value</name>
     <description>
       <![CDATA[
 <p>The type conversion causes a constant to exceed the space allocated for it. You may need to use a larger type for the constant.</p>
@@ -2451,7 +2454,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4310</key>
-    <name>C4310: cast truncates constant value</name>
+    <name>C4310: Cast truncates constant value</name>
     <description>
       <![CDATA[
 <p>A constant value is cast to a smaller type. The compiler performs the cast, which truncates data.</p>
@@ -2462,7 +2465,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4311</key>
-    <name>C4311: 'variable' : pointer truncation from 'type' to 'type'</name>
+    <name>C4311: 'variable': pointer truncation from 'type' to 'type'</name>
     <description>
       <![CDATA[
 <p>This warning detects 64-bit pointer truncation issues. For example, if code is compiled for a 64-bit architecture, the value of a pointer (64 bits) will be truncated if it is assigned to an <strong><code>int</code></strong> (32 bits). For more information, see <a data-linktype="absolute-path" href="/en-us/windows/win32/WinProg64/rules-for-using-pointers">Rules for Using Pointers</a>.</p>
@@ -2473,7 +2476,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4312</key>
-    <name>C4312: 'operation' : conversion from 'type1' to 'type2' of greater size</name>
+    <name>C4312: 'operation': conversion from 'type1' to 'type2' of greater size</name>
     <description>
       <![CDATA[
 <p>This warning detects an attempt to assign a 32-bit value to a 64-bit pointer type, for example, casting a 32-bit <strong><code>int</code></strong> or <strong><code>long</code></strong> to a 64-bit pointer.</p>
@@ -2484,7 +2487,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4313</key>
-    <name>C4313: 'function' : 'format specifier' in format string conflicts with argument number of type 'type'</name>
+    <name>C4313: 'function': 'format specifier' in format string conflicts with argument number of type 'type'</name>
     <description>
       <![CDATA[
 <p>There is a conflict between the format specified and the value that you are passing. For example, you passed a 64-bit parameter to an unqualified %d format specifier, which expects a 32-bit integer parameter. This warning is only in effect when the code is compiled for 64-bit targets.</p>
@@ -2506,7 +2509,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4319</key>
-    <name>C4319: '~' : zero extending 'type1' to 'type2' of greater size</name>
+    <name>C4319: '~': zero extending 'type1' to 'type2' of greater size</name>
     <description>
       <![CDATA[
 <p>The result of the <strong>~</strong> (bitwise complement) operator is unsigned and then zero-extended when it is converted to a larger type.</p>
@@ -2517,10 +2520,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4324</key>
-    <name>C4324: 'struct_name' : structure was padded due to __declspec(align())</name>
+    <name>C4324: 'structname': structure was padded due to alignment specifier</name>
     <description>
       <![CDATA[
-<p>Padding was added at the end of a structure because you specified a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-170">__declspec(align)</a> value.</p>
+<p>Padding was added at the end of a structure because you specified an alignment specifier, such as <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-170">__declspec(align)</a>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4324?view=msvc-170" target="_blank">C4324</a></p>]]>
     </description>
@@ -2528,7 +2531,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4325</key>
-    <name>C4325: attributes for standard section 'section' ignored</name>
+    <name>C4325: Attributes for standard section 'section' ignored</name>
     <description>
       <![CDATA[
 <p>You may not change the attributes of a standard section.</p>
@@ -2539,7 +2542,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4326</key>
-    <name>C4326: return type of 'function' should be 'type1' instead of 'type2'</name>
+    <name>C4326: Return type of 'function' should be 'type1' instead of 'type2'</name>
     <description>
       <![CDATA[
 <p>A function returned a type other than <em>type1</em>. For example, using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>, <strong>main</strong> did not return an <strong><code>int</code></strong>.</p>
@@ -2550,10 +2553,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4329</key>
-    <name>C4329: __declspec(align()) is ignored on enum</name>
+    <name>C4329: Alignment specifier is ignored on enum</name>
     <description>
       <![CDATA[
-<p>Use of the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-170">align</a> keyword of the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/declspec?view=msvc-170">__declspec</a> modifier is not allowed on an <strong><code>enum</code></strong>.</p>
+<p>Use of the alignment specifiers on <code>enum</code> isn't allowed. This pattern includes the use of the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-170"><code>align</code></a> <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/declspec?view=msvc-170"><code>__declspec</code></a> modifier.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4329?view=msvc-170" target="_blank">C4329</a></p>]]>
     </description>
@@ -2561,7 +2564,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4333</key>
-    <name>C4333: 'operator' : right shift by too large amount, data loss</name>
+    <name>C4333: 'operator': right shift by too large amount, data loss</name>
     <description>
       <![CDATA[
 <p>A right shift operation was too large an amount.  All significant bits are shifted out and the result will always be zero.</p>
@@ -2572,10 +2575,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4334</key>
-    <name>C4334: 'operator' : result of 32-bit shift implicitly converted to 64 bits</name>
+    <name>C4334: 'operator': result of 32-bit shift implicitly converted to 64 bits</name>
     <description>
       <![CDATA[
-<p>The result of 32-bit shift was implicitly converted to 64-bits, and the compiler suspects that a 64-bit shift was intended.  To resolve this warning, either use 64-bit shift, or explicitly cast the shift result to 64-bit.</p>
+<p>The result of 32-bit shift was converted to 64-bit, and the compiler suspects that a 64-bit shift was intended. Resolve this warning by using a 64-bit shift. If a 32-bit shift is intentional, then cast the shift result to 32-bit to make it clear to the compiler.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4334?view=msvc-170" target="_blank">C4334</a></p>]]>
     </description>
@@ -2586,7 +2589,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4335: Mac file format detected: please convert the source file to either DOS or UNIX format</name>
     <description>
       <![CDATA[
-<p>The line termination character of the first line of a source file is Macintosh style ('\r') as opposed to UNIX ('\n') or DOS ('\r\n').</p>
+<p>The line termination character of the first line of a source file is the old Macintosh style ('\r') as opposed to UNIX ('\n') or DOS ('\r\n').</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4335?view=msvc-170" target="_blank">C4335</a></p>]]>
     </description>
@@ -2594,7 +2597,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4336</key>
-    <name>C4336: import cross-referenced type library 'type_lib1' before importing 'type_lib2'</name>
+    <name>C4336: Import cross-referenced type library 'type_lib1' before importing 'type_lib2'</name>
     <description>
       <![CDATA[
 <p>A type library was referenced with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170">#import</a> directive. However, the type library contained a reference to another type library that was not referenced with <code>#import</code>. This other .tlb file was found by the compiler.</p>
@@ -2605,7 +2608,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4337</key>
-    <name>C4337: cross-referenced type library 'typelib1' in 'typelib2' is being automatically imported</name>
+    <name>C4337: Cross-referenced type library 'typelib1' in 'typelib2' is being automatically imported</name>
     <description>
       <![CDATA[
 <p>The auto_search attribute of <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170">the #import directive</a> caused a type library to be implicitly imported.</p>
@@ -2616,10 +2619,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4339</key>
-    <name>C4339: 'type' : use of undefined type detected in WinRT or CLR meta-data</name>
+    <name>C4339: 'type': use of undefined type detected in WinRT or CLR meta-data</name>
     <description>
       <![CDATA[
-<p>A type was not defined in code that was compiled for Windows Runtime or the common language runtime. Define the type to avoid a possible runtime exception.</p>
+<p>A type wasn't defined in code that was compiled for Windows Runtime or the common language runtime. Define the type to avoid a possible runtime exception.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4339?view=msvc-170" target="_blank">C4339</a></p>]]>
     </description>
@@ -2627,7 +2630,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4340</key>
-    <name>C4340: 'value' : value wrapped from positive to negative value</name>
+    <name>C4340: 'value': value wrapped from positive to negative value</name>
     <description>
       <![CDATA[
 <p>The <strong><code>enum</code></strong> value is greater than the largest <strong><code>enum</code></strong> positive value wrapped around to a negative value.</p>
@@ -2638,7 +2641,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4342</key>
-    <name>C4342: behavior change: 'function' called, but a member operator was called in previous versions</name>
+    <name>C4342: Behavior change: 'function' called, but a member operator was called in previous versions</name>
     <description>
       <![CDATA[
 <p>In versions of Visual C++ before Visual Studio 2002, a member was called, but this behavior has been changed and the compiler now finds the best match in namespace scope.</p>
@@ -2660,7 +2663,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4344</key>
-    <name>C4344: behavior change: use of explicit template arguments results in call to 'function'</name>
+    <name>C4344: Behavior change: use of explicit template arguments results in call to 'function'</name>
     <description>
       <![CDATA[
 <p>A call to a function using explicit template arguments calls a different function than it would if explicit arguments had not been specified.</p>
@@ -2671,7 +2674,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4346</key>
-    <name>C4346: 'name' : dependent name is not a type</name>
+    <name>C4346: 'name': dependent name is not a type</name>
     <description>
       <![CDATA[
 <p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/typename?view=msvc-170">typename</a> keyword is required if a dependent name is to be treated as a type. For code that works the same in all versions of Visual C++, add <strong><code>typename</code></strong> to the declaration.</p>
@@ -2682,7 +2685,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4348</key>
-    <name>C4348: 'type' : redefinition of default parameter : parameter number</name>
+    <name>C4348: 'type': redefinition of default parameter : parameter number</name>
     <description>
       <![CDATA[
 <p>A template parameter was redefined.</p>
@@ -2693,7 +2696,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4350</key>
-    <name>C4350: behavior change: 'member1' called instead of 'member2'</name>
+    <name>C4350: Behavior change: 'member1' called instead of 'member2'</name>
     <description>
       <![CDATA[
 <p>An rvalue cannot be bound to a non-const reference. In versions of Visual C++ before Visual Studio 2003, it was possible to bind an rvalue to a non-const reference in a direct initialization. This code now gives a warning.</p>
@@ -2704,7 +2707,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4353</key>
-    <name>C4353: nonstandard extension used: constant 0 as function expression</name>
+    <name>C4353: Nonstandard extension used: constant 0 as function expression</name>
     <description>
       <![CDATA[
 <p>You cannot use the constant zero (0) as a function expression. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/intrinsics/noop?view=msvc-170">__noop</a>.</p>
@@ -2715,10 +2718,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4355</key>
-    <name>C4355: 'this' : used in base member initializer list</name>
+    <name>C4355: 'this': used in base member initializer list</name>
     <description>
       <![CDATA[
-<p>The <strong><code>this</code></strong> pointer is valid only within nonstatic member functions. It cannot be used in the initializer list for a base class.</p>
+<p>The <code>this</code> pointer is valid only within nonstatic member functions. It can't be used in the initializer list for a base class.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4355?view=msvc-170" target="_blank">C4355</a></p>]]>
     </description>
@@ -2726,7 +2729,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4356</key>
-    <name>C4356: 'member' : static data member cannot be initialized via derived class</name>
+    <name>C4356: 'member': static data member cannot be initialized via derived class</name>
     <description>
       <![CDATA[
 <p>The initialization of a static data member was ill formed. The compiler accepted the initialization. To avoid the warning, initialize the member through the base class.</p>
@@ -2737,7 +2740,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4357</key>
-    <name>C4357: param array argument in formal argument list for delegate 'del' ignored when generating 'function'</name>
+    <name>C4357: Param array argument in formal argument list for delegate 'del' ignored when generating 'function'</name>
     <description>
       <![CDATA[
 <p>The <code>ParamArray</code> attribute was ignored, and <code>function</code> cannot be called with variable arguments.</p>
@@ -2762,7 +2765,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4359: 'type': actual alignment (8) is greater than the value specified in __declspec(align())</name>
     <description>
       <![CDATA[
-<p>The alignment specified for a type is less than the alignment of the type of one of its data members.  For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-170">align</a>.</p>
+<p>The alignment specified for a type is less than the alignment of the type of one of its data members. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/align-cpp?view=msvc-170">align</a>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4359?view=msvc-170" target="_blank">C4359</a></p>]]>
     </description>
@@ -2781,10 +2784,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4365</key>
-    <name>C4365: 'action' : conversion from 'type_1' to 'type_2', signed/unsigned mismatch</name>
+    <name>C4365: 'action': conversion from 'type_1' to 'type_2', signed/unsigned mismatch</name>
     <description>
       <![CDATA[
-<p>For example, you tried to convert an unsigned value to a signed value.</p>
+<p>For example, you tried to convert an unsigned value to a signed value. This pattern can cause unexpected results when the source value at runtime in not in the range of the destination type. Such as a negative value being converted into a signed value.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4365?view=msvc-170" target="_blank">C4365</a></p>]]>
     </description>
@@ -2803,10 +2806,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4368</key>
-    <name>C4368: cannot define 'member' as a member of managed 'type': mixed types are not supported</name>
+    <name>C4368: Cannot define 'member' as a member of managed 'type': mixed types are not supported</name>
     <description>
       <![CDATA[
-<p>You cannot embed a native data member in a CLR type.</p>
+<p>You can't embed a native data member in a managed type.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4368?view=msvc-170" target="_blank">C4368</a></p>]]>
     </description>
@@ -2814,7 +2817,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4369</key>
-    <name>C4369: 'enumerator' :  enumerator value 'value' cannot be represented as 'type', value is 'new_value'</name>
+    <name>C4369: 'enumerator':  enumerator value 'value' cannot be represented as 'type', value is 'new_value'</name>
     <description>
       <![CDATA[
 <p>An enumerator was calculated to be greater than the greatest value for the specified underlying type.  This caused an overflow and the compiler wrapped the enumerator value to the lowest possible value for the type.</p>
@@ -2828,7 +2831,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4371: 'classname': layout of class may have changed from a previous version of the compiler due to better packing of member 'member'</name>
     <description>
       <![CDATA[
-<p>If your code relies on a particular memory layout for a class, warning C4371 tells you that the layout created by the current compiler may be different from the layout generated by previous versions of the compiler. This may be significant for serialization operations or operating system interfaces that rely on a particular memory layout. In most other cases, this warning is safe to ignore.</p>
+<p>Warning C4371 tells you that the layout created by the current compiler may be different from the layout generated by previous versions of the compiler. This difference may be significant for serialization operations or operating system interfaces that rely on a particular memory layout. In most other cases, this warning is safe to ignore.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4371?view=msvc-170" target="_blank">C4371</a></p>]]>
     </description>
@@ -2839,7 +2842,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4373: 'function': virtual function overrides 'base_function', previous versions of the compiler did not override when parameters only differed by const/volatile qualifiers</name>
     <description>
       <![CDATA[
-<p>Your application contains a method in a derived class that overrides a virtual method in a base class, and the parameters in the overriding method differ by only a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/const-cpp?view=msvc-170">const</a> or <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/volatile-cpp?view=msvc-170">volatile</a> qualifier from the parameters of the virtual method. This means the compiler must bind a function reference to the method in either the base or derived class.</p>
+<p>Your application contains a method in a derived class that overrides a virtual method in a base class. The parameters in the overriding method differ by a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/const-cpp?view=msvc-170"><code>const</code></a> or <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/volatile-cpp?view=msvc-170"><code>volatile</code></a> qualifier from the parameters of the virtual method.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4373?view=msvc-170" target="_blank">C4373</a></p>]]>
     </description>
@@ -2858,7 +2861,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4375</key>
-    <name>C4375: non-public method 'method2' does not override 'method1'</name>
+    <name>C4375: Non-public method 'method2' does not override 'method1'</name>
     <description>
       <![CDATA[
 <p>A type that implements another type defined an override method, but the override was not public. Therefore, the method does not override the base type method.</p>
@@ -2869,7 +2872,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4376</key>
-    <name>C4376: access specifier 'old_specifier:' is no longer supported</name>
+    <name>C4376: Access specifier 'old_specifier:' is no longer supported</name>
     <description>
       <![CDATA[
 <p>Access specifier 'old_specifier:' is no longer supported: please use 'new_specifier:' instead.</p>
@@ -2881,7 +2884,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4377</key>
-    <name>C4377: native types are private by default; -d1PrivateNativeTypes is deprecated</name>
+    <name>C4377: Native types are private by default; -d1PrivateNativeTypes is deprecated</name>
     <description>
       <![CDATA[
 <p>In previous releases, native types in assemblies were public by default, and an internal, undocumented compiler option (<strong>/d1PrivateNativeTypes</strong>) was used to make them private.</p>
@@ -2925,7 +2928,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4382</key>
-    <name>C4382: throwing 'type' : a type with __clrcall destructor or copy constructor can only be caught in /clr:pure module</name>
+    <name>C4382: Throwing 'type': a type with __clrcall destructor or copy constructor can only be caught in /clr:pure module</name>
     <description>
       <![CDATA[
 <p>The <strong>/clr:pure</strong> compiler option is deprecated in Visual Studio 2015 and unsupported in Visual Studio 2017.</p>
@@ -2936,10 +2939,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4383</key>
-    <name>C4383: 'instance_dereference_operator' : the meaning of dereferencing a handle can change, when a user-defined 'operator' operator exists</name>
+    <name>C4383: 'instance_dereference_operator': the meaning of dereferencing a handle can change, when a user-defined 'operator' operator exists</name>
     <description>
       <![CDATA[
-<p>'instance_dereference_operator' : the meaning of dereferencing a handle can change, when a user-defined 'operator' operator exists; write the operator as a static function to be explicit about the operand.</p>
+<p>'instance_dereference_operator': the meaning of dereferencing a handle can change, when a user-defined 'operator' operator exists; write the operator as a static function to be explicit about the operand.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4383?view=msvc-170" target="_blank">C4383</a></p>]]>
     </description>
@@ -2947,10 +2950,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4384</key>
-    <name>C4384: #pragma 'make_public' should only be used at global scope</name>
+    <name>C4384: #pragma 'pragma_name' should only be used at global scope</name>
     <description>
       <![CDATA[
-<p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/make-public?view=msvc-170">make_public</a> pragma was applied incorrectly.</p>
+<p>A <code>pragma</code> directive that must be applied at a global scope, was found in a different scope.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4384?view=msvc-170" target="_blank">C4384</a></p>]]>
     </description>
@@ -2958,7 +2961,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4388</key>
-    <name>C4388: 'token' : signed/unsigned mismatch</name>
+    <name>C4388: 'token': signed/unsigned mismatch</name>
     <description>
       <![CDATA[
 <p>Using the <em>token</em> operator to compare a <strong><code>signed</code></strong> and a larger <strong><code>unsigned</code></strong> number required the compiler to convert the <strong><code>signed</code></strong> value to the larger <strong><code>unsigned</code></strong> type.</p>
@@ -2969,7 +2972,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4389</key>
-    <name>C4389: 'equality-operator' : signed/unsigned mismatch</name>
+    <name>C4389: 'equality-operator': signed/unsigned mismatch</name>
     <description>
       <![CDATA[
 <p>An <strong><code>==</code></strong> or <strong><code>!=</code></strong> operation involved <strong><code>signed</code></strong> and <strong><code>unsigned</code></strong> variables. This could result in a loss of data.</p>
@@ -2980,7 +2983,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4390</key>
-    <name>C4390: ';' : empty controlled statement found</name>
+    <name>C4390: ';': empty controlled statement found</name>
     <description>
       <![CDATA[
 <p>A semicolon was found after a control statement that contains no instructions.</p>
@@ -2991,7 +2994,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4391</key>
-    <name>C4391: 'signature' : incorrect return type for intrinsic function, expected 'type'</name>
+    <name>C4391: 'signature': incorrect return type for intrinsic function, expected 'type'</name>
     <description>
       <![CDATA[
 <p>A function declaration for a compiler intrinsic had the wrong return type. The resulting image may not run correctly.</p>
@@ -3002,10 +3005,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4392</key>
-    <name>C4392: 'signature' : incorrect number of arguments for intrinsic function, expected 'number' arguments</name>
+    <name>C4392: 'signature': incorrect number of arguments for intrinsic function, expected 'number' arguments</name>
     <description>
       <![CDATA[
-<p>A function declaration for a compiler intrinsic had the wrong number of arguments. The resulting image may not run correctly.</p>
+<p>A function declaration for a compiler intrinsic had the wrong number of arguments. The resulting image may not run correctly. To fix this warning, either correct the declaration or delete the declaration and <code>#include</code> the appropriate header file.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4392?view=msvc-170" target="_blank">C4392</a></p>]]>
     </description>
@@ -3013,7 +3016,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4393</key>
-    <name>C4393: 'var' : const has no effect on literal data member; ignored</name>
+    <name>C4393: 'var': const has no effect on literal data member; ignored</name>
     <description>
       <![CDATA[
 <p>A <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/extensions/literal-cpp-component-extensions?view=msvc-170">literal</a> data member was also specified as const.  Since a literal data member implies const, you do not need to add const to the declaration.</p>
@@ -3024,10 +3027,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4394</key>
-    <name>C4394: 'function' : per-appdomain symbol should not be marked with __declspec(dllexport)</name>
+    <name>C4394: 'function': per-appdomain symbol should not be marked with __declspec(dllexport)</name>
     <description>
       <![CDATA[
-<p>A function marked with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/appdomain?view=msvc-170">appdomain</a> <strong><code>__declspec</code></strong> modifier is compiled to MSIL (not to native), and export tables (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/export?view=msvc-170">export</a> <strong><code>__declspec</code></strong> modifier) are not supported for managed functions.</p>
+<p>A function marked with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/appdomain?view=msvc-170">appdomain</a> <strong><code>__declspec</code></strong> modifier is compiled to MSIL (not native), and export tables (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/export?view=msvc-170">export</a> <strong><code>__declspec</code></strong> modifier) aren't supported for managed functions.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4394?view=msvc-170" target="_blank">C4394</a></p>]]>
     </description>
@@ -3035,7 +3038,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4395</key>
-    <name>C4395: 'function' : member function will be invoked on a copy of the initonly data member 'member'</name>
+    <name>C4395: 'function': member function will be invoked on a copy of the initonly data member 'member'</name>
     <description>
       <![CDATA[
 <p>A member function was called on an <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/dotnet/initonly-cpp-cli?view=msvc-170">initonly (C++/CLI)</a> data member.  C4395 warns that the <strong>initonly</strong> data member cannot be modified by the function.</p>
@@ -3046,7 +3049,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4396</key>
-    <name>C4396: "name" : the inline specifier cannot be used when a friend declaration refers to a specialization of a function template</name>
+    <name>C4396: "name": the inline specifier cannot be used when a friend declaration refers to a specialization of a function template</name>
     <description>
       <![CDATA[
 <p>A specialization of a function template cannot specify any of the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/inline-functions-cpp?view=msvc-170">inline</a> specifiers. The compiler issues warning C4396 and ignores the inline specifier.</p>
@@ -3068,7 +3071,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4398</key>
-    <name>C4398: 'variable' : per-process global object might not work correctly with multiple appdomains</name>
+    <name>C4398: 'variable': per-process global object might not work correctly with multiple appdomains</name>
     <description>
       <![CDATA[
 <p>Per-process global object might not work correctly with multiple appdomains; consider using __declspec(appdomain).</p>
@@ -3080,7 +3083,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4399</key>
-    <name>C4399: 'symbol' : per-process symbol should not be marked with __declspec(dllimport) when compiled with /clr:pure</name>
+    <name>C4399: 'symbol': per-process symbol should not be marked with __declspec(dllimport) when compiled with /clr:pure</name>
     <description>
       <![CDATA[
 <p>The <strong>/clr:pure</strong> compiler option is deprecated in Visual Studio 2015 and unsupported in Visual Studio 2017.</p>
@@ -3091,7 +3094,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4400</key>
-    <name>C4400: 'type' : const/volatile qualifiers on this type are not supported</name>
+    <name>C4400: 'type': const/volatile qualifiers on this type are not supported</name>
     <description>
       <![CDATA[
 <p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/const-cpp?view=msvc-170">const</a>and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/volatile-cpp?view=msvc-170">volatile</a>qualifiers will not work with variables of common language runtime types.</p>
@@ -3102,7 +3105,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4401</key>
-    <name>C4401: 'bitfield' : member is bit field</name>
+    <name>C4401: 'bitfield': member is bit field</name>
     <description>
       <![CDATA[
 <p>Inline assembly code tries to access a bit-field member. Inline assembly cannot access bit-field members, so the last packing boundary before the bit-field member is used.</p>
@@ -3113,7 +3116,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4402</key>
-    <name>C4402: must use PTR operator</name>
+    <name>C4402: Must use PTR operator</name>
     <description>
       <![CDATA[
 <p>A type is used on an operand without a PTR operator when referring to or casting to a type in inline assembly code.</p>
@@ -3124,7 +3127,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4403</key>
-    <name>C4403: illegal PTR operator</name>
+    <name>C4403: Illegal PTR operator</name>
     <description>
       <![CDATA[
 <p>A PTR operator is used inappropriately in inline assembler code.</p>
@@ -3135,7 +3138,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4404</key>
-    <name>C4404: period on directive ignored</name>
+    <name>C4404: Period on directive ignored</name>
     <description>
       <![CDATA[
 <p>The optional period preceding the directive is ignored.</p>
@@ -3146,7 +3149,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4405</key>
-    <name>C4405: 'identifier' : identifier is reserved word</name>
+    <name>C4405: 'identifier': identifier is reserved word</name>
     <description>
       <![CDATA[
 <p>A word reserved for inline assembly is used as a variable name. This may cause unpredictable results. To fix this warning, avoid naming variables with words reserved for inline assembly.</p>
@@ -3157,7 +3160,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4406</key>
-    <name>C4406: operand on directive ignored</name>
+    <name>C4406: Operand on directive ignored</name>
     <description>
       <![CDATA[
 <p>The directive does not take any operands, but an operand was specified.</p>
@@ -3168,7 +3171,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4407</key>
-    <name>C4407: cast between different pointer to member representations, compiler may generate incorrect code</name>
+    <name>C4407: Cast between different pointer to member representations, compiler may generate incorrect code</name>
     <description>
       <![CDATA[
 <p>An incorrect cast between pointer-to-member types was detected.</p>
@@ -3179,7 +3182,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4408</key>
-    <name>C4408: anonymousstruct or union did not declare any data members</name>
+    <name>C4408: Anonymousstruct or union did not declare any data members</name>
     <description>
       <![CDATA[
 <p>An anonymous struct or union must have at least one data member.</p>
@@ -3190,7 +3193,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4409</key>
-    <name>C4409: illegal instruction size</name>
+    <name>C4409: Illegal instruction size</name>
     <description>
       <![CDATA[
 <p>The instruction did not have a form with the specified size. The smallest legal size was used.</p>
@@ -3201,7 +3204,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4410</key>
-    <name>C4410: illegal size for operand</name>
+    <name>C4410: Illegal size for operand</name>
     <description>
       <![CDATA[
 <p>One of the operands on the instruction had an incorrect size. The smallest legal size for the operand was used.</p>
@@ -3212,7 +3215,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4411</key>
-    <name>C4411: 'identifier' : symbol resolves to displacement register</name>
+    <name>C4411: 'identifier': symbol resolves to displacement register</name>
     <description>
       <![CDATA[
 <p>The identifier is a local symbol that resolves to a displacement register and therefore may be used on an operand with another symbol.</p>
@@ -3223,7 +3226,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4412</key>
-    <name>C4412: 'function' : function signature contains type 'type'; C++ objects are unsafe to pass between pure code and mixed or native</name>
+    <name>C4412: 'function': function signature contains type 'type'; C++ objects are unsafe to pass between pure code and mixed or native</name>
     <description>
       <![CDATA[
 <p>The <strong>/clr:pure</strong> compiler option is deprecated in Visual Studio 2015 and unsupported in Visual Studio 2017. If you have code that needs to be pure, we recommend that you port it to C#.</p>
@@ -3234,7 +3237,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4414</key>
-    <name>C4414: 'function' : short jump to function converted to near</name>
+    <name>C4414: 'function': short jump to function converted to near</name>
     <description>
       <![CDATA[
 <p>Short jumps generate compact instruction which branches to an address within a limited range from the instruction. The instruction includes a short offset that represents the distance between the jump and the target address, the function definition. During linking a function may be moved or subject to link-time optimizations that cause the function to be moved out of the range reachable from a short offset. The compiler must generate a special record for the jump, which requires the jmp instruction to be either NEAR or FAR. The compiler made the conversion.</p>
@@ -3245,7 +3248,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4420</key>
-    <name>C4420: 'operator' : operator not available, using 'operator' instead; run-time checking may be compromised</name>
+    <name>C4420: 'operator': operator not available, using 'operator' instead; run-time checking may be compromised</name>
     <description>
       <![CDATA[
 <p>This warning is generated when you use the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/rtc-run-time-error-checks?view=msvc-170">/RTCv</a> (vector new/delete checking) and when no vector form is found. In this case, the non-vector form is used.</p>
@@ -3256,7 +3259,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4429</key>
-    <name>C4429: possible incomplete or improperly formed universal-character-name</name>
+    <name>C4429: Possible incomplete or improperly formed universal-character-name</name>
     <description>
       <![CDATA[
 <p>The compiler detected a character sequence that may be a badly formed universal character name. A universal character name is <code>\u</code> followed by four hex digits, or <code>\U</code> followed by eight hex digits.</p>
@@ -3267,7 +3270,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4430</key>
-    <name>C4430: missing type specifier - int assumed</name>
+    <name>C4430: Missing type specifier - int assumed</name>
     <description>
       <![CDATA[
 <p>This error can be generated as a result of compiler conformance work that was done for Visual Studio 2005: all declarations must explicitly specify the type; int is no longer assumed.</p>
@@ -3278,7 +3281,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4431</key>
-    <name>C4431: missing type specifier - int assumed</name>
+    <name>C4431: Missing type specifier - int assumed</name>
     <description>
       <![CDATA[
 <p>This error can be generated as a result of compiler conformance work that was done for Visual Studio 2005: Visual C++ no longer creates untyped identifiers as int by default. The type of an identifier must be specified explicitly.</p>
@@ -3289,7 +3292,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4434</key>
-    <name>C4434: a class constructor must have private accessibility; changing to private access</name>
+    <name>C4434: A class constructor must have private accessibility; changing to private access</name>
     <description>
       <![CDATA[
 <p>C4434 indicates that the compiler changed the accessibility of a static constructor. Static constructors must have private accessibility, as they are only meant to be called by the common language runtime. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli?view=msvc-170#BKMK_Static_constructors">Static constructors</a>.</p>
@@ -3300,7 +3303,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4435</key>
-    <name>C4435: 'class1' : Object layout under /vd2 will change due to virtual base 'class2'</name>
+    <name>C4435: 'class1': Object layout under /vd2 will change due to virtual base 'class2'</name>
     <description>
       <![CDATA[
 <p>This warning is off by default. See <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/compiler-warnings-that-are-off-by-default?view=msvc-170">Compiler Warnings That Are Off by Default</a> for more information.</p>
@@ -3333,7 +3336,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4439</key>
-    <name>C4439: 'function' : function definition with a managed type in the signature must have a __clrcall calling convention</name>
+    <name>C4439: 'function': function definition with a managed type in the signature must have a __clrcall calling convention</name>
     <description>
       <![CDATA[
 <p>The compiler implicitly replaced a calling convention with <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/clrcall?view=msvc-170"><code>__clrcall</code></a>. To resolve this warning, remove the <strong><code>__cdecl</code></strong> or <strong><code>__stdcall</code></strong> calling convention.</p>
@@ -3344,7 +3347,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4440</key>
-    <name>C4440: calling convention redefinition from 'calling_convention1' to 'calling_convention2' ignored</name>
+    <name>C4440: Calling convention redefinition from 'calling_convention1' to 'calling_convention2' ignored</name>
     <description>
       <![CDATA[
 <p>An attempt to change the calling convention was ignored.</p>
@@ -3355,7 +3358,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4441</key>
-    <name>C4441: calling convention of 'cc1' ignored; 'cc2' used instead</name>
+    <name>C4441: Calling convention of 'cc1' ignored; 'cc2' used instead</name>
     <description>
       <![CDATA[
 <p>Member functions in managed user-defined types and global function generics must use the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/clrcall?view=msvc-170">__clrcall</a> calling convention.  The compiler used <code>__clrcall</code>.</p>
@@ -3366,7 +3369,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4445</key>
-    <name>C4445: 'function' : in a WinRT or managed type a virtual method cannot be private</name>
+    <name>C4445: 'function': in a WinRT or managed type a virtual method cannot be private</name>
     <description>
       <![CDATA[
 <p>If a virtual function is private, it cannot be accessed by a derived type. To fix this error, change the accessibility of the virtual member function to protected or public.</p>
@@ -3377,7 +3380,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4456</key>
-    <name>C4456: declaration of 'identifier' hides previous local declaration</name>
+    <name>C4456: Declaration of 'identifier' hides previous local declaration</name>
     <description>
       <![CDATA[
 <p>The declaration of <em>identifier</em> in the local scope hides the declaration of the previous local declaration of the same name. This warning lets you know that references to <em>identifier</em> in the local scope resolve to the locally declared version, not the previous local, which may or may not be your intent. To fix this issue, we recommend you give local variables names that do not conflict with other local names.</p>
@@ -3388,7 +3391,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4457</key>
-    <name>C4457: declaration of 'identifier' hides function parameter</name>
+    <name>C4457: Declaration of 'identifier' hides function parameter</name>
     <description>
       <![CDATA[
 <p>The declaration of <em>identifier</em> in the local scope hides the declaration of the identically-named function parameter. This warning lets you know that references to <em>identifier</em> in the local scope resolve to the locally declared version, not the parameter, which may or may not be your intent. To fix this issue, we recommend you give local variables names that do not conflict with parameter names.</p>
@@ -3399,7 +3402,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4458</key>
-    <name>C4458: declaration of 'identifier' hides class member</name>
+    <name>C4458: Declaration of 'identifier' hides class member</name>
     <description>
       <![CDATA[
 <p>The declaration of <em>identifier</em> in the local scope hides the declaration of the identically-named <em>identifier</em> at class scope. This warning lets you know that references to <em>identifier</em> in this scope resolve to the locally declared version, not the class member version, which may or may not be your intent. To fix this issue, we recommend you give local variables names that do not conflict with class member names.</p>
@@ -3410,7 +3413,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4459</key>
-    <name>C4459: declaration of 'identifier' hides global declaration</name>
+    <name>C4459: Declaration of 'identifier' hides global declaration</name>
     <description>
       <![CDATA[
 <p>The declaration of <em>identifier</em> in the local scope hides the declaration of the identically-named <em>identifier</em> in global scope. This warning lets you know that references to <em>identifier</em> in this scope resolve to the locally declared version, not the global version, which may or may not be your intent. Generally, we recommend you minimize the use of global variables as a good engineering practice. To minimize pollution of the global namespace, we recommend use of a named namespace for global variables.</p>
@@ -3432,7 +3435,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4461</key>
-    <name>C4461: 'type' : this class has a finalizer 'finalizer' but no destructor 'dtor'</name>
+    <name>C4461: 'type': this class has a finalizer 'finalizer' but no destructor 'dtor'</name>
     <description>
       <![CDATA[
 <p>The presence of a finalizer in a type implies resources to delete. Unless a finalizer is explicitly called from the type's destructor, the common language runtime determines when to run the finalizer, after your object goes out of scope.</p>
@@ -3443,7 +3446,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4462</key>
-    <name>C4462: cannot determine the GUID of the type</name>
+    <name>C4462: Cannot determine the GUID of the type</name>
     <description>
       <![CDATA[
 <p>Warning C4462 occurs in a Windows Runtime app or component when a public <code>TypedEventHandler</code> has as one of its type parameters a reference to the enclosing class.</p>
@@ -3454,7 +3457,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4463</key>
-    <name>C4463: overflow; assigning value to bit-field that can only hold values from low_value to high_value</name>
+    <name>C4463: Overflow: assigning value to bit-field that can only hold values from low_value to high_value</name>
     <description>
       <![CDATA[
 <p>The assigned <em>value</em> is outside the range of values that the bit-field can hold. Signed bit-field types use the high-order bit for the sign, so if <em>n</em> is the bit-field size, the range for signed bit-fields is -2<sup>n-1</sup> to 2<sup>n-1</sup>-1, while unsigned bit-fields have a range from 0 to 2<sup>n</sup>-1.</p>
@@ -3465,7 +3468,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4464</key>
-    <name>C4464: relative include path contains '..'</name>
+    <name>C4464: Relative include path contains '..'</name>
     <description>
       <![CDATA[
 <p>A <code>#include</code> directive has a path that includes a parent directory specifier (a <code>..</code> path segment).</p>
@@ -3498,7 +3501,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4473</key>
-    <name>C4473: 'function' : not enough arguments passed for format string</name>
+    <name>C4473: 'function': not enough arguments passed for format string</name>
     <description>
       <![CDATA[
 <p>The compiler detected a mismatch between the number of arguments required to satisfy the placeholders in a format string, and the number of arguments supplied. Correct use of the printf and scanf families of variadic functions requires that you supply as many arguments as specified by the format string. Certain placeholders require additional arguments, to specify the width, precision, or buffer size, as well as an argument for the content. A mismatch generally means there is a bug in your code.</p>
@@ -3509,7 +3512,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4477</key>
-    <name>C4477: 'function' : format string 'string' requires an argument of type 'type', but variadic argument number has type 'type'</name>
+    <name>C4477: 'function': format string 'string' requires an argument of type 'type', but variadic argument number has type 'type'</name>
     <description>
       <![CDATA[
 <p>The compiler detected a mismatch between the type of argument required to satisfy the placeholder in a format string, and the type of argument supplied. Correct use of the printf and scanf families of variadic functions requires that you supply arguments of the types specified by the format string. A mismatch generally means there is a bug in your code.</p>
@@ -3520,7 +3523,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4481</key>
-    <name>C4481: nonstandard extension used: override specifier 'keyword'</name>
+    <name>C4481: Nonstandard extension used: override specifier 'keyword'</name>
     <description>
       <![CDATA[
 <p>A keyword was used that is not in the C++ standard, for example, one of the override specifiers that also works under /clr.</p>
@@ -3531,7 +3534,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4484</key>
-    <name>C4484: 'override_function' : matches base ref class method 'base_class_function', but is not marked 'virtual', 'new' or 'override'; 'new' (and not 'virtual') is assumed</name>
+    <name>C4484: 'override_function': matches base ref class method 'base_class_function', but is not marked 'virtual', 'new' or 'override'; 'new' (and not 'virtual') is assumed</name>
     <description>
       <![CDATA[
 <p>When compiling with <strong>/clr</strong>, the compiler will not implicitly override a base class function, which means the function will get a new slot in the vtable. To resolve, explicitly specify whether a function is an override.</p>
@@ -3542,7 +3545,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4485</key>
-    <name>C4485: 'override_function' : matches base ref class method 'base_class_function ', but is not marked 'new' or 'override'; 'new' (and 'virtual') is assumed</name>
+    <name>C4485: 'override_function': matches base ref class method 'base_class_function ', but is not marked 'new' or 'override'; 'new' (and 'virtual') is assumed</name>
     <description>
       <![CDATA[
 <p>An accessor overrides, with or without the <strong><code>virtual</code></strong> keyword, a base class accessor function, but the <code>override</code> or <strong><code>new</code></strong> specifier was not part of the overriding function signature. Add the <strong><code>new</code></strong> or <code>override</code> specifier to resolve this warning.</p>
@@ -3553,7 +3556,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4486</key>
-    <name>C4486: 'function' : a private virtual method of a ref class or value class should be marked 'sealed'</name>
+    <name>C4486: 'function': a private virtual method of a ref class or value class should be marked 'sealed'</name>
     <description>
       <![CDATA[
 <p>Since a private virtual member function of a managed class or struct cannot be accessed or overridden, it should be marked <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/extensions/sealed-cpp-component-extensions?view=msvc-170">sealed</a>.</p>
@@ -3564,7 +3567,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4487</key>
-    <name>C4487: 'derived_class_function' : matches inherited non-virtual method 'base_class_function' but is not explicitly marked 'new'</name>
+    <name>C4487: 'derived_class_function': matches inherited non-virtual method 'base_class_function' but is not explicitly marked 'new'</name>
     <description>
       <![CDATA[
 <p>A function in a derived class has the same signature as a non-virtual base class function. C4487 reminds you that the derived class function does not override the base class function. Explicitly mark the derived class function as <strong><code>new</code></strong> to resolve this warning.</p>
@@ -3575,7 +3578,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4488</key>
-    <name>C4488: 'function' : requires 'keyword' keyword to implement the interface method 'interface_method'</name>
+    <name>C4488: 'function': requires 'keyword' keyword to implement the interface method 'interface_method'</name>
     <description>
       <![CDATA[
 <p>A class must implement all members of an interface from which it directly inherits. An implemented member must have public accessibility, and must be marked virtual.</p>
@@ -3586,7 +3589,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4489</key>
-    <name>C4489: 'specifier' : not allowed on interface method 'method'; override specifiers are only allowed on ref class and value class methods</name>
+    <name>C4489: 'specifier': not allowed on interface method 'method'; override specifiers are only allowed on ref class and value class methods</name>
     <description>
       <![CDATA[
 <p>A specifier keyword was incorrectly used on an interface method.</p>
@@ -3597,7 +3600,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4490</key>
-    <name>C4490: 'override' : incorrect use of override specifier; 'function' does not match a base ref class method</name>
+    <name>C4490: 'override': incorrect use of override specifier; 'function' does not match a base ref class method</name>
     <description>
       <![CDATA[
 <p>An override specifier was used incorrectly. For example, you do not override an interface function, you implement it.</p>
@@ -3619,7 +3622,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4503</key>
-    <name>C4503: 'identifier' : decorated name length exceeded, name was truncated</name>
+    <name>C4503: 'identifier': decorated name length exceeded, name was truncated</name>
     <description>
       <![CDATA[
 <p>This compiler warning is obsolete and is not generated in Visual Studio 2017 and later compilers.</p>
@@ -3630,7 +3633,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4505</key>
-    <name>C4505: 'function' : unreferenced local function has been removed</name>
+    <name>C4505: 'function': unreferenced local function has been removed</name>
     <description>
       <![CDATA[
 <p>The given function is local and not referenced in the body of the module; therefore, the function is dead code.</p>
@@ -3641,7 +3644,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4506</key>
-    <name>C4506: no definition for inline function 'function'</name>
+    <name>C4506: No definition for inline function 'function'</name>
     <description>
       <![CDATA[
 <p>The given function was declared and marked for inlining but was not defined.</p>
@@ -3652,7 +3655,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4508</key>
-    <name>C4508: 'function' : function should return a value; 'void' return type assumed</name>
+    <name>C4508: 'function': function should return a value; 'void' return type assumed</name>
     <description>
       <![CDATA[
 <p>The function has no return type specified. In this case, C4430 should also fire and the compiler implements the fix reported by C4430 (default value is int).</p>
@@ -3663,7 +3666,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4510</key>
-    <name>C4510: 'class' : default constructor could not be generated</name>
+    <name>C4510: 'class': default constructor could not be generated</name>
     <description>
       <![CDATA[
 <p>The compiler can't generate a default constructor for the specified class, which has no user-defined constructors. Objects of this type can't be created.</p>
@@ -3674,7 +3677,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4511</key>
-    <name>C4511: 'class' : copy constructor could not be generated</name>
+    <name>C4511: 'class': copy constructor could not be generated</name>
     <description>
       <![CDATA[
 <p>The compiler could not generate a default copy-constructor for a class; a base class may have a private copy-constructor.</p>
@@ -3685,7 +3688,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4512</key>
-    <name>C4512: 'class' : assignment operator could not be generated</name>
+    <name>C4512: 'class': assignment operator could not be generated</name>
     <description>
       <![CDATA[
 <p>The compiler cannot generate an assignment operator for the given class. No assignment operator was created.</p>
@@ -3696,7 +3699,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4513</key>
-    <name>C4513: 'class' : destructor could not be generated</name>
+    <name>C4513: 'class': destructor could not be generated</name>
     <description>
       <![CDATA[
 <p>The compiler cannot generate a default destructor for the given class; no destructor was created. The destructor is in a base class that is not accessible to the derived class. If the base class has a private destructor, make it public or protected.</p>
@@ -3707,7 +3710,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4514</key>
-    <name>C4514: 'function' : unreferenced inline function has been removed</name>
+    <name>C4514: 'function': unreferenced inline function has been removed</name>
     <description>
       <![CDATA[
 <p>The optimizer removed an inline function that is not called.</p>
@@ -3718,7 +3721,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4515</key>
-    <name>C4515: 'namespace' : namespace uses itself</name>
+    <name>C4515: 'namespace': namespace uses itself</name>
     <description>
       <![CDATA[
 <p>A namespace is used recursively.</p>
@@ -3729,7 +3732,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4516</key>
-    <name>C4516: 'class::symbol' : access-declarations are deprecated; member using-declarations provide a better alternative</name>
+    <name>C4516: 'class::symbol': access-declarations are deprecated; member using-declarations provide a better alternative</name>
     <description>
       <![CDATA[
 <p>The ANSI C++ committee has declared access declarations (changing the access of a member in a derived class without the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/using-declaration?view=msvc-170">using</a> keyword) to be outdated. Access declarations may not be supported by future versions of C++.</p>
@@ -3740,7 +3743,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4517</key>
-    <name>C4517: access-declarations are deprecated; member using-declarations provide a better alternative</name>
+    <name>C4517: Access-declarations are deprecated; member using-declarations provide a better alternative</name>
     <description>
       <![CDATA[
 <p>The ANSI C++ committee has declared access declarations (changing the access of a member in a derived class without the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/using-declaration?view=msvc-170">using</a> keyword) to be outdated. Access declarations may not be supported by future versions of C++.</p>
@@ -3751,7 +3754,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4518</key>
-    <name>C4518: 'specifier' : storage-class or type specifier(s) unexpected here; ignored</name>
+    <name>C4518: 'specifier': storage-class or type specifier(s) unexpected here; ignored</name>
     <description>
       <![CDATA[
 <p>storage-class or type specifier(s) unexpected here; ignored.</p>
@@ -3762,7 +3765,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4521</key>
-    <name>C4521: 'class' : multiple copy constructors specified</name>
+    <name>C4521: 'class': multiple copy constructors specified</name>
     <description>
       <![CDATA[
 <p>The class has multiple copy constructors of a single type. This warning is informational; the constructors are callable in your program.</p>
@@ -3773,7 +3776,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4522</key>
-    <name>C4522: 'class' : multiple assignment operators specified</name>
+    <name>C4522: 'class': multiple assignment operators specified</name>
     <description>
       <![CDATA[
 <p>The class has multiple assignment operators of a single type. This warning is informational; the constructors are callable in your program.</p>
@@ -3784,7 +3787,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4523</key>
-    <name>C4523: 'class' : multiple destructors specified</name>
+    <name>C4523: 'class': multiple destructors specified</name>
     <description>
       <![CDATA[
 <p>The class has multiple destructors.</p>
@@ -3795,7 +3798,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4526</key>
-    <name>C4526: 'function' : static member function cannot override virtual function 'virtual function'override ignored, virtual function will be hidden</name>
+    <name>C4526: 'function': static member function cannot override virtual function 'virtual function'override ignored, virtual function will be hidden</name>
     <description>
       <![CDATA[
 <p>The static member function meets the criteria to override the virtual function, which makes the member function both virtual and static.</p>
@@ -3817,10 +3820,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4532</key>
-    <name>C4532: 'continue' : jump out of __finally/finally block has undefined behavior during termination handling</name>
+    <name>C4532: 'continue': jump out of __finally/finally block has undefined behavior during termination handling</name>
     <description>
       <![CDATA[
-<p>jump out of __finally/finally block has undefined behavior during termination handling,</p>
+<p>jump out of __finally/finally block has undefined behavior during termination handling.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4532?view=msvc-170" target="_blank">C4532</a></p>]]>
     </description>
@@ -3828,7 +3831,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4533</key>
-    <name>C4533: initialization of 'variable' is skipped by 'instruction'</name>
+    <name>C4533: Initialization of 'variable' is skipped by 'instruction'</name>
     <description>
       <![CDATA[
 <p>An instruction in your program changed the flow of control, so an instruction that initialized a variable wasn't executed.</p>
@@ -3861,7 +3864,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4536</key>
-    <name>C4536: 'type name' : type-name exceeds meta-data limit of 'limit' characters</name>
+    <name>C4536: 'type name': type-name exceeds meta-data limit of 'limit' characters</name>
     <description>
       <![CDATA[
 <p>A type name would be truncated in metadata if it was a managed type. See <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c3180?view=msvc-170">C3180</a> for more information.</p>
@@ -3872,7 +3875,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4537</key>
-    <name>C4537: 'object' : 'operator' applied to non-UDT type</name>
+    <name>C4537: 'object': 'operator' applied to non-UDT type</name>
     <description>
       <![CDATA[
 <p>A reference was passed where an object (user-defined type) was expected. A reference is not an object, but inline assembler code is not able to make the distinction. The compiler generates code as though <em>object</em> were an instance.</p>
@@ -3883,7 +3886,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4538</key>
-    <name>C4538: 'type' : const/volatile qualifiers on this type are not supported</name>
+    <name>C4538: 'type': const/volatile qualifiers on this type are not supported</name>
     <description>
       <![CDATA[
 <p>A qualifier keyword was applied to an array incorrectly. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/extensions/arrays-cpp-component-extensions?view=msvc-170">array</a>.</p>
@@ -3938,7 +3941,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4545</key>
-    <name>C4545: expression before comma evaluates to a function which is missing an argument list</name>
+    <name>C4545: Expression before comma evaluates to a function which is missing an argument list</name>
     <description>
       <![CDATA[
 <p>The compiler detected an ill-formed comma expression.</p>
@@ -3949,7 +3952,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4546</key>
-    <name>C4546: function call before comma missing argument list</name>
+    <name>C4546: Function call before comma missing argument list</name>
     <description>
       <![CDATA[
 <p>The compiler detected an ill-formed comma expression.</p>
@@ -3960,7 +3963,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4547</key>
-    <name>C4547: 'operator' : operator before comma has no effect; expected operator with side-effect</name>
+    <name>C4547: 'operator': operator before comma has no effect; expected operator with side-effect</name>
     <description>
       <![CDATA[
 <p>The compiler detected an ill-formed comma expression.</p>
@@ -3971,7 +3974,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4548</key>
-    <name>C4548: expression before comma has no effect; expected expression with side-effect</name>
+    <name>C4548: Expression before comma has no effect; expected expression with side-effect</name>
     <description>
       <![CDATA[
 <p>The compiler detected an ill-formed comma expression.</p>
@@ -3982,7 +3985,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4549</key>
-    <name>C4549: 'operator' : operator before comma has no effect</name>
+    <name>C4549: 'operator': operator before comma has no effect</name>
     <description>
       <![CDATA[
 <p>The compiler detected an ill-formed comma expression.</p>
@@ -3993,7 +3996,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4550</key>
-    <name>C4550: expression evaluates to a function which is missing an argument list</name>
+    <name>C4550: Expression evaluates to a function which is missing an argument list</name>
     <description>
       <![CDATA[
 <p>A dereferenced pointer to a function is missing an argument list.</p>
@@ -4004,7 +4007,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4551</key>
-    <name>C4551: function call missing argument list</name>
+    <name>C4551: Function call missing argument list</name>
     <description>
       <![CDATA[
 <p>A function call must include the open and close parentheses after the function name even if the function takes no parameters.</p>
@@ -4015,7 +4018,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4552</key>
-    <name>C4552: 'operator' : operator has no effect; expected operator with side-effect</name>
+    <name>C4552: 'operator': operator has no effect; expected operator with side-effect</name>
     <description>
       <![CDATA[
 <p>If an expression statement has an operator with no side effect as the top of the expression, it's probably a mistake.</p>
@@ -4026,7 +4029,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4553</key>
-    <name>C4553: 'operator' : operator has no effect</name>
+    <name>C4553: 'operator': operator has no effect</name>
     <description>
       <![CDATA[
 <p>If an expression statement has an operator with no side effect as the top of the expression, it's probably a mistake.</p>
@@ -4037,7 +4040,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4554</key>
-    <name>C4554: 'operator' : check operator precedence for possible error</name>
+    <name>C4554: 'operator': check operator precedence for possible error</name>
     <description>
       <![CDATA[
 <p>Check operator precedence for possible error; use parentheses to clarify precedence.</p>
@@ -4048,7 +4051,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4555</key>
-    <name>C4555: expression has no effect; expected expression with side-effect</name>
+    <name>C4555: Expression has no effect; expected expression with side-effect</name>
     <description>
       <![CDATA[
 <p>This warning informs you when an expression has no effect.</p>
@@ -4059,7 +4062,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4556</key>
-    <name>C4556: value of intrinsic immediate argument 'value' is out of range 'lowerbound - upperbound'</name>
+    <name>C4556: Value of intrinsic immediate argument 'value' is out of range 'lowerbound - upperbound'</name>
     <description>
       <![CDATA[
 <p>An intrinsic matches a hardware instruction. The hardware instruction has a fixed number of bits to encode the constant. If <em>value</em> is out of range, it will not encode properly. The compiler truncates the extra bits.</p>
@@ -4081,7 +4084,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4558</key>
-    <name>C4558: value of operand 'value' is out of range 'lowerbound - upperbound'</name>
+    <name>C4558: Value of operand 'value' is out of range 'lowerbound - upperbound'</name>
     <description>
       <![CDATA[
 <p>The value passed to an assembly language instruction is out of the range specified for the parameter. The value will be truncated.</p>
@@ -4092,7 +4095,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4559</key>
-    <name>C4559: 'function' : redefinition; the function gains __declspec(modifier)</name>
+    <name>C4559: 'function': redefinition; the function gains __declspec(modifier)</name>
     <description>
       <![CDATA[
 <p>A function was redefined or redeclared and the second definition or declaration added a <strong><code>__declspec</code></strong> modifier (<em>modifier</em>). This warning is informational. To fix this warning, delete one of the definitions.</p>
@@ -4114,7 +4117,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4564</key>
-    <name>C4564: method 'method' of class 'class' defines unsupported default parameter 'parameter'</name>
+    <name>C4564: Method 'method' of class 'class' defines unsupported default parameter 'parameter'</name>
     <description>
       <![CDATA[
 <p>The compiler detected a method with one or more parameters with default values. The default value(s) for the parameters will be ignored when the method is invoked; explicitly specify values for those parameters. If you do not explicitly specify values for those parameters, the C++ compiler will generate an error.</p>
@@ -4125,7 +4128,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4565</key>
-    <name>C4565: 'function' : redefinition; the symbol was previously declared with __declspec(modifier)</name>
+    <name>C4565: 'function': redefinition; the symbol was previously declared with __declspec(modifier)</name>
     <description>
       <![CDATA[
 <p>A symbol was redefined or redeclared and the second definition or declaration, unlike the first definition or declaration, did not have a <strong><code>__declspec</code></strong> modifier (<em>modifier</em>). This warning is informational. To fix this warning, delete one of the definitions.</p>
@@ -4136,7 +4139,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4566</key>
-    <name>C4566: character represented by universal-character-name 'char' cannot be represented in the current code page (page)</name>
+    <name>C4566: Character represented by universal-character-name 'char' cannot be represented in the current code page (page)</name>
     <description>
       <![CDATA[
 <p>Not every Unicode character can be represented in your current ANSI code page.</p>
@@ -4147,7 +4150,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4570</key>
-    <name>C4570: 'type' : is not explicitly declared as abstract but has abstract functions</name>
+    <name>C4570: 'type': is not explicitly declared as abstract but has abstract functions</name>
     <description>
       <![CDATA[
 <p>A type that contains <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/extensions/abstract-cpp-component-extensions?view=msvc-170">abstract</a> functions should itself be marked as abstract.</p>
@@ -4205,7 +4208,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4581</key>
-    <name>C4581: deprecated behavior: '"string1"' replaced with 'string2' to process attribute</name>
+    <name>C4581: Deprecated behavior: '"string1"' replaced with 'string2' to process attribute</name>
     <description>
       <![CDATA[
 <p>This error can be generated as a result of compiler conformance work that was done for Visual Studio 2005: parameter checking for Visual C++ attributes.</p>
@@ -4216,7 +4219,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4584</key>
-    <name>C4584: 'class1' : base-class 'class2' is already a base-class of 'class3'</name>
+    <name>C4584: 'class1': base-class 'class2' is already a base-class of 'class3'</name>
     <description>
       <![CDATA[
 <p>The class you defined inherits from two classes, one of which inherits from the other.</p>
@@ -4235,21 +4238,21 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4596?view=msvc-170" target="_blank">C4596</a></p>]]>
     </description>
     <severity>INFO</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C4597</key>
-    <name>C4597: undefined behavior: offsetof applied to a member of a virtual base</name>
+    <name>C4597: Undefined behavior: offsetof applied to a member of a virtual base</name>
     <description>
       <![CDATA[
 <p>Using <code>offsetof(T, m)</code> where <em><code>m</code></em> refers to a static data member or a member function results in C4597.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4597?view=msvc-170" target="_blank">C4597</a></p>]]>
-      </description>
+    </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4600</key>
-    <name>C4600: #pragma 'macro name' : expected a valid non-empty string</name>
+    <name>C4600: #pragma 'macro name': expected a valid non-empty string</name>
     <description>
       <![CDATA[
 <p>You cannot specify an empty string when you push or pop a macro name with either the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/pop-macro?view=msvc-170">pop_macro</a> or <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/push-macro?view=msvc-170">push_macro</a>.</p>
@@ -4260,7 +4263,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4602</key>
-    <name>C4602: #pragma pop_macro : 'macro name' no previous #pragma push_macro for this identifier</name>
+    <name>C4602: #pragma pop_macro: 'macro name' no previous #pragma push_macro for this identifier</name>
     <description>
       <![CDATA[
 <p>If you use <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/pop-macro?view=msvc-170">pop_macro</a> for a particular macro, you must first have passed that macro name to <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/push-macro?view=msvc-170">push_macro</a>.</p>
@@ -4271,7 +4274,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4603</key>
-    <name>C4603: '&lt;identifier&gt;' : macro is not defined or definition is different after precompiled header use</name>
+    <name>C4603: '&lt;identifier&gt;': macro is not defined or definition is different after precompiled header use</name>
     <description>
       <![CDATA[
 <p>The macro specified by the <em>identifier</em> placeholder is either different or no longer defined after the precompiler header is used.</p>
@@ -4282,7 +4285,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4606</key>
-    <name>C4606: #pragma warning : 'warning_number' ignored; Code Analysis warnings are not associated with warning levels</name>
+    <name>C4606: #pragma warning: 'warning_number' ignored; Code Analysis warnings are not associated with warning levels</name>
     <description>
       <![CDATA[
 <p>For Code Analysis warnings, only <code>error</code>, <code>once</code>, and <code>default</code> are supported with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170">warning</a> pragma.</p>
@@ -4315,7 +4318,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4611</key>
-    <name>C4611: interaction between 'function' and C++ object destruction is non-portable</name>
+    <name>C4611: Interaction between 'function' and C++ object destruction is non-portable</name>
     <description>
       <![CDATA[
 <p>On some platforms, functions that include <strong><code>catch</code></strong> may not support C++ object semantics of destruction when out of scope.</p>
@@ -4326,7 +4329,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4612</key>
-    <name>C4612: error in include filename</name>
+    <name>C4612: Error in include filename</name>
     <description>
       <![CDATA[
 <p>This warning occurs with <strong>#pragma include_alias</strong> when a filename is incorrect or missing.</p>
@@ -4337,7 +4340,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4613</key>
-    <name>C4613: 'segment' : class of segment cannot be changed</name>
+    <name>C4613: 'segment': class of segment cannot be changed</name>
     <description>
       <![CDATA[
 <p>You tried to create a segment with the same class name as a segment used by the compiler. No new segment class was created.</p>
@@ -4348,7 +4351,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4615</key>
-    <name>C4615: #pragma warning : unknown user warning type</name>
+    <name>C4615: #pragma warning: unknown user warning type</name>
     <description>
       <![CDATA[
 <p>An invalid warning specifier was used with <strong>pragma</strong> <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170">warning</a>. To resolve the error, use a valid warning specifier.</p>
@@ -4359,7 +4362,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4616</key>
-    <name>C4616: #pragma warning : warning number 'number' not a valid compiler warning</name>
+    <name>C4616: #pragma warning: warning number 'number' not a valid compiler warning</name>
     <description>
       <![CDATA[
 <p>The warning number specified in the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170">warning</a> pragma cannot be reassigned. The pragma was ignored.</p>
@@ -4370,7 +4373,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4618</key>
-    <name>C4618: pragma parameters included an empty string; pragma ignored</name>
+    <name>C4618: Pragma parameters included an empty string; pragma ignored</name>
     <description>
       <![CDATA[
 <p>A null string was given as an argument to a <strong>#pragma</strong>.</p>
@@ -4381,7 +4384,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4619</key>
-    <name>C4619: #pragma warning : there is no warning number 'number'</name>
+    <name>C4619: #pragma warning: there is no warning number 'number'</name>
     <description>
       <![CDATA[
 <p>An attempt was made to disable a warning that does not exist.</p>
@@ -4392,7 +4395,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4620</key>
-    <name>C4620: no postfix form of 'operator ++' found for type 'type', using prefix form</name>
+    <name>C4620: No postfix form of 'operator ++' found for type 'type', using prefix form</name>
     <description>
       <![CDATA[
 <p>There is no postfix increment operator defined for the given type. The compiler used the overloaded prefix operator.</p>
@@ -4403,7 +4406,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4621</key>
-    <name>C4621: no postfix form of 'operator --' found for type 'type', using prefix form</name>
+    <name>C4621: No postfix form of 'operator --' found for type 'type', using prefix form</name>
     <description>
       <![CDATA[
 <p>There was no postfix decrement operator defined for the given type. The compiler used the overloaded prefix operator.</p>
@@ -4425,7 +4428,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4623</key>
-    <name>C4623: 'derived class' : default constructor was implicitly defined as deleted</name>
+    <name>C4623: 'derived class': default constructor was implicitly defined as deleted</name>
     <description>
       <![CDATA[
 <p>Because the default constructor is deleted or inaccessible in a base class, the compiler can't generate a default constructor for the derived class. Attempts to create an object of this type by using the default constructor (for example, in an array) cause a compiler error.</p>
@@ -4436,7 +4439,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4624</key>
-    <name>C4624: 'derived class' : destructor was implicitly defined as deleted because a base class destructor is inaccessible or deleted</name>
+    <name>C4624: 'derived class': destructor was implicitly defined as deleted because a base class destructor is inaccessible or deleted</name>
     <description>
       <![CDATA[
 <p>A destructor was not accessible or deleted in a base class and was therefore not generated for a derived class. Any attempt to create an object of this type on the stack will cause a compiler error.</p>
@@ -4447,7 +4450,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4625</key>
-    <name>C4625: 'derived class' : copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted</name>
+    <name>C4625: 'derived class': copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted</name>
     <description>
       <![CDATA[
 <p>A copy constructor was deleted or not accessible in a base class and was therefore not generated for a derived class. Any attempt to copy an object of this type will cause a compiler error.</p>
@@ -4458,7 +4461,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4626</key>
-    <name>C4626: 'derived class' : assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted</name>
+    <name>C4626: 'derived class': assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted</name>
     <description>
       <![CDATA[
 <p>An assignment operator was deleted or not accessible in a base class and was therefore not generated for a derived class. Any attempt to assign objects of this type will cause a compiler error.</p>
@@ -4480,7 +4483,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4628</key>
-    <name>C4628: digraphs not supported with -Ze</name>
+    <name>C4628: Digraphs not supported with -Ze</name>
     <description>
       <![CDATA[
 <p>Digraphs are not supported under <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Ze</a>. This warning will be followed by an error.</p>
@@ -4491,7 +4494,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4629</key>
-    <name>C4629: digraph used, character sequence 'digraph' interpreted as token 'char'</name>
+    <name>C4629: Digraph used, character sequence 'digraph' interpreted as token 'char'</name>
     <description>
       <![CDATA[
 <p>Under <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170">/Za</a>, the compiler warns when it detects a digraph.</p>
@@ -4502,7 +4505,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4630</key>
-    <name>C4630: 'symbol' : 'extern' storage class specifier illegal on member definition</name>
+    <name>C4630: 'symbol': 'extern' storage class specifier illegal on member definition</name>
     <description>
       <![CDATA[
 <p>A data member or member function is defined as <strong><code>extern</code></strong>. Members cannot be external, although entire objects can. The compiler ignores the <strong><code>extern</code></strong> keyword.</p>
@@ -4612,7 +4615,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4640</key>
-    <name>C4640: 'instance' : construction of local static object is not thread-safe</name>
+    <name>C4640: 'instance': construction of local static object is not thread-safe</name>
     <description>
       <![CDATA[
 <p>A static instance of an object is not thread safe.</p>
@@ -4634,7 +4637,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4645</key>
-    <name>C4645: function declared with __declspec(noreturn) has a return statement</name>
+    <name>C4645: Function declared with __declspec(noreturn) has a return statement</name>
     <description>
       <![CDATA[
 <p>A <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/program-termination?view=msvc-170">return</a> statement was found in a function that is marked with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/noreturn?view=msvc-170">noreturn</a> <strong><code>__declspec</code></strong> modifier. The <strong><code>return</code></strong> statement was ignored.</p>
@@ -4645,7 +4648,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4646</key>
-    <name>C4646: function declared with __declspec(noreturn) has non-void return type</name>
+    <name>C4646: Function declared with __declspec(noreturn) has non-void return type</name>
     <description>
       <![CDATA[
 <p>A function marked with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/noreturn?view=msvc-170">noreturn</a> <strong><code>__declspec</code></strong> modifier should have a <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/void-cpp?view=msvc-170">void</a> return type.</p>
@@ -4656,7 +4659,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4650</key>
-    <name>C4650: debugging information not in precompiled header; only global symbols from the header will be available</name>
+    <name>C4650: Debugging information not in precompiled header; only global symbols from the header will be available</name>
     <description>
       <![CDATA[
 <p>The precompiled header file was not compiled with Microsoft symbolic debugging information.</p>
@@ -4678,7 +4681,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4652</key>
-    <name>C4652: compiler option 'option' inconsistent with precompiled header; current command-line option will override that defined in the precompiled header</name>
+    <name>C4652: Compiler option 'option' inconsistent with precompiled header; current command-line option will override that defined in the precompiled header</name>
     <description>
       <![CDATA[
 <p>The given command-line option differed from that given when the precompiled header (.pch) was created. The option specified in the current command line was used.</p>
@@ -4689,7 +4692,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4653</key>
-    <name>C4653: compiler option 'option' inconsistent with precompiled header; current command-line option ignored</name>
+    <name>C4653: Compiler option 'option' inconsistent with precompiled header; current command-line option ignored</name>
     <description>
       <![CDATA[
 <p>An option specified with the Use Precompiled Headers (<a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/yu-use-precompiled-header-file?view=msvc-170">/Yu</a>) option was inconsistent with the options specified when the precompiled header was created. This compilation used the option specified when the precompiled header was created.</p>
@@ -4700,7 +4703,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4655</key>
-    <name>C4655: 'symbol' : variable type is new since the last build, or is defined differently elsewhere</name>
+    <name>C4655: 'symbol': variable type is new since the last build, or is defined differently elsewhere</name>
     <description>
       <![CDATA[
 <p>You changed or added a new data type since the last successful build. Edit and Continue does not support changes to existing data types.</p>
@@ -4711,7 +4714,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4656</key>
-    <name>C4656: 'symbol' : data type is new or has changed since the last build, or is defined differently elsewhere</name>
+    <name>C4656: 'symbol': data type is new or has changed since the last build, or is defined differently elsewhere</name>
     <description>
       <![CDATA[
 <p>You added or changed a data type, making it new to your source code since the last successful build. Edit and Continue does not support changes to existing data types.</p>
@@ -4722,7 +4725,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4657</key>
-    <name>C4657: expression involves a data type that is new since the last build</name>
+    <name>C4657: Expression involves a data type that is new since the last build</name>
     <description>
       <![CDATA[
 <p>You added or changed a data type, making it new to your source code since the last successful build. Edit and Continue does not support changes to existing data types.</p>
@@ -4733,7 +4736,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4659</key>
-    <name>C4659: #pragma 'pragma' : use of reserved segment 'segment' has undefined behavior</name>
+    <name>C4659: #pragma 'pragma': use of reserved segment 'segment' has undefined behavior</name>
     <description>
       <![CDATA[
 <p>The .drectve option was used to pass an option to the linker. Instead use pragma <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/comment-c-cpp?view=msvc-170">comment</a> for passing a linker option.</p>
@@ -4744,7 +4747,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4661</key>
-    <name>C4661: 'identifier' : no suitable definition provided for explicit template instantiation request</name>
+    <name>C4661: 'identifier': no suitable definition provided for explicit template instantiation request</name>
     <description>
       <![CDATA[
 <p>A member of the template class is not defined.</p>
@@ -4755,7 +4758,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4662</key>
-    <name>C4662: explicit instantiation; template-class 'identifier1' has no definition from which to specialize 'identifier2'</name>
+    <name>C4662: Explicit instantiation; template-class 'identifier1' has no definition from which to specialize 'identifier2'</name>
     <description>
       <![CDATA[
 <p>The specified template-class was declared, but not defined.</p>
@@ -4766,7 +4769,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4667</key>
-    <name>C4667: 'function' : no function template defined that matches forced instantiation</name>
+    <name>C4667: 'function': no function template defined that matches forced instantiation</name>
     <description>
       <![CDATA[
 <p>You cannot instantiate a function template that has not been declared.</p>
@@ -4788,7 +4791,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4669</key>
-    <name>C4669: 'cast' : unsafe conversion: 'class' is a managed or WinRT type object</name>
+    <name>C4669: 'cast': unsafe conversion: 'class' is a managed or WinRT type object</name>
     <description>
       <![CDATA[
 <p>A cast contains a Windows Runtime or managed type. The compiler completes the cast by performing a bit-wise copy of one pointer to the other, but provides no other checking. To resolve this warning, do not cast classes containing managed members or Windows Runtime types.</p>
@@ -4799,7 +4802,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4670</key>
-    <name>C4670: 'identifier' : this base class is inaccessible</name>
+    <name>C4670: 'identifier': this base class is inaccessible</name>
     <description>
       <![CDATA[
 <p>The specified base class of an object to be thrown in a <strong><code>try</code></strong> block is not accessible. The object cannot be instantiated if it is thrown. Check that the base class is inherited with the correct access specifier.</p>
@@ -4810,10 +4813,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4672</key>
-    <name>C4672: 'identifier1' : ambiguous</name>
+    <name>C4672: 'identifier1': ambiguous</name>
     <description>
       <![CDATA[
-<p>'identifier1' : ambiguous. First seen as 'identifier2'.</p>
+<p>'identifier1': ambiguous. First seen as 'identifier2'.</p>
 <p>The specified object to be thrown in a <strong><code>try</code></strong> block is ambiguous. The object cannot be disambiguated if it is thrown.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4672?view=msvc-170" target="_blank">C4672</a></p>]]>
@@ -4822,7 +4825,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4673</key>
-    <name>C4673: throwing 'identifier' the following types will not be considered at the catch site</name>
+    <name>C4673: Throwing 'identifier' the following types will not be considered at the catch site</name>
     <description>
       <![CDATA[
 <p>A throw object cannot be handled in the <strong><code>catch</code></strong> block. Each type that cannot be handled is listed in the error output immediately following the line containing this warning. Each unhandled type has its own warning. Read the warning for each specific type for more information.</p>
@@ -4855,7 +4858,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4678</key>
-    <name>C4678: base class 'base_type' is less accessible than 'derived_type'</name>
+    <name>C4678: Base class 'base_type' is less accessible than 'derived_type'</name>
     <description>
       <![CDATA[
 <p>A public type derives from a private type. If the public type is instantiated in a referenced assembly, members of the private base type will not be accessible.</p>
@@ -4866,7 +4869,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4679</key>
-    <name>C4679: 'member' : could not import member</name>
+    <name>C4679: 'member': could not import member</name>
     <description>
       <![CDATA[
 <p>The compiler encountered a construct that it cannot support, that cannot be imported from metadata.</p>
@@ -4877,7 +4880,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4680</key>
-    <name>C4680: 'class' : coclass does not specify a default interface</name>
+    <name>C4680: 'class': coclass does not specify a default interface</name>
     <description>
       <![CDATA[
 <p>A <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/default-cpp?view=msvc-170">default</a> interface was not specified for a class that was marked with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/coclass?view=msvc-170">coclass</a> attribute. In order for an object to be useful, it must implement an interface.</p>
@@ -4888,7 +4891,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4681</key>
-    <name>C4681: 'class' : coclass does not specify a default interface that is an event source</name>
+    <name>C4681: 'class': coclass does not specify a default interface that is an event source</name>
     <description>
       <![CDATA[
 <p>A <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/source-cpp?view=msvc-170">source</a> interface was not specified for a class.</p>
@@ -4899,7 +4902,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4682</key>
-    <name>C4682: 'parameter' : no directional parameter attribute specified, defaulting to [in]</name>
+    <name>C4682: 'parameter': no directional parameter attribute specified, defaulting to [in]</name>
     <description>
       <![CDATA[
 <p>A method on a parameter in an attributed interface does not have one of the directional attributes: <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/in-cpp?view=msvc-170">in</a> or <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/out-cpp?view=msvc-170">out</a>. The parameter defaults to in.</p>
@@ -4921,7 +4924,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4684</key>
-    <name>C4684: 'attribute' : WARNING!! attribute may cause invalid code generation</name>
+    <name>C4684: 'attribute': WARNING!! attribute may cause invalid code generation</name>
     <description>
       <![CDATA[
 <p>You used an attribute that should not commonly be used.</p>
@@ -4932,7 +4935,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4685</key>
-    <name>C4685: expecting '&gt; &gt;' found '&gt;&gt;' when parsing template parameters</name>
+    <name>C4685: Expecting '&gt; &gt;' found '&gt;&gt;' when parsing template parameters</name>
     <description>
       <![CDATA[
 <p>A template definition was not terminated correctly.</p>
@@ -4943,7 +4946,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4686</key>
-    <name>C4686: 'user-defined type' : possible change in behavior, change in UDT return calling convention</name>
+    <name>C4686: 'user-defined type': possible change in behavior, change in UDT return calling convention</name>
     <description>
       <![CDATA[
 <p>A class template specialization wasn't defined before it was used in a return type. Anything that instantiates the class resolves C4686; declaring an instance or accessing a member (for example, <code>C&lt;int&gt;::some_member</code>) are also options.</p>
@@ -4976,7 +4979,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4690</key>
-    <name>C4690: [ emitidl( pop ) ] : more pops than pushes</name>
+    <name>C4690: [ emitidl( pop ) ]: more pops than pushes</name>
     <description>
       <![CDATA[
 <p>The <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/windows/attributes/emitidl?view=msvc-170">emitidl</a> attribute was popped one more time that it was pushed.</p>
@@ -4987,7 +4990,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4691</key>
-    <name>C4691: 'type' : type referenced was expected in unreferenced assembly 'file', type defined in current translation unit used instead</name>
+    <name>C4691: 'type': type referenced was expected in unreferenced assembly 'file', type defined in current translation unit used instead</name>
     <description>
       <![CDATA[
 <p>The metadata file containing the original type definition is not referenced, and the compiler is using a local type definition.</p>
@@ -5028,7 +5031,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4694?view=msvc-170" target="_blank">C4694</a></p>]]>
     </description>
     <severity>INFO</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C4698</key>
     <name>C4698: 'feature' is for evaluation purposes only and is subject to change or removal in future updates</name>
@@ -5037,12 +5040,12 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>WinRT APIs that are released for experimentation and feedback are decorated with the <code>Windows.Foundation.Metadata.ExperimentalAttribute</code> attribute. In Visual Studio 2017 version 15.3, the compiler produces warning C4698 for this attribute. A few APIs in previous versions of the Windows SDK have already been decorated with the attribute, and calls to these APIs now trigger this compiler warning. Newer Windows SDKs have the attribute removed from all shipped types. If you're using an older SDK, you'll need to suppress these warnings for all calls to shipped types.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4698?view=msvc-170" target="_blank">C4698</a></p>]]>
-      </description>
+    </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4700</key>
-    <name>C4700: uninitialized local variable 'name' used</name>
+    <name>C4700: Uninitialized local variable 'name' used</name>
     <description>
       <![CDATA[
 <p>The local variable <em>name</em> has been <em>used</em>, that is, read from, before it has been assigned a value. In C and C++, local variables aren't initialized by default. Uninitialized variables can contain any value, and their use leads to undefined behavior. Warning C4700 almost always indicates a bug that can cause unpredictable results or crashes in your program.</p>
@@ -5064,7 +5067,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4702</key>
-    <name>C4702: unreachable code</name>
+    <name>C4702: Unreachable code</name>
     <description>
       <![CDATA[
 <p>When the compiler back end detects unreachable code, it generates C4702 as a level 4 warning.</p>
@@ -5086,7 +5089,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4706</key>
-    <name>C4706: assignment within conditional expression</name>
+    <name>C4706: Assignment within conditional expression</name>
     <description>
       <![CDATA[
 <p>The test value in a conditional expression was the result of an assignment.</p>
@@ -5097,7 +5100,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4709</key>
-    <name>C4709: comma operator within array index expression</name>
+    <name>C4709: Comma operator within array index expression</name>
     <description>
       <![CDATA[
 <p>When a comma occurs in an array index expression, the compiler uses the value after the last comma.</p>
@@ -5108,7 +5111,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4710</key>
-    <name>C4710: 'function' : function not inlined</name>
+    <name>C4710: 'function': function not inlined</name>
     <description>
       <![CDATA[
 <p>The specified function was marked for inline expansion, but the compiler didn't inline the function.</p>
@@ -5119,7 +5122,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4711</key>
-    <name>C4711: function 'function' selected for inline expansion</name>
+    <name>C4711: Function 'function' selected for inline expansion</name>
     <description>
       <![CDATA[
 <p>The compiler performed inlining on the given function, although it was not marked for inlining.</p>
@@ -5130,7 +5133,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4714</key>
-    <name>C4714: function 'function' marked as __forceinline not inlined</name>
+    <name>C4714: Function 'function' marked as __forceinline not inlined</name>
     <description>
       <![CDATA[
 <p>The given function was selected for inline expansion, but the compiler did not perform the inlining.</p>
@@ -5141,7 +5144,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4715</key>
-    <name>C4715: 'function' : not all control paths return a value</name>
+    <name>C4715: 'function': not all control paths return a value</name>
     <description>
       <![CDATA[
 <p>The specified function can potentially not return a value.</p>
@@ -5163,7 +5166,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4717</key>
-    <name>C4717: 'function' : recursive on all control paths, function will cause runtime stack overflow</name>
+    <name>C4717: 'function': recursive on all control paths, function will cause runtime stack overflow</name>
     <description>
       <![CDATA[
 <p>Every path through a function contains a call to the function. Since there is no way to exit the function without first calling itself recursively, the function will never exit.</p>
@@ -5174,7 +5177,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4718</key>
-    <name>C4718: 'function call' : recursive call has no side effects, deleting</name>
+    <name>C4718: 'function call': recursive call has no side effects, deleting</name>
     <description>
       <![CDATA[
 <p>A function contains a recursive call, but otherwise has no side effects. A call to this function is being deleted. The correctness of the program is not affected, but the behavior is. Whereas leaving the call in could result in a runtime stack overflow exception, deleting the call removes that possibility.</p>
@@ -5185,7 +5188,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4722</key>
-    <name>C4722: 'function' : destructor never returns, potential memory leak</name>
+    <name>C4722: 'function': destructor never returns, potential memory leak</name>
     <description>
       <![CDATA[
 <p>The flow of control terminates in a destructor. The thread or the entire program will terminate and allocated resources may not be released.  Furthermore, if a destructor will be called for stack unwinding during exception processing, the behavior of executable is undefined.</p>
@@ -5196,7 +5199,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4723</key>
-    <name>C4723: potential divide by 0</name>
+    <name>C4723: Potential divide by 0</name>
     <description>
       <![CDATA[
 <p>The second operand in a divide operation evaluated to zero at compile time, giving undefined results.</p>
@@ -5207,7 +5210,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4724</key>
-    <name>C4724: potential mod by 0</name>
+    <name>C4724: Potential mod by 0</name>
     <description>
       <![CDATA[
 <p>The second operand in a remainder operation evaluated to zero at compile time, giving undefined results.</p>
@@ -5218,7 +5221,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4725</key>
-    <name>C4725: instruction may be inaccurate on some Pentiums</name>
+    <name>C4725: Instruction may be inaccurate on some Pentiums</name>
     <description>
       <![CDATA[
 <p>Your code contains an inline assembly instruction that may not produce accurate results on some Pentium microprocessors.</p>
@@ -5229,7 +5232,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4727</key>
-    <name>C4727: "PCH named pch_file with same timestamp found in obj_file_1 and obj_file_2</name>
+    <name>C4727: PCH named pch_file with same timestamp found in obj_file_1 and obj_file_2</name>
     <description>
       <![CDATA[
 <p>C4727 occurs when compiling multiple compilands with <strong>/Yc</strong>, and where the compiler was able to mark all .obj files with the same .pch timestamp.</p>
@@ -5240,7 +5243,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4729</key>
-    <name>C4729: function too big for flow graph based warnings</name>
+    <name>C4729: Function too big for flow graph based warnings</name>
     <description>
       <![CDATA[
 <p>This warning is generated when a function is too big to be compiled with reliable checking for situations that would generate a warning. This warning is only generated when the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/od-disable-debug?view=msvc-170">/Od</a> compiler option used.</p>
@@ -5251,7 +5254,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4730</key>
-    <name>C4730: 'main' : mixing _m64 and floating point expressions may result in incorrect code</name>
+    <name>C4730: 'main': mixing _m64 and floating point expressions may result in incorrect code</name>
     <description>
       <![CDATA[
 <p>A function uses <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/m64?view=msvc-170">__m64</a> and <strong><code>float</code></strong>/<strong><code>double</code></strong> types. Because the MMX and floating-point registers share the same physical register space (cannot be used simultaneously), using <strong><code>__m64</code></strong> and <strong><code>float</code></strong>/<strong><code>double</code></strong> types in the same function can result in data corruption, possibly causing an exception.</p>
@@ -5262,7 +5265,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4731</key>
-    <name>C4731: 'pointer' : frame pointer register 'register' modified by inline assembly code</name>
+    <name>C4731: 'pointer': frame pointer register 'register' modified by inline assembly code</name>
     <description>
       <![CDATA[
 <p>A frame pointer register was modified. You must save and restore the register in your inline assembly block or frame variable (local or parameter, depending on the register modified), or your code may not work properly.</p>
@@ -5273,7 +5276,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4733</key>
-    <name>C4733: Inline asm assigning to 'FS:0' : handler not registered as safe handler</name>
+    <name>C4733: Inline asm assigning to 'FS:0': handler not registered as safe handler</name>
     <description>
       <![CDATA[
 <p>A function modifying the value at FS:0 to add a new exception handler may not work with Safe Exceptions, because the handler may not be registered as a valid exception handler (see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/safeseh-image-has-safe-exception-handlers?view=msvc-170">/SAFESEH</a>).</p>
@@ -5284,7 +5287,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4738</key>
-    <name>C4738: storing 32-bit float result in memory, possible loss of performance</name>
+    <name>C4738: Storing 32-bit float result in memory, possible loss of performance</name>
     <description>
       <![CDATA[
 <p>C4738 warns that the result of an assignment, cast, passed argument, or other operation may need to be rounded or that the operation ran out of registers and needed to use memory (spilling). This can result in performance loss.</p>
@@ -5295,7 +5298,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4739</key>
-    <name>C4739: reference to variable 'var' exceeds its storage space</name>
+    <name>C4739: Reference to variable 'var' exceeds its storage space</name>
     <description>
       <![CDATA[
 <p>A value was assigned to a variable, but the value is greater than the size of the variable. Memory will be written beyond the variable's memory location, and data loss is possible.</p>
@@ -5306,7 +5309,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4740</key>
-    <name>C4740: flow in or out of inline asm code suppresses global optimization</name>
+    <name>C4740: Flow in or out of inline asm code suppresses global optimization</name>
     <description>
       <![CDATA[
 <p>When there is a jump in to or out of an <strong><code>asm</code></strong> block, global optimizations are disabled for that function.</p>
@@ -5350,7 +5353,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4746</key>
-    <name>C4746: volatile access of '&lt;expression&gt;' is subject to /volatile:[iso|ms] setting</name>
+    <name>C4746: Volatile access of '&lt;expression&gt;' is subject to /volatile:[iso|ms] setting</name>
     <description>
       <![CDATA[
 <p>C4746 is emitted whenever a volatile variable is accessed directly. It's intended to help developers identify code locations that are affected by the specific volatile model currently specified (which can be controlled with the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/volatile-volatile-keyword-interpretation?view=msvc-170"><code>/volatile</code></a> compiler option). In particular, it can be useful in locating compiler-generated hardware memory barriers when <code>/volatile:ms</code> is used.</p>
@@ -5394,7 +5397,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4756</key>
-    <name>C4756: overflow in constant arithmetic</name>
+    <name>C4756: Overflow in constant arithmetic</name>
     <description>
       <![CDATA[
 <p>The compiler generated an exception while doing constant arithmetic during compilation.</p>
@@ -5413,7 +5416,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4764?view=msvc-170" target="_blank">C4764</a></p>]]>
     </description>
     <severity>INFO</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C4768</key>
     <name>C4768: __declspec attributes before linkage specification are ignored</name>
@@ -5422,20 +5425,20 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>The compiler warns if <code>__declspec(...)</code> is applied before the <code>extern "C"</code> linkage specification. Previously, the compiler would ignore the attribute, which could have runtime implications.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4768?view=msvc-170" target="_blank">C4768</a></p>]]>
-      </description>
+    </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4770</key>
-    <name>C4770: partially validated enum 'symbol' used as index</name>
+    <name>C4770: Partially validated enum 'symbol' used as index</name>
     <description>
       <![CDATA[
 <p>The compiler warns if an enum value is cast or aliased to an integer type, but the result isn't checked for non-negative or excessive values.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4770?view=msvc-170" target="_blank">C4770</a></p>]]>
-      </description>
+    </description>
     <severity>INFO</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C4772</key>
     <name>C4772: #import referenced a type from a missing type library; 'missing-type' used as a placeholder</name>
@@ -5449,7 +5452,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4788</key>
-    <name>C4788: 'identifier' : identifier was truncated to 'number' characters</name>
+    <name>C4788: 'identifier': identifier was truncated to 'number' characters</name>
     <description>
       <![CDATA[
 <p>The compiler limits the maximum length allowed for a function name. When the compiler generates funclets for EH/SEH code, it forms the funclet name by prepending the function name with some text, for example "__catch", "__unwind", or another string.</p>
@@ -5460,7 +5463,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4789</key>
-    <name>C4789: buffer 'identifier' of size N bytes will be overrun; M bytes will be written starting at offset L</name>
+    <name>C4789: Buffer 'identifier' of size N bytes will be overrun; M bytes will be written starting at offset L</name>
     <description>
       <![CDATA[
 <p><strong>C4789</strong> warns about buffer overruns when specific C run-time (CRT) functions are used. It can also report size mismatches when parameters are passed or assignments are made. The warning is possible if the data sizes are known at compile time. This warning is for situations that might elude typical data-size mismatch detection.</p>
@@ -5471,7 +5474,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4792</key>
-    <name>C4792: function 'function' declared using sysimport and referenced from native code; import library required to link</name>
+    <name>C4792: Function 'function' declared using sysimport and referenced from native code; import library required to link</name>
     <description>
       <![CDATA[
 <p>A native function that was imported into the program with DllImport was called from an unmanaged function. Therefore, you must link to the import library for the DLL.</p>
@@ -5482,7 +5485,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4793</key>
-    <name>C4793: 'function' : function is compiled as native code: 'reason'</name>
+    <name>C4793: 'function': function is compiled as native code: 'reason'</name>
     <description>
       <![CDATA[
 <p>The compiler cannot compile <em>function</em> into managed code, even though the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/clr-common-language-runtime-compilation?view=msvc-170">/clr</a> compiler option is specified. Instead, the compiler emits warning C4793 and an explanatory continuation message, and then compiles <em>function</em> into native code. The continuation message contains the <em>reason</em> text that explains why <em>function</em> cannot be compiled to <code>MSIL</code>.</p>
@@ -5493,7 +5496,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4794</key>
-    <name>C4794: segment of thread local storage variable 'variable' changed from 'section name' to '.tls$'</name>
+    <name>C4794: Segment of thread local storage variable 'variable' changed from 'section name' to '.tls$'</name>
     <description>
       <![CDATA[
 <p>You used <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/data-seg?view=msvc-170">#pragma data_seg</a> to put a tls variable in a section not starting with .tls$.</p>
@@ -5526,7 +5529,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4803</key>
-    <name>C4803: 'method' : the raise method has a different storage class from that of the event, 'event'</name>
+    <name>C4803: 'method': the raise method has a different storage class from that of the event, 'event'</name>
     <description>
       <![CDATA[
 <p>Event methods must have the same storage class as the event declaration. The compiler adjusts the event's methods so that the storage classes are the same.</p>
@@ -5537,7 +5540,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4804</key>
-    <name>C4804: 'operation' : unsafe use of type 'bool' in operation</name>
+    <name>C4804: 'operation': unsafe use of type 'bool' in operation</name>
     <description>
       <![CDATA[
 <p>This warning is for when you used a <strong><code>bool</code></strong> variable or value in an unexpected way. For example, C4804 is generated if you use operators such as the negative unary operator (<strong>-</strong>) or the complement operator (<code>~</code>). The compiler evaluates the expression.</p>
@@ -5548,7 +5551,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4805</key>
-    <name>C4805: 'operation' : unsafe mix of type 'type' and type 'type' in operation</name>
+    <name>C4805: 'operation': unsafe mix of type 'type' and type 'type' in operation</name>
     <description>
       <![CDATA[
 <p>This warning is generated for comparison operations between <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/bool-cpp?view=msvc-170">bool</a> and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/c-language/integer-types?view=msvc-170">int</a>.</p>
@@ -5559,7 +5562,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4806</key>
-    <name>C4806: 'operation' : unsafe operation: no value of type 'type' promoted to type 'type' can equal the given constant</name>
+    <name>C4806: 'operation': unsafe operation: no value of type 'type' promoted to type 'type' can equal the given constant</name>
     <description>
       <![CDATA[
 <p>This message warns against code such as <code>b == 3</code>, where <code>b</code> has type <strong><code>bool</code></strong>. The promotion rules cause <strong><code>bool</code></strong> to be promoted to <strong><code>int</code></strong>. This is legal, but it can never be <strong><code>true</code></strong>.</p>
@@ -5570,7 +5573,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4807</key>
-    <name>C4807: 'operation' : unsafe mix of type 'type' and signed bitfield of type 'type'</name>
+    <name>C4807: 'operation': unsafe mix of type 'type' and signed bitfield of type 'type'</name>
     <description>
       <![CDATA[
 <p>This warning is generated when comparing a one-bit signed bit field to a <strong><code>bool</code></strong> variable. Because a one-bit, signed bit field can only contain the values -1 or 0, it is dangerous to compare it to <strong><code>bool</code></strong>. No warnings are generated about mixing <strong><code>bool</code></strong> and one-bit, unsigned bitfields since they are identical to <strong><code>bool</code></strong> and can only hold 0 or 1.</p>
@@ -5581,7 +5584,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4810</key>
-    <name>C4810: value of pragma pack(show) == n</name>
+    <name>C4810: Value of pragma pack(show) == n</name>
     <description>
       <![CDATA[
 <p>This warning is issued when you use the <strong>show</strong> option of the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/pack?view=msvc-170">pack</a> pragma. <em>n</em> is the current pack value.</p>
@@ -5592,7 +5595,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4811</key>
-    <name>C4811: value of pragma conform(forScope, show) == value</name>
+    <name>C4811: Value of pragma conform(forScope, show) == value</name>
     <description>
       <![CDATA[
 <p>This warning is issued when you use the <strong>show</strong> option of the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/conform?view=msvc-170">conform</a> pragma. <em>value</em> is the current conform value.</p>
@@ -5603,7 +5606,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4812</key>
-    <name>C4812: obsolete declaration style</name>
+    <name>C4812: Obsolete declaration style</name>
     <description>
       <![CDATA[
 <p>In the current release of Visual C++, the explicit constructor specialization is still supported, but it may not be supported in a future release.</p>
@@ -5614,7 +5617,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4813</key>
-    <name>C4813: 'function' : a friend function of a local class must have been previously declared</name>
+    <name>C4813: 'function': a friend function of a local class must have been previously declared</name>
     <description>
       <![CDATA[
 <p>A friend function in an inner class was not declared in the outer class.</p>
@@ -5625,7 +5628,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4816</key>
-    <name>C4816: 'param' : parameter has a zero-sized array which will be truncated</name>
+    <name>C4816: 'param': parameter has a zero-sized array which will be truncated</name>
     <description>
       <![CDATA[
 <p>A parameter to an object with a zero-size array was not passed by reference. The array will not get copied when the object is passed.</p>
@@ -5636,7 +5639,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4817</key>
-    <name>C4817: 'member' : illegal use of '.' to access this member; compiler replaced with '-&gt;'</name>
+    <name>C4817: 'member': illegal use of '.' to access this member; compiler replaced with '-&gt;'</name>
     <description>
       <![CDATA[
 <p>The wrong member access operator was used.</p>
@@ -5680,7 +5683,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4822</key>
-    <name>C4822: 'member' : local class member function does not have a body</name>
+    <name>C4822: 'member': local class member function does not have a body</name>
     <description>
       <![CDATA[
 <p>A local class member function was declared but not defined in the class. To use a local class member function, you must define it in the class. You can't declare it in class and define it out of class.</p>
@@ -5691,7 +5694,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4823</key>
-    <name>C4823: 'function' : uses pinning pointers but unwind semantics are not enabled</name>
+    <name>C4823: 'function': uses pinning pointers but unwind semantics are not enabled</name>
     <description>
       <![CDATA[
 <p>To unpin an object on the managed heap pointed to by a pinning pointer declared in a block scope, the compiler simulates the behavior of destructors of local classes, "pretending" the pinning pointer has a destructor that nullifies the pointer. To enable a call to a destructor after throwing an exception, you must enable object unwinding, which you can do by using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170">/EHsc</a>.</p>
@@ -5710,21 +5713,21 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4829?view=msvc-170" target="_blank">C4829</a></p>]]>
     </description>
     <severity>INFO</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C4834</key>
-    <name>C4834: discarding return value of function with 'nodiscard' attribute</name>
+    <name>C4834: Discarding return value of function with 'nodiscard' attribute</name>
     <description>
       <![CDATA[
-<p>Starting in the C++17 Standard, the <code>[[nodiscard]]</code> attribute specifies that a function's return value isn't intended to be discarded. If a caller discards the return value, the compiler generates warning C4834.</p>
+<p>Starting in the C++17 Standard, the <code>[[nodiscard]]</code> attribute specifies that a function's return value isn't intended to be discarded. If a caller discards the return value, the compiler generates warning C4834. Although this attribute was introduced in C++17, the compiler respects this attribute and generates warnings related to it when using <code>/std:c++14</code> and later.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4834?view=msvc-170" target="_blank">C4834</a></p>]]>
-      </description>
+    </description>
     <severity>INFO</severity>
   </rule>
   <rule>
     <key>C4835</key>
-    <name>C4835: 'variable' : the initializer for exported data will not be run until managed code is first executed in the host assembly</name>
+    <name>C4835: 'variable': the initializer for exported data will not be run until managed code is first executed in the host assembly</name>
     <description>
       <![CDATA[
 <p>When accessing data between managed components, it is recommended that you not use native C++ import and export mechanisms. Instead, declare your data members inside a managed type and reference the metadata with <code>#using</code> in the client. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-using-directive-cpp?view=msvc-170">#using Directive</a>.</p>
@@ -5735,7 +5738,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4838</key>
-    <name>C4838: conversion from 'type_1' to 'type_2' requires a narrowing conversion</name>
+    <name>C4838: Conversion from 'type_1' to 'type_2' requires a narrowing conversion</name>
     <description>
       <![CDATA[
 <p>An implicit narrowing conversion was found when using aggregate or list initialization.</p>
@@ -5746,7 +5749,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4839</key>
-    <name>C4839: non-standard use of class 'type' as an argument to a variadic function</name>
+    <name>C4839: Non-standard use of class 'type' as an argument to a variadic function</name>
     <description>
       <![CDATA[
 <p>Classes or structs that are passed to a variadic function such as <code>printf</code> must be trivially copyable. When passing such objects, the compiler simply makes a bitwise copy and does not call the constructor or destructor.</p>
@@ -5757,7 +5760,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4840</key>
-    <name>C4840: non-portable use of class 'type' as an argument to a variadic function</name>
+    <name>C4840: Non-portable use of class 'type' as an argument to a variadic function</name>
     <description>
       <![CDATA[
 <p>Classes or structs that are passed to a variadic function must be trivially copyable. When passing such objects, the compiler simply makes a bitwise copy and does not call the constructor or destructor.</p>
@@ -5765,18 +5768,18 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4840?view=msvc-170" target="_blank">C4840</a></p>]]>
     </description>
     <severity>INFO</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C4841</key>
-    <name>C4841: non-standard extension used: compound member designator used in offsetof</name>
+    <name>C4841: Non-standard extension used: compound member designator used in offsetof</name>
     <description>
       <![CDATA[
 <p>If you use <code>offsetof(T, m)</code>, where <em><code>m</code></em> is a compound member designator, the compiler generates a warning when you compile with the <strong><code>/Wall</code></strong> option.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4841?view=msvc-170" target="_blank">C4841</a></p>]]>
-      </description>
+    </description>
     <severity>INFO</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C4843</key>
     <name>C4843: 'type1': An exception handler of reference to array or function type is unreachable</name>
@@ -5785,7 +5788,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>Handlers of reference to array or function type are never a match for any exception object. Starting in Visual Studio 2017 version 15.5, the compiler honors this rule and raises a level 4 warning. It also no longer matches a handler of <code>char*</code> or <code>wchar_t*</code> to a string literal when <strong><code>/Zc:strictStrings</code></strong> is used.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4843?view=msvc-170" target="_blank">C4843</a></p>]]>
-      </description>
+    </description>
     <severity>INFO</severity>
   </rule>
   <rule>
@@ -5804,7 +5807,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C4867: 'function': function call missing argument list</name>
     <description>
       <![CDATA[
-<p>Function call missing argument list; use 'call' to create a pointer to member.</p>
+<p>A pointer to member function was initialized incorrectly.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4867?view=msvc-170" target="_blank">C4867</a></p>]]>
     </description>
@@ -5823,7 +5826,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4900</key>
-    <name>C4900: intermediate language mismatch between 'tool1' version 'version1' and 'tool2' version 'version2'</name>
+    <name>C4900: Intermediate language mismatch between 'tool1' version 'version1' and 'tool2' version 'version2'</name>
     <description>
       <![CDATA[
 <p>The intermediate language used in <em>tool1</em> and <em>tool2</em> did not match. Check that the most current version of each tool has been installed.</p>
@@ -5834,7 +5837,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4905</key>
-    <name>C4905: wide string literal cast to 'LPSTR'</name>
+    <name>C4905: Wide string literal cast to 'LPSTR'</name>
     <description>
       <![CDATA[
 <p>The compiler detected an unsafe cast. The cast did succeed, but you should use a conversion routine.</p>
@@ -5845,7 +5848,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4906</key>
-    <name>C4906: string literal cast to 'LPWSTR'</name>
+    <name>C4906: String literal cast to 'LPWSTR'</name>
     <description>
       <![CDATA[
 <p>The compiler detected an unsafe cast. The cast did succeed, but you should use a conversion routine.</p>
@@ -5856,7 +5859,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4910</key>
-    <name>C4910: '&lt;identifier&gt;' : '__declspec(dllexport)' and 'extern' are incompatible on an explicit instantiation</name>
+    <name>C4910: '&lt;identifier&gt;': '__declspec(dllexport)' and 'extern' are incompatible on an explicit instantiation</name>
     <description>
       <![CDATA[
 <p>The explicit template instantiation named <em>&lt;identifier&gt;</em> is modified by both the <code>__declspec(dllexport)</code> and <strong><code>extern</code></strong> keywords. However, these keywords are mutually exclusive. The <code>__declspec(dllexport)</code> keyword means instantiate the template class, while the <strong><code>extern</code></strong> keyword means do not automatically instantiate the template class.</p>
@@ -5878,7 +5881,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4913</key>
-    <name>C4913: user defined binary operator ',' exists but no overload could convert all operands, default built-in binary operator ',' used</name>
+    <name>C4913: User defined binary operator ',' exists but no overload could convert all operands, default built-in binary operator ',' used</name>
     <description>
       <![CDATA[
 <p>A call to the built-in comma operator occurred in a program that also had an overloaded comma operator; a conversion that you thought may have occurred did not.</p>
@@ -5889,7 +5892,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4917</key>
-    <name>C4917: 'declarator' : a GUID can only be associated with a class, interface or namespace</name>
+    <name>C4917: 'declarator': a GUID can only be associated with a class, interface or namespace</name>
     <description>
       <![CDATA[
 <p>A user-defined structure other than <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/class-cpp?view=msvc-170">class</a>, <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/interface?view=msvc-170">interface</a>, or <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/cpp/namespaces-cpp?view=msvc-170">namespace</a> cannot have a GUID.</p>
@@ -5900,7 +5903,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4918</key>
-    <name>C4918: 'character' : invalid character in pragma optimization list</name>
+    <name>C4918: 'character': invalid character in pragma optimization list</name>
     <description>
       <![CDATA[
 <p>An unknown character was found in the optimization list of an <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/optimize?view=msvc-170">optimize</a> pragma statement.</p>
@@ -5911,7 +5914,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4920</key>
-    <name>C4920: enum enum member member=value already seen in enum enum as member=value</name>
+    <name>C4920: enum member value already seen in other enum</name>
     <description>
       <![CDATA[
 <p>If a .tlb that you pass to #import has the same symbol defined in two or more enums, this warning indicates that subsequent identical symbols are ignored and will be commented out in the .tlh file.</p>
@@ -5944,7 +5947,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4927</key>
-    <name>C4927: illegal conversion; more than one user-defined conversion has been implicitly applied</name>
+    <name>C4927: Illegal conversion; more than one user-defined conversion has been implicitly applied</name>
     <description>
       <![CDATA[
 <p>More than one user-defined conversion is implicitly applied to a single value -- the compiler did not find an explicit conversion but did find a conversion, which it used.</p>
@@ -5955,7 +5958,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4928</key>
-    <name>C4928: illegal copy-initialization; more than one user-defined conversion has been implicitly applied</name>
+    <name>C4928: Illegal copy-initialization; more than one user-defined conversion has been implicitly applied</name>
     <description>
       <![CDATA[
 <p>More than one user-defined conversion routine was found. The compiler executed the code in all such routines.</p>
@@ -5988,7 +5991,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4931</key>
-    <name>C4931: we are assuming the type library was built for number-bit pointers</name>
+    <name>C4931: We are assuming the type library was built for number-bit pointers</name>
     <description>
       <![CDATA[
 <p>Explicit information was not supplied with the <strong>ptrsize</strong> attribute of the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170">#import</a> directive; the compiler concluded that pointer size of the type library is <em>number</em>.</p>
@@ -6010,7 +6013,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4935</key>
-    <name>C4935: assembly access specifier modified from 'access'</name>
+    <name>C4935: Assembly access specifier modified from 'access'</name>
     <description>
       <![CDATA[
 <p>The assembly visibility of a type was modified. The compiler uses the last specifier that it encounters. For example, the assembly visibility of a forward declaration may be different from the assembly visibility of the class definition.</p>
@@ -6021,7 +6024,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4936</key>
-    <name>C4936: this __declspec is supported only when compiled with /clr or /clr:pure</name>
+    <name>C4936: This __declspec is supported only when compiled with /clr or /clr:pure</name>
     <description>
       <![CDATA[
 <p>The <strong>/clr:pure</strong> compiler option is deprecated in Visual Studio 2015 and unsupported in Visual Studio 2017.</p>
@@ -6043,7 +6046,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4938</key>
-    <name>C4938: 'var' : Floating point reduction variable may cause inconsistent results under /fp:strict or #pragma fenv_access</name>
+    <name>C4938: 'var': Floating point reduction variable may cause inconsistent results under /fp:strict or #pragma fenv_access</name>
     <description>
       <![CDATA[
 <p>You should not use <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/fp-specify-floating-point-behavior?view=msvc-170">/fp:strict</a> or <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/fenv-access?view=msvc-170">fenv_access</a> with OpenMP floating-point reductions, because the sum is computed in a different order. Thus, results can differ from the results without /openmp.</p>
@@ -6065,7 +6068,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4944</key>
-    <name>C4944: 'symbol' : cannot import symbol from 'assembly1': as 'symbol' already exists in the current scope</name>
+    <name>C4944: 'symbol': cannot import symbol from 'assembly1': as 'symbol' already exists in the current scope</name>
     <description>
       <![CDATA[
 <p>A symbol was defined in a source code file and then a #using statement referenced an assembly that also defined the symbol. The symbol in the assembly is ignored.</p>
@@ -6076,7 +6079,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4945</key>
-    <name>C4945: 'symbol' : cannot import symbol from 'assembly2': as 'symbol' has already been imported from another assembly 'assembly1'</name>
+    <name>C4945: 'symbol': cannot import symbol from 'assembly2': as 'symbol' has already been imported from another assembly 'assembly1'</name>
     <description>
       <![CDATA[
 <p>A symbol was imported from a referenced assembly but that symbol was already imported from another referenced assembly. Either do not reference one of the assemblies or get the symbol name changed in one of the assemblies.</p>
@@ -6098,7 +6101,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4947</key>
-    <name>C4947: 'type_or_member' : marked as obsolete</name>
+    <name>C4947: 'type_or_member': marked as obsolete</name>
     <description>
       <![CDATA[
 <p>A member or type was marked as obsolete with the <a class="no-loc" data-linktype="absolute-path" href="/en-us/dotnet/api/system.obsoleteattribute">ObsoleteAttribute</a> class.</p>
@@ -6109,7 +6112,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4948</key>
-    <name>C4948: return type of 'accessor' does not match the last parameter type of the corresponding setter</name>
+    <name>C4948: Return type of 'accessor' does not match the last parameter type of the corresponding setter</name>
     <description>
       <![CDATA[
 <p>The compiler found a mismatch between what data type is being get and set for an indexed property.</p>
@@ -6120,7 +6123,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4949</key>
-    <name>C4949: pragmas 'managed' and 'unmanaged' are meaningful only when compiled with '/clr[:option]'</name>
+    <name>C4949: Pragmas 'managed' and 'unmanaged' are meaningful only when compiled with '/clr[:option]'</name>
     <description>
       <![CDATA[
 <p>The compiler ignores the <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/preprocessor/managed-unmanaged?view=msvc-170">managed</a> and unmanaged pragmas if the source code is not compiled with <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/clr-common-language-runtime-compilation?view=msvc-170">/clr</a>. This warning is informational.</p>
@@ -6131,7 +6134,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4950</key>
-    <name>C4950: 'type_or_member' : marked as obsolete</name>
+    <name>C4950: 'type_or_member': marked as obsolete</name>
     <description>
       <![CDATA[
 <p>A member or type was marked as obsolete with the <a class="no-loc" data-linktype="absolute-path" href="/en-us/dotnet/api/system.obsoleteattribute">ObsoleteAttribute</a> attribute.</p>
@@ -6153,7 +6156,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4952</key>
-    <name>C4952: 'function' : no profile data found in program database 'pgd_file'</name>
+    <name>C4952: 'function': no profile data found in program database 'pgd_file'</name>
     <description>
       <![CDATA[
 <p>When using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=msvc-170">/LTCG:PGUPDATE</a>, the compiler detected an input module that was recompiled after <code>/LTCG:PGINSTRUMENT</code> and has a new function (<em>function</em>) present.</p>
@@ -6175,7 +6178,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4956</key>
-    <name>C4956: 'type' : this type is not verifiable</name>
+    <name>C4956: 'type': this type is not verifiable</name>
     <description>
       <![CDATA[
 <p>This warning is generated when <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/build/reference/clr-common-language-runtime-compilation?view=msvc-170">/clr:safe</a> is specified and your code contains a type that is not verifiable. The <strong>/clr:safe</strong> compiler option is deprecated in Visual Studio 2015 and unsupported in Visual Studio 2017.</p>
@@ -6186,7 +6189,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4957</key>
-    <name>C4957: 'cast' : explicit cast from 'cast_from' to 'cast_to' is not verifiable</name>
+    <name>C4957: 'cast': explicit cast from 'cast_from' to 'cast_to' is not verifiable</name>
     <description>
       <![CDATA[
 <p>A cast will result in an unverifiable image.</p>
@@ -6197,7 +6200,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4958</key>
-    <name>C4958: 'operation' : pointer arithmetic is not verifiable</name>
+    <name>C4958: 'operation': pointer arithmetic is not verifiable</name>
     <description>
       <![CDATA[
 <p>Using pointer arithmetic will produce an unverifiable image.</p>
@@ -6208,7 +6211,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4959</key>
-    <name>C4959: cannot define unmanaged struct 'type' in /clr:safe because accessing its members yields unverifiable code</name>
+    <name>C4959: Cannot define unmanaged struct 'type' in /clr:safe because accessing its members yields unverifiable code</name>
     <description>
       <![CDATA[
 <p>Accessing a member of an unmanaged type will produce an unverifiable (peverify.exe) image.</p>
@@ -6241,7 +6244,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4962</key>
-    <name>C4962: 'function' : Profile-guided optimizations disabled because optimizations caused profile data to become inconsistent"</name>
+    <name>C4962: 'function': Profile-guided optimizations disabled because optimizations caused profile data to become inconsistent"</name>
     <description>
       <![CDATA[
 <p>A function was not compiled with /LTCG:PGO, because count (profile) data for the function was unreliable. Redo profiling to regenerate the .pgc file that contains the unreliable profile data for that function.</p>
@@ -6263,7 +6266,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C4965</key>
-    <name>C4965: implicit box of integer 0</name>
+    <name>C4965: Implicit box of integer 0</name>
     <description>
       <![CDATA[
 <p>Implicit box of integer 0; use nullptr or explicit cast.</p>
@@ -6407,7 +6410,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C5046</key>
-    <name>C5046: 'function' : Symbol involving type with internal linkage not defined</name>
+    <name>C5046: 'function': Symbol involving type with internal linkage not defined</name>
     <description>
       <![CDATA[
 <p>The compiler has detected a use of a function that doesn't have a definition, but the signature of this function involves types that aren't visible outside this translation unit. Because these types aren't externally visible, no other translation unit can provide a definition for this function, so the program can't be successfully linked.</p>
@@ -6462,7 +6465,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     </rule>
   <rule>
     <key>C5105</key>
-    <name>C5105: macro expansion producing 'defined' has undefined behavior</name>
+    <name>C5105: Macro expansion producing 'defined' has undefined behavior</name>
     <description>
       <![CDATA[
 <p>The preprocessor detected a <code>defined</code> operator in the output of a macro expansion. If a <code>defined</code> operator appears as the result of a macro expansion, the C standard specifies the behavior as undefined. The C5105 warning is a portability and standards conformance warning, issued because other conformant compilers may have different behavior. To resolve this issue, move the <code>defined</code> operator out of the macro, or suppress warning C5105.</p>
@@ -6473,7 +6476,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C5208</key>
-    <name>C5208: unnamed class used in typedef name cannot declare members other than non-static data members, member enumerations, or member classes</name>
+    <name>C5208: Unnamed class used in typedef name cannot declare members other than non-static data members, member enumerations, or member classes</name>
     <description>
       <![CDATA[
 <p>Unnamed classes within a <strong><code>typedef</code></strong> declaration can't have any members other than: non-static data members with no default member initializers, member classes, or member enumerations.</p>
@@ -6481,7 +6484,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5208?view=msvc-170" target="_blank">C5208</a></p>]]>
     </description>
     <severity>INFO</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C5240</key>
     <name>C5240: 'attribute-string': attribute is ignored in this syntactic position</name>
@@ -6490,40 +6493,97 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>Warning C5240 occurs when a <code>[[nodiscard]]</code> or <code>[[maybe_unused]]</code> attribute is found in the wrong syntactic position. For example, the <code>[[nodiscard]]</code> attribute in this syntactic position applies to the <em><code>decl-specifier-seq</code></em>, not to the function <code>f</code>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5240?view=msvc-170" target="_blank">C5240</a></p>]]>
-      </description>
+    </description>
     <severity>INFO</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C5243</key>
     <name>C5243: 'type': using incomplete class 'class-name' can cause ODR violation due to ABI limitation</name>
     <description>
       <![CDATA[
-<p>The Microsoft C++ ABI in Visual Studio 2019 and earlier versions uses more than one kind of pointer-to-member type. These types have different sizes that depend on the inheritance model used by the class. The C++ standard allows you to declare a pointer-to-member of an incomplete class type. If you declare a variable of pointer-to-member type for an incomplete class, the compiler must use the most general representation. It can lead to a <em>one definition rule</em>, or ODR violation, since the compiler may use a smaller, more specific representation for this pointer-to-member type in other translation units where the complete class type is available.</p>
+<p>The Microsoft C++ ABI uses more than one kind of pointer-to-member type. These types have different sizes that depend on the inheritance model used by the class. The C++ standard allows you to declare a pointer-to-member of an incomplete class type. If you declare a variable of pointer-to-member type for an incomplete class, the compiler must use the most general representation. It can lead to a <em>one definition rule</em>, or ODR violation, since the compiler may use a smaller, more specific representation for this pointer-to-member type in other translation units where the complete class type is available.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5243?view=msvc-170" target="_blank">C5243</a></p>]]>
-      </description>
+    </description>
     <severity>INFO</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C5247</key>
-    <name>C5247: section 'section-name' is reserved for C++ dynamic initialization</name>
+    <name>C5247: Section 'section-name' is reserved for C++ dynamic initialization</name>
     <description>
       <![CDATA[
 <p>The Microsoft C++ compiler uses reserved section names for internal implementation of features such as C++ dynamic initialization. If your code creates a section with the same name as a reserved section, such as <code>.CRT$XCU</code>, it interferes with the compiler. It may prevent other dynamic initialization and cause undefined behavior.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5247?view=msvc-170" target="_blank">C5247</a></p>]]>
-      </description>
+    </description>
     <severity>INFO</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C5248</key>
-    <name>C5248: section 'section-name' is reserved for C++ dynamic initialization</name>
+    <name>C5248: Section 'section-name' is reserved for C++ dynamic initialization</name>
     <description>
       <![CDATA[
 <p>The Microsoft C++ compiler uses reserved section names for internal implementation of features such as C++ dynamic initialization. If your code inserts a variable in a reserved section, such as <code>.CRT$XCU</code>, it interferes with the compiler. Your variable isn't considered a C++ dynamic initializer. Also, its relative initialization order compared to compiler generated dynamic initializers isn't specified.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5248?view=msvc-170" target="_blank">C5248</a></p>]]>
-      </description>
+    </description>
+    <severity>INFO</severity>
+  </rule>
+  <rule>
+    <key>C5262</key>
+    <name>C5262: Implicit fall-through occurs here</name>
+    <description>
+      <![CDATA[
+<p>Implicit fall-through occurs here; are you missing a break statement? Use [[fallthrough]] when a break statement is intentionally omitted between cases.</p>
+<p>Control flow that implicitly falls between cases of switch statements is a historical source of bugs for both C and C++. While we had the <code>__fallthrough</code> SAL macro, it wasn't useful for the build-compiler diagnostics. Since customers have legacy code that "falls through" on purpose, it isn't viable to give an actionable warning without some way of indicating an intentional fall through. In C++17, the <code>[[fallthrough]]</code> attribute was added to indicate such an instance. The compiler can take this attribute into account and suppress the new warning.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5262?view=msvc-170" target="_blank">C5262</a></p>]]>
+    </description>
+    <severity>INFO</severity>
+  </rule>
+  <rule>
+    <key>C5266</key>
+    <name>C5266: 'const' qualifier on return type has no effect</name>
+    <description>
+      <![CDATA[
+<p>The C++ Standard specifies that a top-level const (or volatile) qualification on a function return type is ignored.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c5266?view=msvc-170" target="_blank">C5266</a></p>]]>
+    </description>
+    <severity>INFO</severity>
+  </rule>
+  <rule>
+    <key>C5267</key>
+    <name>C5267: Definition of implicit copy constructor/assignment operator for 'type' is deprecated</name>
+    <description>
+      <![CDATA[
+<p>Definition of implicit copy constructor/assignment operator for 'type' is deprecated because it has a user-provided assignment operator/copy constructor.</p>
+<p>The C++ Standard deprecated (but didn't remove) the implicit generation of copy and assignment operators under some conditions. The MSVC compiler still generates the copy and assignment operators under those conditions, but may change its behavior in the future if the standard removes the deprecated behavior. The purpose of this warning is to help future proof your code if the committee decides to remove this functionality.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5267?view=msvc-170" target="_blank">C5267</a></p>]]>
+    </description>
+    <severity>INFO</severity>
+  </rule>
+  <rule>
+    <key>C5301</key>
+    <name>C5301: '#pragma omp for': 'loop-index' increases while loop condition uses 'comparison'</name>
+    <description>
+      <![CDATA[
+<p>Along with improved support for OpenMP 3.1, we've added two diagnostics, C5301 and C5302, to improve the developer experience. These diagnostics check that the loop conditions for <code>omp parallel for</code> are correct, based on whether the loop index variable is increasing or decreasing. These checks work for both integral and pointer indices.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5301-c5302?view=msvc-170" target="_blank">C5301</a></p>]]>
+    </description>
+    <severity>INFO</severity>
+  </rule>
+  <rule>
+    <key>C5302</key>
+    <name>C5302: '#pragma omp for': 'loop-index' increases while loop condition uses 'comparison'</name>
+    <description>
+      <![CDATA[
+<p>Along with improved support for OpenMP 3.1, we've added two diagnostics, C5301 and C5302, to improve the developer experience. These diagnostics check that the loop conditions for <code>omp parallel for</code> are correct, based on whether the loop index variable is increasing or decreasing. These checks work for both integral and pointer indices.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5301-c5302?view=msvc-170" target="_blank">C5302</a></p>]]>
+    </description>
     <severity>INFO</severity>
   </rule>
   <rule>
@@ -6564,12 +6624,23 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6029</key>
-    <name>C6029: Possible buffer overrun in call to 'function': use of unchecked value</name>
+    <name>C6029: Possible buffer overrun in call to 'function'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a function that takes a buffer and a size is being passed an unchecked size. The data read-in from some external source hasn't been verified to see whether it's smaller than the buffer size. An attacker might intentionally specify a much larger than expected value for the size, which will lead to a buffer overrun.</p>
+<p>Possible buffer overrun in called function due to an unchecked buffer length/size parameter.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6029?view=msvc-170" target="_blank">C6029</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
+    <key>C6030</key>
+    <name>C6030: Use attribute [[noreturn]] over __declspec(noreturn) in function 'function-name'</name>
+    <description>
+      <![CDATA[
+<p>This warning suggests using the C++11 standard attribute <code>[[noreturn]]</code> in place of the declspec variant <code>__declspec(noreturn)</code>. The standard attribute provides better cross-platform support because it doesn't rely on language extensions.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6030?view=msvc-170" target="_blank">C6030</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
   </rule>
@@ -6634,12 +6705,23 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6064: Missing integer argument to 'function-name' corresponding to conversion specifier 'number'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that not enough arguments are provided to match a format string and one of the missing arguments is an integer.</p>
+<p>This warning indicates that the code doesn't provide enough arguments to match a format string and one of the missing arguments is an integer.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6064?view=msvc-170" target="_blank">C6064</a></p>]]>
     </description>
     <severity>CRITICAL</severity>
     <type>BUG</type>
+  </rule>
+  <rule>
+    <key>C6065</key>
+    <name>C6065: Missing pointer to 'string type' argument to 'function' that corresponds to argument 'number'</name>
+    <description>
+      <![CDATA[
+<p>This warning indicates that there's a mismatch between the format specifiers in a string and the types of the associated parameters. The format specifier indicates that at least one of the mismatched arguments should be a pointer to a counted string such as <code>UNICODE_STRING</code> or <code>ANSI_STRING</code> but it not. This defect can cause crashes, buffer overflows, and potentially incorrect output.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6065?view=msvc-170" target="_blank">C6065</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
   </rule>
   <rule>
     <key>C6066</key>
@@ -6669,7 +6751,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6101: Returning uninitialized memory</name>
     <description>
       <![CDATA[
-<p>This message is generated based on SAL annotations that indicate that the function in question always succeeds. A function that doesn't return a success/failure indication should set all of its <code>_Out_</code> parameters because the analyzer assumes that the <code>_Out_</code> parameter is uninitialized data before the function is called, and that the function will set the parameter so that it's no longer uninitialized. If, however, the function does indicate success/failure and failure occurs, then the <code>_Out_</code> parameter doesn't have to be set. You can then detect and avoid the uninitialized location. In either case, the objective is to avoid the reading of an uninitialized location. If the function sometimes doesn't touch an <code>_Out_</code> parameter that's later used, then the parameter should be initialized before the function call and be marked with the <code>_Inout_</code> annotation, or the more explicit <code>_Pre_null_</code> or <code>_Pre_satisfies_()</code> when appropriate. "Partial success" can be handled with the <code>_When_</code> annotation. For more information, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">Using SAL Annotations to Reduce C/C++ Code Defects</a>.</p>
+<p>A successful path through the function doesn't set the <code>_Out_</code> annotated parameter.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6101?view=msvc-170" target="_blank">C6101</a></p>]]>
     </description>
@@ -6702,10 +6784,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6200</key>
-    <name>C6200: Index 'index' is out of valid index range 'min' to 'max' for non-stack buffer 'parameter-name'</name>
+    <name>C6200: Index 'index' is out of valid index range 'min' to 'max' for nonstack buffer 'parameter-name'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an integer offset into the specified non-stack array exceeds the maximum bounds of that array, potentially causing random behavior and/or crashes.</p>
+<p>This warning indicates that an integer offset into the specified nonstack array exceeds the maximum bounds of that array, causing undefined behavior and potentially crashes.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6200?view=msvc-170" target="_blank">C6200</a></p>]]>
     </description>
@@ -6717,7 +6799,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6201: Index 'index-name' is out of valid index range 'minimum' to 'maximum' for possibly stack allocated buffer 'variable'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an integer offset into the specified stack array exceeds the maximum bounds of that array. It may potentially cause stack overflow errors, random behavior, or crashes.</p>
+<p>This warning indicates that an integer offset into the specified stack array exceeds the maximum bounds of that array. It might potentially cause stack overflow errors, undefined behavior, or crashes.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6201?view=msvc-170" target="_blank">C6201</a></p>]]>
     </description>
@@ -6729,7 +6811,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6211: Leaking memory 'pointer' due to an exception</name>
     <description>
       <![CDATA[
-<p>This warning indicates that allocated memory is not being freed when an exception is thrown. The statement at the end of the path could throw an exception. The analyzer checks for this condition only when the <code>_Analysis_mode_(_Analysis_local_leak_checks_)</code> SAL annotation is specified. By default, this annotation is specified for Windows kernel mode (driver) code. For more information about SAL annotations, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">Using SAL Annotations to Reduce C/C++ Code Defects</a>.</p>
+<p>This warning indicates that allocated memory isn't freed when an exception is thrown. The statement at the end of the path could throw an exception.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6211?view=msvc-170" target="_blank">C6211</a></p>]]>
     </description>
@@ -6737,10 +6819,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6214</key>
-    <name>C6214: cast between semantically different integer types: HRESULT to a Boolean type</name>
+    <name>C6214: Cast between semantically different integer types: HRESULT to a Boolean type</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an <code>HRESULT</code> is being cast to a Boolean type. The success value (<code>S_OK</code>) of an <code>HRESULT</code> equals 0. However, 0 indicates failure for a Boolean type. Casting an <code>HRESULT</code> to a Boolean type and then using it in a test expression will yield an incorrect result. Sometimes, this warning occurs if an <code>HRESULT</code> is being stored in a Boolean variable. Any comparison that uses the Boolean variable to test for <code>HRESULT</code> success or failure could lead to incorrect results.</p>
+<p>This warning indicates that an <code>HRESULT</code> is being cast to a Boolean type. The success value (<code>S_OK</code>) of an <code>HRESULT</code> equals 0. However, 0 indicates failure for a Boolean type. Casting an <code>HRESULT</code> to a Boolean type and then using it in a test expression will yield an incorrect result.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6214?view=msvc-170" target="_blank">C6214</a></p>]]>
     </description>
@@ -6748,7 +6830,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6215</key>
-    <name>C6215: cast between semantically different integer types: a Boolean type to HRESULT</name>
+    <name>C6215: Cast between semantically different integer types: a Boolean type to HRESULT</name>
     <description>
       <![CDATA[
 <p>This warning indicates that a Boolean is being cast to an <code>HRESULT</code>. Boolean types indicate success by a non-zero value, whereas success (<code>S_OK</code>) in <code>HRESULT</code> is indicated by a value of 0. Casting a Boolean type to an <code>HRESULT</code> and then using it in a test expression will yield an incorrect result.</p>
@@ -6759,10 +6841,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6216</key>
-    <name>C6216: compiler-inserted cast between semantically different integral types: a Boolean type to HRESULT</name>
+    <name>C6216: Compiler-inserted cast between semantically different integral types: a Boolean type to HRESULT</name>
     <description>
       <![CDATA[
-<p>A Boolean type is being used as an <code>HRESULT</code> without being explicitly cast. Boolean types indicate success by a non-zero value; success (<code>S_OK</code>) in <code>HRESULT</code> is indicated by a value of 0.  This means a Boolean false value used as an <code>HRESULT</code> would indicate <code>S_OK</code>, which is frequently a mistake.</p>
+<p>A Boolean type is being used as an <code>HRESULT</code> without being explicitly cast.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6216?view=msvc-170" target="_blank">C6216</a></p>]]>
     </description>
@@ -6773,7 +6855,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6217: Implicit cast between semantically different integer types: testing HRESULT with 'not'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an <code>HRESULT</code> is being tested with the logical-not (<code>!</code>) operator. A success (<code>S_OK</code>) in <code>HRESULT</code> is indicated by a value of 0. However, 0 indicates failure for a Boolean type. Testing <code>HRESULT</code> with the logical-not operator (<code>!</code>) to determine which code block to run can cause following the wrong code path. This test will lead to unwanted results.</p>
+<p>This warning indicates that the code tests an <code>HRESULT</code> with the logical-not (<code>!</code>) operator. A value of 0 (the value defined for <code>S_OK</code>) indicates success in an <code>HRESULT</code>. However, 0 also indicates failure for a Boolean type. If you test an <code>HRESULT</code> with the logical-not operator (<code>!</code>) to determine which code block to run, it can cause incorrect behavior or code that confuses future maintainers.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6217?view=msvc-170" target="_blank">C6217</a></p>]]>
     </description>
@@ -6795,7 +6877,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6220: - Implicit cast between semantically different integer types: comparing HRESULT to -1</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an <code>HRESULT</code> is being compared with an explicit, non-<code>HRESULT</code> value of -1, which is not a well-formed <code>HRESULT</code>. A failure in <code>HRESULT</code> (<code>E_FAIL</code>) is not represented by a -1. Therefore, an implicit cast of an <code>HRESULT</code> to an integer will generate an incorrect value and is likely to lead to the wrong result.</p>
+<p>This warning indicates that an <code>HRESULT</code> is being compared with an explicit, non-<code>HRESULT</code> value of -1, which isn't a well-formed <code>HRESULT</code>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6220?view=msvc-170" target="_blank">C6220</a></p>]]>
     </description>
@@ -6806,7 +6888,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6221: Implicit cast between semantically different integer types: comparing HRESULT to an integer</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an <code>HRESULT</code> is being compared to an integer other than zero. A success in <code>HRESULT</code> (<code>S_OK</code>) is represented by a 0. Therefore, an implicit cast of an <code>HRESULT</code> to an integer will generate an incorrect value and is likely to lead to the wrong result. It is often caused by mistakenly expecting a function to return an integer when it actually returns an <code>HRESULT</code>.</p>
+<p>This warning indicates that an <code>HRESULT</code> is being compared to an integer other than zero.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6221?view=msvc-170" target="_blank">C6221</a></p>]]>
     </description>
@@ -6817,7 +6899,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6225: Implicit cast between semantically different integer types: assigning 1 or TRUE to HRESULT</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an <code>HRESULT</code> is being assigned or initialized with a value of an explicit 1. Boolean types indicate success by a non-zero value; success (<code>S_OK</code>) in <code>HRESULT</code> is indicated by a value of 0. This warning is frequently caused by accidental confusion of Boolean and <code>HRESULT</code> types. To indicate success, the symbolic constant <code>S_OK</code> should be used.</p>
+<p>This warning indicates that an <code>HRESULT</code> is being assigned or initialized with a value of an explicit 1. Boolean types indicate success by a non-zero value; success (<code>S_OK</code>) in <code>HRESULT</code> is indicated by a value of 0.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6225?view=msvc-170" target="_blank">C6225</a></p>]]>
     </description>
@@ -6828,7 +6910,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6226: Implicit cast between semantically different integer types: assigning -1 to HRESULT</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an <code>HRESULT</code> is assigned or initialized to an explicit value of -1. This warning is frequently caused by accidental confusion of integer and <code>HRESULT</code> types. To indicate success, use the symbolic constant <code>S_OK</code> instead. To indicate failure, use the symbolic constants that start with E_<em>constant</em>, such as <code>E_FAIL</code>.</p>
+<p>This warning indicates that an <code>HRESULT</code> is assigned or initialized to an explicit value of -1.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6226?view=msvc-170" target="_blank">C6226</a></p>]]>
     </description>
@@ -6836,7 +6918,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6230</key>
-    <name>C6230: implicit cast between semantically different integer types: using HRESULT in a Boolean context</name>
+    <name>C6230: Implicit cast between semantically different integer types: using HRESULT in a Boolean context</name>
     <description>
       <![CDATA[
 <p>This warning indicates that a bare <code>HRESULT</code> is used in a context where a Boolean result is expected, such as an <strong><code>if</code></strong> statement. This test is likely to yield incorrect results. For example, the typical success value for <code>HRESULT</code> (<code>S_OK</code>) is false when it's tested as a Boolean.</p>
@@ -6850,7 +6932,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6235: ('non-zero constant' || 'expression') is always a non-zero constant</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a non-zero constant value, other than one, was detected on the left side of a logical-or operation that occurs in a test context. The right side of the logical-or operation isn't evaluated because the resulting expression always evaluates to true. This language feature is referred to as "short-circuit evaluation."</p>
+<p>This warning indicates that a non-zero constant value, other than one, was detected on the left side of a logical-or operation that occurs in a test context. The right side of the logical-or operation isn't evaluated because the resulting expression always evaluates to true. This language feature is referred to as "short-circuit evaluation".</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6235?view=msvc-170" target="_blank">C6235</a></p>]]>
     </description>
@@ -6875,7 +6957,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <description>
       <![CDATA[
 <p>('zero' &amp;&amp; 'expression') is always zero. 'expression' is never evaluated and may have side effects.</p>
-<p>This warning indicates that a constant value of zero was detected on the left side of a logical-and operation that occurs in a test context. The resulting expression always evaluates to false. Therefore, the right side of the logical-AND operation isn't evaluated. This language feature is referred to as "short-circuit evaluation."</p>
+<p>This warning indicates that a constant value of zero was detected on the left side of a logical-and operation that occurs in a test context. The resulting expression always evaluates to false. Therefore, the right side of the logical-AND operation isn't evaluated. This language feature is referred to as "short-circuit evaluation".</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6237?view=msvc-170" target="_blank">C6237</a></p>]]>
     </description>
@@ -6941,7 +7023,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6248</key>
-    <name>C6248: setting a SECURITY_DESCRIPTOR's DACL to NULL will result in an unprotected object</name>
+    <name>C6248: Setting a SECURITY_DESCRIPTOR's DACL to NULL will result in an unprotected object</name>
     <description>
       <![CDATA[
 <p>If the DACL that belongs to the security descriptor of an object is set to NULL, a null DACL is created. A null DACL grants full access to any user who requests it; normal security checking isn't performed with respect to the object. A null DACL shouldn't be confused with an empty DACL. An empty DACL is a properly allocated and initialized DACL that contains no ACEs. An empty DACL grants no access to the object it's assigned to. Objects that have null DACLs can have their security descriptors altered by malicious users, making it so that no one has access to the object. Even in a situation where everyone needs access to an object, only administrators should be able to alter that object's security. If only the creator needs access to an object, a DACL shouldn't be set on the object; the system will choose an appropriate default.</p>
@@ -6966,7 +7048,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6255: _alloca indicates failure by raising a stack overflow exception</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a call to <code>_alloca</code> has been detected outside of local exception handling. <code>_alloca</code> should always be called from within the protected range of an exception handler because it can raise a stack overflow exception on failure. If possible, instead of using <code>_alloca</code>, consider using <code>_malloca</code> which is a more secure version of <code>_alloca</code>.</p>
+<p>This warning indicates that a call to <code>_alloca</code> has been detected outside of local exception handling.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6255?view=msvc-170" target="_blank">C6255</a></p>]]>
     </description>
@@ -6974,7 +7056,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6258</key>
-    <name>C6258: using TerminateThread does not allow proper thread clean up</name>
+    <name>C6258: Using TerminateThread does not allow proper thread clean up</name>
     <description>
       <![CDATA[
 <p>This warning indicates that a call to <code>TerminateThread</code> has been detected.</p>
@@ -6999,7 +7081,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6260: sizeof * sizeof is almost always wrong</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the results of two <strong><code>sizeof</code></strong> operations have been multiplied together. The C/C++ <strong><code>sizeof</code></strong> operator returns the number of bytes of storage an object uses. It is typically incorrect to multiply it by another <strong><code>sizeof</code></strong> operation; usually one is interested in the number of bytes in an object or the number of elements in an array (for example the number of wide-characters in an array).</p>
+<p>This warning indicates that the results of two <strong><code>sizeof</code></strong> operations have been multiplied together.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6260?view=msvc-170" target="_blank">C6260</a></p>]]>
     </description>
@@ -7019,7 +7101,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6263</key>
-    <name>C6263: using _alloca in a loop; this can quickly overflow stack</name>
+    <name>C6263: Using _alloca in a loop; this can quickly overflow stack</name>
     <description>
       <![CDATA[
 <p>This warning indicates that calling <code>_alloca</code> inside a loop to allocate memory can cause stack overflow. <code>_alloca</code> allocates memory from the stack, but that memory is only freed when the calling function exits. Stack, even in user-mode, is limited, and failure to commit a page of stack causes a stack overflow exception. The <code>_resetstkoflw</code> function recovers from a stack overflow condition, allowing a program to continue instead of failing with a fatal exception error. If the <code>_resetstkoflw</code> function isn't called, there's no guard page after the previous exception. The next time that there's a stack overflow, there are no exceptions at all and the process terminates without warning.</p>
@@ -7042,7 +7124,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6269</key>
-    <name>C6269: possible incorrect order of operations: dereference ignored</name>
+    <name>C6269: Possible incorrect order of operations: dereference ignored</name>
     <description>
       <![CDATA[
 <p>This warning indicates that the result of a pointer dereference is being ignored, which raises the question of why the pointer is being dereferenced in the first place.</p>
@@ -7056,7 +7138,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6270: Missing float argument to 'function-name': add a float argument corresponding to conversion specifier 'number'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that not enough arguments are provided to match a format string; at least one of the missing arguments is a floating-point number.</p>
+<p>This warning indicates that not enough arguments are provided to match a format string.  At least one of the missing arguments is a floating-point number. This defect can lead to crashes, in addition to potentially incorrect output.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6270?view=msvc-170" target="_blank">C6270</a></p>]]>
     </description>
@@ -7064,10 +7146,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6271</key>
-    <name>C6271: Extra argument passed to 'function': parameter 'number' is not used by the format string</name>
+    <name>C6271: Extra argument passed to 'function'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that additional arguments are being provided beyond the ones specified by the format string. By itself, this defect won't have any visible effect although it indicates that the programmer's intent isn't reflected in the code.</p>
+<p>This warning indicates that extra arguments are being provided beyond the ones specified by the format string. By itself, this defect doesn't have any visible effect although it indicates that the programmer's intent isn't reflected in the code.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6271?view=msvc-170" target="_blank">C6271</a></p>]]>
     </description>
@@ -7078,7 +7160,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6272: Non-float passed as argument 'number' when float is required in call to 'function-name'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the format string specifies that a float is required, for example, a <code>%f</code> or <code>%g</code> specification for <code>printf,</code> but a non-float such as an integer or string is being passed. This defect is likely to result in incorrect output; however, in certain circumstances it could result in a crash.</p>
+<p>This warning indicates that the format string specifies that a float is required. For example, a <code>%f</code> or <code>%g</code> specification for <code>printf</code>, but a non-float such as an integer or string is being passed. This defect can lead to crashes, in addition to potentially incorrect output.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6272?view=msvc-170" target="_blank">C6272</a></p>]]>
     </description>
@@ -7087,7 +7169,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6273</key>
-    <name>C6273: Non-integer passed as parameter 'number' when integer is required in call to 'function'</name>
+    <name>C6273: Non-integer passed as parameter 'number' when an integer is required in call to 'function'</name>
     <description>
       <![CDATA[
 <p>Non-integer passed as parameter 'number' when integer is required in call to 'function': if a pointer value is being passed, %p should be used.</p>
@@ -7160,7 +7242,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6280: 'variable-name' is allocated with 'function-name-1', but deleted with 'function-name-2'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the calling function has inconsistently allocated memory by using a function from one memory allocation family and freed it by using a function from another memory allocation family. The analyzer checks for this condition only when the <code>_Analysis_mode_(_Analysis_local_leak_checks_)</code> SAL annotation is specified. By default, this annotation is specified for Windows kernel mode (driver) code. For more information about SAL annotations, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">Using SAL Annotations to Reduce C/C++ Code Defects</a>.</p>
+<p>This warning indicates that the calling function has inconsistently allocated memory by using a function from one family and freed it by using a function from another.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6280?view=msvc-170" target="_blank">C6280</a></p>]]>
     </description>
@@ -7168,7 +7250,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6281</key>
-    <name>C6281: incorrect order of operations: relational operators have higher precedence than bitwise operators</name>
+    <name>C6281: Incorrect order of operations: relational operators have higher precedence than bitwise operators</name>
     <description>
       <![CDATA[
 <p>This warning indicates a possible error in the operator precedence, which might produce incorrect results. You should check the precedence and use parentheses to clarify the intent. Relational operators (<code>&lt;</code>, <code>&gt;</code>, <code>&lt;=</code>, <code>&gt;=</code>, <code>==</code>, <code>!=</code>) have higher precedence than bitwise operators (<code>&amp;</code>, <code>|</code>, <code>^</code>).</p>
@@ -7193,7 +7275,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6283: 'variable-name' is allocated with array new [], but deleted with scalar delete</name>
     <description>
       <![CDATA[
-<p>This warning appears only in C++ code and indicates that the calling function has inconsistently allocated memory with the array <code>new []</code> operator, but freed it with the scalar <strong><code>delete</code></strong> operator. This defect might cause leaks, memory corruptions, and, in situations where operators have been overridden, crashes. If memory is allocated with array <code>new []</code>, it should typically be freed with array <code>delete[]</code>.</p>
+<p>This warning appears only in C++ code and indicates that the calling function has inconsistently allocated memory with the array <code>new []</code> operator, but freed it with the scalar <code>delete</code> operator.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6283?view=msvc-170" target="_blank">C6283</a></p>]]>
     </description>
@@ -7205,7 +7287,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6284: Object passed as parameter when string is required in call to '*function*'</name>
     <description>
       <![CDATA[
-<p>This warning indicates that there's a mismatch between the format specifier and the type being used in a <code>printf</code>-style function.  The format specifier is a C style String type such as <code>%s</code> or <code>%ws</code>, and the argument matched with it's an object type.</p>
+<p>This warning indicates that there's a mismatch between the format specifier and the type being used in a <code>printf</code>-style function.  The format specifier is a C style String type such as <code>%s</code> or <code>%ws</code>, and the argument is a class/struct/union type. This defect can lead to crashes, in addition to potentially incorrect output.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6284?view=msvc-170" target="_blank">C6284</a></p>]]>
     </description>
@@ -7235,7 +7317,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6287</key>
-    <name>C6287: redundant code: the left and right subexpressions are identical</name>
+    <name>C6287: Redundant code: the left and right subexpressions are identical</name>
     <description>
       <![CDATA[
 <p>This warning is emitted when an expression contains redundant logic. The warning can indicate a logic error. For example, accidentally using the wrong variable. It might also be a redundant test that can be removed. Inspect the code to verify that there's no logic error.</p>
@@ -7291,7 +7373,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6292</key>
-    <name>C6292: ill-defined for-loop: counts up from maximum</name>
+    <name>C6292: Ill-defined for-loop: counts up from maximum</name>
     <description>
       <![CDATA[
 <p>This warning indicates that a for-loop might not function as intended.</p>
@@ -7371,7 +7453,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6299</key>
-    <name>C6299: explicitly comparing a bit field to a Boolean type will yield unexpected results</name>
+    <name>C6299: Explicitly comparing a bit field to a Boolean type will yield unexpected results</name>
     <description>
       <![CDATA[
 <p>This warning indicates an incorrect assumption that Booleans and bit fields are equivalent. Assigning 1 to bit fields will place 1 in its single bit; however, any comparison of this bit field to 1 includes an implicit cast of the bit field to a signed int. This cast will convert the stored 1 to a -1 and the comparison can yield unexpected results.</p>
@@ -7383,10 +7465,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6302</key>
-    <name>C6302: Format string mismatch: character string passed as parameter 'number' when wide character string is required in call to 'function'</name>
+    <name>C6302: Format string mismatch</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the format string specifies a wide character string is expected. However, a character string is being passed. This will likely cause the output to be malformed or for the program to crash at runtime.</p>
+<p>This warning indicates that a format string specifies a wide character string, but is being passed a narrow character string instead. One cause of the warning is because the meaning of <code>%s</code> and <code>%S</code> flip when used with <code>printf</code> or <code>wprintf</code>. This defect can lead to crashes, in addition to potentially incorrect output.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6302?view=msvc-170" target="_blank">C6302</a></p>]]>
     </description>
@@ -7394,10 +7476,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6303</key>
-    <name>C6303: Format string mismatch: wide character string passed as parameter 'number' when character string is required in call to 'function-name'</name>
+    <name>C6303: Format string mismatch</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the format string specifies that a character string is required. However, a wide character string is being passed. This defect is likely to cause a crash or corruption of some form.</p>
+<p>This warning indicates that a format string specifies a narrow character string, but is being passed a wide character string instead. One cause of the warning is because the meaning of <code>%s</code> and <code>%S</code> flip when used with <code>printf</code> or <code>wprintf</code>. This defect can lead to crashes, in addition to potentially incorrect output.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6303?view=msvc-170" target="_blank">C6303</a></p>]]>
     </description>
@@ -7405,7 +7487,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6305</key>
-    <name>C6305: potential mismatch between sizeof and countof quantities</name>
+    <name>C6305: Potential mismatch between sizeof and countof quantities</name>
     <description>
       <![CDATA[
 <p>This warning indicates that a variable holding a <strong><code>sizeof</code></strong> result is being added to or subtracted from a pointer or <code>countof</code> expression. This operation will cause unexpected scaling in pointer arithmetic.</p>
@@ -7441,7 +7523,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6310</key>
-    <name>C6310: illegal constant in exception filter can cause unexpected behavior</name>
+    <name>C6310: Illegal constant in exception filter can cause unexpected behavior</name>
     <description>
       <![CDATA[
 <p>This message indicates that an illegal constant was detected in the filter expression of a structured exception handler.</p>
@@ -7509,7 +7591,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6317</key>
-    <name>C6317: incorrect operator: logical-not (!) is not interchangeable with ones-complement (~)</name>
+    <name>C6317: Incorrect operator: logical-not (!) is not interchangeable with ones-complement (~)</name>
     <description>
       <![CDATA[
 <p>This warning indicates that a logical-not (<code>!</code>) is being applied to a constant that is likely to be a bit-flag. The result of logical-not is Boolean; it's incorrect to apply the bitwise-and (<code>&amp;</code>) operator to a Boolean value. Use the ones-complement (<code>~</code>) operator to flip flags.</p>
@@ -7532,7 +7614,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6319</key>
-    <name>C6319: use of the comma-operator in a tested expression causes the left argument to be ignored when it has no side-effects</name>
+    <name>C6319: Use of the comma-operator in a tested expression causes the left argument to be ignored when it has no side-effects</name>
     <description>
       <![CDATA[
 <p>This warning indicates an ignored sub-expression in test context because of the comma-operator (<strong><code>,</code></strong>). The comma operator has left-to-right associativity. The result of the comma-operator is the last expression evaluated. If the left expression to comma-operator has no side effects, the compiler might omit code generation for the expression.</p>
@@ -7543,7 +7625,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6320</key>
-    <name>C6320: exception-filter expression is the constant EXCEPTION_EXECUTE_HANDLER</name>
+    <name>C6320: Exception-filter expression is the constant EXCEPTION_EXECUTE_HANDLER</name>
     <description>
       <![CDATA[
 <p>This warning indicates the side effect of using <code>EXCEPTION_EXECUTE_HANDLER</code> constant in an <code>__except</code> block. In this case, the statement in the <code>__except</code> block will always execute to handle the exception, including exceptions you didn't want to handle in a particular function. It's recommended that you check the exception before handling it.</p>
@@ -7588,7 +7670,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6326</key>
-    <name>C6326: potential comparison of a constant with another constant</name>
+    <name>C6326: Potential comparison of a constant with another constant</name>
     <description>
       <![CDATA[
 <p>This warning indicates a potential comparison of a constant with another constant, which is redundant code. You must check to make sure that your intent is properly captured in the code. In some cases, you can simplify the test condition to achieve the same result.</p>
@@ -7599,10 +7681,11 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6328</key>
-    <name>C6328: Size mismatch: 'type' passed as parameter 'number' when 'type' is required in call to 'function-name'</name>
+    <name>C6328: Size mismatch: 'type' passed as Param(number) when 'type' is required in call to 'function-name'</name>
     <description>
       <![CDATA[
-<p>An argument of type <code>char</code> passed to C runtime, character-based routines named <code>is&lt;xxx&gt;</code> (for example, <code>isspace</code>) can have unpredictable results. For example, an SBCS or MBCS single-byte character of type <code>char</code> with a value greater than <code>0x7F</code> is a negative value. If a <code>char</code> is passed, the compiler might convert the value to a signed <code>int</code> or a signed <code>long</code>. This value could be sign-extended by the compiler, with unexpected results. This issue could result in a function like <code>isspace</code>, which only expects values from 0-255 or <code>EOF</code>, being sent a negative value.</p>
+<p>This warning indicates that type required by the format specifier and the type of the expression passed in don't match.
+Using the wrong format specifier is undefined behavior. To fix the warning, make sure that the format specifiers match the types of the expressions passed in.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6328?view=msvc-170" target="_blank">C6328</a></p>]]>
     </description>
@@ -7646,7 +7729,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6332: Invalid parameter: passing zero as the dwFreeType parameter to 'function' is not allowed</name>
     <description>
       <![CDATA[
-<p>This warning indicates that an invalid parameter is being passed to VirtualFree or VirtualFreeEx. VirtualFree and VirtualFreeEx both reject a dwFreeType parameter of zero. The dwFreeType parameter can be either MEM_DECOMMIT or MEM_RELEASE. However, the values MEM_DECOMMIT and MEM_RELEASE may not be used together in the same call. Also, make sure that the return value of the VirtualFree function is not ignored.</p>
+<p>This warning indicates that an invalid parameter is being passed to <code>VirtualFree</code> or <code>VirtualFreeEx</code>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6332?view=msvc-170" target="_blank">C6332</a></p>]]>
     </description>
@@ -7689,7 +7772,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6336</key>
-    <name>C6336: arithmetic operator has precedence over question operator</name>
+    <name>C6336: Arithmetic operator has precedence over question operator</name>
     <description>
       <![CDATA[
 <p>This warning indicates a possible operator precedence problem. The '<code>+</code>','<code>-</code>','<code>*</code>' and '<code>/</code>' operators have precedence over the '<code>?</code>' operator. If the precedence in the expression isn't correct, use parentheses to change the operator precedence.</p>
@@ -7700,10 +7783,11 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6340</key>
-    <name>C6340: Mismatch on sign: Incorrect type passed as parameter in call to function</name>
+    <name>C6340: Mismatch on sign: 'type' passed as Param(number) when some (signed|unsigned) type is required in call to 'function-name'</name>
     <description>
       <![CDATA[
-<p>Mismatch on sign: Incorrect type passed as parameter in call to function.</p>
+<p>This warning indicates that sign of the type required by the format specifier and sign of the type of the expression passed in don't match.
+Using the wrong format specifier is undefined behavior. To fix the warning, make sure that the format specifiers match the types of the expressions passed in.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6340?view=msvc-170" target="_blank">C6340</a></p>]]>
     </description>
@@ -7725,7 +7809,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C6383: Buffer overrun due to conversion of an element count into a byte count: an element count is expected for parameter *parameter_name* in call to *function_name*</name>
     <description>
       <![CDATA[
-<p>This warning indicates that a non-constant byte count is being passed when an element count is required. Typically, this occurs when a variable is multiplied by the <strong><code>sizeof</code></strong> a type, but code analysis suggests that an element count is required.</p>
+<p>This warning indicates that a non-constant byte count is being passed when an element count is instead required.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6383?view=msvc-170" target="_blank">C6383</a></p>]]>
     </description>
@@ -7734,7 +7818,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6384</key>
-    <name>C6384: dividing sizeof a pointer by another value</name>
+    <name>C6384: Dividing sizeof a pointer by another value</name>
     <description>
       <![CDATA[
 <p>This warning indicates that a size calculation might be incorrect. To calculate the number of elements in an array, you sometimes divide the size of the array by the size of the first element. However, when the array is actually a pointer, the result is typically different than intended.</p>
@@ -7745,7 +7829,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6385</key>
-    <name>C6385: invalid data: accessing buffer-name, the readable size is size1 bytes, but size2 bytes may be read: Lines: x, y</name>
+    <name>C6385: Invalid data: accessing buffer-name, the readable size is size1 bytes, but size2 bytes may be read: Lines: x, y</name>
     <description>
       <![CDATA[
 <p>The readable extent of the buffer might be smaller than the index used to read from it. Attempts to read data outside the valid range leads to buffer overrun.</p>
@@ -7795,9 +7879,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>This check is intended to help reduce the visibility of certain symbols and to modularize the code. In multi-file C++ projects, each declaration should be either local to a C++ file (part of the anonymous namespace) or declared in a common header file that's included by multiple C++ files.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6389?view=msvc-170" target="_blank">C6389</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C6390</key>
     <name>C6390: According to the C++ standard, the value of 'this' is never null</name>
@@ -7806,9 +7890,87 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>While MSVC doesn't do such optimizations, some compilers optimize null checks for <code>this</code> out. Code that relies on null-valued <code>this</code> can trigger unexpected behavior when compiled with other compilers. This warning helps detect these portability problems.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6390?view=msvc-170" target="_blank">C6390</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
+  <rule>
+    <key>C6392</key>
+    <name>C6392: This expression writes the value of the pointer to the stream</name>
+    <description>
+      <![CDATA[
+<p>This expression writes the value of the pointer to the stream. If this is intentional, add an explicit cast to 'void *'.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6392?view=msvc-170" target="_blank">C6392</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
+    <key>C6393</key>
+    <name>C6393: A lookup table of size 365 isn't sufficient to handle leap years</name>
+    <description>
+      <![CDATA[
+<p>A leap year bug occurs when software doesn't account for leap year logic, or uses flawed logic. This can affect reliability, availability, or even the security of the affected system.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6393?view=msvc-170" target="_blank">C6393</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
+    <key>C6394</key>
+    <name>C6394: A lookup table of size 365 isn't sufficient to handle leap years</name>
+    <description>
+      <![CDATA[
+<p>A leap year bug occurs when software doesn't account for leap year logic, or uses flawed logic. This can affect reliability, availability, or even the security of the affected system.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6394?view=msvc-170" target="_blank">C6394</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
+    <key>C6395</key>
+    <name>C6395: %variable% has unsequenced reads and/or writes before C++17</name>
+    <description>
+      <![CDATA[
+<p>%variable% has unsequenced reads and/or writes before C++17; changing the language standard might change the behavior of the code.</p>
+<p>C++17 made the evaluation order of certain expressions stricter. MSVC complied, which changed the evaluation order for some expressions. Thus, changing the language version might change the observable behavior of the program. This check diagnoses some of the cases where the meaning of the code changes due to switching language versions.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6395?view=msvc-170" target="_blank">C6395</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
+    <key>C6396</key>
+    <name>C6396: sizeof('integerConstant') always returns the size of the underlying integer type</name>
+    <description>
+      <![CDATA[
+<p>This warning indicates where an integral constant is used as a <code>sizeof</code> argument. Such expression always returns the size of the type of the constant. It's better to write <code>sizeof(type)</code> instead. This warning catches common typos in buffer offset calculations.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6396?view=msvc-170" target="_blank">C6396</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
+    <key>C6397</key>
+    <name>C6397: The address-of operator cannot return null pointer in well-defined code</name>
+    <description>
+      <![CDATA[
+<p>The address-of operator returns the address of its operand. This value should never be compared to <code>nullptr</code>.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6397?view=msvc-170" target="_blank">C6397</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
+    <key>C6398</key>
+    <name>C6398: The address-of a field cannot be null in well-defined code</name>
+    <description>
+      <![CDATA[
+<p>The address-of operator returns the address of its operand. This value should never be compared to <code>nullptr</code>.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6398?view=msvc-170" target="_blank">C6398</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
   <rule>
     <key>C6400</key>
     <name>C6400: Using 'function name' to perform a case-insensitive compare to constant string 'string name'</name>
@@ -7888,10 +8050,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6504</key>
-    <name>C6504: invalid annotation: property may only be used on values of pointer, pointer-to-member, or array type</name>
+    <name>C6504: Invalid annotation: property may only be used on values of pointer, pointer-to-member, or array type</name>
     <description>
       <![CDATA[
-<p>This warning indicates the use of a pointer-specific SAL annotation on a non-pointer data type. For more information about what data types are supported by properties, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">Annotation Properties</a>.</p>
+<p>This warning indicates the use of a pointer-specific SAL annotation on a non-pointer data type.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c6504?view=msvc-170" target="_blank">C6504</a></p>]]>
     </description>
@@ -7899,7 +8061,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6505</key>
-    <name>C6505: invalid annotation: MustCheck property may not be used on values of void type</name>
+    <name>C6505: Invalid annotation: MustCheck property may not be used on values of void type</name>
     <description>
       <![CDATA[
 <p>This warning indicated that MustCheck property was used on a void data type. You can't use <code>MustCheck</code> property on <code>void</code> type. Either remove the <code>MustCheck</code> property or use another data type.</p>
@@ -7921,7 +8083,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6508</key>
-    <name>C6508: invalid annotation: write access is not allowed on const values</name>
+    <name>C6508: Invalid annotation: write access is not allowed on const values</name>
     <description>
       <![CDATA[
 <p>This warning indicates that the Access property specified on a const parameter implies that it can be written to. For constant values, Access=Read is the only valid setting.</p>
@@ -7932,7 +8094,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6509</key>
-    <name>C6509: invalid annotation: 'return' cannot be referenced from a precondition</name>
+    <name>C6509: Invalid annotation: 'return' cannot be referenced from a precondition</name>
     <description>
       <![CDATA[
 <p>This warning indicates that the <strong><code>return</code></strong>  keyword can't be used in a precondition. The <strong><code>return</code></strong> keyword is used to terminate the execution of a function and return control to the calling function.</p>
@@ -7954,7 +8116,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6511</key>
-    <name>C6511: invalid annotation: MustCheck property must be Yes or No</name>
+    <name>C6511: Invalid annotation: MustCheck property must be Yes or No</name>
     <description>
       <![CDATA[
 <p>This warning indicates an invalid value for MustCheck property was specified. The only valid values for this property are: Yes and No.</p>
@@ -7965,7 +8127,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6513</key>
-    <name>C6513: invalid annotation: ElementSizeConst requires additional size properties</name>
+    <name>C6513: Invalid annotation: ElementSizeConst requires additional size properties</name>
     <description>
       <![CDATA[
 <p>This warning indicates that ElementSizeConst requires other properties that are missing from the annotation. Specifying ElementSizeConst alone does not provide any benefit to the analysis process. In addition to specifying ElementSize, other properties such as ValidElementsConst or WritableElementsConst must also be specified.</p>
@@ -8031,7 +8193,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6522</key>
-    <name>C6522: invalid size specification: expression must be of integral type</name>
+    <name>C6522: Invalid size specification: expression must be of integral type</name>
     <description>
       <![CDATA[
 <p>This warning indicates that an integral type was expected, but an incorrect data type was used. You can use annotation properties that accept the size of a parameter in terms of another parameter, but you must use correct data type. For a list of annotation properties, see <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects?view=msvc-170">Using SAL Annotations to reduce code defects</a>.</p>
@@ -8042,7 +8204,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C6525</key>
-    <name>C6525: invalid size specification: property value may not be valid</name>
+    <name>C6525: Invalid size specification: property value may not be valid</name>
     <description>
       <![CDATA[
 <p>This warning indicates that the property value used to specify the size is not valid. This occurs if the size parameter is annotated using Valid=No.</p>
@@ -8434,7 +8596,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C26402: Return a scoped object instead of a heap-allocated if it has a move constructor</name>
     <description>
       <![CDATA[
-<p>To avoid confusion about whether a pointer owns an object, a function that returns a movable object should allocate it on the stack. It should then return the object by value instead of returning a heap-allocated object. If pointer semantics are required, return a smart pointer instead of a raw pointer. For more information, see <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-ptr">C++ Core Guidelines R.3</a>: <em>Warn if a function returns an object that was allocated within the function but has a move constructor. Suggest considering returning it by value instead.</em></p>
+<p>To avoid confusion about whether a pointer owns an object, a function that returns a movable object should allocate it on the stack. It should then return the object by value instead of returning a heap-allocated object. If pointer semantics are required, return a smart pointer instead of a raw pointer. For more information, see <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rr-ptr">C++ Core Guidelines R.3</a>: <em>Warn if a function returns an object that was allocated within the function but has a move constructor. Suggest considering returning it by value instead</em>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26402?view=msvc-170" target="_blank">C26402</a></p>]]>
     </description>
@@ -8768,7 +8930,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Do not slice.</p>
 <p><strong>C++ Core Guidelines</strong>:
-<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Res-slice">ES.63: Don't slice</a>.</p>
+<a data-linktype="external" href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-slice">ES.63: Don't slice</a></p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26437?view=msvc-170" target="_blank">C26437</a></p>]]>
     </description>
@@ -8822,7 +8984,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Guard objects must be named.</p>
 <p><strong>C++ Core Guidelines</strong>:
-<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#cp44-remember-to-name-your-lock_guards-and-unique_locks">CP.44</a>: Remember to name your lock_guards and unique_locks.</p>
+<p><a data-linktype="external" href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#cp44-remember-to-name-your-lock_guards-and-unique_locks">CP.44</a>: Remember to name your <code>lock_guard</code>s and <code>unique_lock</code>s</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26441?view=msvc-170" target="_blank">C26441</a></p>]]>
     </description>
@@ -8844,10 +9006,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26444</key>
-    <name>C26444: Avoid unnamed objects with custom construction and destruction</name>
+    <name>C26444: Don't try to declare a local variable with no name</name>
     <description>
       <![CDATA[
-<p>Avoid unnamed objects with custom construction and destruction.</p>
+<p>Don't try to declare a local variable with no name.</p>
 <p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Res-noname">ES.84: Don't (try to) declare a local variable with no name</a>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26444?view=msvc-170" target="_blank">C26444</a></p>]]>
@@ -8991,7 +9153,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <description>
       <![CDATA[
 <p>Default constructor should not throw. Declare it 'noexcept' (f.6).</p>
-<p>The C++ Core Guidelines suggest that default constructors shouldn't do anything that can throw. If the default constructor is allowed to throw, operations such as move and swap will also throw which is undesirable because move and swap should always succeed. Parameterized constructors may throw.</p>
+<p>The C++ Core Guidelines suggest that default constructors shouldn't do anything that can throw. When the default constructor can throw, all code that relies on a properly instantiated object may also throw.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26455?view=msvc-170" target="_blank">C26455</a></p>]]>
     </description>
@@ -9009,17 +9171,30 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C26457</key>
     <name>C26457: (void) should not be used to ignore return values</name>
     <description>
       <![CDATA[
 <p>(void) should not be used to ignore return values, use 'std::ignore =' instead (es.48).</p>
-<p>Excerpt from the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es48-avoid-casts">C++ Core Guideline ES.48</a>.</p>
+<p>Excerpt from the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es48-avoid-casts">C++ Core Guideline ES.48</a>:</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26457?view=msvc-170" target="_blank">C26457</a></p>]]>
-      </description>
+    </description>
+    <tag>core-guideline</tag>
+    <severity>INFO</severity>
+  </rule>
+  <rule>
+    <key>C26459</key>
+    <name>C26459: You called an STL function with a raw pointer parameter that may be unsafe</name>
+    <description>
+      <![CDATA[
+<p>You called an STL function '%function%' with a raw pointer parameter at position '%position%' that may be unsafe - this relies on the caller to check that the passed values are correct. Consider wrapping your range in a gsl::span and pass as a span iterator (stl.1).</p>
+<p>Out of bound writes are one of the leading causes of remote code execution vulnerabilities. One remedy is to use bounds checked data structures like <code>gsl::span</code>. This warning identifies cases where Standard Template Library (STL) algorithms operate on raw pointers as output ranges. Raw pointers aren't bounds checked. To prevent vulnerabilities, use <code>gsl::span</code> instead.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26459?view=msvc-170" target="_blank">C26459</a></p>]]>
+    </description>
     <tag>core-guideline</tag>
     <severity>INFO</severity>
   </rule>
@@ -9084,7 +9259,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <description>
       <![CDATA[
 <p>Don't use const_cast to cast away const. const_cast is not required; constness or volatility is not being removed by this conversion.</p>
-<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-constcast">C++ Core Guidelines Type.3</a>.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-constcast">C++ Core Guidelines Type.3</a></p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26465?view=msvc-170" target="_blank">C26465</a></p>]]>
     </description>
@@ -9096,7 +9271,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <description>
       <![CDATA[
 <p>Don't use <code>static_cast</code> downcasts. A cast from a polymorphic type should use dynamic_cast.</p>
-<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-downcast">C++ Core Guidelines Type.2</a>.</p>
+<p><a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Pro-type-downcast">C++ Core Guidelines Type.2</a></p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26466?view=msvc-170" target="_blank">C26466</a></p>]]>
     </description>
@@ -9122,7 +9297,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast, or gsl::narrow.</p>
 <p><strong>C++ Core Guidelines</strong>:
-<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#prosafety-type-safety-profile">Type.1</a>: Avoid casts.</p>
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#prosafety-type-safety-profile">Type.1</a>: Avoid casts</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26472?view=msvc-170" target="_blank">C26472</a></p>]]>
     </description>
@@ -9136,7 +9311,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
       <![CDATA[
 <p>Don't cast between pointer types where the source type and the target type are the same.</p>
 <p><strong>C++ Core Guidelines</strong>:
-<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#prosafety-type-safety-profile">Type.1</a>: Avoid casts.</p>
+<a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#prosafety-type-safety-profile">Type.1</a>: Avoid casts</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26473?view=msvc-170" target="_blank">C26473</a></p>]]>
     </description>
@@ -9209,11 +9384,24 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <severity>INFO</severity>
   </rule>
   <rule>
+    <key>C26479</key>
+    <name>C26479: Don't use std::move to return a local variable</name>
+    <description>
+      <![CDATA[
+<p>The <code>return</code> statement is the last use of a local variable, so the compiler uses move semantics to return it whenever possible.
+Adding a <code>std::move</code> is redundant in this scenario. Moreover, redundant <code>std::move</code>s can prevent copy elision.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26479?view=msvc-170" target="_blank">C26479</a></p>]]>
+    </description>
+    <tag>core-guideline</tag>
+    <severity>INFO</severity>
+  </rule>
+  <rule>
     <key>C26481</key>
     <name>C26481: Don't use pointer arithmetic</name>
     <description>
       <![CDATA[
-<p>Don't use pointer arithmetic. Use span instead (bounds.1).</name>
+<p>Don't use pointer arithmetic. Use span instead (bounds.1).</p>
 <p>This check supports the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md">C++ Core Guidelines</a> rule <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-array">I.13</a>: <em>Do not pass an array as a single pointer</em>. Whenever raw pointers are used in arithmetic operations they should be replaced with safer kinds of buffers, such as <code>span&lt;T&gt;</code> or <code>vector&lt;T&gt;</code>.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26481?view=msvc-170" target="_blank">C26481</a></p>]]>
@@ -9415,7 +9603,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C26498: The function 'function' is constexpr, mark variable 'variable' constexpr if compile-time evaluation is desired</name>
     <description>
       <![CDATA[
-<p>This rule helps to enforce Con.5 from the <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#con5-use-constexpr-for-values-that-can-be-computed-at-compile-time">C++ Core Guidelines</a>: use constexpr for values that can be computed at compile time.</p>
+<p>This rule helps to enforce Con.5 from the <a data-linktype="external" href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rconst-constexpr">C++ Core Guidelines</a>: use constexpr for values that can be computed at compile time.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26498?view=msvc-170" target="_blank">C26498</a></p>]]>
     </description>
@@ -9426,7 +9614,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C26800: Use of a moved from object: 'object'</name>
     <description>
       <![CDATA[
-<p>Warning C26800 is triggered when variable is used after it has been moved from. A variable is considered moved from after it was passed to a function as rvalue reference. There are some legitimate exceptions for uses such as assignment, destruction, and some state resetting functions such as <code>std::vector::clear</code>.</p>
+<p>Warning C26800 is triggered when a variable is used after it has been moved from. A variable is considered moved from after it's passed to a function as rvalue reference. There are some exceptions for assignment, destruction, and some state resetting functions such as <code>std::vector::clear</code>. After using a state resetting function, we're free to use the variable. This check only reasons about the local variables.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26800?view=msvc-170" target="_blank">C26800</a></p>]]>
     </description>
@@ -9437,7 +9625,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C26810: Lifetime of captured variable 'var' might end by the time the coroutine is resumed</name>
     <description>
       <![CDATA[
-<p>Warning C26810 is triggered when a memory region might be used after it went out of scope in a resumed coroutine.</p>
+<p>Warning C26810 is triggered when a variable might be used after its lifetime ended in a resumed coroutine.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26810?view=msvc-170" target="_blank">C26810</a></p>]]>
     </description>
@@ -9448,7 +9636,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C26811: Lifetime of the memory referenced by parameter 'var' might end by the time the coroutine is resumed</name>
     <description>
       <![CDATA[
-<p>Warning C26811 is triggered when a memory region might be used after it went out of scope in a resumed coroutine.</p>
+<p>Warning C26811 is triggered when a variable might be used after its lifetime ended in a resumed coroutine.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26811?view=msvc-170" target="_blank">C26811</a></p>]]>
     </description>
@@ -9474,9 +9662,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>Most <code>enum</code> types with power of two member values are intended to be used as bit flags. As a result, you rarely want to compare these flags for equality. Instead, extract the bits you're interested in by using bitwise operations.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26813?view=msvc-170" target="_blank">C26813</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C26814</key>
     <name>C26814: The const variable 'variable' can be computed at compile time</name>
@@ -9494,7 +9682,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C26815: The pointer is dangling because it points at a temporary instance that was destroyed</name>
     <description>
       <![CDATA[
-<p>There's a dangling pointer that is the result of an unnamed temporary that has been destroyed (ES.65).</p>
+<p>The created pointer or view refers to an unnamed temporary object that is destroyed at the end of the statement. The pointer or view will dangle.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26815?view=msvc-170" target="_blank">C26815</a></p>]]>
     </description>
@@ -9519,7 +9707,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <description>
       <![CDATA[
 <p>Potentially expensive copy of variable name in range-for loop. Consider making it a const reference (es.71).</p>
-<p>For more information, see <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#note-214">ES.71 notes</a> in the C++ Core Guidelines.</p>
+<p>For more information, see <a data-linktype="external" href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-for-range">ES.71 notes</a> in the C++ Core Guidelines.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26817?view=msvc-170" target="_blank">C26817</a></p>]]>
     </description>
@@ -9553,11 +9741,11 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C26820</key>
-    <name>C26820: Assigning by value when a const-reference would suffice</name>
+    <name>C26820: This is a potentially expensive copy operation</name>
     <description>
       <![CDATA[
-<p>Assigning by value when a const-reference would suffice, use const auto&amp; instead (p.9.</p>
-<p>For more information, see <a data-linktype="external" href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#p9-dont-waste-time-or-space">P.9: Don't waste time or space</a> in the C++ Core Guidelines.</p>
+<p>This is a potentially expensive copy operation. Consider using a reference unless a copy is required (p.9).</p>
+<p>For more information, see <a data-linktype="external" href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rp-waste">P.9: Don't waste time or space</a> in the C++ Core Guidelines.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26820?view=msvc-170" target="_blank">C26820</a></p>]]>
     </description>
@@ -9572,9 +9760,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>Dereferencing a null pointer is frequent problem in C and C++. We have several checks to deal with such problems. See this <a data-linktype="external" href="https://devblogs.microsoft.com/cppblog/improved-null-pointer-dereference-detection-in-visual-studio-2022-version-17-0-preview-4/">blog post</a> for a comparison. When the analysis engine deduces the value of a pointer to be null and sees that pointer get dereferenced, it will emit a <code>C26822</code> warning. You can also enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26823?view=msvc-170">C26823</a> for a stricter analysis. This check also supports <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/understanding-sal?view=msvc-170">SAL annotations</a> and <a data-linktype="external" href="https://github.com/microsoft/GSL"><code>gsl::not_null</code></a> to describe invariants of the code (lifetime.1).</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26822?view=msvc-170" target="_blank">C26822</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C26823</key>
     <name>C26823: Dereferencing a possibly null pointer 'variable'</name>
@@ -9583,9 +9771,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>Dereferencing a null pointer is frequent problem in C and C++. We have several checks to deal with such problems. See this <a data-linktype="external" href="https://devblogs.microsoft.com/cppblog/improved-null-pointer-dereference-detection-in-visual-studio-2022-version-17-0-preview-4/">blog post</a> for a comparison. When the analysis engine deduces that the value of a pointer might be null and sees that pointer get dereferenced, it will emit a <code>C26823</code> warning. You can enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26822?view=msvc-170">C26822</a> only for a more permissive analysis. This check also supports <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/understanding-sal?view=msvc-170">SAL annotations</a> and <a data-linktype="external" href="https://github.com/microsoft/GSL"><code>gsl::not_null</code></a> to describe invariants of the code (lifetime.1).</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26823?view=msvc-170" target="_blank">C26823</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C26824</key>
     <name>C26824: Postcondition for null pointer 'variable' requires it to be non-null</name>
@@ -9594,9 +9782,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>Dereferencing a null pointer is a frequent problem in C and C++. We have several checks to deal with such problems. See this <a data-linktype="external" href="https://devblogs.microsoft.com/cppblog/improved-null-pointer-dereference-detection-in-visual-studio-2022-version-17-0-preview-4/">blog post</a> for a comparison. When the analysis engine sees a null pointer returned from a function that has a contract forbidding such an operation, it will emit a <code>C26824</code> warning. You can also enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26825?view=msvc-170">C26825</a> for a stricter analysis. This check only works on functions annotated using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/understanding-sal?view=msvc-170">SAL annotations</a> (lifetime.1).</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26824?view=msvc-170" target="_blank">C26824</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C26825</key>
     <name>C26825: Postcondition for possibly null pointer 'variable' requires it to be non-null</name>
@@ -9605,9 +9793,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>Dereferencing a null pointer is a frequent problem in C and C++. We have several checks to deal with such problems. See this <a data-linktype="external" href="https://devblogs.microsoft.com/cppblog/improved-null-pointer-dereference-detection-in-visual-studio-2022-version-17-0-preview-4/">blog post</a> for a comparison. When the analysis engine sees a potentially null pointer returned from a function that has a contract forbidding such operation, it will emit a <code>C26825</code> warning. You can enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26824?view=msvc-170">C26824</a> only for a more permissive analysis. This check only works on functions annotated using <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/understanding-sal?view=msvc-170">SAL annotations</a> (lifetime.1).</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26825?view=msvc-170" target="_blank">C26825</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C26826</key>
     <name>C26826: Don't use C-style variable arguments</name>
@@ -9617,9 +9805,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>For more information, see <a data-linktype="external" href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#F-varargs">F.55: Don't use <code>va_arg</code> arguments</a> in the C++ Core Guidelines.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26826?view=msvc-170" target="_blank">C26826</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C26827</key>
     <name>C26827: Did you forget to initialize an enum, or intend to use another type?</name>
@@ -9628,9 +9816,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>Most <code>enum</code> types used in bitwise operations are expected to have members with values of powers of two. This warning attempts to find cases where a value wasn't given explicitly to an enumeration constant. It also finds cases where the wrong enumeration type may have been used inadvertently.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26827?view=msvc-170" target="_blank">C26827</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C26828</key>
     <name>C26828: Different enum types have overlapping values</name>
@@ -9640,9 +9828,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>Most of the time, a single enumeration type describes all the bit flags that you can use for an option. If you use two different enumeration types that have overlapping values in the same bitwise expression, the chances are good those enumeration types weren't designed for use together.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26828?view=msvc-170" target="_blank">C26828</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C26829</key>
     <name>C26829: Empty optional 'variable' is unwrapped</name>
@@ -9651,9 +9839,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>Unwrapping empty <code>std::optional</code> values is undefined behavior. Such operation is considered a security vulnerability as it can result in a crash, reading uninitialized memory, or other unexpected behavior. This check will attempt to find cases where a <code>std::optional</code> is known to be empty and unwrapped. You can also enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26830?view=msvc-170">C26830</a>, <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26859?view=msvc-170">C26859</a>, and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26860?view=msvc-170">C26860</a> for a stricter analysis.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26829?view=msvc-170" target="_blank">C26829</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C26830</key>
     <name>C26830: Potentially empty optional 'variable' is unwrapped</name>
@@ -9662,9 +9850,65 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>Unwrapping empty <code>std::optional</code> values is undefined behavior. Such operation is considered a security vulnerability as it can result in a crash, reading uninitialized memory, or other unexpected behavior. This check will attempt to find cases where a <code>std::optional</code> isn't checked for emptiness before unwrap operations. You can enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26829?view=msvc-170">C26829</a> only for a more permissive analysis.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26830?view=msvc-170" target="_blank">C26830</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
+  <rule>
+    <key>C26831</key>
+    <name>C26831: Allocation size might be the result of a numerical overflow</name>
+    <description>
+      <![CDATA[
+<p>This warning reports that the size specified for an allocation may be the result of a numerical overflow.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26831?view=msvc-170" target="_blank">C26831</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
+    <key>C26832</key>
+    <name>C26832: Allocation size is the result of a narrowing conversion that could result in overflow</name>
+    <description>
+      <![CDATA[
+<p>This warning reports that the size specified for an allocation may be the result of a narrowing conversion that results in a numerical overflow.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26832?view=msvc-170" target="_blank">C26832</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
+    <key>C26833</key>
+    <name>C26833: Allocation size might be the result of a numerical overflow before the bound check</name>
+    <description>
+      <![CDATA[
+<p>This warning reports that the size specified for an allocation may be the result of a numerical overflow.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26833?view=msvc-170" target="_blank">C26833</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
+    <key>C26835</key>
+    <name>C26835: RtlCompareMemory returns the number of matching bytes</name>
+    <description>
+      <![CDATA[
+<p>C26835: RtlCompareMemory returns the number of matching bytes. Consider replacing this call with RtlEqualMemory.</p>
+<p>When <code>RtlCompareMemory</code>'s return value is treated as a boolean, it evaluates to true when there is at least 1 equal byte before finding a difference. Moreover, comparing the result of <code>RtlCompareMemory</code> to 0 evaluates to false if there is at least 1 matching byte. This behavior may be unexpected because it's different from other comparison functions such as <code>strcmp</code>, making the code harder to understand. To check for equality, consider using <code>RtlEqualMemory</code> instead.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26835?view=msvc-170" target="_blank">C26835</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
+    <key>C26837</key>
+    <name>C26837: Value for the comparand comp for function func has been loaded from the destination location dest through non-volatile read</name>
+    <description>
+      <![CDATA[
+<p>This rule was added in Visual Studio 2022 17.8.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26837?view=msvc-170" target="_blank">C26837</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
   <rule>
     <key>C26859</key>
     <name>C26859: Empty optional 'variable' is unwrapped, will throw exception</name>
@@ -9673,9 +9917,9 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>Unwrapping empty <code>std::optional</code> values via the <code>value</code> method will throw an exception. Such operation can result in a crash when the exception isn't handled. This check will attempt to find cases where a <code>std::optional</code> is known to be empty and unwrapped using the <code>value</code> method. You can also enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26829?view=msvc-170">C26829</a>, <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26830?view=msvc-170">C26830</a>, and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26860?view=msvc-170">C26860</a> for a stricter analysis.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26859?view=msvc-170" target="_blank">C26859</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
   <rule>
     <key>C26860</key>
     <name>C26860: Potentially empty optional 'variable' is unwrapped, may throw exception</name>
@@ -9684,9 +9928,53 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
 <p>Unwrapping empty <code>std::optional</code> values via the <code>value</code> method will throw an exception. Such operation can result in a crash when the exception isn't handled. This check will attempt to find cases where a <code>std::optional</code> isn't checked for emptiness before unwrapping it via the <code>value</code> method. You can enable <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26829?view=msvc-170">C26829</a>, and <a data-linktype="relative-path" href="https://learn.microsoft.com/en-us/cpp/code-quality/c26859?view=msvc-170">C26859</a> only for a more permissive analysis.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26860?view=msvc-170" target="_blank">C26860</a></p>]]>
-      </description>
+    </description>
     <severity>CRITICAL</severity>
-    </rule>
+  </rule>
+  <rule>
+    <key>C26861</key>
+    <name>C26861: Field of a date-time object var has been modified without proper leap year checking</name>
+    <description>
+      <![CDATA[
+<p>This rule was added in Visual Studio 2022 17.8.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26861?view=msvc-170" target="_blank">C26861</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
+    <key>C26862</key>
+    <name>C26862: A date-time object var has been created from a different type of date-time object but conversion was incomplete</name>
+    <description>
+      <![CDATA[
+<p>This rule was added in Visual Studio 2022 17.8.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26862?view=msvc-170" target="_blank">C26862</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
+    <key>C26863</key>
+    <name>C26863: Return value from a date-time handling function func is ignored</name>
+    <description>
+      <![CDATA[
+<p>This rule was added in Visual Studio 2022 17.8.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26863?view=msvc-170" target="_blank">C26863</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
+  <rule>
+    <key>C26864</key>
+    <name>C26864: Day field of a date-time object var has been modified assuming 365 days per year without proper leap year checking</name>
+    <description>
+      <![CDATA[
+<p>This rule was added in Visual Studio 2022 17.8.</p>
+<h2>Microsoft Documentation</h2>
+<p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c26864?view=msvc-170" target="_blank">C26864</a></p>]]>
+    </description>
+    <severity>CRITICAL</severity>
+  </rule>
   <rule>
     <key>C28020</key>
     <name>C28020: The expression 'expr' is not true at this call</name>
@@ -9904,7 +10192,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C28160: Error annotation</name>
     <description>
       <![CDATA[
-<p>This warning is reported when a <code>__drv_error</code> annotation has been encountered. This annotation is used to flag coding practices that should be fixed, and can be used with a <code>__drv_when</code> annotation to indicate specific combinations of parameters.</p>
+<p>This warning is reported when a <code>__drv_error</code> annotation has been encountered.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28160?view=msvc-170" target="_blank">C28160</a></p>]]>
     </description>
@@ -9978,7 +10266,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C28195</key>
-    <name>C28195: The function was declared as acquiring memory in  a variable and exited without doing so</name>
+    <name>C28195: The function was declared as acquiring memory in a variable and exited without doing so</name>
     <description>
       <![CDATA[
 <p>This warning indicates that the function prototype for the function being analyzed has a <code>__drv_allocatesMem</code> annotation. The <code>__drv_allocatesMem</code> annotation indicates that the function acquires memory in the designated result location, but in at least one path, the function didn't acquire the memory. The Code Analysis tool won't recognize the actual implementation of a memory allocator (involving address arithmetic) and won't recognize that memory is allocated (although many wrappers will be recognized). In this case, the Code Analysis tool doesn't recognize that the memory was allocated and issues this warning. To suppress the false positive, use a <code>#pragma</code> warning on the line that precedes the opening brace <code>{</code> of the function body.</p>
@@ -9992,7 +10280,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C28196: The requirement is not satisfied</name>
     <description>
       <![CDATA[
-<p>This warning indicates that the function prototype for the function being analyzed has a <code>__notnull</code>, <code>__null</code> or <code>__drv_valueIs</code> on an <code>_Out_</code> parameter or the return value, but the value returned is inconsistent with that annotation.</p>
+<p>This warning indicates that the function being analyzed has a <code>__notnull</code>, <code>__null</code>, <code>__drv_valueIs</code> or similar annotation on an <code>_Out_</code> parameter or the return value, but the value returned is inconsistent with that annotation.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28196?view=msvc-170" target="_blank">C28196</a></p>]]>
     </description>
@@ -10056,7 +10344,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C28204</key>
-    <name>C28204: &lt;function&gt; : Only one of this overload and the one at 'filename'('line') are annotated for 'paramname': both or neither must be annotated</name>
+    <name>C28204: &lt;function&gt;: Only one of this overload and the one at 'filename'('line') are annotated for 'paramname': both or neither must be annotated</name>
     <description>
       <![CDATA[
 <p>This warning is reported when there's an error in the annotations.</p>
@@ -10078,7 +10366,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C28206</key>
-    <name>C28206: &lt;expression&gt; : left operand points to a struct</name>
+    <name>C28206: &lt;expression&gt;: left operand points to a struct</name>
     <description>
       <![CDATA[
 <p>This warning is reported when the struct pointer dereference notation <code>-&gt;</code> was expected.</p>
@@ -10158,7 +10446,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C28213: The _Use_decl_annotations_ annotation must be used to reference, without modification, a prior declaration</name>
     <description>
       <![CDATA[
-<p><code>_Use_decl_annotations_</code> tells the compiler to use the annotations from an earlier declaration of the function. If no earlier declaration can be found, or if the current declaration makes changes to the annotations, then this warning is emitted.</p>
+<p><code>_Use_decl_annotations_</code> tells the compiler to use the annotations from an earlier declaration of the function. If it can't find an earlier declaration, or if the current declaration makes changes to the annotations, it emits this warning. <code>_Use_decl_annotations_</code> also lets you remove all other annotations from the definition, and uses the declaration annotations for analysis of the function.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28213?view=msvc-170" target="_blank">C28213</a></p>]]>
     </description>
@@ -10375,10 +10663,10 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C28233</key>
-    <name>C28233: pre, post, or deref applied to a block</name>
+    <name>C28233: Pre, post, or deref applied to a block</name>
     <description>
       <![CDATA[
-<p>pre, post, or deref applied to a block.</p>
+<p>Pre, post, or deref applied to a block.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28233?view=msvc-170" target="_blank">C28233</a></p>]]>
     </description>
@@ -10760,7 +11048,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
   </rule>
   <rule>
     <key>C28290</key>
-    <name>C28290: the annotation for function contains more Externals than the actual number of parameters</name>
+    <name>C28290: The annotation for function contains more Externals than the actual number of parameters</name>
     <description>
       <![CDATA[
 <p>The Code Analysis tool reports this warning when the annotation for the function contains more Externals than the actual number of parameters.</p>
@@ -10873,7 +11161,7 @@ Under strict ANSI compatibility (<a data-linktype="relative-path" href="https://
     <name>C28308: The format list argument position specified by the annotation is incorrect</name>
     <description>
       <![CDATA[
-<p>The format list argument position must be either a parameter name, or an integer offset that's in the parameter list, or zero.</p>
+<p>This warning indicates a <code>_*_format_strings_param(position)</code> SAL annotation is specifying an invalid position for the first parameter to the format string. The annotation helps the checker verify <code>printf</code> style formatting strings passed to the function. Other format string validity checks that rely on this annotation won't run as a result of this warning.</p>
 <h2>Microsoft Documentation</h2>
 <p><a href="https://learn.microsoft.com/en-us/cpp/code-quality/c28308?view=msvc-170" target="_blank">C28308</a></p>]]>
     </description>
@@ -10982,7 +11270,7 @@ initialized on input, and is then passed to an API such as <code>VariantClear</c
   </rule>
   <rule>
     <key>C33010</key>
-    <name>C33010: Unchecked lower bound for enum enum_name used as index</name>
+    <name>C33010: Unchecked lower bound for enum 'enum' used as index</name>
     <description>
       <![CDATA[
 <p>This warning is triggered if an enum is both used as an index into an array and isn't checked on the lower bound.</p>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/compiler/vc/CxxCompilerVcRuleRepositoryTest.java
@@ -38,7 +38,7 @@ class CxxCompilerVcRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxCompilerVcRuleRepository.KEY);
-    assertThat(repo.rules()).hasSize(982);
+    assertThat(repo.rules()).hasSize(1007);
   }
 
 }

--- a/cxx-sensors/src/tools/vc_createrules.py
+++ b/cxx-sensors/src/tools/vc_createrules.py
@@ -69,6 +69,14 @@ URLS = {
         'severity': 'INFO',
         'type': 'CODE_SMELL',
         },
+    'https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warnings-c5000-through-c5199' : {
+        'severity': 'INFO',
+        'type': 'CODE_SMELL',
+        },
+    'https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warnings-c5200-through-c5399' : {
+        'severity': 'INFO',
+        'type': 'CODE_SMELL',
+        },
     'https://learn.microsoft.com/en-us/cpp/code-quality/code-analysis-for-c-cpp-warnings' : {
         'severity': 'CRITICAL',
         'type': 'CODE_SMELL',
@@ -308,6 +316,9 @@ def parse_warning_page(page_source, warning):
     # parse HTML page
     soup = BeautifulSoup(page_source, 'html.parser')
     content = soup.find("div", class_="content")
+
+    if not content:
+        return warning
 
     # use header, sometimes only message ID
     key = warning['key']


### PR DESCRIPTION
add new VS 2022 rules (v17.9):
- C5262
- C5266
- C5267
- C5301
- C5302
- C6030
- C6065
- C6392
- C6393
- C6394
- C6395
- C6396
- C6397
- C6398
- C26459
- C26479
- C26831
- C26832
- C26833
- C26835
- C26837
- C26861
- C26862
- C26863
- C26864

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2707)
<!-- Reviewable:end -->
