### PR TITLE
C++23 extend init-statement to allow alias-declaration

### DIFF
--- a/cxx-squid/dox/diff-cpp20-cpp23_grammar.txt
+++ b/cxx-squid/dox/diff-cpp20-cpp23_grammar.txt
@@ -184,11 +184,6 @@ postfix-expression:
 
 **A.6 Statements [gram.stmt]**
 
-init-statement:
-   expression-statement
-   simple-declaration
-   alias-declaration
-
 label:
    attribute-specifier-seqopt identifier :
    attribute-specifier-seqopt case constant-expression :

--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -928,7 +928,8 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
     b.rule(initStatement).is(
       b.firstOf(
         expressionStatement, // C++
-        simpleDeclaration // C++
+        simpleDeclaration, // C++
+        aliasDeclaration // C++23
       )
     );
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/StatementTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/StatementTest.java
@@ -251,7 +251,9 @@ class StatementTest extends ParserBaseTestHelper {
       // CLI extension
       .matches("for each(String^% s in arr) { s = i++.ToString(); }")
       // C++17 structered bindings
-      .matches("for (const auto&[key, val] : mymap) { std::cout << key << \": \" << val << std::endl; }");
+      .matches("for (const auto&[key, val] : mymap) { std::cout << key << \": \" << val << std::endl; }")
+      // C++23
+      .matches("for (using T = int; T e : v) ;");
   }
 
   @Test
@@ -259,7 +261,8 @@ class StatementTest extends ParserBaseTestHelper {
     setRootRule(CxxGrammarImpl.initStatement);
 
     assertThatParser()
-      .matches("int i=1;");
+      .matches("int i=1;")
+      .matches("using T = int;"); // C++23
   }
 
   @Test

--- a/cxx-squid/src/test/resources/parser/own/C++23/init-statement.cc
+++ b/cxx-squid/src/test/resources/parser/own/C++23/init-statement.cc
@@ -1,0 +1,4 @@
+void sample() {
+   for (using T = int; T e : v)
+      /* something */;
+}


### PR DESCRIPTION
- Extend init-statement (of for loop) to allow alias-declaration [P2360R0](https://wg21.link/P2360R0)
- linked #2536

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2734)
<!-- Reviewable:end -->
