### PR TITLE
C++23: some more grammar changes

### DIFF
--- a/cxx-squid/dox/diff-cpp20-cpp23_grammar.txt
+++ b/cxx-squid/dox/diff-cpp20-cpp23_grammar.txt
@@ -131,32 +131,3 @@ d-char:
    any member of the basic character set except:
    u+0020 space, u+0028 left parenthesis, u+0029 right parenthesis, u+005c reverse solidus,
    u+0009 character tabulation, u+000b line tabulation, u+000c form feed, and new-line
-
-**A.5 Expressions [gram.expr]**
-
-requirement-parameter-list:
-   ( parameter-declaration-clause )
-
-requirement-seq:
-   requirement
-   requirement requirement-seq
-
-**A.7 Declarations [gram.dcl]**
-
-elaborated-type-specifier:
-   class-key attribute-specifier-seqopt nested-name-specifieropt identifier
-   class-key simple-template-id
-   class-key nested-name-specifier templateopt simple-template-id
-   enum nested-name-specifieropt identifier
-
-using-enum-declaration:
-   using enum using-enum-declarator ;
-
-using-enum-declarator:
-   nested-name-specifieropt identifier
-   nested-name-specifieropt simple-template-id
-
-**A.11 Templates [gram.temp]**
-
-concept-definition:
-   concept concept-name attribute-specifier-seqopt = constraint-expression ;

--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxGrammarImpl.java
@@ -164,7 +164,6 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
   decltypeSpecifier,
   placeholderTypeSpecifier,
   elaboratedTypeSpecifier,
-  elaboratedEnumSpecifier,
   enumName,
   enumSpecifier,
   enumHead,
@@ -176,6 +175,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
   enumeratorDefinition,
   enumerator,
   usingEnumDeclaration,
+  usingEnumDeclarator,
   namespaceName,
   namespaceDefinition,
   namedNamespaceDefinition,
@@ -649,7 +649,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
     );
 
     b.rule(requirementParameterList).is(
-      "(", b.optional(parameterDeclarationClause), ")" // C++
+      "(", parameterDeclarationClause, ")" // C++
     );
 
     b.rule(requirementBody).is(
@@ -1290,12 +1290,8 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
             b.sequence(b.optional(attributeSpecifierSeq), b.optional(nestedNameSpecifier), IDENTIFIER) // C++
           )
         ),
-        elaboratedEnumSpecifier // C++
+        b.sequence(CxxKeyword.ENUM, b.optional(nestedNameSpecifier), IDENTIFIER) // C++
       )
-    );
-
-    b.rule(elaboratedEnumSpecifier).is(
-      CxxKeyword.ENUM, b.optional(nestedNameSpecifier), IDENTIFIER // C++
     );
 
     b.rule(decltypeSpecifier).is(
@@ -1632,7 +1628,15 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
     );
 
     b.rule(usingEnumDeclaration).is(
-      CxxKeyword.USING, elaboratedEnumSpecifier, ";"
+      CxxKeyword.USING, CxxKeyword.ENUM, usingEnumDeclarator, ";"
+    );
+
+    b.rule(usingEnumDeclarator).is(
+      b.optional(nestedNameSpecifier),
+      b.firstOf(
+        IDENTIFIER,
+        simpleTemplateId
+      )
     );
 
     b.rule(namespaceName).is(
@@ -2306,7 +2310,7 @@ public enum CxxGrammarImpl implements GrammarRuleKey {
     );
 
     b.rule(conceptDefinition).is(
-      CxxKeyword.CONCEPT, conceptName, "=", constraintExpression, ";" // C++
+      CxxKeyword.CONCEPT, conceptName, b.optional(attributeSpecifierSeq), "=", constraintExpression, ";" // C++
     );
 
     b.rule(conceptName).is(

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/DeclarationsTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/DeclarationsTest.java
@@ -433,7 +433,6 @@ class DeclarationsTest extends ParserBaseTestHelper {
     mockRule(CxxGrammarImpl.attributeSpecifierSeq);
     mockRule(CxxGrammarImpl.nestedNameSpecifier);
     mockRule(CxxGrammarImpl.simpleTemplateId);
-    mockRule(CxxGrammarImpl.elaboratedEnumSpecifier);
 
     assertThatParser()
       .matches("classKey foo")
@@ -443,7 +442,8 @@ class DeclarationsTest extends ParserBaseTestHelper {
       .matches("classKey simpleTemplateId")
       .matches("classKey nestedNameSpecifier simpleTemplateId")
       .matches("classKey nestedNameSpecifier template simpleTemplateId")
-      .matches("elaboratedEnumSpecifier");
+      .matches("enum foo")
+      .matches("enum nestedNameSpecifier foo");
   }
 
   @Test

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/ExpressionTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/ExpressionTest.java
@@ -87,7 +87,6 @@ class ExpressionTest extends ParserBaseTestHelper {
     mockRule(CxxGrammarImpl.parameterDeclarationClause);
 
     assertThatParser()
-      .matches("( )")
       .matches("( parameterDeclarationClause )");
   }
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/parser/TemplatesTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/parser/TemplatesTest.java
@@ -279,8 +279,11 @@ class TemplatesTest extends ParserBaseTestHelper {
 
     mockRule(CxxGrammarImpl.conceptName);
     mockRule(CxxGrammarImpl.constraintExpression);
+    mockRule(CxxGrammarImpl.attributeSpecifierSeq);
 
-    assertThatParser().matches("concept conceptName = constraintExpression ;");
+    assertThatParser()
+      .matches("concept conceptName = constraintExpression ;")
+      .matches("concept conceptName attributeSpecifierSeq = constraintExpression ;");
   }
 
   @Test

--- a/cxx-squid/src/test/resources/parser/own/C++23/auto.cc
+++ b/cxx-squid/src/test/resources/parser/own/C++23/auto.cc
@@ -1,0 +1,31 @@
+void foo() {
+   // variable definition
+   auto v(x);
+   auto v{x};
+   ClassTemplate v(x);
+   ClassTemplate v{x};
+
+   // new expression
+   new auto(x);
+   new auto{x};
+   new ClassTemplate(x);
+   new ClassTemplate{x};
+}
+
+// function-style cast
+template<typename T, typename U>
+T cast1(U const &u) {
+  return auto(u);
+}
+template<typename T, typename U>
+T cast2(U const &u) {
+  return auto{u};
+}
+template<typename T, typename U>
+T cast3(U const &u) {
+  return ClassTemplate(u);
+}
+template<typename T, typename U>
+T cast4(U const &u) {
+  return ClassTemplate{u};
+}

--- a/cxx-squid/src/test/resources/parser/own/C++23/duplicate-attributes.cc
+++ b/cxx-squid/src/test/resources/parser/own/C++23/duplicate-attributes.cc
@@ -1,0 +1,8 @@
+[[gnu::sample]] [[gnu::sample]] [[gnu::hot]] [[nodiscard]]
+inline int f(); // declare f with four attributes
+ 
+[[gnu::sample, gnu::sample, gnu::hot, nodiscard]]
+int f(); // same as above, but uses a single attr specifier that contains four attributes
+ 
+[[using gnu : sample, sample, hot]] [[nodiscard]] [[gnu::sample]]
+int f(); // same as above

--- a/cxx-squid/src/test/resources/parser/own/C++23/static-constexpr.cc
+++ b/cxx-squid/src/test/resources/parser/own/C++23/static-constexpr.cc
@@ -1,0 +1,9 @@
+char xdigit1(int n) {
+  static constexpr char digits[] = "0123456789abcdef";
+  return digits[n];
+}
+
+constexpr char xdigit2(int n) {
+  static constexpr char digits[] = "0123456789abcdef"; // C++23
+  return digits[n];
+}

--- a/cxx-squid/src/test/resources/parser/own/C++23/static-operator.cc
+++ b/cxx-squid/src/test/resources/parser/own/C++23/static-operator.cc
@@ -1,0 +1,56 @@
+// --- static operator() ---
+
+// Overload Resolution
+struct less {
+	static constexpr auto operator()(int i, int j) -> bool {
+		return i < j;
+	}
+	using P = bool( * )(int, int);
+	operator P() const {
+		return operator();
+	}
+};
+
+void foo() {
+	static_assert(less {}(1, 2));
+}
+
+// Lambdas
+auto four = []() static {
+	return 4;
+};
+
+//  Static lambdas with capture
+auto under_lock = [lock = std::unique_lock(mtx)]() static {
+	/* do something */ ;
+};
+
+// --- static operator[] ---
+
+template < typename T, std::size_t S > struct array: std::array < T, S > {
+	static constexpr inline std::size_t extent = []() -> std::size_t {
+		if constexpr(_is_array < T > ) {
+			return 1 + T::extent;
+		}
+		return 1;
+	}();
+	constexpr decltype(auto)
+	operator[](std::size_t idx) {
+		return * (this -> data() + idx);
+	}
+	constexpr decltype(auto)
+	operator[](std::size_t idx, convertible_to < std::size_t > auto && ...args)
+	requires(sizeof...(args) < extent) && (sizeof...(args) >= 1) {
+		typename std::array < T, S > ::reference v = * (this -> data() + idx);
+		return v.operator[](args...);
+	}
+	constexpr decltype(auto)
+	operator[](std::size_t idx) const {
+		return * (this -> data() + idx);
+	}
+	constexpr decltype(auto)
+	operator[](std::size_t idx, convertible_to < std::size_t > auto && ...args) const requires(sizeof...(args) < extent) && (sizeof...(args) >= 1) {
+		typename std::array < T, S > ::reference v = * (this -> data() + idx);
+		return v.operator[](args...);
+	}
+};


### PR DESCRIPTION
- add final grammar changes for C++23
- auto(x) and auto{x} [P0849R8](https://wg21.link/P0849R8)
- duplicate attributes [P2156R1](https://wg21.link/P2156R1)
- static constexpr [P2647R1](https://wg21.link/P2647R1)
- static operator [P2589R0](https://wg21.link/P2589R0) [P1169R4](https://wg21.link/P1169R4)
- linked #2536

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2740)
<!-- Reviewable:end -->
