### PR TITLE
Clang-Tidy: handle clang warnings in the report file (-W)

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/ClangTidyParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/clangtidy/ClangTidyParser.java
@@ -123,6 +123,14 @@ public class ClangTidyParser {
       } else {
         if (c == '[') {
           issue.ruleId = issue.info.substring(start + 1, end);
+          if(issue.ruleId.startsWith("-W")) {
+            // Let's support also clang, the compiler, output
+            //
+            // clang reports warnings as -W<warning>
+            // clang-tidy reports the exact same warning as clang-diagnostic-<warning>, and no actual clang-tidy warning
+            // starts with "-W"
+            issue.ruleId = issue.ruleId.replaceFirst("^-W", "clang-diagnostic-");
+          }
           issue.info = issue.info.substring(0, start - 1);
         } else {
           issue.aliasRuleIds.clear();

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/clang.report-warning.txt
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/clang.report-warning.txt
@@ -1,0 +1,4 @@
+to_array.hpp:19:16: warning: unsafe buffer access [-Wunsafe-buffer-usage]
+   19 |     return { { array[I]... } };
+      |                ^~~~~
+1 warning generated.

--- a/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/cpd.clang-mixed-output.txt
+++ b/cxx-sensors/src/test/resources/org/sonar/cxx/sensors/reports-project/clang-tidy-reports/cpd.clang-mixed-output.txt
@@ -1,0 +1,8 @@
+to_array.hpp:17:88: warning: use c++14 style type templates [modernize-type-traits]
+   17 | to_array_impl(T (&array)[N], boost::mp11::index_sequence<I...>) -> std::array<typename std::remove_cv<T>::type, N>
+      |                                                                               ~~~~~~~~ ^                ~~~~~~
+      |                                                                                                      _t
+to_array.hpp:19:16: warning: unsafe buffer access [-Wunsafe-buffer-usage]
+   19 |     return { { array[I]... } };
+      |                ^~~~~
+1 warning generated.


### PR DESCRIPTION
Extend the existing Clang-Tidy sensor to also understand clang compiler issues (`[-W...]`) in the LOG files and map them to clang-tidy rules (`[clang-diagnostic-...]`). Clang compiler issues would be visualized in the SQ UI as Clang-Tidy issues (as per https://github.com/SonarOpenCommunity/sonar-cxx/issues/2325#issuecomment-1058039331).

Sample:
* clang `[-Wunneeded-internal-declaration]`
* clang-tidy: `[clang-diagnostic-unneeded-internal-declaration]`
* `[-W...]`  => `[clang-diagnostic-...]`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2803)
<!-- Reviewable:end -->
