### PR TITLE
C++23: Trimming whitespaces before line splicing

### DIFF
--- a/cxx-squid/src/main/java/org/sonar/cxx/channels/BackslashChannel.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/channels/BackslashChannel.java
@@ -25,21 +25,23 @@ import org.sonar.cxx.sslr.channel.CodeReader;
 
 public class BackslashChannel extends Channel<Lexer> {
 
-  private static boolean isNewLine(char ch) {
-    return (ch == '\n') || (ch == '\r');
-  }
+  private final StringBuilder sb = new StringBuilder(256);
 
   @Override
   public boolean consume(CodeReader code, Lexer output) {
-    var ch = (char) code.peek();
-
-    if ((ch == '\\') && isNewLine(code.charAt(1))) {
-      // just throw away the backslash
-      code.pop();
-      return true;
+    if (code.charAt(0) != '\\') {
+      return false;
     }
 
-    return false;
+    var lineSplicing = read(code, sb);
+    sb.delete(0, sb.length());
+    return lineSplicing != 0;
+  }
+
+  public static int read(CodeReader code, StringBuilder sb) {
+    var end = ChannelUtils.handleLineSplicing(code, 0);
+    code.skip(end); // remove line splicing
+    return end;
   }
 
 }

--- a/cxx-squid/src/main/java/org/sonar/cxx/channels/ChannelUtils.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/channels/ChannelUtils.java
@@ -1,0 +1,88 @@
+/*
+ * C++ Community Plugin (cxx plugin)
+ * Copyright (C) 2010-2023 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.channels;
+
+import org.sonar.cxx.sslr.channel.CodeReader;
+
+public class ChannelUtils {
+
+  public static final char LF = '\n';
+  public static final char CR = '\r';
+  public static final char EOF = (char) -1;
+
+  private ChannelUtils() {
+    // empty
+  }
+
+  public static boolean isNewLine(char ch) {
+    return (ch == LF) || (ch == CR);
+  }
+
+  public static boolean isWhitespace(char ch) {
+    return (ch == ' ') || (ch == '\t');
+  }
+
+  public static boolean isSuffix(char c) {
+    return Character.isLowerCase(c) || Character.isUpperCase(c) || (c == '_');
+  }
+
+  /**
+   * Handle line splicing.
+   * - lines terminated by a \ are spliced together with the next line
+   * - P2178R0 making trailing whitespaces non-significant
+   *
+   * line endings:
+   * - Linux/Unix, Mac from OS X a.k.a macOS: LF
+   * - Windows/DOS: CR LF
+   * - Classic Mac OS: CR
+   *
+   * @return numbers of sign to remove to splice the lines
+   */
+  public static int handleLineSplicing(CodeReader code, int start) {
+    int next = start;
+    if (code.charAt(next) != '\\') {
+      return 0;
+    }
+
+    boolean newline = false;
+    next++;
+    while (true) {
+      var charAt = code.charAt(next);
+      if (charAt == LF) {
+        newline = true;
+        break;
+      }
+      if (charAt == CR) {
+        if (code.charAt(next + 1) == LF) {
+          next++;
+        }
+        newline = true;
+        break;
+      }
+      if (!isWhitespace(charAt)) {
+        break;
+      }
+      next++;
+    }
+
+    return newline ? (next - start + 1) : 0;
+  }
+
+}

--- a/cxx-squid/src/main/java/org/sonar/cxx/channels/CharacterLiteralsChannel.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/channels/CharacterLiteralsChannel.java
@@ -30,8 +30,6 @@ import org.sonar.cxx.sslr.channel.CodeReader;
  */
 public class CharacterLiteralsChannel extends Channel<Lexer> {
 
-  private static final char EOF = (char) -1;
-
   private final StringBuilder sb = new StringBuilder(256);
 
   private int index = 0;
@@ -67,7 +65,7 @@ public class CharacterLiteralsChannel extends Channel<Lexer> {
   private boolean read(CodeReader code) {
     index++;
     while (code.charAt(index) != ch) {
-      if (code.charAt(index) == EOF) {
+      if (code.charAt(index) == ChannelUtils.EOF) {
         return false;
       }
       if (code.charAt(index) == '\\') {
@@ -95,10 +93,10 @@ public class CharacterLiteralsChannel extends Channel<Lexer> {
     int len = 0;
     for (int start_index = index;; index++) {
       var charAt = code.charAt(index);
-      if (charAt == EOF) {
+      if (charAt == ChannelUtils.EOF) {
         return;
       }
-      if (isSuffix(charAt)) {
+      if (ChannelUtils.isSuffix(charAt)) {
         len++;
       } else if (Character.isDigit(charAt)) {
         if (len > 0) {
@@ -111,10 +109,6 @@ public class CharacterLiteralsChannel extends Channel<Lexer> {
         return;
       }
     }
-  }
-
-  private static boolean isSuffix(char c) {
-    return Character.isLowerCase(c) || Character.isUpperCase(c) || (c == '_');
   }
 
 }

--- a/cxx-squid/src/main/java/org/sonar/cxx/channels/KeywordChannel.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/channels/KeywordChannel.java
@@ -38,8 +38,7 @@ public class KeywordChannel extends Channel<Lexer> {
   private final Matcher matcher;
   private final Token.Builder tokenBuilder = Token.builder();
 
-  public KeywordChannel(String regexp, TokenType[]
-    ... keywordSets) {
+  public KeywordChannel(String regexp, TokenType[]... keywordSets) {
     for (var keywords : keywordSets) {
       for (var keyword : keywords) {
         keywordsMap.put(keyword.getValue(), keyword);

--- a/cxx-squid/src/main/java/org/sonar/cxx/channels/MultiLineCommentChannel.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/channels/MultiLineCommentChannel.java
@@ -1,0 +1,111 @@
+/*
+ * C++ Community Plugin (cxx plugin)
+ * Copyright (C) 2010-2023 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.channels;
+
+import static com.sonar.cxx.sslr.api.GenericTokenType.COMMENT;
+import com.sonar.cxx.sslr.api.Token;
+import com.sonar.cxx.sslr.api.Trivia;
+import com.sonar.cxx.sslr.impl.Lexer;
+import org.sonar.cxx.sslr.channel.Channel;
+import org.sonar.cxx.sslr.channel.CodeReader;
+
+public class MultiLineCommentChannel extends Channel<Lexer> {
+
+  private final StringBuilder sb = new StringBuilder(256);
+  private final Token.Builder tokenBuilder = Token.builder();
+
+  @Override
+  public boolean consume(CodeReader code, Lexer lexer) {
+    // start of multi line comment?
+    int next = isComment(code);
+    if (next == 0) {
+      return false;
+    }
+
+    int line = code.getLinePosition();
+    int column = code.getColumnPosition();
+
+    code.skip(next);
+    sb.append('/');
+    sb.append('*');
+
+    read(code, sb); // search end of multi line comment
+
+    var value = sb.toString();
+    var token = tokenBuilder
+      .setType(COMMENT)
+      .setValueAndOriginalValue(value)
+      .setURI(lexer.getURI())
+      .setLine(line)
+      .setColumn(column)
+      .build();
+
+    lexer.addTrivia(Trivia.createComment(token));
+    sb.delete(0, sb.length());
+    return true;
+  }
+
+  public static int isComment(CodeReader code) {
+    int next = 0;
+
+    // start of multi line comment?
+    if (code.charAt(next) != '/') {
+      return 0;
+    }
+    next += 1;
+    next += ChannelUtils.handleLineSplicing(code, next);
+
+    if (code.charAt(next) != '*') {
+      return 0;
+    }
+    next += 1;
+    return next;
+  }
+
+  public static boolean read(CodeReader code, StringBuilder sb) {
+    boolean first = false;
+    while (true) { // search end of multi line comment: */
+      var end = ChannelUtils.handleLineSplicing(code, 0);
+      code.skip(end); // remove line splicing
+
+      var charAt = (char) code.pop();
+      switch (charAt) {
+        case '*':
+          first = true;
+          break;
+        case '/':
+          if (first) {
+            sb.append('/');
+            return true;
+          }
+          break;
+        case ChannelUtils.EOF:
+          return false;
+        default:
+          first = false;
+          break;
+      }
+
+      sb.append(charAt);
+    }
+
+  }
+
+}

--- a/cxx-squid/src/main/java/org/sonar/cxx/channels/RightAngleBracketsChannel.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/channels/RightAngleBracketsChannel.java
@@ -48,10 +48,9 @@ public class RightAngleBracketsChannel extends Channel<Lexer> {
 
   @Override
   public boolean consume(CodeReader code, Lexer output) {
-    var ch = (char) code.peek();
     var consumed = false;
 
-    switch (ch) {
+    switch (code.charAt(0)) {
       case '(':
         if (angleBracketLevel > 0) {
           parentheseLevel++;

--- a/cxx-squid/src/main/java/org/sonar/cxx/channels/SingleLineCommentChannel.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/channels/SingleLineCommentChannel.java
@@ -1,0 +1,98 @@
+/*
+ * C++ Community Plugin (cxx plugin)
+ * Copyright (C) 2010-2023 SonarOpenCommunity
+ * http://github.com/SonarOpenCommunity/sonar-cxx
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.cxx.channels;
+
+import static com.sonar.cxx.sslr.api.GenericTokenType.COMMENT;
+import com.sonar.cxx.sslr.api.Token;
+import com.sonar.cxx.sslr.api.Trivia;
+import com.sonar.cxx.sslr.impl.Lexer;
+import org.sonar.cxx.sslr.channel.Channel;
+import org.sonar.cxx.sslr.channel.CodeReader;
+
+public class SingleLineCommentChannel extends Channel<Lexer> {
+
+  private final StringBuilder sb = new StringBuilder(256);
+  private final Token.Builder tokenBuilder = Token.builder();
+
+  @Override
+  public boolean consume(CodeReader code, Lexer lexer) {
+    // start of single line comment?
+    int next = isComment(code);
+    if (next == 0) {
+      return false;
+    }
+
+    int line = code.getLinePosition();
+    int column = code.getColumnPosition();
+
+    code.skip(next);
+    sb.append('/');
+    sb.append('/');
+
+    // search end of line
+    read(code, sb);
+
+    var value = sb.toString();
+    var token = tokenBuilder
+      .setType(COMMENT)
+      .setValueAndOriginalValue(value)
+      .setURI(lexer.getURI())
+      .setLine(line)
+      .setColumn(column)
+      .build();
+
+    lexer.addTrivia(Trivia.createComment(token));
+    sb.delete(0, sb.length());
+    return true;
+  }
+
+  public static int isComment(CodeReader code) {
+    int next = 0;
+
+    // start of single line comment?
+    if (code.charAt(next) != '/') {
+      return 0;
+    }
+
+    next += 1;
+    next += ChannelUtils.handleLineSplicing(code, next);
+
+    if (code.charAt(next) != '/') {
+      return 0;
+    }
+    next += 1;
+    return next;
+  }
+
+  public static boolean read(CodeReader code, StringBuilder sb) {
+    while (true) { // search end of line
+      var end = ChannelUtils.handleLineSplicing(code, 0);
+      code.skip(end); // remove line splicing
+
+      var charAt = code.charAt(0);
+      if (ChannelUtils.isNewLine(charAt) || charAt == ChannelUtils.EOF) {
+        break;
+      }
+      sb.append((char) code.pop());
+    }
+    return true;
+  }
+
+}

--- a/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxLexerPool.java
+++ b/cxx-squid/src/main/java/org/sonar/cxx/parser/CxxLexerPool.java
@@ -25,9 +25,7 @@ import com.sonar.cxx.sslr.impl.channel.BlackHoleChannel;
 import com.sonar.cxx.sslr.impl.channel.BomCharacterChannel;
 import com.sonar.cxx.sslr.impl.channel.IdentifierAndKeywordChannel;
 import com.sonar.cxx.sslr.impl.channel.PunctuatorChannel;
-import static com.sonar.cxx.sslr.impl.channel.RegexpChannelBuilder.ANY_CHAR;
 import static com.sonar.cxx.sslr.impl.channel.RegexpChannelBuilder.and;
-import static com.sonar.cxx.sslr.impl.channel.RegexpChannelBuilder.commentRegexp;
 import static com.sonar.cxx.sslr.impl.channel.RegexpChannelBuilder.g;
 import static com.sonar.cxx.sslr.impl.channel.RegexpChannelBuilder.o2n;
 import static com.sonar.cxx.sslr.impl.channel.RegexpChannelBuilder.opt;
@@ -39,8 +37,10 @@ import java.util.HashSet;
 import java.util.Set;
 import org.sonar.cxx.channels.BackslashChannel;
 import org.sonar.cxx.channels.CharacterLiteralsChannel;
+import org.sonar.cxx.channels.MultiLineCommentChannel;
 import org.sonar.cxx.channels.PreprocessorChannel;
 import org.sonar.cxx.channels.RightAngleBracketsChannel;
+import org.sonar.cxx.channels.SingleLineCommentChannel;
 import org.sonar.cxx.channels.StringLiteralsChannel;
 import org.sonar.cxx.preprocessor.PPSpecialIdentifier;
 
@@ -81,8 +81,8 @@ public final class CxxLexerPool {
       .withFailIfNoChannelToConsumeOneCharacter(true)
       .withChannel(new BlackHoleChannel("\\s++"))
       // C++ Standard, Section 2.8 "Comments"
-      .withChannel(commentRegexp("//[^\\n\\r]*+"))
-      .withChannel(commentRegexp("/\\*", ANY_CHAR + "*?", "\\*/"))
+      .withChannel(new SingleLineCommentChannel())
+      .withChannel(new MultiLineCommentChannel())
       // backslash at the end of the line: just throw away
       .withChannel(new BackslashChannel())
       // detects preprocessor directives:

--- a/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithoutPreprocessorTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/lexer/CxxLexerWithoutPreprocessorTest.java
@@ -66,7 +66,7 @@ class CxxLexerWithoutPreprocessorTest {
   @Test
   void preprocessor_continued_define() {
     assertThat(lexer.lex("#define M\\\n"
-                           + "0")).anySatisfy(token -> assertThat(token).isValue("#define M 0").hasType(
+                           + "0")).anySatisfy(token -> assertThat(token).isValue("#define M0").hasType(
       CxxTokenType.PREPROCESSOR));
   }
 

--- a/cxx-squid/src/test/java/org/sonar/cxx/lexer/LexerAssert.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/lexer/LexerAssert.java
@@ -51,6 +51,15 @@ public class LexerAssert extends AbstractAssert<LexerAssert, Token> {
     return this;
   }
 
+  public LexerAssert isLine(int line) {
+    isNotNull();
+    int tokenLine = actual.getLine();
+    if (tokenLine != line) {
+      failWithMessage("Expected the Token line to be <%s> but was <%s>", line, tokenLine);
+    }
+    return this;
+  }
+
   public LexerAssert hasTrivia() {
     isNotNull();
     boolean exists = actual.hasTrivia();

--- a/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/IncludeFileLexerTest.java
+++ b/cxx-squid/src/test/java/org/sonar/cxx/preprocessor/IncludeFileLexerTest.java
@@ -44,8 +44,10 @@ class IncludeFileLexerTest {
 
   @Test
   void continued_lines_are_handled_correctly() {
-    List<Token> tokens = LEXER.lex("#define\\\nname");
-    assertThat(hasToken("#define name", CxxTokenType.PREPROCESSOR)
+    List<Token> tokens = LEXER.lex("#define \\\n"
+                                     + "name \\\n"
+                                     + "10");
+    assertThat(hasToken("#define name 10", CxxTokenType.PREPROCESSOR)
       .matches(tokens)).isTrue();
     assertThat(tokens).hasSize(2);
   }

--- a/cxx-squid/src/test/resources/metrics/nosonar.cc
+++ b/cxx-squid/src/test/resources/metrics/nosonar.cc
@@ -10,4 +10,4 @@ int c; /* NOSONAR */
 
 int d; // NOSONAR
 
-/* EOF '/
+/* EOF */

--- a/cxx-sslr/sslr-core/src/main/java/org/sonar/cxx/sslr/channel/CodeBuffer.java
+++ b/cxx-sslr/sslr-core/src/main/java/org/sonar/cxx/sslr/channel/CodeBuffer.java
@@ -113,6 +113,20 @@ public class CodeBuffer implements CharSequence {
     return character;
   }
 
+  /**
+   * Read and consume the next characters
+   *
+   * @param number number of characters to consume
+   * @return the next character or -1 if the end of the stream is reached
+   */
+  public final int skip(int number) {
+    while (number != 0) {
+      pop();
+      number--;
+    }
+    return peek();
+  }
+
   private void updateCursorPosition(int character) {
     // see Java Language Specification : http://java.sun.com/docs/books/jls/third_edition/html/lexical.html#3.4
     if (character == LF || character == CR && peek() != LF) {

--- a/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/channel/CodeBufferTest.java
+++ b/cxx-sslr/sslr-core/src/test/java/org/sonar/cxx/sslr/channel/CodeBufferTest.java
@@ -42,6 +42,13 @@ class CodeBufferTest {
   }
 
   @Test
+  void testSkip() {
+    var code = new CodeBuffer("1234", defaulConfiguration);
+    assertThat((char) code.skip(2)).isEqualTo('3');
+    assertThat(code.skip(2)).isEqualTo(-1);
+  }
+
+  @Test
   void testPeek() {
     var code = new CodeBuffer("pa", defaulConfiguration);
     assertThat((char) code.peek()).isEqualTo('p');


### PR DESCRIPTION
- [P2223R2](https://wg21.link/P2223R2)
- the cxx plugin supports line splicing still not in all cases (e.g. middle of number or identifier)
- related to #2536

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2749)
<!-- Reviewable:end -->
