### PR TITLE
Update clang-tidy rules

### DIFF
--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -4944,7 +4944,7 @@ struct Derived : Base {
 <p>The object returned by a postfix increment or decrement operator is supposed to be a snapshot of the object's value prior to modification. With such an implementation, any modifications made to the resulting object from calling operator++(int) would be modifying a temporary object. Thus, such an implementation of a postfix increment or decrement operator should instead return a const object, prohibiting accidental mutation of a temporary object. Similarly, it is unexpected for the postfix operator to return a reference to its previous state, and any subsequent modifications would be operating on a stale object.</p>
 <p>This check corresponds to the CERT C++ Coding Standard recommendation DCL21-CPP. Overloaded postfix increment and decrement operators should return a const object. However, all of the CERT recommendations have been removed from public view, and so their justification for the behavior of this check requires an account on their wiki to view.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl21-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="https://releases.llvm.org/18.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/cert/dcl21-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     </rule>
   <rule>
@@ -5842,7 +5842,7 @@ void func(const char *buff) {
 <h1 id="clang-analyzer-core.dynamictypepropagation">clang-analyzer-core.DynamicTypePropagation</h1>
 <p>Generate dynamic type information</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.DynamicTypePropagation.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="https://releases.llvm.org/17.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/clang-analyzer/core.DynamicTypePropagation.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -22481,7 +22481,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is a C++23 extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-default-comp-relaxed-constexpr" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="https://releases.llvm.org/18.1.0/tools/clang/docs/DiagnosticsReference.html#wc-23-default-comp-relaxed-constexpr" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -24136,7 +24136,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: ISO C++20 does not permit the 'bool' keyword after 'concept'</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconcepts-ts-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="https://releases.llvm.org/15.0.0/tools/clang/docs/DiagnosticsReference.html#wconcepts-ts-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -25085,7 +25085,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: support for std::experimental::%0 will be removed in LLVM 15; use std::%0 instead</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-experimental-coroutine" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="https://releases.llvm.org/16.0.0/tools/clang/docs/DiagnosticsReference.html#wdeprecated-experimental-coroutine" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -25272,7 +25272,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: analyzer option '%0' is deprecated. This flag will be removed in %1, and passing this option will be an error. Use '%2' instead.</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-static-analyzer-flag" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="https://releases.llvm.org/18.1.0/tools/clang/docs/DiagnosticsReference.html#wdeprecated-static-analyzer-flag" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -26105,7 +26105,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: ISO C++20 does not permit using directive to be exported</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexport-using-directive" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="https://releases.llvm.org/16.0.0/tools/clang/docs/DiagnosticsReference.html#wexport-using-directive" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -26861,7 +26861,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: passing a type argument as the first operand to '_Generic' is a Clang extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgeneric-type-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="https://releases.llvm.org/18.1.0/tools/clang/docs/DiagnosticsReference.html#wgeneric-type-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28521,7 +28521,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: interrupt service routine should only call a function with attribute 'no_caller_saved_registers'</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winterrupt-service-routine" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="https://releases.llvm.org/17.0.1/tools/clang/docs/DiagnosticsReference.html#winterrupt-service-routine" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28811,7 +28811,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: KNL, KNM related Intel Xeon Phi CPU's specific ISA's supports will be removed in LLVM 19.</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wknl-knm-isa-support-removed" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="https://releases.llvm.org/18.1.0/tools/clang/docs/DiagnosticsReference.html#wknl-knm-isa-support-removed" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -31959,7 +31959,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: overriding '%0' option with '%1'</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverriding-t-option" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="https://releases.llvm.org/17.0.1/tools/clang/docs/DiagnosticsReference.html#woverriding-t-option" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -32797,7 +32797,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2b-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="https://releases.llvm.org/16.0.0/tools/clang/docs/DiagnosticsReference.html#wpre-c-2b-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -32814,7 +32814,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2b-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="https://releases.llvm.org/16.0.0/tools/clang/docs/DiagnosticsReference.html#wpre-c-2b-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -33473,7 +33473,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: this requires expression will only be checked for syntactic validity; did you intend to place it in a nested requirement? (add another 'requires' before the expression)</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrequires-expression" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="https://releases.llvm.org/13.0.0/tools/clang/docs/DiagnosticsReference.html#wrequires-expression" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -35427,7 +35427,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: builtin call has undefined behaviour when called from a %0 function</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-streaming" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="https://releases.llvm.org/18.1.0/tools/clang/docs/DiagnosticsReference.html#wundefined-arm-streaming" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>

--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -19562,6 +19562,32 @@ Derived();             // and so temporary construction is okay</code></pre>
   <!-- Clang Diagnostic Rules -->
 
   <rule>
+    <key>clang-diagnostic-#pragma-messages</key>
+    <name>clang-diagnostic-#pragma-messages</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#w-pragma-messages" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-#warnings</key>
+    <name>clang-diagnostic-#warnings</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#w-warnings" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-aarch64-sme-attributes</key>
     <name>clang-diagnostic-aarch64-sme-attributes</name>
     <description>
@@ -19573,131 +19599,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waarch64-sme-attributes" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-aix-compat</key>
-    <name>clang-diagnostic-aix-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #pragma align(packed) may not be compatible with objects generated with AIX XL C/C++</li>
-<li>warning: alignment of 16 bytes for a struct member is not binary compatible with IBM XL C/C++ for AIX 16.1.0 or older</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waix-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-arc-non-pod-memaccess</key>
-    <name>clang-diagnostic-arc-non-pod-memaccess</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{destination for|source of}0 this %1 call is a pointer to ownership-qualified type %2</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-non-pod-memaccess" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-arc-repeated-use-of-weak</key>
-    <name>clang-diagnostic-arc-repeated-use-of-weak</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: weak %select{variable|property|implicit property|instance variable}0 %1 is accessed multiple times in this %select{function|method|block|lambda}2 but may be unpredictably set to nil; assign to a strong variable to keep the object alive</li>
-<li>warning: weak %select{variable|property|implicit property|instance variable}0 %1 may be accessed multiple times in this %select{function|method|block|lambda}2 and may be unpredictably set to nil; assign to a strong variable to keep the object alive</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-repeated-use-of-weak" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-arc-maybe-repeated-use-of-weak</key>
-    <name>clang-diagnostic-arc-maybe-repeated-use-of-weak</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: weak %select{variable|property|implicit property|instance variable}0 %1 may be accessed multiple times in this %select{function|method|block|lambda}2 and may be unpredictably set to nil; assign to a strong variable to keep the object alive</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-maybe-repeated-use-of-weak" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-arc-retain-cycles</key>
-    <name>clang-diagnostic-arc-retain-cycles</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: capturing %0 strongly in this block is likely to lead to a retain cycle</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-retain-cycles" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-arc-unsafe-retained-assign</key>
-    <name>clang-diagnostic-arc-unsafe-retained-assign</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: assigning %select{array literal|dictionary literal|numeric literal|boxed expression|&lt;should not happen&gt;|block literal}0 to a weak %select{property|variable}1; object will be released after assignment</li>
-<li>warning: assigning retained object to %select{weak|unsafe_unretained}0 %select{property|variable}1; object will be released after assignment</li>
-<li>warning: assigning retained object to unsafe property; object will be released after assignment</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-unsafe-retained-assign" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-asm</key>
-    <name>clang-diagnostic-asm</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: value size does not match register size specified by the constraint and modifier</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wasm" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-asm-operand-widths</key>
-    <name>clang-diagnostic-asm-operand-widths</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: value size does not match register size specified by the constraint and modifier</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wasm-operand-widths" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-avr-rtlib-linking-quirks</key>
-    <name>clang-diagnostic-avr-rtlib-linking-quirks</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: no avr-libc installation can be found on the system, cannot link standard libraries</li>
-<li>warning: no target microcontroller specified on command line, cannot link standard libraries, please pass -mmcu=&lt;mcu name&gt;</li>
-<li>warning: standard library not linked and so no interrupt vector table or compiler runtime routines will be linked</li>
-<li>warning: support for linking stdlibs for microcontroller '%0' is not implemented</li>
-<li>warning: support for passing the data section address to the linker for microcontroller '%0' is not implemented</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wavr-rtlib-linking-quirks" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -19731,6 +19632,49 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-abstract-vbase-init</key>
+    <name>clang-diagnostic-abstract-vbase-init</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: initializer for virtual base class %0 of abstract class %1 will never be used</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wabstract-vbase-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-address</key>
+    <name>clang-diagnostic-address</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: address of %select{'%1'|function '%1'|array '%1'|lambda function pointer conversion operator}0 will always evaluate to 'true'</li>
+<li>warning: comparison of %select{address of|function|array}0 '%1' %select{not |}2equal to a null pointer is always %select{true|false}2</li>
+<li>warning: comparison of nonnull %select{function call|parameter}0 '%1' %select{not |}2equal to a null pointer is '%select{true|false}2' on first encounter</li>
+<li>warning: nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter</li>
+<li>warning: result of comparison against %select{a string literal|@encode}0 is unspecified (use an explicit string comparison function instead)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waddress" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-address-of-packed-member</key>
+    <name>clang-diagnostic-address-of-packed-member</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: taking address of packed member %0 of class or structure %q1 may result in an unaligned pointer value</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waddress-of-packed-member" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-address-of-temporary</key>
     <name>clang-diagnostic-address-of-temporary</name>
     <description>
@@ -19742,6 +19686,46 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waddress-of-temporary" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-aix-compat</key>
+    <name>clang-diagnostic-aix-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma align(packed) may not be compatible with objects generated with AIX XL C/C++</li>
+<li>warning: alignment of 16 bytes for a struct member is not binary compatible with IBM XL C/C++ for AIX 16.1.0 or older</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waix-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-alias-template-in-declaration-name</key>
+    <name>clang-diagnostic-alias-template-in-declaration-name</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: a declarative nested name specifier cannot name an alias template</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walias-template-in-declaration-name" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-align-mismatch</key>
+    <name>clang-diagnostic-align-mismatch</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: passing %0-byte aligned argument to %1-byte aligned parameter %2%select{| of %4}3 may result in an unaligned pointer access</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walign-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-all</key>
@@ -19959,6 +19943,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>CRITICAL</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-alloca</key>
+    <name>clang-diagnostic-alloca</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: use of function %0 is discouraged; there is no way to check for failure but failure may still occur, resulting in a possibly exploitable security vulnerability</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walloca" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-alloca-with-align-alignof</key>
+    <name>clang-diagnostic-alloca-with-align-alignof</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: second argument to __builtin_alloca_with_align is supposed to be in bits</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walloca-with-align-alignof" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-always-inline-coroutine</key>
     <name>clang-diagnostic-always-inline-coroutine</name>
     <description>
@@ -19972,15 +19982,28 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-ambiguous-member-template</key>
-    <name>clang-diagnostic-ambiguous-member-template</name>
+    <key>clang-diagnostic-ambiguous-delete</key>
+    <name>clang-diagnostic-ambiguous-delete</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: lookup of %0 in member access expression is ambiguous; using member of %1</li>
+<li>warning: multiple suitable %0 functions for %1; no 'operator delete' function will be invoked if initialization throws an exception</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wambiguous-member-template" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wambiguous-delete" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-ambiguous-ellipsis</key>
+    <name>clang-diagnostic-ambiguous-ellipsis</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '...' in this location creates a C-style varargs function%select{, not a function parameter pack|}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wambiguous-ellipsis" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -19998,6 +20021,58 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-ambiguous-member-template</key>
+    <name>clang-diagnostic-ambiguous-member-template</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: lookup of %0 in member access expression is ambiguous; using member of %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wambiguous-member-template" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-ambiguous-reversed-operator</key>
+    <name>clang-diagnostic-ambiguous-reversed-operator</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++20 considers use of overloaded operator '%0' (with operand types %1 and %2) to be ambiguous despite there being a unique best viable function%select{ with non-reversed arguments|}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wambiguous-reversed-operator" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-analyzer-incompatible-plugin</key>
+    <name>clang-diagnostic-analyzer-incompatible-plugin</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: checker plugin '%0' is not compatible with this version of the analyzer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wanalyzer-incompatible-plugin" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-android-unversioned-fallback</key>
+    <name>clang-diagnostic-android-unversioned-fallback</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: using unversioned Android target directory %0 for target %1; unversioned directories will not be used in Clang 19 -- provide a versioned directory for the target version or lower instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wandroid-unversioned-fallback" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-anon-enum-enum-conversion</key>
     <name>clang-diagnostic-anon-enum-enum-conversion</name>
     <description>
@@ -20008,6 +20083,182 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wanon-enum-enum-conversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-anonymous-pack-parens</key>
+    <name>clang-diagnostic-anonymous-pack-parens</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++11 requires a parenthesized pack declaration to have a name</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wanonymous-pack-parens" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-apinotes</key>
+    <name>clang-diagnostic-apinotes</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wapinotes" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-arc</key>
+    <name>clang-diagnostic-arc</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{destination for|source of}0 this %1 call is a pointer to ownership-qualified type %2</li>
+<li>warning: assigning %select{array literal|dictionary literal|numeric literal|boxed expression|&lt;should not happen&gt;|block literal}0 to a weak %select{property|variable}1; object will be released after assignment</li>
+<li>warning: assigning retained object to %select{weak|unsafe_unretained}0 %select{property|variable}1; object will be released after assignment</li>
+<li>warning: assigning retained object to unsafe property; object will be released after assignment</li>
+<li>warning: capturing %0 strongly in this block is likely to lead to a retain cycle</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-arc-bridge-casts-disallowed-in-nonarc</key>
+    <name>clang-diagnostic-arc-bridge-casts-disallowed-in-nonarc</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' casts have no effect when not using ARC</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-bridge-casts-disallowed-in-nonarc" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-arc-maybe-repeated-use-of-weak</key>
+    <name>clang-diagnostic-arc-maybe-repeated-use-of-weak</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: weak %select{variable|property|implicit property|instance variable}0 %1 may be accessed multiple times in this %select{function|method|block|lambda}2 and may be unpredictably set to nil; assign to a strong variable to keep the object alive</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-maybe-repeated-use-of-weak" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-arc-non-pod-memaccess</key>
+    <name>clang-diagnostic-arc-non-pod-memaccess</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{destination for|source of}0 this %1 call is a pointer to ownership-qualified type %2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-non-pod-memaccess" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-arc-performSelector-leaks</key>
+    <name>clang-diagnostic-arc-performSelector-leaks</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: performSelector may cause a leak because its selector is unknown</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-performSelector-leaks" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-arc-repeated-use-of-weak</key>
+    <name>clang-diagnostic-arc-repeated-use-of-weak</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: weak %select{variable|property|implicit property|instance variable}0 %1 is accessed multiple times in this %select{function|method|block|lambda}2 but may be unpredictably set to nil; assign to a strong variable to keep the object alive</li>
+<li>warning: weak %select{variable|property|implicit property|instance variable}0 %1 may be accessed multiple times in this %select{function|method|block|lambda}2 and may be unpredictably set to nil; assign to a strong variable to keep the object alive</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-repeated-use-of-weak" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-arc-retain-cycles</key>
+    <name>clang-diagnostic-arc-retain-cycles</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: capturing %0 strongly in this block is likely to lead to a retain cycle</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-retain-cycles" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-arc-unsafe-retained-assign</key>
+    <name>clang-diagnostic-arc-unsafe-retained-assign</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: assigning %select{array literal|dictionary literal|numeric literal|boxed expression|&lt;should not happen&gt;|block literal}0 to a weak %select{property|variable}1; object will be released after assignment</li>
+<li>warning: assigning retained object to %select{weak|unsafe_unretained}0 %select{property|variable}1; object will be released after assignment</li>
+<li>warning: assigning retained object to unsafe property; object will be released after assignment</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-unsafe-retained-assign" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-argument-outside-range</key>
+    <name>clang-diagnostic-argument-outside-range</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: argument value %0 is outside the valid range [%1, %2]</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wargument-outside-range" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-argument-undefined-behaviour</key>
+    <name>clang-diagnostic-argument-undefined-behaviour</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: argument value %0 will result in undefined behaviour</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wargument-undefined-behaviour" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-arm-interrupt-vfp-clobber</key>
+    <name>clang-diagnostic-arm-interrupt-vfp-clobber</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: interrupt service routine with vfp enabled may clobber the interruptee's vfp state</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warm-interrupt-vfp-clobber" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -20056,6 +20307,84 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-asm</key>
+    <name>clang-diagnostic-asm</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: value size does not match register size specified by the constraint and modifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wasm" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-asm-operand-widths</key>
+    <name>clang-diagnostic-asm-operand-widths</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: value size does not match register size specified by the constraint and modifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wasm-operand-widths" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-assign-enum</key>
+    <name>clang-diagnostic-assign-enum</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: integer constant not in range of enumerated type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wassign-enum" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-assume</key>
+    <name>clang-diagnostic-assume</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: assumption is ignored because it contains (potential) side-effects</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wassume" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-atimport-in-framework-header</key>
+    <name>clang-diagnostic-atimport-in-framework-header</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: use of '@import' in framework header is discouraged, including this header requires -fmodules</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watimport-in-framework-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-atomic-access</key>
+    <name>clang-diagnostic-atomic-access</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: accessing a member of an atomic structure or union is undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-access" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-atomic-alignment</key>
     <name>clang-diagnostic-atomic-alignment</name>
     <description>
@@ -20066,6 +20395,32 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-alignment" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-atomic-implicit-seq-cst</key>
+    <name>clang-diagnostic-atomic-implicit-seq-cst</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit use of sequentially-consistent atomic may incur stronger memory barriers than necessary</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-implicit-seq-cst" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-atomic-memory-ordering</key>
+    <name>clang-diagnostic-atomic-memory-ordering</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{|success |failure }0memory order argument to atomic operation is invalid</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-memory-ordering" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -20081,6 +20436,46 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-properties" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-atomic-property-with-user-defined-accessor</key>
+    <name>clang-diagnostic-atomic-property-with-user-defined-accessor</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: writable atomic property %0 cannot pair a synthesized %select{getter|setter}1 with a user defined %select{getter|setter}2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-property-with-user-defined-accessor" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-attribute-packed-for-bitfield</key>
+    <name>clang-diagnostic-attribute-packed-for-bitfield</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'packed' attribute was ignored on bit-fields with single-byte alignment in older versions of GCC and Clang</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wattribute-packed-for-bitfield" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-attribute-warning</key>
+    <name>clang-diagnostic-attribute-warning</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: -mtocdata option is ignored for %0 because %1</li>
+<li>warning: call to '%0' declared with 'warning' attribute: %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wattribute-warning" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -20187,6 +20582,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-auto-decl-extensions</key>
+    <name>clang-diagnostic-auto-decl-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: type inference of a declaration other than a plain identifier with optional trailing attributes is a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wauto-decl-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-auto-disable-vptr-sanitizer</key>
     <name>clang-diagnostic-auto-disable-vptr-sanitizer</name>
     <description>
@@ -20213,19 +20621,28 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-arc</key>
-    <name>clang-diagnostic-arc</name>
+    <key>clang-diagnostic-auto-storage-class</key>
+    <name>clang-diagnostic-auto-storage-class</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{destination for|source of}0 this %1 call is a pointer to ownership-qualified type %2</li>
-<li>warning: assigning %select{array literal|dictionary literal|numeric literal|boxed expression|&lt;should not happen&gt;|block literal}0 to a weak %select{property|variable}1; object will be released after assignment</li>
-<li>warning: assigning retained object to %select{weak|unsafe_unretained}0 %select{property|variable}1; object will be released after assignment</li>
-<li>warning: assigning retained object to unsafe property; object will be released after assignment</li>
-<li>warning: capturing %0 strongly in this block is likely to lead to a retain cycle</li>
+<li>warning: 'auto' storage class specifier is not permitted in C++11, and will not be supported in future releases</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wauto-storage-class" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-auto-var-id</key>
+    <name>clang-diagnostic-auto-var-id</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'auto' deduced as 'id' in declaration of %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wauto-var-id" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -20253,83 +20670,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-frame-larger-than</key>
-    <name>clang-diagnostic-frame-larger-than</name>
+    <key>clang-diagnostic-avr-rtlib-linking-quirks</key>
+    <name>clang-diagnostic-avr-rtlib-linking-quirks</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %0</li>
-<li>warning: stack frame size (%0) exceeds limit (%1) in '%2'</li>
+<li>warning: no avr-libc installation can be found on the system, cannot link standard libraries</li>
+<li>warning: no target microcontroller specified on command line, cannot link standard libraries, please pass -mmcu=&lt;mcu name&gt;</li>
+<li>warning: standard library not linked and so no interrupt vector table or compiler runtime routines will be linked</li>
+<li>warning: support for linking stdlibs for microcontroller '%0' is not implemented</li>
+<li>warning: support for passing the data section address to the linker for microcontroller '%0' is not implemented</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wframe-larger-than" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-inline-asm</key>
-    <name>clang-diagnostic-inline-asm</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winline-asm" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pass-failed</key>
-    <name>clang-diagnostic-pass-failed</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpass-failed" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pass</key>
-    <name>clang-diagnostic-pass</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>remark: %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rpass" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pass-analysis</key>
-    <name>clang-diagnostic-pass-analysis</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>remark: %0</li>
-<li>remark: %0; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'</li>
-<li>remark: %0; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop; if the arrays will always be independent, specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments -- erroneous results will occur if these options are incorrectly applied</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rpass-analysis" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pass-missed</key>
-    <name>clang-diagnostic-pass-missed</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>remark: %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rpass-missed" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wavr-rtlib-linking-quirks" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -20348,29 +20701,15 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-source-mgr</key>
-    <name>clang-diagnostic-source-mgr</name>
+    <key>clang-diagnostic-backslash-newline-escape</key>
+    <name>clang-diagnostic-backslash-newline-escape</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %0</li>
+<li>warning: backslash and newline separated by space</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsource-mgr" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-attribute-warning</key>
-    <name>clang-diagnostic-attribute-warning</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: -mtocdata option is ignored for %0 because %1</li>
-<li>warning: call to '%0' declared with 'warning' attribute: %1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wattribute-warning" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbackslash-newline-escape" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -20417,6 +20756,33 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-binding-in-condition</key>
+    <name>clang-diagnostic-binding-in-condition</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++17 does not permit structured binding declaration in a condition</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbinding-in-condition" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-bit-int-extension</key>
+    <name>clang-diagnostic-bit-int-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '_BitInt' in %select{C17 and earlier|C++}0 is a Clang extension</li>
+<li>warning: '_BitInt' suffix for literals is a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbit-int-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-bitfield-constant-conversion</key>
     <name>clang-diagnostic-bitfield-constant-conversion</name>
     <description>
@@ -20455,20 +20821,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbitfield-width" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-bit-int-extension</key>
-    <name>clang-diagnostic-bit-int-extension</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '_BitInt' in %select{C17 and earlier|C++}0 is a Clang extension</li>
-<li>warning: '_BitInt' suffix for literals is a Clang extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbit-int-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -20542,6 +20894,23 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-bool-conversions</key>
+    <name>clang-diagnostic-bool-conversions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true</li>
+<li>warning: address of %select{'%1'|function '%1'|array '%1'|lambda function pointer conversion operator}0 will always evaluate to 'true'</li>
+<li>warning: initialization of pointer of type %0 to null from a constant boolean expression</li>
+<li>warning: nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter</li>
+<li>warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; pointer may be assumed to always convert to true</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbool-conversions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-bool-operation</key>
     <name>clang-diagnostic-bool-operation</name>
     <description>
@@ -20569,6 +20938,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-braced-scalar-init</key>
+    <name>clang-diagnostic-braced-scalar-init</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: braces around %select{scalar |}0initializer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbraced-scalar-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-branch-protection</key>
     <name>clang-diagnostic-branch-protection</name>
     <description>
@@ -20581,6 +20963,33 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbranch-protection" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-bridge-cast</key>
+    <name>clang-diagnostic-bridge-cast</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 bridges to %1, not %2</li>
+<li>warning: %0 cannot bridge to %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbridge-cast" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-builtin-assume-aligned-alignment</key>
+    <name>clang-diagnostic-builtin-assume-aligned-alignment</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: requested alignment must be %0 bytes or smaller; maximum alignment assumed</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbuiltin-assume-aligned-alignment" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -20599,6 +21008,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-builtin-memcpy-chk-size</key>
+    <name>clang-diagnostic-builtin-memcpy-chk-size</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' will always overflow; destination buffer has size %1, but size argument is %2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbuiltin-memcpy-chk-size" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-builtin-requires-header</key>
     <name>clang-diagnostic-builtin-requires-header</name>
     <description>
@@ -20612,265 +21034,130 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c11-extensions</key>
-    <name>clang-diagnostic-c11-extensions</name>
+    <key>clang-diagnostic-c++-compat</key>
+    <name>clang-diagnostic-c++-compat</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: '%0' is a C11 extension</li>
-<li>warning: anonymous structs are a C11 extension</li>
-<li>warning: anonymous unions are a C11 extension</li>
-<li>warning: pointer comparisons before C11 need to be between two complete or two incomplete types; %0 is %select{|in}2complete and %1 is %select{|in}3complete</li>
+<li>warning: %select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc11-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c23-extensions</key>
-    <name>clang-diagnostic-c23-extensions</name>
+    <key>clang-diagnostic-c++0x-compat</key>
+    <name>clang-diagnostic-c++0x-compat</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: #embed is a %select{C23|Clang}0 extension</li>
-<li>warning: '_BitInt' suffix for literals is a C23 extension</li>
-<li>warning: '_Static_assert' with no message is a C23 extension</li>
-<li>warning: 'nullptr' is a C23 extension</li>
-<li>warning: [[]] attributes are a C23 extension</li>
-<li>warning: binary integer literals are a C23 extension</li>
-<li>warning: defining a type within '%select{__builtin_offsetof|offsetof}0' is a C23 extension</li>
-<li>warning: label at end of compound statement is a C23 extension</li>
-<li>warning: label followed by a declaration is a C23 extension</li>
-<li>warning: omitting the parameter name in a function definition is a C23 extension</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is a C23 extension</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is a C23 extension</li>
-<li>warning: use of an empty initializer is a C23 extension</li>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: '%0' is a keyword in C++11</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'auto' storage class specifier is redundant and incompatible with C++11</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: conversion from string literal to %0 is deprecated</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
+<li>warning: explicit instantiation cannot be 'inline'</li>
+<li>warning: explicit instantiation of %0 must occur at global scope</li>
+<li>warning: explicit instantiation of %0 not in a namespace enclosing %1</li>
+<li>warning: explicit instantiation of %q0 must occur in namespace %1</li>
+<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
+<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: identifier after literal will be treated as a reserved user-defined literal suffix in C++11</li>
+<li>warning: identifier after literal will be treated as a user-defined literal suffix in C++11</li>
+<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
+<li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: use of right-shift operator ('&gt;&gt;') in template argument will require parentheses in C++11</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc23-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
-    <severity>INFO</severity>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c23-compat</key>
-    <name>clang-diagnostic-c23-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%0' is a keyword in C23</li>
-<li>warning: type of UTF-8 string literal will change from array of char to array of char8_t in C23</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc23-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c2y-extensions</key>
-    <name>clang-diagnostic-c2y-extensions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%select{--|++}0' on an object of complex type is a C2y extension</li>
-<li>warning: 'alignof' on an incomplete array type is a C2y extension</li>
-<li>warning: passing a type argument as the first operand to '_Generic' is a C2y extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc2y-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c99-extensions</key>
-    <name>clang-diagnostic-c99-extensions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{qualifier in |static |}0array size %select{||'[*] '}0is a C99 feature</li>
-<li>warning: '%0' is a C99 extension</li>
-<li>warning: ISO C99 requires whitespace after the macro name</li>
-<li>warning: array designators are a C99 extension</li>
-<li>warning: brace elision for designated initializer is a C99 extension</li>
-<li>warning: commas at the end of enumerator lists are a C99-specific feature</li>
-<li>warning: compound literals are a C99-specific feature</li>
-<li>warning: designated initializers are a C++20 extension</li>
-<li>warning: designated initializers are a C99 feature</li>
-<li>warning: empty macro arguments are a C99 feature</li>
-<li>warning: flexible array members are a C99 feature</li>
-<li>warning: hexadecimal floating constants are a C99 feature</li>
-<li>warning: initializer for aggregate is not a compile-time constant</li>
-<li>warning: mixture of designated and non-designated initializers in the same initializer list is a C99 extension</li>
-<li>warning: nested designators are a C99 extension</li>
-<li>warning: variable declaration in for loop is a C99-specific feature</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc99-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c99-compat</key>
-    <name>clang-diagnostic-c99-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{using this character in an identifier|starting an identifier with this character}0 is incompatible with C99</li>
-<li>warning: '%0' is a keyword in C99</li>
-<li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C89; this literal will %select{have type 'long long'|be ill-formed}0 in C99 onwards</li>
-<li>warning: unicode literals are incompatible with C99</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc99-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c99-designator</key>
-    <name>clang-diagnostic-c99-designator</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: array designators are a C99 extension</li>
-<li>warning: brace elision for designated initializer is a C99 extension</li>
-<li>warning: designated initializers are a C++20 extension</li>
-<li>warning: designated initializers are a C99 feature</li>
-<li>warning: mixture of designated and non-designated initializers in the same initializer list is a C99 extension</li>
-<li>warning: nested designators are a C99 extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc99-designator" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c11-compat</key>
-    <name>clang-diagnostic-pre-c11-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%0' is incompatible with C standards before C11</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c11-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c11-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c11-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%0' is incompatible with C standards before C11</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c23-compat</key>
-    <name>clang-diagnostic-pre-c23-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #embed is incompatible with C standards before C23</li>
-<li>warning: #warning is incompatible with C standards before C23</li>
-<li>warning: '%0' is incompatible with C standards before C23</li>
-<li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
-<li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
-<li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
-<li>warning: [[]] attributes are incompatible with C standards before C23</li>
-<li>warning: binary integer literals are incompatible with C standards before C23</li>
-<li>warning: digit separators are incompatible with C standards before C23</li>
-<li>warning: label at end of compound statement is incompatible with C standards before C23</li>
-<li>warning: label followed by a declaration is incompatible with C standards before C23</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C standards before C23</li>
-<li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
-<li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
-<li>warning: use of an empty initializer is incompatible with C standards before C23</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c23-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c23-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c23-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #embed is incompatible with C standards before C23</li>
-<li>warning: #warning is incompatible with C standards before C23</li>
-<li>warning: '%0' is incompatible with C standards before C23</li>
-<li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
-<li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
-<li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
-<li>warning: [[]] attributes are incompatible with C standards before C23</li>
-<li>warning: binary integer literals are incompatible with C standards before C23</li>
-<li>warning: digit separators are incompatible with C standards before C23</li>
-<li>warning: label at end of compound statement is incompatible with C standards before C23</li>
-<li>warning: label followed by a declaration is incompatible with C standards before C23</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C standards before C23</li>
-<li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
-<li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
-<li>warning: use of an empty initializer is incompatible with C standards before C23</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c23-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c2y-compat</key>
-    <name>clang-diagnostic-pre-c2y-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%select{--|++}0' on an object of complex type is incompatible with C standards before C2y</li>
-<li>warning: 'alignof' on an incomplete array type is incompatible with C standards before C2y</li>
-<li>warning: passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2y-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c2y-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c2y-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%select{--|++}0' on an object of complex type is incompatible with C standards before C2y</li>
-<li>warning: 'alignof' on an incomplete array type is incompatible with C standards before C2y</li>
-<li>warning: passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2y-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-ctad-maybe-unsupported</key>
-    <name>clang-diagnostic-ctad-maybe-unsupported</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0 may not intend to support class template argument deduction</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wctad-maybe-unsupported" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++11-extensions</key>
-    <name>clang-diagnostic-c++11-extensions</name>
+    <key>clang-diagnostic-c++0x-extensions</key>
+    <name>clang-diagnostic-c++0x-extensions</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
@@ -20905,9 +21192,31 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: variadic templates are a C++11 extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++0x-narrowing</key>
+    <name>clang-diagnostic-c++0x-narrowing</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-narrowing" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-c++11-compat</key>
@@ -21234,6 +21543,47 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++11-extensions</key>
+    <name>clang-diagnostic-c++11-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{defaulted|deleted}0 function definitions are a C++11 extension</li>
+<li>warning: '%0' keyword is a C++11 extension</li>
+<li>warning: 'auto' type specifier is a C++11 extension</li>
+<li>warning: 'long long' is a C++11 extension</li>
+<li>warning: 'template' keyword outside of a template</li>
+<li>warning: 'typename' occurs outside of a template</li>
+<li>warning: [[]] attributes are a C++11 extension</li>
+<li>warning: alias declarations are a C++11 extension</li>
+<li>warning: commas at the end of enumerator lists are a C++11 extension</li>
+<li>warning: default member initializer for non-static data member is a C++11 extension</li>
+<li>warning: default template arguments for a function template are a C++11 extension</li>
+<li>warning: enumeration types with a fixed underlying type are a C++11 extension</li>
+<li>warning: explicit conversion functions are a C++11 extension</li>
+<li>warning: extern templates are a C++11 extension</li>
+<li>warning: extra ';' outside of a function is a C++11 extension</li>
+<li>warning: generalized initializer lists are a C++11 extension</li>
+<li>warning: implicit conversion from array size expression of type %0 to %select{integral|enumeration}1 type %2 is a C++11 extension</li>
+<li>warning: inline namespaces are a C++11 feature</li>
+<li>warning: lambdas are a C++11 extension</li>
+<li>warning: non-class friend type %0 is a C++11 extension</li>
+<li>warning: non-type template argument referring to %select{function|object}0 %1 with internal linkage is a C++11 extension</li>
+<li>warning: range-based for loop is a C++11 extension</li>
+<li>warning: reference qualifiers on functions are a C++11 extension</li>
+<li>warning: rvalue references are a C++11 extension</li>
+<li>warning: scoped enumerations are a C++11 extension</li>
+<li>warning: static data member %0 in union is a C++11 extension</li>
+<li>warning: unelaborated friend declaration is a C++11 extension; specify '%select{struct|interface|union|class|enum}0' to befriend %1</li>
+<li>warning: use of enumeration in a nested name specifier is a C++11 extension</li>
+<li>warning: variadic templates are a C++11 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-c++11-extra-semi</key>
     <name>clang-diagnostic-c++11-extra-semi</name>
     <description>
@@ -21308,79 +21658,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-11-narrowing-const-reference" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-inconsistent-missing-destructor-override</key>
-    <name>clang-diagnostic-inconsistent-missing-destructor-override</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %sub{warn_destructor_marked_not_override_overriding}0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winconsistent-missing-destructor-override" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-inconsistent-missing-override</key>
-    <name>clang-diagnostic-inconsistent-missing-override</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %sub{warn_function_marked_not_override_overriding}0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winconsistent-missing-override" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-suggest-override</key>
-    <name>clang-diagnostic-suggest-override</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %sub{warn_function_marked_not_override_overriding}0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsuggest-override" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-suggest-destructor-override</key>
-    <name>clang-diagnostic-suggest-destructor-override</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %sub{warn_destructor_marked_not_override_overriding}0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsuggest-destructor-override" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++14-extensions</key>
-    <name>clang-diagnostic-c++14-extensions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'decltype(auto)' type specifier is a C++14 extension</li>
-<li>warning: binary integer literals are a C++14 extension</li>
-<li>warning: initialized lambda captures are a C++14 extension</li>
-<li>warning: multiple return statements in constexpr function is a C++14 extension</li>
-<li>warning: type definition in a constexpr %select{function|constructor}0 is a C++14 extension</li>
-<li>warning: use of the %0 attribute is a C++14 extension</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++14 extension</li>
-<li>warning: variable declaration in a constexpr %select{function|constructor}0 is a C++14 extension</li>
-<li>warning: variable templates are a C++14 extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-14-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-c++14-attribute-extensions</key>
@@ -21629,32 +21906,23 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++17-extensions</key>
-    <name>clang-diagnostic-c++17-extensions</name>
+    <key>clang-diagnostic-c++14-extensions</key>
+    <name>clang-diagnostic-c++14-extensions</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: '%select{if|switch}0' initialization statements are a C++17 extension</li>
-<li>warning: 'begin' and 'end' returning different types (%0 and %1) is a C++17 extension</li>
-<li>warning: 'constexpr' on lambda expressions is a C++17 extension</li>
-<li>warning: 'static_assert' with no message is a C++17 extension</li>
-<li>warning: ISO C++ standards before C++17 do not allow new expression for type %0 to use list-initialization</li>
-<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are a C++17 extension</li>
-<li>warning: capture of '*this' by copy is a C++17 extension</li>
-<li>warning: constexpr if is a C++17 extension</li>
-<li>warning: decomposition declarations are a C++17 extension</li>
-<li>warning: default scope specifier for attributes is a C++17 extension</li>
-<li>warning: hexadecimal floating literals are a C++17 feature</li>
-<li>warning: inline variables are a C++17 extension</li>
-<li>warning: nested namespace definition is a C++17 extension; define each namespace separately</li>
-<li>warning: pack expansion of using declaration is a C++17 extension</li>
-<li>warning: pack fold expression is a C++17 extension</li>
-<li>warning: template template parameter using 'typename' is a C++17 extension</li>
-<li>warning: use of multiple declarators in a single using declaration is a C++17 extension</li>
-<li>warning: use of the %0 attribute is a C++17 extension</li>
+<li>warning: 'decltype(auto)' type specifier is a C++14 extension</li>
+<li>warning: binary integer literals are a C++14 extension</li>
+<li>warning: initialized lambda captures are a C++14 extension</li>
+<li>warning: multiple return statements in constexpr function is a C++14 extension</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is a C++14 extension</li>
+<li>warning: use of the %0 attribute is a C++14 extension</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++14 extension</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is a C++14 extension</li>
+<li>warning: variable templates are a C++14 extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-17-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-14-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -21858,38 +22126,158 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++20-extensions</key>
-    <name>clang-diagnostic-c++20-extensions</name>
+    <key>clang-diagnostic-c++17-extensions</key>
+    <name>clang-diagnostic-c++17-extensions</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: aggregate initialization of type %0 from a parenthesized list of values is a C++20 extension</li>
-<li>warning: captured structured bindings are a C++20 extension</li>
-<li>warning: constexpr constructor that does not initialize all members is a C++20 extension</li>
-<li>warning: constexpr union constructor that does not initialize any member is a C++20 extension</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is a C++20 extension</li>
-<li>warning: default member initializer for bit-field is a C++20 extension</li>
-<li>warning: defaulted comparison operators are a C++20 extension</li>
-<li>warning: designated initializers are a C++20 extension</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is a C++20 extension</li>
-<li>warning: explicit template parameter list for lambdas is a C++20 extension</li>
-<li>warning: explicit(bool) is a C++20 extension</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is a C++20 extension</li>
-<li>warning: initialized lambda pack captures are a C++20 extension</li>
-<li>warning: inline nested namespace definition is a C++20 extension</li>
-<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is a C++20 extension</li>
-<li>warning: missing 'typename' prior to dependent type name %0%1; implicit 'typename' is a C++20 extension</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is a C++20 extension</li>
-<li>warning: range-based for loop initialization statements are a C++20 extension</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is a C++20 extension</li>
-<li>warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension</li>
-<li>warning: use of the %0 attribute is a C++20 extension</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++20 extension</li>
-<li>warning: using declaration naming a scoped enumerator is a C++20 extension</li>
-<li>warning: using enum declaration is a C++20 extension</li>
+<li>warning: '%select{if|switch}0' initialization statements are a C++17 extension</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is a C++17 extension</li>
+<li>warning: 'constexpr' on lambda expressions is a C++17 extension</li>
+<li>warning: 'static_assert' with no message is a C++17 extension</li>
+<li>warning: ISO C++ standards before C++17 do not allow new expression for type %0 to use list-initialization</li>
+<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are a C++17 extension</li>
+<li>warning: capture of '*this' by copy is a C++17 extension</li>
+<li>warning: constexpr if is a C++17 extension</li>
+<li>warning: decomposition declarations are a C++17 extension</li>
+<li>warning: default scope specifier for attributes is a C++17 extension</li>
+<li>warning: hexadecimal floating literals are a C++17 feature</li>
+<li>warning: inline variables are a C++17 extension</li>
+<li>warning: nested namespace definition is a C++17 extension; define each namespace separately</li>
+<li>warning: pack expansion of using declaration is a C++17 extension</li>
+<li>warning: pack fold expression is a C++17 extension</li>
+<li>warning: template template parameter using 'typename' is a C++17 extension</li>
+<li>warning: use of multiple declarators in a single using declaration is a C++17 extension</li>
+<li>warning: use of the %0 attribute is a C++17 extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-20-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-17-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++1y-extensions</key>
+    <name>clang-diagnostic-c++1y-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'decltype(auto)' type specifier is a C++14 extension</li>
+<li>warning: binary integer literals are a C++14 extension</li>
+<li>warning: initialized lambda captures are a C++14 extension</li>
+<li>warning: multiple return statements in constexpr function is a C++14 extension</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is a C++14 extension</li>
+<li>warning: use of the %0 attribute is a C++14 extension</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++14 extension</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is a C++14 extension</li>
+<li>warning: variable templates are a C++14 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1y-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++1z-compat</key>
+    <name>clang-diagnostic-c++1z-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
+<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
+<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
+<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
+<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
+<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++1z-compat-mangling</key>
+    <name>clang-diagnostic-c++1z-compat-mangling</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat-mangling" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++1z-extensions</key>
+    <name>clang-diagnostic-c++1z-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%select{if|switch}0' initialization statements are a C++17 extension</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is a C++17 extension</li>
+<li>warning: 'constexpr' on lambda expressions is a C++17 extension</li>
+<li>warning: 'static_assert' with no message is a C++17 extension</li>
+<li>warning: ISO C++ standards before C++17 do not allow new expression for type %0 to use list-initialization</li>
+<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are a C++17 extension</li>
+<li>warning: capture of '*this' by copy is a C++17 extension</li>
+<li>warning: constexpr if is a C++17 extension</li>
+<li>warning: decomposition declarations are a C++17 extension</li>
+<li>warning: default scope specifier for attributes is a C++17 extension</li>
+<li>warning: hexadecimal floating literals are a C++17 feature</li>
+<li>warning: inline variables are a C++17 extension</li>
+<li>warning: nested namespace definition is a C++17 extension; define each namespace separately</li>
+<li>warning: pack expansion of using declaration is a C++17 extension</li>
+<li>warning: pack fold expression is a C++17 extension</li>
+<li>warning: template template parameter using 'typename' is a C++17 extension</li>
+<li>warning: use of multiple declarators in a single using declaration is a C++17 extension</li>
+<li>warning: use of the %0 attribute is a C++17 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -22019,6 +22407,85 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++20-extensions</key>
+    <name>clang-diagnostic-c++20-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: aggregate initialization of type %0 from a parenthesized list of values is a C++20 extension</li>
+<li>warning: captured structured bindings are a C++20 extension</li>
+<li>warning: constexpr constructor that does not initialize all members is a C++20 extension</li>
+<li>warning: constexpr union constructor that does not initialize any member is a C++20 extension</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is a C++20 extension</li>
+<li>warning: default member initializer for bit-field is a C++20 extension</li>
+<li>warning: defaulted comparison operators are a C++20 extension</li>
+<li>warning: designated initializers are a C++20 extension</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is a C++20 extension</li>
+<li>warning: explicit template parameter list for lambdas is a C++20 extension</li>
+<li>warning: explicit(bool) is a C++20 extension</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is a C++20 extension</li>
+<li>warning: initialized lambda pack captures are a C++20 extension</li>
+<li>warning: inline nested namespace definition is a C++20 extension</li>
+<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is a C++20 extension</li>
+<li>warning: missing 'typename' prior to dependent type name %0%1; implicit 'typename' is a C++20 extension</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is a C++20 extension</li>
+<li>warning: range-based for loop initialization statements are a C++20 extension</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is a C++20 extension</li>
+<li>warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension</li>
+<li>warning: use of the %0 attribute is a C++20 extension</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++20 extension</li>
+<li>warning: using declaration naming a scoped enumerator is a C++20 extension</li>
+<li>warning: using enum declaration is a C++20 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-20-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++23-attribute-extensions</key>
+    <name>clang-diagnostic-c++23-attribute-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: use of the %0 attribute is a C++23 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-attribute-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++23-compat</key>
+    <name>clang-diagnostic-c++23-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++23-default-comp-relaxed-constexpr</key>
+    <name>clang-diagnostic-c++23-default-comp-relaxed-constexpr</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is a C++23 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-default-comp-relaxed-constexpr" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-c++23-extensions</key>
     <name>clang-diagnostic-c++23-extensions</name>
     <description>
@@ -22042,19 +22509,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++23-attribute-extensions</key>
-    <name>clang-diagnostic-c++23-attribute-extensions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: use of the %0 attribute is a C++23 extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-attribute-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-c++23-lambda-attributes</key>
     <name>clang-diagnostic-c++23-lambda-attributes</name>
     <description>
@@ -22064,23 +22518,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-lambda-attributes" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++23-compat</key>
-    <name>clang-diagnostic-c++23-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
-<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
-<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
-<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
-<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -22102,6 +22539,164 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++2a-compat</key>
+    <name>clang-diagnostic-c++2a-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: '%0' is a keyword in C++20</li>
+<li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: taking address of non-addressable standard library function is incompatible with C++20</li>
+<li>warning: this expression will be parsed as explicit(bool) in C++20</li>
+<li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of implicit 'typename' is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++2a-compat-pedantic</key>
+    <name>clang-diagnostic-c++2a-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: '%0' is a keyword in C++20</li>
+<li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: taking address of non-addressable standard library function is incompatible with C++20</li>
+<li>warning: this expression will be parsed as explicit(bool) in C++20</li>
+<li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of implicit 'typename' is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++2a-extensions</key>
+    <name>clang-diagnostic-c++2a-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: aggregate initialization of type %0 from a parenthesized list of values is a C++20 extension</li>
+<li>warning: captured structured bindings are a C++20 extension</li>
+<li>warning: constexpr constructor that does not initialize all members is a C++20 extension</li>
+<li>warning: constexpr union constructor that does not initialize any member is a C++20 extension</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is a C++20 extension</li>
+<li>warning: default member initializer for bit-field is a C++20 extension</li>
+<li>warning: defaulted comparison operators are a C++20 extension</li>
+<li>warning: designated initializers are a C++20 extension</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is a C++20 extension</li>
+<li>warning: explicit template parameter list for lambdas is a C++20 extension</li>
+<li>warning: explicit(bool) is a C++20 extension</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is a C++20 extension</li>
+<li>warning: initialized lambda pack captures are a C++20 extension</li>
+<li>warning: inline nested namespace definition is a C++20 extension</li>
+<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is a C++20 extension</li>
+<li>warning: missing 'typename' prior to dependent type name %0%1; implicit 'typename' is a C++20 extension</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is a C++20 extension</li>
+<li>warning: range-based for loop initialization statements are a C++20 extension</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is a C++20 extension</li>
+<li>warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension</li>
+<li>warning: use of the %0 attribute is a C++20 extension</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++20 extension</li>
+<li>warning: using declaration naming a scoped enumerator is a C++20 extension</li>
+<li>warning: using enum declaration is a C++20 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++2b-extensions</key>
+    <name>clang-diagnostic-c++2b-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{an attribute specifier sequence|%0}1 in this position is a C++23 extension</li>
+<li>warning: 'size_t' suffix for literals is a C++23 extension</li>
+<li>warning: alias declaration in this context is a C++23 extension</li>
+<li>warning: consteval if is a C++23 extension</li>
+<li>warning: declaring overloaded %0 as 'static' is a C++23 extension</li>
+<li>warning: definition of a %select{static|thread_local}1 variable in a constexpr %select{function|constructor}0 is a C++23 extension</li>
+<li>warning: label at end of compound statement is a C++23 extension</li>
+<li>warning: lambda without a parameter clause is a C++23 extension</li>
+<li>warning: static lambdas are a C++23 extension</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is a C++23 extension</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++23 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2b-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-c++2c-compat</key>
     <name>clang-diagnostic-c++2c-compat</name>
     <description>
@@ -22112,6 +22707,225 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2c-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++2c-extensions</key>
+    <name>clang-diagnostic-c++2c-extensions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning:  '%0' in a raw string literal delimiter is a C++2c extension</li>
+<li>warning: '= delete' with a message is a C++2c extension</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is a C++2c extension</li>
+<li>warning: pack indexing is a C++2c extension</li>
+<li>warning: placeholder variables are a C++2c extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2c-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat</key>
+    <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
+<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
+<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
+<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
+<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</key>
+    <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
+<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: designated initializers are incompatible with C++ standards before C++20</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
+<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
+<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
+<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++98-c++11-c++14-compat</key>
+    <name>clang-diagnostic-c++98-c++11-c++14-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</key>
+    <name>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: hexadecimal floating literals are incompatible with C++ standards before C++17</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++98-c++11-compat</key>
+    <name>clang-diagnostic-c++98-c++11-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++98-c++11-compat-binary-literal</key>
+    <name>clang-diagnostic-c++98-c++11-compat-binary-literal</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat-binary-literal" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++98-c++11-compat-pedantic</key>
+    <name>clang-diagnostic-c++98-c++11-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -22553,337 +23367,186 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++-compat</key>
-    <name>clang-diagnostic-c++-compat</name>
+    <key>clang-diagnostic-c11-extensions</key>
+    <name>clang-diagnostic-c11-extensions</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++</li>
+<li>warning: '%0' is a C11 extension</li>
+<li>warning: anonymous structs are a C11 extension</li>
+<li>warning: anonymous unions are a C11 extension</li>
+<li>warning: pointer comparisons before C11 need to be between two complete or two incomplete types; %0 is %select{|in}2complete and %1 is %select{|in}3complete</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc11-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pre-c++14-compat</key>
-    <name>clang-diagnostic-pre-c++14-compat</name>
+    <key>clang-diagnostic-c23-compat</key>
+    <name>clang-diagnostic-c23-compat</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
-<li>warning: digit separators are incompatible with C++ standards before C++14</li>
-<li>warning: generic lambdas are incompatible with C++11</li>
-<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
-<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
-<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
-<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+<li>warning: '%0' is a keyword in C23</li>
+<li>warning: type of UTF-8 string literal will change from array of char to array of char8_t in C23</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-14-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc23-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++98-c++11-compat-binary-literal</key>
-    <name>clang-diagnostic-c++98-c++11-compat-binary-literal</name>
+    <key>clang-diagnostic-c23-extensions</key>
+    <name>clang-diagnostic-c23-extensions</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
+<li>warning: #embed is a %select{C23|Clang}0 extension</li>
+<li>warning: '_BitInt' suffix for literals is a C23 extension</li>
+<li>warning: '_Static_assert' with no message is a C23 extension</li>
+<li>warning: 'nullptr' is a C23 extension</li>
+<li>warning: [[]] attributes are a C23 extension</li>
+<li>warning: binary integer literals are a C23 extension</li>
+<li>warning: defining a type within '%select{__builtin_offsetof|offsetof}0' is a C23 extension</li>
+<li>warning: label at end of compound statement is a C23 extension</li>
+<li>warning: label followed by a declaration is a C23 extension</li>
+<li>warning: omitting the parameter name in a function definition is a C23 extension</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is a C23 extension</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is a C23 extension</li>
+<li>warning: use of an empty initializer is a C23 extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat-binary-literal" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc23-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pre-c++14-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c++14-compat-pedantic</name>
+    <key>clang-diagnostic-c2x-compat</key>
+    <name>clang-diagnostic-c2x-compat</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
-<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
-<li>warning: digit separators are incompatible with C++ standards before C++14</li>
-<li>warning: generic lambdas are incompatible with C++11</li>
-<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
-<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
-<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
-<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+<li>warning: '%0' is a keyword in C23</li>
+<li>warning: type of UTF-8 string literal will change from array of char to array of char8_t in C23</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-14-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc2x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pre-c++17-compat</key>
-    <name>clang-diagnostic-pre-c++17-compat</name>
+    <key>clang-diagnostic-c2x-extensions</key>
+    <name>clang-diagnostic-c2x-extensions</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
-<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
-<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
-<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
-<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
-<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
-<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
-<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
-<li>warning: inline variables are incompatible with C++ standards before C++17</li>
-<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
-<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
-<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
-<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
-<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
-<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: #embed is a %select{C23|Clang}0 extension</li>
+<li>warning: '_BitInt' suffix for literals is a C23 extension</li>
+<li>warning: '_Static_assert' with no message is a C23 extension</li>
+<li>warning: 'nullptr' is a C23 extension</li>
+<li>warning: [[]] attributes are a C23 extension</li>
+<li>warning: binary integer literals are a C23 extension</li>
+<li>warning: defining a type within '%select{__builtin_offsetof|offsetof}0' is a C23 extension</li>
+<li>warning: label at end of compound statement is a C23 extension</li>
+<li>warning: label followed by a declaration is a C23 extension</li>
+<li>warning: omitting the parameter name in a function definition is a C23 extension</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is a C23 extension</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is a C23 extension</li>
+<li>warning: use of an empty initializer is a C23 extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-17-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc2x-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pre-c++17-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c++17-compat-pedantic</name>
+    <key>clang-diagnostic-c2y-extensions</key>
+    <name>clang-diagnostic-c2y-extensions</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
-<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
-<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
-<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
-<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
-<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
-<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
-<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
-<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
-<li>warning: hexadecimal floating literals are incompatible with C++ standards before C++17</li>
-<li>warning: inline variables are incompatible with C++ standards before C++17</li>
-<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
-<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
-<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
-<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
-<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
-<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: '%select{--|++}0' on an object of complex type is a C2y extension</li>
+<li>warning: 'alignof' on an incomplete array type is a C2y extension</li>
+<li>warning: passing a type argument as the first operand to '_Generic' is a C2y extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-17-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc2y-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pre-c++20-compat</key>
-    <name>clang-diagnostic-pre-c++20-compat</name>
+    <key>clang-diagnostic-c99-compat</key>
+    <name>clang-diagnostic-c99-compat</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
-<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
-<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
-<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
-<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
-<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
-<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
-<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
-<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
-<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
-<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
-<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
+<li>warning: %select{using this character in an identifier|starting an identifier with this character}0 is incompatible with C99</li>
+<li>warning: '%0' is a keyword in C99</li>
+<li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C89; this literal will %select{have type 'long long'|be ill-formed}0 in C99 onwards</li>
+<li>warning: unicode literals are incompatible with C99</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-20-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc99-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pre-c++20-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c++20-compat-pedantic</name>
+    <key>clang-diagnostic-c99-designator</key>
+    <name>clang-diagnostic-c99-designator</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
-<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
-<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
-<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
-<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
-<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: designated initializers are incompatible with C++ standards before C++20</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
-<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
-<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
-<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
-<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
-<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
-<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
-<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
+<li>warning: array designators are a C99 extension</li>
+<li>warning: brace elision for designated initializer is a C99 extension</li>
+<li>warning: designated initializers are a C++20 extension</li>
+<li>warning: designated initializers are a C99 feature</li>
+<li>warning: mixture of designated and non-designated initializers in the same initializer list is a C99 extension</li>
+<li>warning: nested designators are a C99 extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-20-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc99-designator" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pre-c++2b-compat</key>
-    <name>clang-diagnostic-pre-c++2b-compat</name>
+    <key>clang-diagnostic-c99-extensions</key>
+    <name>clang-diagnostic-c99-extensions</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+<li>warning: %select{qualifier in |static |}0array size %select{||'[*] '}0is a C99 feature</li>
+<li>warning: '%0' is a C99 extension</li>
+<li>warning: ISO C99 requires whitespace after the macro name</li>
+<li>warning: array designators are a C99 extension</li>
+<li>warning: brace elision for designated initializer is a C99 extension</li>
+<li>warning: commas at the end of enumerator lists are a C99-specific feature</li>
+<li>warning: compound literals are a C99-specific feature</li>
+<li>warning: designated initializers are a C++20 extension</li>
+<li>warning: designated initializers are a C99 feature</li>
+<li>warning: empty macro arguments are a C99 feature</li>
+<li>warning: flexible array members are a C99 feature</li>
+<li>warning: hexadecimal floating constants are a C99 feature</li>
+<li>warning: initializer for aggregate is not a compile-time constant</li>
+<li>warning: mixture of designated and non-designated initializers in the same initializer list is a C99 extension</li>
+<li>warning: nested designators are a C99 extension</li>
+<li>warning: variable declaration in for loop is a C99-specific feature</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2b-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc99-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pre-c++23-compat</key>
-    <name>clang-diagnostic-pre-c++23-compat</name>
+    <key>clang-diagnostic-call-to-pure-virtual-from-ctor-dtor</key>
+    <name>clang-diagnostic-call-to-pure-virtual-from-ctor-dtor</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: #warning is incompatible with C++ standards before C++23</li>
-<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
-<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
-<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
-<li>warning: consteval if is incompatible with C++ standards before C++23</li>
-<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
-<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: call to pure virtual member function %0 has undefined behavior; overrides of %0 in subclasses are not available in the %select{constructor|destructor}1 of %2</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-23-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c++2b-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c++2b-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
-<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
-<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2b-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c++23-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c++23-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #warning is incompatible with C++ standards before C++23</li>
-<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
-<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
-<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
-<li>warning: consteval if is incompatible with C++ standards before C++23</li>
-<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
-<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-23-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c++26-compat</key>
-    <name>clang-diagnostic-pre-c++26-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
-<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
-<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
-<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
-<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-26-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c++26-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c++26-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
-<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
-<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
-<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
-<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-26-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcall-to-pure-virtual-from-ctor-dtor" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -22915,6 +23578,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-align" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-cast-calling-convention</key>
+    <name>clang-diagnostic-cast-calling-convention</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: cast between incompatible calling conventions '%0' and '%1'; calls through this pointer may abort at runtime</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-calling-convention" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -22959,6 +23635,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-cast-of-sel-type</key>
+    <name>clang-diagnostic-cast-of-sel-type</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: cast of type %0 to %1 is deprecated; use sel_getName instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-of-sel-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-cast-qual</key>
     <name>clang-diagnostic-cast-qual</name>
     <description>
@@ -22969,6 +23658,32 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-qual" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-cast-qual-unrelated</key>
+    <name>clang-diagnostic-cast-qual-unrelated</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++ does not allow %select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast|}0 from %1 to %2 because it casts away qualifiers, even though the source and destination types are unrelated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-qual-unrelated" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-CFString-literal</key>
+    <name>clang-diagnostic-CFString-literal</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: input conversion stopped due to an input byte that does not belong to the input codeset UTF-8</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wCFString-literal" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -22985,6 +23700,245 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wchar-subscripts" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-CL4</key>
+    <name>clang-diagnostic-CL4</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma execution_character_set expected '%0'</li>
+<li>warning: #pragma execution_character_set expected 'push' or 'pop'</li>
+<li>warning: #pragma execution_character_set invalid value '%0', only 'UTF-8' is supported</li>
+<li>warning: #pragma warning expected '%0'</li>
+<li>warning: #pragma warning expected 'push', 'pop', 'default', 'disable', 'error', 'once', 'suppress', 1, 2, 3, or 4</li>
+<li>warning: #pragma warning expected a warning number</li>
+<li>warning: #pragma warning(push, level) requires a level between 0 and 4</li>
+<li>warning: %0</li>
+<li>warning: %0 has C-linkage specified, but returns incomplete type %1 which could be incompatible with C</li>
+<li>warning: %0 has C-linkage specified, but returns user-defined type %1 which is incompatible with C</li>
+<li>warning: %0 has lower precedence than %1; %1 will be evaluated first</li>
+<li>warning: %2 defined as %select{a struct|an interface|a class}0%select{| template}1 here but previously declared as %select{a struct|an interface|a class}3%select{| template}1; this is valid, but may result in linker errors under the Microsoft C++ ABI</li>
+<li>warning: %plural{1:enumeration value %1 not handled in switch|2:enumeration values %1 and %2 not handled in switch|3:enumeration values %1, %2, and %3 not handled in switch|:%0 enumeration values not handled in switch: %1, %2, %3...}0</li>
+<li>warning: %q0 hides overloaded virtual %select{function|functions}1</li>
+<li>warning: %select{aligning a value|the result of checking whether a value is aligned}0 to 1 byte is %select{a no-op|always true}0</li>
+<li>warning: %select{delete|destructor}0 called on %1 that is abstract but has non-virtual destructor</li>
+<li>warning: %select{delete|destructor}0 called on non-final %1 that has virtual functions but non-virtual destructor</li>
+<li>warning: %select{equality|inequality|relational|three-way}0 comparison result unused</li>
+<li>warning: %select{field width|precision}0 used with '%1' conversion specifier, resulting in undefined behavior</li>
+<li>warning: %select{field|base class}0 %1 will be initialized after %select{field|base}2 %3</li>
+<li>warning: %select{function|variable}0 %1 is not needed and will not be emitted</li>
+<li>warning: %select{self-|array }0comparison always evaluates to %select{a constant|true|false|'std::strong_ordering::equal'}1</li>
+<li>warning: %select{struct|interface|class}0%select{| template}1 %2 was previously declared as a %select{struct|interface|class}3%select{| template}1; this is valid, but may result in linker errors under the Microsoft C++ ABI</li>
+<li>warning: %select{values of type|enum values with underlying type}2 '%0' should not be used as format arguments; add an explicit cast to %1 instead</li>
+<li>warning: %select{void function|void method|constructor|destructor}1 %0 should not return a value</li>
+<li>warning: %select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++</li>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+<li>warning: %sub{subst_format_overflow}0,1,2</li>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
+<li>warning: %sub{subst_format_truncation}0,1,2</li>
+<li>warning: '%%n' specifier not supported on this platform</li>
+<li>warning: '%0' is not a valid object format flag</li>
+<li>warning: '%0' qualifier on function type %1 has no effect</li>
+<li>warning: '%0' qualifier on omitted return type %1 has no effect</li>
+<li>warning: '%0' qualifier on reference type %1 has no effect</li>
+<li>warning: '%0' type qualifier%s1 on return type %plural{1:has|:have}1 no effect</li>
+<li>warning: '%0' within '%1'</li>
+<li>warning: '%select{*|.*}0' specified field %select{width|precision}0 is missing a matching 'int' argument</li>
+<li>warning: '&amp;&amp;' of a value and its negation always evaluates to false</li>
+<li>warning: '&amp;&amp;' within '||'</li>
+<li>warning: '-fuse-ld=' taking a path is deprecated; use '--ld-path=' instead</li>
+<li>warning: '/*' within block comment</li>
+<li>warning: 'static' function %0 declared in header file should be declared 'static inline'</li>
+<li>warning: 'this' pointer cannot be null in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0</li>
+<li>warning: '||' of a value and its negation always evaluates to true</li>
+<li>warning: // comments are not allowed in this language</li>
+<li>warning: ARC %select{unused|__unsafe_unretained|__strong|__weak|__autoreleasing}0 lifetime qualifier on return type is ignored</li>
+<li>warning: ISO C++ requires field designators to be specified in declaration order; field %1 will be initialized after field %0</li>
+<li>warning: add explicit braces to avoid dangling else</li>
+<li>warning: adding %0 to a string does not append to the string</li>
+<li>warning: all paths through this function will call itself</li>
+<li>warning: angle-bracketed include &lt;%0&gt; cannot be aliased to double-quoted include "%1"</li>
+<li>warning: argument %0 of type %1 with mismatched bound</li>
+<li>warning: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension</li>
+<li>warning: array section %select{lower bound|length}0 is of type 'char'</li>
+<li>warning: array subscript is of type 'char'</li>
+<li>warning: assigning %select{field|instance variable}0 to itself</li>
+<li>warning: base class %0 is uninitialized when used here to access %q1</li>
+<li>warning: bitwise comparison always evaluates to %select{false|true}0</li>
+<li>warning: bitwise negation of a boolean expression%select{;| always evaluates to 'true';}0 did you mean logical negation?</li>
+<li>warning: bitwise or with non-zero value always evaluates to true</li>
+<li>warning: block pointer variable %0 is %select{uninitialized|null}1 when captured by block</li>
+<li>warning: call to undeclared function %0; ISO C99 and later do not support implicit function declarations</li>
+<li>warning: call to undeclared library function '%0' with type %1; ISO C99 and later do not support implicit function declarations</li>
+<li>warning: calling '%0' with a nonzero argument is unsafe</li>
+<li>warning: cannot mix positional and non-positional arguments in format string</li>
+<li>warning: case value not in enumerated type %0</li>
+<li>warning: cast %diff{from $ to $ |}0,1converts to incompatible function type</li>
+<li>warning: cast of type %0 to %1 is deprecated; use sel_getName instead</li>
+<li>warning: comparison of %select{address of|function|array}0 '%1' %select{not |}2equal to a null pointer is always %select{true|false}2</li>
+<li>warning: comparison of integers of different signs: %0 and %1</li>
+<li>warning: comparison of nonnull %select{function call|parameter}0 '%1' %select{not |}2equal to a null pointer is '%select{true|false}2' on first encounter</li>
+<li>warning: comparisons like 'X&lt;=Y&lt;=Z' don't have their mathematical meaning</li>
+<li>warning: container access result unused - container access should not be used for side effects</li>
+<li>warning: convenience initializer missing a 'self' call to another initializer</li>
+<li>warning: convenience initializer should not invoke an initializer on 'super'</li>
+<li>warning: converting the enum constant to a boolean</li>
+<li>warning: converting the result of '&lt;&lt;' to a boolean always evaluates to %select{false|true}0</li>
+<li>warning: converting the result of '&lt;&lt;' to a boolean; did you mean '(%0) != 0'?</li>
+<li>warning: converting the result of '?:' with integer constants to a boolean always evaluates to 'true'</li>
+<li>warning: data argument not used by format string</li>
+<li>warning: data argument position '%0' exceeds the number of data arguments (%1)</li>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared copy %select{assignment operator|constructor}1</li>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided copy %select{assignment operator|constructor}1</li>
+<li>warning: designated initializer invoked a non-designated initializer</li>
+<li>warning: designated initializer missing a 'super' call to a designated initializer of the super class</li>
+<li>warning: designated initializer should only invoke a designated initializer on 'super'</li>
+<li>warning: double-quoted include "%0" cannot be aliased to angle-bracketed include &lt;%1&gt;</li>
+<li>warning: empty initialization statement of '%select{if|switch|range-based for}0' has no effect</li>
+<li>warning: equality comparison with extraneous parentheses</li>
+<li>warning: escaped newline between */ characters at block comment end</li>
+<li>warning: expected 'ON' or 'OFF' or 'DEFAULT' in pragma</li>
+<li>warning: expected end of directive in pragma</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1</li>
+<li>warning: explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1</li>
+<li>warning: explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1</li>
+<li>warning: explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1</li>
+<li>warning: expression result unused</li>
+<li>warning: expression result unused; should this cast be to 'void'?</li>
+<li>warning: expression with side effects has no effect in an unevaluated context</li>
+<li>warning: expression with side effects will be evaluated despite being used as an operand to 'typeid'</li>
+<li>warning: field %0 can overwrite instance variable %1 with variable sized type %2 in superclass %3</li>
+<li>warning: field %0 is uninitialized when used here</li>
+<li>warning: field %0 with variable sized type %1 is not visible to subclasses and can conflict with their instance variables</li>
+<li>warning: field %select{width|precision}0 should have type %1, but argument has type %2</li>
+<li>warning: flag '%0' is ignored when flag '%1' is present</li>
+<li>warning: flag '%0' results in undefined behavior with '%1' conversion specifier</li>
+<li>warning: format specifies type %0 but the argument has %select{type|underlying type}2 %1</li>
+<li>warning: format string contains '\0' within the string body</li>
+<li>warning: format string is empty</li>
+<li>warning: format string is not a string literal (potentially insecure)</li>
+<li>warning: format string is not null-terminated</li>
+<li>warning: format string missing</li>
+<li>warning: format string should not be a wide string</li>
+<li>warning: ignored trigraph would end block comment</li>
+<li>warning: ignoring return value of function declared with %0 attribute</li>
+<li>warning: ignoring return value of function declared with %0 attribute</li>
+<li>warning: ignoring return value of function declared with %0 attribute: %1</li>
+<li>warning: ignoring temporary created by a constructor declared with %0 attribute</li>
+<li>warning: ignoring temporary created by a constructor declared with %0 attribute: %1</li>
+<li>warning: implicit declaration of function %0</li>
+<li>warning: implicitly declaring library function '%0' with type %1</li>
+<li>warning: incomplete format specifier</li>
+<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
+<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
+<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
+<li>warning: initializer order does not match the declaration order</li>
+<li>warning: invalid conversion specifier '%0'</li>
+<li>warning: invalid position specified for %select{field width|field precision}0</li>
+<li>warning: ivar %0 which backs the property is not referenced in this property's accessor</li>
+<li>warning: lambda capture %0 is not %select{used|required to be captured for this use}1</li>
+<li>warning: left operand of comma operator has no effect</li>
+<li>warning: length modifier '%0' results in undefined behavior or no effect with '%1' conversion specifier</li>
+<li>warning: logical not is only applied to the left hand side of this %select{comparison|bitwise operator}0</li>
+<li>warning: loop variable %0 %diff{of type $ binds to a temporary constructed from type $|binds to a temporary constructed from a different type}1,2</li>
+<li>warning: loop variable %0 creates a copy from type %1</li>
+<li>warning: method has no return type specified; defaults to 'id'</li>
+<li>warning: method override for the designated initializer of the superclass %objcinstance0 not found</li>
+<li>warning: method possibly missing a [super %0] call</li>
+<li>warning: misleading indentation; statement is not part of the previous '%select{if|else|for|while}0'</li>
+<li>warning: missing field %0 initializer</li>
+<li>warning: missing field %0 initializer</li>
+<li>warning: missing object format flag</li>
+<li>warning: more '%%' conversions than data arguments</li>
+<li>warning: moving a local object in a return statement prevents copy elision</li>
+<li>warning: moving a temporary object prevents copy elision</li>
+<li>warning: multi-character character constant</li>
+<li>warning: multi-line // comment</li>
+<li>warning: no closing ']' for '%%[' in scanf format string</li>
+<li>warning: non-void %select{function|method}1 %0 should return a value</li>
+<li>warning: non-void %select{function|method}1 %0 should return a value</li>
+<li>warning: non-void coroutine does not return a value</li>
+<li>warning: non-void coroutine does not return a value in all control paths</li>
+<li>warning: non-void function does not return a value</li>
+<li>warning: non-void function does not return a value in all control paths</li>
+<li>warning: non-void lambda does not return a value</li>
+<li>warning: non-void lambda does not return a value in all control paths</li>
+<li>warning: not packing field %0 as it is non-POD for the purposes of layout</li>
+<li>warning: null passed to a callee that requires a non-null argument</li>
+<li>warning: null returned from %select{function|method}0 that requires a non-null return value</li>
+<li>warning: object format flags cannot be used with '%0' conversion specifier</li>
+<li>warning: operator '%0' has lower precedence than '%1'; '%1' will be evaluated first</li>
+<li>warning: operator '?:' has lower precedence than '%0'; '%0' will be evaluated first</li>
+<li>warning: operator '?:' has lower precedence than '%0'; '%0' will be evaluated first</li>
+<li>warning: overflow converting case value to switch condition type (%0 to %1)</li>
+<li>warning: overlapping comparisons always evaluate to %select{false|true}0</li>
+<li>warning: overloaded operator %select{&gt;&gt;|&lt;&lt;}0 has higher precedence than comparison operator</li>
+<li>warning: parameter %0 set but not used</li>
+<li>warning: parameter %0 was not declared, defaults to 'int'; ISO C99 and later do not support implicit int</li>
+<li>warning: performing pointer arithmetic on a null pointer has undefined behavior%select{| if the offset is nonzero}0</li>
+<li>warning: performing pointer subtraction with a null pointer %select{has|may have}0 undefined behavior</li>
+<li>warning: position arguments in format strings start counting at 1 (not 0)</li>
+<li>warning: pragma STDC FENV_ROUND is not supported</li>
+<li>warning: pragma diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'</li>
+<li>warning: pragma diagnostic expected option name (e.g. "-Wundef")</li>
+<li>warning: pragma diagnostic pop could not pop, no matching push</li>
+<li>warning: pragma include_alias expected '%0'</li>
+<li>warning: pragma include_alias expected include filename</li>
+<li>warning: private field %0 is not used</li>
+<li>warning: redundant move in return statement</li>
+<li>warning: reference %0 is not yet bound to a value when used here</li>
+<li>warning: reference %0 is not yet bound to a value when used within its own initialization</li>
+<li>warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0</li>
+<li>warning: result of comparison of %select{constant %0|true|false}1 with %select{expression of type %2|boolean expression}3 is always %4</li>
+<li>warning: result of comparison of %select{constant %0|true|false}1 with %select{expression of type %2|boolean expression}3 is always %4</li>
+<li>warning: result of comparison of constant %0 with expression of type 'BOOL' is always %1, as the only well defined values for 'BOOL' are YES and NO</li>
+<li>warning: semicolon before method body is ignored</li>
+<li>warning: sizeof on array function parameter will return size of %0 instead of %1</li>
+<li>warning: sizeof on pointer operation will return size of %0 instead of %1</li>
+<li>warning: static variable %0 is suspiciously used within its own initialization</li>
+<li>warning: suggest braces around initialization of subobject</li>
+<li>warning: suspicious concatenation of string literals in an array initialization; did you mean to separate the elements with a comma?</li>
+<li>warning: switch condition has boolean value</li>
+<li>warning: trigraph converted to '%0' character</li>
+<li>warning: trigraph ends block comment</li>
+<li>warning: trigraph ignored</li>
+<li>warning: type specifier missing, defaults to 'int'</li>
+<li>warning: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int</li>
+<li>warning: unexpected token in pragma diagnostic</li>
+<li>warning: unknown pragma ignored</li>
+<li>warning: unknown pragma in STDC namespace</li>
+<li>warning: unused %select{typedef|type alias}0 %1</li>
+<li>warning: unused function %0</li>
+<li>warning: unused label %0</li>
+<li>warning: unused parameter %0</li>
+<li>warning: unused variable %0</li>
+<li>warning: unused variable %0</li>
+<li>warning: use of __private_extern__ on a declaration may not produce external symbol private to the linkage unit and is deprecated</li>
+<li>warning: use of bitwise '%0' with boolean operands</li>
+<li>warning: use of unknown builtin %0</li>
+<li>warning: using '%%P' format specifier with an Objective-C pointer results in dumping runtime object structure, not object value</li>
+<li>warning: using '%%P' format specifier without precision</li>
+<li>warning: using '%0' format specifier annotation outside of os_log()/os_trace()</li>
+<li>warning: using '%0' format specifier, but argument has boolean value</li>
+<li>warning: using the result of an assignment as a condition without parentheses</li>
+<li>warning: variable %0 is %select{decremented|incremented}1 both in the loop header and in the loop body</li>
+<li>warning: variable %0 is %select{used|captured}1 uninitialized whenever %select{'%3' condition is %select{true|false}4|'%3' loop %select{is entered|exits because its condition is false}4|'%3' loop %select{condition is true|exits because its condition is false}4|switch %3 is taken|its declaration is reached|%3 is called}2</li>
+<li>warning: variable %0 is uninitialized when %select{used here|captured by block}1</li>
+<li>warning: variable %0 is uninitialized when passed as a const reference argument here</li>
+<li>warning: variable %0 is uninitialized when used within its own initialization</li>
+<li>warning: variable %0 set but not used</li>
+<li>warning: variable length arrays in C++ are a Clang extension</li>
+<li>warning: variable length arrays in C++ are a Clang extension</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
+<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
+<li>warning: variable%select{s| %1|s %1 and %2|s %1, %2, and %3|s %1, %2, %3, and %4}0 used in loop condition not modified in loop body</li>
+<li>warning: zero field width in scanf format string is unused</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wCL4" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-clang-cl-pch</key>
@@ -23035,6 +23989,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>CRITICAL</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-cmse-union-leak</key>
+    <name>clang-diagnostic-cmse-union-leak</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: passing union across security boundary via %select{parameter %1|return value}0 may leak information</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcmse-union-leak" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-comma</key>
+    <name>clang-diagnostic-comma</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: possible misuse of comma operator here</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcomma" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-comment</key>
     <name>clang-diagnostic-comment</name>
     <description>
@@ -23047,6 +24027,22 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcomment" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-comments</key>
+    <name>clang-diagnostic-comments</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '/*' within block comment</li>
+<li>warning: // comments are not allowed in this language</li>
+<li>warning: escaped newline between */ characters at block comment end</li>
+<li>warning: multi-line // comment</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcomments" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -23075,6 +24071,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcompletion-handler" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-complex-component-init</key>
+    <name>clang-diagnostic-complex-component-init</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: complex initialization specifying real and imaginary components is an extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcomplex-component-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -23119,6 +24128,45 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-concepts-ts-compat</key>
+    <name>clang-diagnostic-concepts-ts-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++20 does not permit the 'bool' keyword after 'concept'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconcepts-ts-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-conditional-type-mismatch</key>
+    <name>clang-diagnostic-conditional-type-mismatch</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: pointer/integer type mismatch in conditional expression%diff{ ($ and $)|}0,1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconditional-type-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-conditional-uninitialized</key>
+    <name>clang-diagnostic-conditional-uninitialized</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: variable %0 may be uninitialized when %select{used here|captured by block}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconditional-uninitialized" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-config-macros</key>
     <name>clang-diagnostic-config-macros</name>
     <description>
@@ -23144,6 +24192,45 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconstant-conversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-constant-evaluated</key>
+    <name>clang-diagnostic-constant-evaluated</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' will always evaluate to 'true' in a manifestly constant-evaluated expression</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconstant-evaluated" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-constant-logical-operand</key>
+    <name>clang-diagnostic-constant-logical-operand</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: use of logical '%0' with constant operand</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconstant-logical-operand" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-constexpr-not-const</key>
+    <name>clang-diagnostic-constexpr-not-const</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconstexpr-not-const" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -23230,6 +24317,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>CRITICAL</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-conversion-null</key>
+    <name>clang-diagnostic-conversion-null</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion of %select{NULL|nullptr}0 constant to %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconversion-null" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-coro-non-aligned-allocation-function</key>
     <name>clang-diagnostic-coro-non-aligned-allocation-function</name>
     <description>
@@ -23286,6 +24386,45 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-cpp</key>
+    <name>clang-diagnostic-cpp</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcpp" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-cstring-format-directive</key>
+    <name>clang-diagnostic-cstring-format-directive</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: using %0 directive in %select{NSString|CFString}1 which is being passed as a formatting argument to the formatting %select{method|CFfunction}2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcstring-format-directive" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-ctad-maybe-unsupported</key>
+    <name>clang-diagnostic-ctad-maybe-unsupported</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 may not intend to support class template argument deduction</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wctad-maybe-unsupported" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-ctu</key>
     <name>clang-diagnostic-ctu</name>
     <description>
@@ -23316,20 +24455,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-unknown-cuda-version</key>
-    <name>clang-diagnostic-unknown-cuda-version</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: CUDA version %0 is only partially supported</li>
-<li>warning: CUDA version%0 is newer than the latest%select{| partially}1 supported version %2</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-cuda-version" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-custom-atomic-properties</key>
     <name>clang-diagnostic-custom-atomic-properties</name>
     <description>
@@ -23343,15 +24468,15 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-dxil-validation</key>
-    <name>clang-diagnostic-dxil-validation</name>
+    <key>clang-diagnostic-cxx-attribute-extension</key>
+    <name>clang-diagnostic-cxx-attribute-extension</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: dxv not found; resulting DXIL will not be validated or signed for use in release environment</li>
+<li>warning: ISO C++ does not allow %select{an attribute list|%0}1 to appear here</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdxil-validation" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcxx-attribute-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -23464,6 +24589,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-darwin-sdk-settings</key>
+    <name>clang-diagnostic-darwin-sdk-settings</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: SDK settings were ignored as 'SDKSettings.json' could not be parsed</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdarwin-sdk-settings" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-date-time</key>
+    <name>clang-diagnostic-date-time</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: expansion of date or time macro is not reproducible</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdate-time" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-dealloc-in-category</key>
     <name>clang-diagnostic-dealloc-in-category</name>
     <description>
@@ -23473,6 +24624,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdealloc-in-category" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-debug-compression-unavailable</key>
+    <name>clang-diagnostic-debug-compression-unavailable</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: cannot compress debug sections (%0 not enabled)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdebug-compression-unavailable" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -23501,6 +24665,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdefaulted-function-deleted" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-delayed-template-parsing-in-cxx20</key>
+    <name>clang-diagnostic-delayed-template-parsing-in-cxx20</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: -fdelayed-template-parsing is deprecated after C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdelayed-template-parsing-in-cxx20" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -23572,6 +24749,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-delimited-escape-sequence-extension</key>
+    <name>clang-diagnostic-delimited-escape-sequence-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{delimited|named}0 escape sequences are a %select{Clang|C++23}1 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdelimited-escape-sequence-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecate-lax-vec-conv-all</key>
+    <name>clang-diagnostic-deprecate-lax-vec-conv-all</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit conversion between vector types ('%0' and '%1') is deprecated; in the future, the behavior implied by '-fno-lax-vector-conversions' will be the default</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecate-lax-vec-conv-all" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-deprecated</key>
     <name>clang-diagnostic-deprecated</name>
     <description>
@@ -23626,6 +24829,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecated-altivec-src-compat</key>
+    <name>clang-diagnostic-deprecated-altivec-src-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: current handling of vector bool and vector pixel types in this context are deprecated; the default behaviour will soon change to that implied by the '-altivec-compat=xl' option</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-altivec-src-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -23707,6 +24923,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-copy" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecated-copy-dtor</key>
+    <name>clang-diagnostic-deprecated-copy-dtor</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared destructor</li>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided destructor</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-copy-dtor" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -23940,19 +25170,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-deprecated-ofast</key>
-    <name>clang-diagnostic-deprecated-ofast</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-ofast" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-deprecated-objc-isa-usage</key>
     <name>clang-diagnostic-deprecated-objc-isa-usage</name>
     <description>
@@ -23963,6 +25180,46 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-objc-isa-usage" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecated-objc-pointer-introspection</key>
+    <name>clang-diagnostic-deprecated-objc-pointer-introspection</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: bitmasking for introspection of Objective-C object pointers is strongly discouraged</li>
+<li>warning: bitmasking for introspection of Objective-C object pointers is strongly discouraged</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-objc-pointer-introspection" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecated-objc-pointer-introspection-performSelector</key>
+    <name>clang-diagnostic-deprecated-objc-pointer-introspection-performSelector</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: bitmasking for introspection of Objective-C object pointers is strongly discouraged</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-objc-pointer-introspection-performSelector" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecated-ofast</key>
+    <name>clang-diagnostic-deprecated-ofast</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-ofast" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -24076,6 +25333,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-direct-ivar-access</key>
+    <name>clang-diagnostic-direct-ivar-access</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: instance variable %0 is being directly accessed</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdirect-ivar-access" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-disabled-macro-expansion</key>
+    <name>clang-diagnostic-disabled-macro-expansion</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: disabled expansion of recursive macro</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdisabled-macro-expansion" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-distributed-object-modifiers</key>
     <name>clang-diagnostic-distributed-object-modifiers</name>
     <description>
@@ -24086,6 +25369,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdistributed-object-modifiers" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-div-by-zero</key>
+    <name>clang-diagnostic-div-by-zero</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{remainder|division}0 by zero is undefined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdiv-by-zero" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -24103,6 +25399,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-dll-attribute-on-redeclaration</key>
+    <name>clang-diagnostic-dll-attribute-on-redeclaration</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: redeclaration of %q0 should not add %q1 attribute</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdll-attribute-on-redeclaration" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-dllexport-explicit-instantiation-decl</key>
     <name>clang-diagnostic-dllexport-explicit-instantiation-decl</name>
     <description>
@@ -24112,6 +25421,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdllexport-explicit-instantiation-decl" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-dllimport-static-field-def</key>
+    <name>clang-diagnostic-dllimport-static-field-def</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: definition of dllimport static field</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdllimport-static-field-def" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -24211,6 +25533,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-dollar-in-identifier-extension</key>
+    <name>clang-diagnostic-dollar-in-identifier-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '$' in identifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdollar-in-identifier-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-double-promotion</key>
     <name>clang-diagnostic-double-promotion</name>
     <description>
@@ -24239,17 +25574,17 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-duplicate-method-arg</key>
-    <name>clang-diagnostic-duplicate-method-arg</name>
+    <key>clang-diagnostic-dtor-typedef</key>
+    <name>clang-diagnostic-dtor-typedef</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: redeclaration of method parameter %0</li>
+<li>warning: destructor cannot be declared using a %select{typedef|type alias}1 %0 of the class name</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-method-arg" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdtor-typedef" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
-    <severity>INFO</severity>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-duplicate-decl-specifier</key>
@@ -24264,6 +25599,71 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-decl-specifier" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-duplicate-enum</key>
+    <name>clang-diagnostic-duplicate-enum</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: element %0 has been implicitly assigned %1 which another element has been assigned</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-enum" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-duplicate-method-arg</key>
+    <name>clang-diagnostic-duplicate-method-arg</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: redeclaration of method parameter %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-method-arg" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-duplicate-method-match</key>
+    <name>clang-diagnostic-duplicate-method-match</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: multiple declarations of method %0 found and ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-method-match" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-duplicate-protocol</key>
+    <name>clang-diagnostic-duplicate-protocol</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: duplicate protocol definition of %0 is ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-protocol" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-dxil-validation</key>
+    <name>clang-diagnostic-dxil-validation</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: dxv not found; resulting DXIL will not be validated or signed for use in release environment</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdxil-validation" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -24295,6 +25695,71 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>CRITICAL</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-eager-load-cxx-named-modules</key>
+    <name>clang-diagnostic-eager-load-cxx-named-modules</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: the form '-fmodule-file=&lt;BMI-path&gt;' is deprecated for standard C++ named modules;consider to use '-fmodule-file=&lt;module-name&gt;=&lt;BMI-path&gt;' instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#weager-load-cxx-named-modules" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-effc++</key>
+    <name>clang-diagnostic-effc++</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 has virtual functions but non-virtual destructor</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#weffc-" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-elaborated-enum-base</key>
+    <name>clang-diagnostic-elaborated-enum-base</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: non-defining declaration of enumeration with a fixed underlying type is only permitted as a standalone declaration%select{|; missing list of enumerators?}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#welaborated-enum-base" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-elaborated-enum-class</key>
+    <name>clang-diagnostic-elaborated-enum-class</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: reference to enumeration must use 'enum' not 'enum %select{struct|class}0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#welaborated-enum-class" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-embedded-directive</key>
+    <name>clang-diagnostic-embedded-directive</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: embedding a directive within macro arguments has undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wembedded-directive" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-empty-body</key>
     <name>clang-diagnostic-empty-body</name>
     <description>
@@ -24312,6 +25777,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-empty-decomposition</key>
+    <name>clang-diagnostic-empty-decomposition</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++17 does not allow a decomposition group to be empty</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wempty-decomposition" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-empty-init-stmt</key>
     <name>clang-diagnostic-empty-init-stmt</name>
     <description>
@@ -24321,6 +25799,46 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wempty-init-stmt" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-empty-translation-unit</key>
+    <name>clang-diagnostic-empty-translation-unit</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C requires a translation unit to contain at least one declaration</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wempty-translation-unit" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-encode-type</key>
+    <name>clang-diagnostic-encode-type</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: encoding of %0 type is incomplete because %1 component has unknown encoding</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wencode-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-endif-labels</key>
+    <name>clang-diagnostic-endif-labels</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: extra tokens at end of #%0 directive</li>
+<li>warning: extra tokens at the end of '#pragma omp %0' are ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wendif-labels" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -24365,6 +25883,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wenum-compare-switch" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-enum-constexpr-conversion</key>
+    <name>clang-diagnostic-enum-constexpr-conversion</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: integer value %0 is outside the valid range of values [%1, %2] for the enumeration type %3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wenum-constexpr-conversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-enum-conversion</key>
@@ -24459,6 +25990,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-excessive-regsave</key>
+    <name>clang-diagnostic-excessive-regsave</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{interrupt service routine|function with attribute 'no_caller_saved_registers'}0 should only call a function with attribute 'no_caller_saved_registers' or be compiled with '-mgeneral-regs-only'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexcessive-regsave" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-exit-time-destructors</key>
     <name>clang-diagnostic-exit-time-destructors</name>
     <description>
@@ -24486,6 +26030,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-experimental-header-units</key>
+    <name>clang-diagnostic-experimental-header-units</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: the implementation of header units is in an experimental phase</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexperimental-header-units" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-explicit-initialize-call</key>
     <name>clang-diagnostic-explicit-initialize-call</name>
     <description>
@@ -24496,6 +26053,32 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexplicit-initialize-call" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-explicit-ownership-type</key>
+    <name>clang-diagnostic-explicit-ownership-type</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: method parameter of type %0 with no explicit ownership</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexplicit-ownership-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-explicit-specialization-storage-class</key>
+    <name>clang-diagnostic-explicit-specialization-storage-class</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: explicit specialization cannot have a storage class</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexplicit-specialization-storage-class" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -24514,15 +26097,15 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-explicit-specialization-storage-class</key>
-    <name>clang-diagnostic-explicit-specialization-storage-class</name>
+    <key>clang-diagnostic-export-using-directive</key>
+    <name>clang-diagnostic-export-using-directive</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: explicit specialization cannot have a storage class</li>
+<li>warning: ISO C++20 does not permit using directive to be exported</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexplicit-specialization-storage-class" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexport-using-directive" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -24536,6 +26119,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextern-c-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-extern-initializer</key>
+    <name>clang-diagnostic-extern-initializer</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'extern' variable has an initializer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextern-initializer" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -24574,6 +26170,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextra" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-extra-qualification</key>
+    <name>clang-diagnostic-extra-qualification</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: extra qualification on member %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextra-qualification" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-extra-semi</key>
@@ -24633,19 +26242,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-fuse-ld-path</key>
-    <name>clang-diagnostic-fuse-ld-path</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '-fuse-ld=' taking a path is deprecated; use '--ld-path=' instead</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfuse-ld-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-final-dtor-non-final-class</key>
     <name>clang-diagnostic-final-dtor-non-final-class</name>
     <description>
@@ -24668,6 +26264,32 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfinal-macro" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-fixed-enum-extension</key>
+    <name>clang-diagnostic-fixed-enum-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: enumeration types with a fixed underlying type are a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfixed-enum-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-fixed-point-overflow</key>
+    <name>clang-diagnostic-fixed-point-overflow</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: overflow in expression; result is %0 with type %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfixed-point-overflow" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -24711,6 +26333,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfloat-conversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-float-equal</key>
+    <name>clang-diagnostic-float-equal</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: comparing floating point with == or != is unsafe</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfloat-equal" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -24806,20 +26441,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-format=2</key>
-    <name>clang-diagnostic-format=2</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: format string is not a string literal</li>
-<li>warning: format string is not a string literal (potentially insecure)</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat=2" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-format-extra-args</key>
     <name>clang-diagnostic-format-extra-args</name>
     <description>
@@ -24859,19 +26480,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-format-nonliteral</key>
-    <name>clang-diagnostic-format-nonliteral</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: format string is not a string literal</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-nonliteral" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-format-non-iso</key>
     <name>clang-diagnostic-format-non-iso</name>
     <description>
@@ -24883,6 +26491,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-non-iso" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-format-nonliteral</key>
+    <name>clang-diagnostic-format-nonliteral</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: format string is not a string literal</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-nonliteral" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -25007,6 +26628,20 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-format=2</key>
+    <name>clang-diagnostic-format=2</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: format string is not a string literal</li>
+<li>warning: format string is not a string literal (potentially insecure)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat=2" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-fortify-source</key>
     <name>clang-diagnostic-fortify-source</name>
     <description>
@@ -25023,20 +26658,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfortify-source" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-receiver-forward-class</key>
-    <name>clang-diagnostic-receiver-forward-class</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: receiver %0 is a forward class and corresponding @interface may not exist</li>
-<li>warning: receiver type %0 for instance message is a forward declaration</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreceiver-forward-class" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -25067,28 +26688,30 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-atimport-in-framework-header</key>
-    <name>clang-diagnostic-atimport-in-framework-header</name>
+    <key>clang-diagnostic-frame-larger-than</key>
+    <name>clang-diagnostic-frame-larger-than</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: use of '@import' in framework header is discouraged, including this header requires -fmodules</li>
+<li>warning: %0</li>
+<li>warning: stack frame size (%0) exceeds limit (%1) in '%2'</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watimport-in-framework-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wframe-larger-than" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-quoted-include-in-framework-header</key>
-    <name>clang-diagnostic-quoted-include-in-framework-header</name>
+    <key>clang-diagnostic-frame-larger-than=</key>
+    <name>clang-diagnostic-frame-larger-than=</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: double-quoted include "%0" in framework header, expected angle-bracketed instead</li>
+<li>warning: %0</li>
+<li>warning: stack frame size (%0) exceeds limit (%1) in '%2'</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wquoted-include-in-framework-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wframe-larger-than=" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -25115,6 +26738,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfree-nonheap-object" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-friend-enum</key>
+    <name>clang-diagnostic-friend-enum</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: elaborated enum specifier cannot be declared as a friend</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfriend-enum" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -25165,6 +26801,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-fuse-ld-path</key>
+    <name>clang-diagnostic-fuse-ld-path</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '-fuse-ld=' taking a path is deprecated; use '--ld-path=' instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfuse-ld-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-future-attribute-extensions</key>
     <name>clang-diagnostic-future-attribute-extensions</name>
     <description>
@@ -25181,16 +26830,66 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-write-strings</key>
-    <name>clang-diagnostic-write-strings</name>
+    <key>clang-diagnostic-gcc-compat</key>
+    <name>clang-diagnostic-gcc-compat</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: ISO C++11 does not allow conversion from string literal to %0</li>
-<li>warning: conversion from string literal to %0 is deprecated</li>
+<li>warning: '%0' is bound to current loop, GCC binds it to the enclosing loop</li>
+<li>warning: 'break' is bound to loop, GCC binds it to switch</li>
+<li>warning: 'diagnose_if' is a clang extension</li>
+<li>warning: 'enable_if' is a clang extension</li>
+<li>warning: GCC does not allow %0 attribute in this position on a function definition</li>
+<li>warning: GCC does not allow an attribute in this position on a function declaration</li>
+<li>warning: GCC does not allow the %0 attribute to be written on a type</li>
+<li>warning: GCC does not allow the 'cleanup' attribute argument to be anything other than a simple identifier</li>
+<li>warning: GCC does not allow variable declarations in for loop initializers before C99</li>
+<li>warning: GCC requires a function with the %0 attribute to be variadic</li>
+<li>warning: __final is a GNU extension, consider using C++11 final</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wwrite-strings" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgcc-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-generic-type-extension</key>
+    <name>clang-diagnostic-generic-type-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: passing a type argument as the first operand to '_Generic' is a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgeneric-type-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-global-constructors</key>
+    <name>clang-diagnostic-global-constructors</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration requires a global constructor</li>
+<li>warning: declaration requires a global destructor</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wglobal-constructors" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-global-isel</key>
+    <name>clang-diagnostic-global-isel</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: -fglobal-isel support for the '%0' architecture is incomplete</li>
+<li>warning: -fglobal-isel support is incomplete for this architecture at the current optimization level</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wglobal-isel" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -25274,6 +26973,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-anonymous-struct" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-gnu-array-member-paren-init</key>
+    <name>clang-diagnostic-gnu-array-member-paren-init</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: parenthesized initialization of a member array is a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-array-member-paren-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-gnu-auto-type</key>
@@ -25464,6 +27176,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-gnu-inline-cpp-without-extern</key>
+    <name>clang-diagnostic-gnu-inline-cpp-without-extern</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'gnu_inline' attribute without 'extern' in C++ treated as externally available, this changed in Clang 10</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-inline-cpp-without-extern" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-gnu-label-as-value</key>
     <name>clang-diagnostic-gnu-label-as-value</name>
     <description>
@@ -25650,66 +27375,54 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-gcc-compat</key>
-    <name>clang-diagnostic-gcc-compat</name>
+    <key>clang-diagnostic-gpu-maybe-wrong-side</key>
+    <name>clang-diagnostic-gpu-maybe-wrong-side</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: '%0' is bound to current loop, GCC binds it to the enclosing loop</li>
-<li>warning: 'break' is bound to loop, GCC binds it to switch</li>
-<li>warning: 'diagnose_if' is a clang extension</li>
-<li>warning: 'enable_if' is a clang extension</li>
-<li>warning: GCC does not allow %0 attribute in this position on a function definition</li>
-<li>warning: GCC does not allow an attribute in this position on a function declaration</li>
-<li>warning: GCC does not allow the %0 attribute to be written on a type</li>
-<li>warning: GCC does not allow the 'cleanup' attribute argument to be anything other than a simple identifier</li>
-<li>warning: GCC does not allow variable declarations in for loop initializers before C99</li>
-<li>warning: GCC requires a function with the %0 attribute to be variadic</li>
-<li>warning: __final is a GNU extension, consider using C++11 final</li>
+<li>warning: capture host side class data member by this pointer in device or host device lambda function may result in invalid memory access if this pointer is not accessible on device side</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgcc-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgpu-maybe-wrong-side" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-global-constructors</key>
-    <name>clang-diagnostic-global-constructors</name>
+    <key>clang-diagnostic-header-guard</key>
+    <name>clang-diagnostic-header-guard</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: declaration requires a global constructor</li>
-<li>warning: declaration requires a global destructor</li>
+<li>warning: %0 is used as a header guard here, followed by #define of a different macro</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wglobal-constructors" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wheader-guard" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-global-isel</key>
-    <name>clang-diagnostic-global-isel</name>
+    <key>clang-diagnostic-header-hygiene</key>
+    <name>clang-diagnostic-header-hygiene</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: -fglobal-isel support for the '%0' architecture is incomplete</li>
-<li>warning: -fglobal-isel support is incomplete for this architecture at the current optimization level</li>
+<li>warning: using namespace directive in global context in header</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wglobal-isel" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wheader-hygiene" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-hip-only</key>
-    <name>clang-diagnostic-hip-only</name>
+    <key>clang-diagnostic-higher-precision-fp</key>
+    <name>clang-diagnostic-higher-precision-fp</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: '%0' is ignored since it is only supported for HIP</li>
+<li>warning: higher precision floating-point type size has the same size than floating-point type size</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whip-only" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whigher-precision-fp" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -25725,6 +27438,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whip-omp-target-directives" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-hip-only</key>
+    <name>clang-diagnostic-hip-only</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' is ignored since it is only supported for HIP</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whip-only" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-hlsl-availability</key>
@@ -25754,28 +27480,15 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-mix-packoffset</key>
-    <name>clang-diagnostic-mix-packoffset</name>
+    <key>clang-diagnostic-idiomatic-parentheses</key>
+    <name>clang-diagnostic-idiomatic-parentheses</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: cannot mix packoffset elements with nonpackoffset elements in a cbuffer</li>
+<li>warning: using the result of an assignment as a condition without parentheses</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmix-packoffset" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-header-hygiene</key>
-    <name>clang-diagnostic-header-hygiene</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: using namespace directive in global context in header</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wheader-hygiene" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#widiomatic-parentheses" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -25877,6 +27590,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-attributes" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-ignored-availability-without-sdk-settings</key>
+    <name>clang-diagnostic-ignored-availability-without-sdk-settings</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 availability is ignored without a valid 'SDKSettings.json' in the SDK</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-availability-without-sdk-settings" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -26087,6 +27813,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-implicit-exception-spec-mismatch</key>
+    <name>clang-diagnostic-implicit-exception-spec-mismatch</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: function previously declared with an %select{explicit|implicit}0 exception specification redeclared with an %select{implicit|explicit}0 exception specification</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-exception-spec-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-implicit-fallthrough</key>
     <name>clang-diagnostic-implicit-fallthrough</name>
     <description>
@@ -26206,6 +27945,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-implicit-retain-self</key>
+    <name>clang-diagnostic-implicit-retain-self</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-retain-self" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-implicitly-unsigned-literal</key>
     <name>clang-diagnostic-implicitly-unsigned-literal</name>
     <description>
@@ -26215,6 +27967,71 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicitly-unsigned-literal" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-import-preprocessor-directive-pedantic</key>
+    <name>clang-diagnostic-import-preprocessor-directive-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #import is a language extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimport-preprocessor-directive-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-inaccessible-base</key>
+    <name>clang-diagnostic-inaccessible-base</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: direct base %0 is inaccessible due to ambiguity:%1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winaccessible-base" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-include-angled-in-module-purview</key>
+    <name>clang-diagnostic-include-angled-in-module-purview</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '#include &lt;filename&gt;' attaches the declarations to the named module '%0', which is not usually intended; consider moving that directive before the module declaration</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winclude-angled-in-module-purview" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-include-next-absolute-path</key>
+    <name>clang-diagnostic-include-next-absolute-path</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #include_next in file found relative to primary source file or found by absolute path; will search from start of include path</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winclude-next-absolute-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-include-next-outside-header</key>
+    <name>clang-diagnostic-include-next-outside-header</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #include_next in primary source file; will search from start of include path</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winclude-next-outside-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -26244,6 +28061,32 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-function-pointer-types" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-incompatible-function-pointer-types-strict</key>
+    <name>clang-diagnostic-incompatible-function-pointer-types-strict</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: incompatible function pointer types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-function-pointer-types-strict" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-incompatible-library-redeclaration</key>
+    <name>clang-diagnostic-incompatible-library-redeclaration</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: incompatible redeclaration of library function %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-library-redeclaration" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-incompatible-ms-pragma-section</key>
@@ -26305,6 +28148,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-incompatible-property-type</key>
+    <name>clang-diagnostic-incompatible-property-type</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: property type %0 is incompatible with type %1 inherited from %2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-property-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-incompatible-sysroot</key>
+    <name>clang-diagnostic-incompatible-sysroot</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: using sysroot for '%0' but targeting '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-sysroot" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-incomplete-framework-module-declaration</key>
     <name>clang-diagnostic-incomplete-framework-module-declaration</name>
     <description>
@@ -26314,6 +28183,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincomplete-framework-module-declaration" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-incomplete-implementation</key>
+    <name>clang-diagnostic-incomplete-implementation</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: method definition for %0 not found</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincomplete-implementation" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -26335,6 +28217,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-incomplete-setjmp-declaration</key>
+    <name>clang-diagnostic-incomplete-setjmp-declaration</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration of built-in function '%0' requires the declaration of the 'jmp_buf' type, commonly provided in the header &lt;setjmp.h&gt;</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincomplete-setjmp-declaration" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-incomplete-umbrella</key>
     <name>clang-diagnostic-incomplete-umbrella</name>
     <description>
@@ -26346,6 +28241,46 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincomplete-umbrella" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-inconsistent-dllimport</key>
+    <name>clang-diagnostic-inconsistent-dllimport</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %q0 redeclared without %1 attribute: previous %1 ignored</li>
+<li>warning: %q0 redeclared without 'dllimport' attribute: 'dllexport' attribute added</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winconsistent-dllimport" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-inconsistent-missing-destructor-override</key>
+    <name>clang-diagnostic-inconsistent-missing-destructor-override</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %sub{warn_destructor_marked_not_override_overriding}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winconsistent-missing-destructor-override" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-inconsistent-missing-override</key>
+    <name>clang-diagnostic-inconsistent-missing-override</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %sub{warn_function_marked_not_override_overriding}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winconsistent-missing-override" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -26406,6 +28341,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>CRITICAL</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-injected-class-name</key>
+    <name>clang-diagnostic-injected-class-name</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++ specifies that qualified reference to %0 is a constructor name rather than a %select{template name|type}1 in this context, despite preceding %select{'typename'|'template'}2 keyword</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winjected-class-name" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-inline-asm</key>
+    <name>clang-diagnostic-inline-asm</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winline-asm" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-inline-namespace-reopened-noninline</key>
     <name>clang-diagnostic-inline-namespace-reopened-noninline</name>
     <description>
@@ -26415,6 +28376,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winline-namespace-reopened-noninline" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-inline-new-delete</key>
+    <name>clang-diagnostic-inline-new-delete</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: replacement function %0 cannot be declared 'inline'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winline-new-delete" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -26444,6 +28418,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-instantiation-after-specialization</key>
+    <name>clang-diagnostic-instantiation-after-specialization</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: explicit instantiation of %0 that occurs after an explicit specialization has no effect</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winstantiation-after-specialization" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-int-conversion</key>
     <name>clang-diagnostic-int-conversion</name>
     <description>
@@ -26454,6 +28441,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wint-conversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-int-conversions</key>
+    <name>clang-diagnostic-int-conversions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: incompatible integer to pointer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+<li>warning: incompatible pointer to integer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wint-conversions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>CRITICAL</severity>
     </rule>
@@ -26499,6 +28500,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-integer-overflow</key>
+    <name>clang-diagnostic-integer-overflow</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: overflow in expression; result is %0 with type %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winteger-overflow" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-interrupt-service-routine</key>
+    <name>clang-diagnostic-interrupt-service-routine</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: interrupt service routine should only call a function with attribute 'no_caller_saved_registers'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winterrupt-service-routine" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-invalid-command-line-argument</key>
     <name>clang-diagnostic-invalid-command-line-argument</name>
     <description>
@@ -26524,6 +28551,59 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-invalid-constexpr</key>
+    <name>clang-diagnostic-invalid-constexpr</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{constexpr|consteval}1 %select{function|constructor}0 never produces a constant expression</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-constexpr" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-invalid-feature-combination</key>
+    <name>clang-diagnostic-invalid-feature-combination</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: invalid feature combination: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-feature-combination" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-invalid-iboutlet</key>
+    <name>clang-diagnostic-invalid-iboutlet</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{instance variable|property}2 with %0 attribute must be an object type (invalid %1)</li>
+<li>warning: IBOutletCollection properties should be copy/strong and not assign</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-iboutlet" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-invalid-initializer-from-system-header</key>
+    <name>clang-diagnostic-invalid-initializer-from-system-header</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: invalid constructor from class in system header, should not be explicit</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-initializer-from-system-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-invalid-ios-deployment-target</key>
     <name>clang-diagnostic-invalid-ios-deployment-target</name>
     <description>
@@ -26535,6 +28615,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-ios-deployment-target" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-invalid-no-builtin-names</key>
+    <name>clang-diagnostic-invalid-no-builtin-names</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' is not a valid builtin name for %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-no-builtin-names" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-invalid-noreturn</key>
@@ -26578,6 +28671,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-invalid-partial-specialization</key>
+    <name>clang-diagnostic-invalid-partial-specialization</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{class|variable}0 template partial specialization is not more specialized than the primary template</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-partial-specialization" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-invalid-pp-token</key>
     <name>clang-diagnostic-invalid-pp-token</name>
     <description>
@@ -26606,15 +28712,80 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-knr-promoted-parameter</key>
-    <name>clang-diagnostic-knr-promoted-parameter</name>
+    <key>clang-diagnostic-invalid-static-assert-message</key>
+    <name>clang-diagnostic-invalid-static-assert-message</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %diff{promoted type $ of K&amp;R function parameter is not compatible with the parameter type $|promoted type of K&amp;R function parameter is not compatible with parameter type}0,1 declared in a previous prototype</li>
+<li>warning: the message in this static assertion is not a constant expression</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wknr-promoted-parameter" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-static-assert-message" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-invalid-token-paste</key>
+    <name>clang-diagnostic-invalid-token-paste</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: pasting formed '%0', an invalid preprocessing token</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-token-paste" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-invalid-unevaluated-string</key>
+    <name>clang-diagnostic-invalid-unevaluated-string</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: encoding prefix '%0' on an unevaluated string literal has no effect%select{| and is incompatible with c++2c}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-unevaluated-string" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-invalid-utf8</key>
+    <name>clang-diagnostic-invalid-utf8</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: invalid UTF-8 in comment</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-utf8" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-jump-seh-finally</key>
+    <name>clang-diagnostic-jump-seh-finally</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: jump out of __finally block has undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wjump-seh-finally" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-keyword-compat</key>
+    <name>clang-diagnostic-keyword-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: keyword '%0' will be made available as an identifier %select{here|for the remainder of the translation unit}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wkeyword-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -26632,15 +28803,41 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-keyword-compat</key>
-    <name>clang-diagnostic-keyword-compat</name>
+    <key>clang-diagnostic-knl-knm-isa-support-removed</key>
+    <name>clang-diagnostic-knl-knm-isa-support-removed</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: keyword '%0' will be made available as an identifier %select{here|for the remainder of the translation unit}1</li>
+<li>warning: KNL, KNM related Intel Xeon Phi CPU's specific ISA's supports will be removed in LLVM 19.</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wkeyword-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wknl-knm-isa-support-removed" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-knr-promoted-parameter</key>
+    <name>clang-diagnostic-knr-promoted-parameter</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %diff{promoted type $ of K&amp;R function parameter is not compatible with the parameter type $|promoted type of K&amp;R function parameter is not compatible with parameter type}0,1 declared in a previous prototype</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wknr-promoted-parameter" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-language-extension-token</key>
+    <name>clang-diagnostic-language-extension-token</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: extension used</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wlanguage-extension-token" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -26830,6 +29027,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-many-braces-around-scalar-init</key>
+    <name>clang-diagnostic-many-braces-around-scalar-init</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: too many braces around %select{scalar |}0initializer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmany-braces-around-scalar-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-mathematical-notation-identifier-extension</key>
+    <name>clang-diagnostic-mathematical-notation-identifier-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: mathematical notation character &lt;U+%0&gt; in an identifier is a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmathematical-notation-identifier-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-max-tokens</key>
     <name>clang-diagnostic-max-tokens</name>
     <description>
@@ -26870,33 +29093,15 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-objc-method-access</key>
-    <name>clang-diagnostic-objc-method-access</name>
+    <key>clang-diagnostic-memsize-comparison</key>
+    <name>clang-diagnostic-memsize-comparison</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: class method %objcclass0 not found (return type defaults to 'id')</li>
-<li>warning: class method %objcclass0 not found (return type defaults to 'id'); did you mean %objcclass2?</li>
-<li>warning: instance method %0 found instead of class method %1</li>
-<li>warning: instance method %0 is being used on 'Class' which is not in the root class</li>
-<li>warning: instance method %objcinstance0 not found (return type defaults to 'id')</li>
-<li>warning: instance method %objcinstance0 not found (return type defaults to 'id'); did you mean %objcinstance2?</li>
+<li>warning: size argument in %0 call is a comparison</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-method-access" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-duplicate-method-match</key>
-    <name>clang-diagnostic-duplicate-method-match</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: multiple declarations of method %0 found and ignored</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-method-match" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmemsize-comparison" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -27152,6 +29357,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-microsoft-exists</key>
+    <name>clang-diagnostic-microsoft-exists</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: dependent %select{__if_not_exists|__if_exists}0 declarations are ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-exists" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-microsoft-explicit-constructor-call</key>
     <name>clang-diagnostic-microsoft-explicit-constructor-call</name>
     <description>
@@ -27240,20 +29458,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-include" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-inconsistent-dllimport</key>
-    <name>clang-diagnostic-inconsistent-dllimport</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %q0 redeclared without %1 attribute: previous %1 ignored</li>
-<li>warning: %q0 redeclared without 'dllimport' attribute: 'dllexport' attribute added</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winconsistent-dllimport" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -27463,6 +29667,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-mismatched-new-delete</key>
+    <name>clang-diagnostic-mismatched-new-delete</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'delete%select{|[]}0' applied to a pointer that was allocated with 'new%select{[]|}0'; did you mean 'delete%select{[]|}0'?</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmismatched-new-delete" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-mismatched-parameter-types</key>
     <name>clang-diagnostic-mismatched-parameter-types</name>
     <description>
@@ -27516,6 +29733,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-missing-constinit</key>
+    <name>clang-diagnostic-missing-constinit</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'constinit' specifier missing on initializing declaration of %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-constinit" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-missing-declarations</key>
     <name>clang-diagnostic-missing-declarations</name>
     <description>
@@ -27541,6 +29771,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-designated-field-initializers" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-missing-exception-spec</key>
+    <name>clang-diagnostic-missing-exception-spec</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is missing exception specification '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-exception-spec" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -27585,6 +29828,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-missing-multilib</key>
+    <name>clang-diagnostic-missing-multilib</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: no multilib found matching flags: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-multilib" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-missing-noescape</key>
     <name>clang-diagnostic-missing-noescape</name>
     <description>
@@ -27612,6 +29868,84 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-missing-prototype-for-cc</key>
+    <name>clang-diagnostic-missing-prototype-for-cc</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: function with no prototype cannot use the %0 calling convention</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-prototype-for-cc" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-missing-prototypes</key>
+    <name>clang-diagnostic-missing-prototypes</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: no previous prototype for function %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-prototypes" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-missing-selector-name</key>
+    <name>clang-diagnostic-missing-selector-name</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 used as the name of the previous parameter rather than as part of the selector</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-selector-name" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-missing-sysroot</key>
+    <name>clang-diagnostic-missing-sysroot</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: no such sysroot directory: '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-sysroot" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-missing-template-arg-list-after-template-kw</key>
+    <name>clang-diagnostic-missing-template-arg-list-after-template-kw</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: a template argument list is expected after a name prefixed by the template keyword</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-template-arg-list-after-template-kw" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-missing-variable-declarations</key>
+    <name>clang-diagnostic-missing-variable-declarations</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: no previous extern declaration for non-static variable %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-variable-declarations" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-misspelled-assumption</key>
     <name>clang-diagnostic-misspelled-assumption</name>
     <description>
@@ -27621,6 +29955,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmisspelled-assumption" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-mix-packoffset</key>
+    <name>clang-diagnostic-mix-packoffset</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: cannot mix packoffset elements with nonpackoffset elements in a cbuffer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmix-packoffset" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -27655,6 +30002,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-module-file-config-mismatch</key>
+    <name>clang-diagnostic-module-file-config-mismatch</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: module file %0 cannot be loaded due to a configuration mismatch with the current compilation</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodule-file-config-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-module-file-extension</key>
     <name>clang-diagnostic-module-file-extension</name>
     <description>
@@ -27681,6 +30041,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-module-import-in-extern-c</key>
+    <name>clang-diagnostic-module-import-in-extern-c</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: import of C++ module '%0' appears within extern "C" language linkage specification</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodule-import-in-extern-c" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-module-include-translation</key>
     <name>clang-diagnostic-module-include-translation</name>
     <description>
@@ -27705,6 +30078,32 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rmodule-lock" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-modules-ambiguous-internal-linkage</key>
+    <name>clang-diagnostic-modules-ambiguous-internal-linkage</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ambiguous use of internal linkage declaration %0 defined in multiple modules</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodules-ambiguous-internal-linkage" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-modules-import-nested-redundant</key>
+    <name>clang-diagnostic-modules-import-nested-redundant</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: redundant #include of module '%0' appears within %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodules-import-nested-redundant" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-most</key>
@@ -27916,15 +30315,28 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-multichar</key>
-    <name>clang-diagnostic-multichar</name>
+    <key>clang-diagnostic-msvc-include</key>
+    <name>clang-diagnostic-msvc-include</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: multi-character character constant</li>
+<li>warning: #include resolved using non-portable Microsoft search rules as: %0</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmultichar" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmsvc-include" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-msvc-not-found</key>
+    <name>clang-diagnostic-msvc-not-found</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: unable to find a Visual Studio installation; try running Clang from a developer command prompt</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmsvc-not-found" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -27942,41 +30354,89 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-nsconsumed-mismatch</key>
-    <name>clang-diagnostic-nsconsumed-mismatch</name>
+    <key>clang-diagnostic-multichar</key>
+    <name>clang-diagnostic-multichar</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: overriding method has mismatched ns_consumed attribute on its parameter</li>
+<li>warning: multi-character character constant</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnsconsumed-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmultichar" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-nsreturns-mismatch</key>
-    <name>clang-diagnostic-nsreturns-mismatch</name>
+    <key>clang-diagnostic-multiple-move-vbase</key>
+    <name>clang-diagnostic-multiple-move-vbase</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: overriding method has mismatched ns_returns_%select{not_retained|retained}0 attributes</li>
+<li>warning: defaulted move assignment operator of %0 will move assign virtual base class %1 multiple times</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnsreturns-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmultiple-move-vbase" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-NSObject-attribute</key>
-    <name>clang-diagnostic-NSObject-attribute</name>
+    <key>clang-diagnostic-nan-infinity-disabled</key>
+    <name>clang-diagnostic-nan-infinity-disabled</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: 'NSObject' attribute may be put on a typedef only; attribute is ignored</li>
+<li>warning: use of %select{infinity|NaN}0%select{| via a macro}1 is undefined behavior due to the currently enabled floating-point options</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wNSObject-attribute" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnan-infinity-disabled" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-narrowing</key>
+    <name>clang-diagnostic-narrowing</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
+<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
+<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
+<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnarrowing" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-nested-anon-types</key>
+    <name>clang-diagnostic-nested-anon-types</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: anonymous types declared in an anonymous %select{struct|union}0 are an extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnested-anon-types" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-new-returns-null</key>
+    <name>clang-diagnostic-new-returns-null</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 should not return a null pointer unless it is declared 'throw()'%select{| or 'noexcept'}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnew-returns-null" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28019,6 +30479,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnoexcept-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-non-c-typedef-for-linkage</key>
+    <name>clang-diagnostic-non-c-typedef-for-linkage</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: anonymous non-C-compatible type given name for linkage purposes by %select{typedef|alias}0 declaration; add a tag name here</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnon-c-typedef-for-linkage" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28129,20 +30602,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-nonnull</key>
-    <name>clang-diagnostic-nonnull</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: null passed to a callee that requires a non-null argument</li>
-<li>warning: null returned from %select{function|method}0 that requires a non-null return value</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonnull" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-non-pod-varargs</key>
     <name>clang-diagnostic-non-pod-varargs</name>
     <description>
@@ -28159,15 +30618,15 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>CRITICAL</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-nontrivial-memaccess</key>
-    <name>clang-diagnostic-nontrivial-memaccess</name>
+    <key>clang-diagnostic-non-power-of-two-alignment</key>
+    <name>clang-diagnostic-non-power-of-two-alignment</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{destination for|source of|first operand of|second operand of}0 this %1 call is a pointer to record %2 that is not trivial to %select{primitive-default-initialize|primitive-copy}3</li>
+<li>warning: requested alignment is not a power of 2</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnontrivial-memaccess" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnon-power-of-two-alignment" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28181,6 +30640,137 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnon-virtual-dtor" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-nonnull</key>
+    <name>clang-diagnostic-nonnull</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: null passed to a callee that requires a non-null argument</li>
+<li>warning: null returned from %select{function|method}0 that requires a non-null return value</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonnull" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-nonportable-include-path</key>
+    <name>clang-diagnostic-nonportable-include-path</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: non-portable path to file '%0'; specified path differs in case from file name on disk</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-include-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-nonportable-private-apinotes-path</key>
+    <name>clang-diagnostic-nonportable-private-apinotes-path</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: private API notes file for module '%0' should be named '%0_private.apinotes', not '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-private-apinotes-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-nonportable-private-system-apinotes-path</key>
+    <name>clang-diagnostic-nonportable-private-system-apinotes-path</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: private API notes file for module '%0' should be named '%0_private.apinotes', not '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-private-system-apinotes-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-nonportable-system-include-path</key>
+    <name>clang-diagnostic-nonportable-system-include-path</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: non-portable path to file '%0'; specified path differs in case from file name on disk</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-system-include-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-nonportable-vector-initialization</key>
+    <name>clang-diagnostic-nonportable-vector-initialization</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: vector initializers are not compatible with NEON intrinsics in big endian mode</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-vector-initialization" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-nontrivial-memaccess</key>
+    <name>clang-diagnostic-nontrivial-memaccess</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{destination for|source of|first operand of|second operand of}0 this %1 call is a pointer to record %2 that is not trivial to %select{primitive-default-initialize|primitive-copy}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnontrivial-memaccess" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-nsconsumed-mismatch</key>
+    <name>clang-diagnostic-nsconsumed-mismatch</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: overriding method has mismatched ns_consumed attribute on its parameter</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnsconsumed-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-NSObject-attribute</key>
+    <name>clang-diagnostic-NSObject-attribute</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'NSObject' attribute may be put on a typedef only; attribute is ignored</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wNSObject-attribute" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-nsreturns-mismatch</key>
+    <name>clang-diagnostic-nsreturns-mismatch</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: overriding method has mismatched ns_returns_%select{not_retained|retained}0 attributes</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnsreturns-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28324,6 +30914,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>CRITICAL</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-nullability-extension</key>
+    <name>clang-diagnostic-nullability-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: type nullability specifier %0 is a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnullability-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-nullability-inferred-on-nested-type</key>
     <name>clang-diagnostic-nullability-inferred-on-nested-type</name>
     <description>
@@ -28350,32 +30953,28 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-odr</key>
-    <name>clang-diagnostic-odr</name>
+    <key>clang-diagnostic-nvcc-compat</key>
+    <name>clang-diagnostic-nvcc-compat</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{class|instance}0 method %1 has a different number of parameters in different translation units (%2 vs. %3)</li>
-<li>warning: %select{class|instance}0 method %1 has a parameter with a different types in different translation units (%2 vs. %3)</li>
-<li>warning: %select{class|instance}0 method %1 has incompatible result types in different translation units (%2 vs. %3)</li>
-<li>warning: %select{class|instance}0 method %1 is variadic in one translation unit and not variadic in another</li>
-<li>warning: class %0 has incompatible superclasses</li>
-<li>warning: external function %0 declared with incompatible types in different translation units (%1 vs. %2)</li>
-<li>warning: external variable %0 declared with incompatible types in different translation units (%1 vs. %2)</li>
-<li>warning: external variable %0 defined in multiple translation units</li>
-<li>warning: field %0 declared with incompatible types in different translation units (%1 vs. %2)</li>
-<li>warning: instance variable %0 declared with incompatible types in different translation units (%1 vs. %2)</li>
-<li>warning: non-type template parameter declared with incompatible types in different translation units (%0 vs. %1)</li>
-<li>warning: parameter kind mismatch; parameter is %select{not a|a}0 parameter pack</li>
-<li>warning: property %0 declared with incompatible types in different translation units (%1 vs. %2)</li>
-<li>warning: property %0 is implemented with %select{@synthesize|@dynamic}1 in one translation but %select{@dynamic|@synthesize}1 in another translation unit</li>
-<li>warning: property %0 is synthesized to different ivars in different translation units (%1 vs. %2)</li>
-<li>warning: template parameter has different kinds in different translation units</li>
-<li>warning: template parameter lists have a different number of parameters (%0 vs %1)</li>
-<li>warning: type %0 has incompatible definitions in different translation units</li>
+<li>warning: target-attribute based function overloads are not supported by NVCC and will be treated as a function redeclaration:new declaration is %select{__device__|__global__|__host__|__host__ __device__}0 function, old declaration is %select{__device__|__global__|__host__|__host__ __device__}1 function</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wodr" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnvcc-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-objc-autosynthesis-property-ivar-name-match</key>
+    <name>clang-diagnostic-objc-autosynthesis-property-ivar-name-match</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: autosynthesized property %0 will use %select{|synthesized}1 instance variable %2, not existing instance variable %3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-autosynthesis-property-ivar-name-match" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28406,29 +31005,15 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-bridge-cast</key>
-    <name>clang-diagnostic-bridge-cast</name>
+    <key>clang-diagnostic-objc-circular-container</key>
+    <name>clang-diagnostic-objc-circular-container</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %0 bridges to %1, not %2</li>
-<li>warning: %0 cannot bridge to %1</li>
+<li>warning: adding %0 to %1 might cause circular dependency in container</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbridge-cast" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-cstring-format-directive</key>
-    <name>clang-diagnostic-cstring-format-directive</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: using %0 directive in %select{NSString|CFString}1 which is being passed as a formatting argument to the formatting %select{method|CFfunction}2</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcstring-format-directive" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-circular-container" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28464,6 +31049,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-objc-dictionary-duplicate-keys</key>
+    <name>clang-diagnostic-objc-dictionary-duplicate-keys</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: duplicate key in dictionary literal</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-dictionary-duplicate-keys" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-objc-duplicate-category-definition</key>
+    <name>clang-diagnostic-objc-duplicate-category-definition</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: duplicate definition of category %1 on interface %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-duplicate-category-definition" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-objc-flexible-array</key>
     <name>clang-diagnostic-objc-flexible-array</name>
     <description>
@@ -28478,16 +31089,28 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-invalid-iboutlet</key>
-    <name>clang-diagnostic-invalid-iboutlet</name>
+    <key>clang-diagnostic-objc-forward-class-redefinition</key>
+    <name>clang-diagnostic-objc-forward-class-redefinition</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{instance variable|property}2 with %0 attribute must be an object type (invalid %1)</li>
-<li>warning: IBOutletCollection properties should be copy/strong and not assign</li>
+<li>warning: redefinition of forward class %0 of a typedef name of an object type is ignored</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-iboutlet" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-forward-class-redefinition" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-objc-interface-ivars</key>
+    <name>clang-diagnostic-objc-interface-ivars</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration of instance variables in the interface is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-interface-ivars" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28520,6 +31143,63 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-objc-macro-redefinition</key>
+    <name>clang-diagnostic-objc-macro-redefinition</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ignoring redefinition of Objective-C qualifier macro</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-macro-redefinition" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-objc-messaging-id</key>
+    <name>clang-diagnostic-objc-messaging-id</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: messaging unqualified id</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-messaging-id" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-objc-method-access</key>
+    <name>clang-diagnostic-objc-method-access</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: class method %objcclass0 not found (return type defaults to 'id')</li>
+<li>warning: class method %objcclass0 not found (return type defaults to 'id'); did you mean %objcclass2?</li>
+<li>warning: instance method %0 found instead of class method %1</li>
+<li>warning: instance method %0 is being used on 'Class' which is not in the root class</li>
+<li>warning: instance method %objcinstance0 not found (return type defaults to 'id')</li>
+<li>warning: instance method %objcinstance0 not found (return type defaults to 'id'); did you mean %objcinstance2?</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-method-access" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-objc-missing-property-synthesis</key>
+    <name>clang-diagnostic-objc-missing-property-synthesis</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: auto property synthesis is synthesizing property not explicitly synthesized</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-missing-property-synthesis" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-objc-missing-super-calls</key>
     <name>clang-diagnostic-objc-missing-super-calls</name>
     <description>
@@ -28546,17 +31226,15 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-objc-property-synthesis</key>
-    <name>clang-diagnostic-objc-property-synthesis</name>
+    <key>clang-diagnostic-objc-noncopy-retain-block-property</key>
+    <name>clang-diagnostic-objc-noncopy-retain-block-property</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: auto property synthesis will not synthesize property %0 because it cannot share an ivar with another synthesized property</li>
-<li>warning: auto property synthesis will not synthesize property %0 because it is 'readwrite' but it will be synthesized 'readonly' via another property</li>
-<li>warning: auto property synthesis will not synthesize property %0; it will be implemented by its superclass, use @dynamic to acknowledge intention</li>
+<li>warning: retain'ed block property does not copy the block - use copy attribute instead</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-synthesis" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-noncopy-retain-block-property" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28570,46 +31248,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-nonunified-exceptions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-deprecated-objc-pointer-introspection</key>
-    <name>clang-diagnostic-deprecated-objc-pointer-introspection</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: bitmasking for introspection of Objective-C object pointers is strongly discouraged</li>
-<li>warning: bitmasking for introspection of Objective-C object pointers is strongly discouraged</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-objc-pointer-introspection" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-deprecated-objc-pointer-introspection-performSelector</key>
-    <name>clang-diagnostic-deprecated-objc-pointer-introspection-performSelector</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: bitmasking for introspection of Objective-C object pointers is strongly discouraged</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-objc-pointer-introspection-performSelector" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-potentially-direct-selector</key>
-    <name>clang-diagnostic-potentially-direct-selector</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: @selector expression formed with potentially direct selector %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpotentially-direct-selector" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28643,6 +31281,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-objc-property-implicit-mismatch</key>
+    <name>clang-diagnostic-objc-property-implicit-mismatch</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: primary property declaration is implicitly strong while redeclaration in class extension is weak</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-implicit-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-objc-property-matches-cocoa-ownership-rule</key>
+    <name>clang-diagnostic-objc-property-matches-cocoa-ownership-rule</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: property follows Cocoa naming convention for returning 'owned' objects</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-matches-cocoa-ownership-rule" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-objc-property-no-attribute</key>
     <name>clang-diagnostic-objc-property-no-attribute</name>
     <description>
@@ -28657,6 +31321,21 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-objc-property-synthesis</key>
+    <name>clang-diagnostic-objc-property-synthesis</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: auto property synthesis will not synthesize property %0 because it cannot share an ivar with another synthesized property</li>
+<li>warning: auto property synthesis will not synthesize property %0 because it is 'readwrite' but it will be synthesized 'readonly' via another property</li>
+<li>warning: auto property synthesis will not synthesize property %0; it will be implemented by its superclass, use @dynamic to acknowledge intention</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-synthesis" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-objc-protocol-method-implementation</key>
     <name>clang-diagnostic-objc-protocol-method-implementation</name>
     <description>
@@ -28666,6 +31345,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-protocol-method-implementation" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-objc-protocol-property-synthesis</key>
+    <name>clang-diagnostic-objc-protocol-property-synthesis</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: auto property synthesis will not synthesize property %0 declared in protocol %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-protocol-property-synthesis" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28696,19 +31388,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-receiver-expr</key>
-    <name>clang-diagnostic-receiver-expr</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: receiver type %0 is not 'id' or interface pointer, consider casting it to 'id'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreceiver-expr" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-objc-redundant-api-use</key>
     <name>clang-diagnostic-objc-redundant-api-use</name>
     <description>
@@ -28731,19 +31410,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-redundant-literal-use" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-noncopy-retain-block-property</key>
-    <name>clang-diagnostic-objc-noncopy-retain-block-property</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: retain'ed block property does not copy the block - use copy attribute instead</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-noncopy-retain-block-property" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28803,20 +31469,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-strict-potentially-direct-selector</key>
-    <name>clang-diagnostic-strict-potentially-direct-selector</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: @selector expression formed with potentially direct selector %0</li>
-<li>warning: @selector expression formed with potentially direct selector %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrict-potentially-direct-selector" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-objc-string-compare</key>
     <name>clang-diagnostic-objc-string-compare</name>
     <description>
@@ -28839,6 +31491,49 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-string-concatenation" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-objc-unsafe-perform-selector</key>
+    <name>clang-diagnostic-objc-unsafe-perform-selector</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is incompatible with selectors that return a %select{struct|union|vector}1 type</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-unsafe-perform-selector" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-odr</key>
+    <name>clang-diagnostic-odr</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{class|instance}0 method %1 has a different number of parameters in different translation units (%2 vs. %3)</li>
+<li>warning: %select{class|instance}0 method %1 has a parameter with a different types in different translation units (%2 vs. %3)</li>
+<li>warning: %select{class|instance}0 method %1 has incompatible result types in different translation units (%2 vs. %3)</li>
+<li>warning: %select{class|instance}0 method %1 is variadic in one translation unit and not variadic in another</li>
+<li>warning: class %0 has incompatible superclasses</li>
+<li>warning: external function %0 declared with incompatible types in different translation units (%1 vs. %2)</li>
+<li>warning: external variable %0 declared with incompatible types in different translation units (%1 vs. %2)</li>
+<li>warning: external variable %0 defined in multiple translation units</li>
+<li>warning: field %0 declared with incompatible types in different translation units (%1 vs. %2)</li>
+<li>warning: instance variable %0 declared with incompatible types in different translation units (%1 vs. %2)</li>
+<li>warning: non-type template parameter declared with incompatible types in different translation units (%0 vs. %1)</li>
+<li>warning: parameter kind mismatch; parameter is %select{not a|a}0 parameter pack</li>
+<li>warning: property %0 declared with incompatible types in different translation units (%1 vs. %2)</li>
+<li>warning: property %0 is implemented with %select{@synthesize|@dynamic}1 in one translation but %select{@dynamic|@synthesize}1 in another translation unit</li>
+<li>warning: property %0 is synthesized to different ivars in different translation units (%1 vs. %2)</li>
+<li>warning: template parameter has different kinds in different translation units</li>
+<li>warning: template parameter lists have a different number of parameters (%0 vs %1)</li>
+<li>warning: type %0 has incompatible definitions in different translation units</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wodr" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -28871,16 +31566,28 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pedantic-core-features</key>
-    <name>clang-diagnostic-pedantic-core-features</name>
+    <key>clang-diagnostic-openacc-deprecated-clause-alias</key>
+    <name>clang-diagnostic-openacc-deprecated-clause-alias</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %0 is a core feature in %select{OpenCL C|C++ for OpenCL}1 version %2 but not supported on this target</li>
-<li>warning: OpenCL extension %0 is core feature or supported optional core feature - ignoring</li>
+<li>warning: OpenACC clause name '%0' is a deprecated clause name and is now an alias for '%1'</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpedantic-core-features" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenacc-deprecated-clause-alias" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-openacc-self-if-potential-conflict</key>
+    <name>clang-diagnostic-openacc-self-if-potential-conflict</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: OpenACC construct 'self' has no effect when an 'if' clause evaluates to true</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenacc-self-if-potential-conflict" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -29032,19 +31739,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pre-openmp-51-compat</key>
-    <name>clang-diagnostic-pre-openmp-51-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: specifying OpenMP directives with [[]] is incompatible with OpenMP standards before OpenMP 5.1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-openmp-51-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-openmp-target</key>
     <name>clang-diagnostic-openmp-target</name>
     <description>
@@ -29071,19 +31765,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenmp-target-exception" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-new-returns-null</key>
-    <name>clang-diagnostic-new-returns-null</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0 should not return a null pointer unless it is declared 'throw()'%select{| or 'noexcept'}1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnew-returns-null" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -29145,6 +31826,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>CRITICAL</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-out-of-scope-function</key>
+    <name>clang-diagnostic-out-of-scope-function</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: use of out-of-scope declaration of %0%select{| whose type is not compatible with that of an implicit declaration}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wout-of-scope-function" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-over-aligned</key>
     <name>clang-diagnostic-over-aligned</name>
     <description>
@@ -29197,6 +31891,34 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-override-init</key>
+    <name>clang-diagnostic-override-init</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
+<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
+<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverride-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-override-module</key>
+    <name>clang-diagnostic-override-module</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: overriding the module target triple with %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverride-module" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-overriding-method-mismatch</key>
     <name>clang-diagnostic-overriding-method-mismatch</name>
     <description>
@@ -29212,6 +31934,32 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverriding-method-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-overriding-option</key>
+    <name>clang-diagnostic-overriding-option</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: overriding '%0' option with '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverriding-option" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-overriding-t-option</key>
+    <name>clang-diagnostic-overriding-t-option</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: overriding '%0' option with '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverriding-t-option" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -29311,6 +32059,116 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-partial-availability</key>
+    <name>clang-diagnostic-partial-availability</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is only available %select{|in %4 environment }3on %1 %2 or newer</li>
+<li>warning: %0 is only available %select{|in %4 environment }3on %1 %2 or newer</li>
+<li>warning: %0 is unavailable</li>
+<li>warning: %0 is unavailable</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpartial-availability" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pass</key>
+    <name>clang-diagnostic-pass</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>remark: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rpass" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pass-analysis</key>
+    <name>clang-diagnostic-pass-analysis</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>remark: %0</li>
+<li>remark: %0; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'</li>
+<li>remark: %0; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop; if the arrays will always be independent, specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments -- erroneous results will occur if these options are incorrectly applied</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rpass-analysis" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pass-failed</key>
+    <name>clang-diagnostic-pass-failed</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpass-failed" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pass-missed</key>
+    <name>clang-diagnostic-pass-missed</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>remark: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rpass-missed" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pch-date-time</key>
+    <name>clang-diagnostic-pch-date-time</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{precompiled header|module}0 uses __DATE__ or __TIME__</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpch-date-time" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pch-vfs-diff</key>
+    <name>clang-diagnostic-pch-vfs-diff</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: PCH was compiled with different VFS overlay files than are currently in use</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpch-vfs-diff" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pedantic-core-features</key>
+    <name>clang-diagnostic-pedantic-core-features</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is a core feature in %select{OpenCL C|C++ for OpenCL}1 version %2 but not supported on this target</li>
+<li>warning: OpenCL extension %0 is core feature or supported optional core feature - ignoring</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpedantic-core-features" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-pedantic-macros</key>
     <name>clang-diagnostic-pedantic-macros</name>
     <description>
@@ -29375,6 +32233,45 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-pointer-compare</key>
+    <name>clang-diagnostic-pointer-compare</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: comparing a pointer to a null character constant; did you mean to compare to %select{NULL|(void *)0}0?</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pointer-integer-compare</key>
+    <name>clang-diagnostic-pointer-integer-compare</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: comparison between pointer and integer (%0 and %1)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-integer-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pointer-sign</key>
+    <name>clang-diagnostic-pointer-sign</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2 converts between pointers to integer types %select{with different sign|where one is of the unique plain 'char' type and the other is not}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-sign" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-pointer-to-enum-cast</key>
     <name>clang-diagnostic-pointer-to-enum-cast</name>
     <description>
@@ -29406,6 +32303,45 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-pointer-type-mismatch</key>
+    <name>clang-diagnostic-pointer-type-mismatch</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: pointer type mismatch%diff{ ($ and $)|}0,1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-type-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-poison-system-directories</key>
+    <name>clang-diagnostic-poison-system-directories</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: include location '%0' is unsafe for cross-compilation</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpoison-system-directories" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-potentially-direct-selector</key>
+    <name>clang-diagnostic-potentially-direct-selector</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: @selector expression formed with potentially direct selector %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpotentially-direct-selector" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-potentially-evaluated-expression</key>
     <name>clang-diagnostic-potentially-evaluated-expression</name>
     <description>
@@ -29419,32 +32355,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-#pragma-messages</key>
-    <name>clang-diagnostic-#pragma-messages</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#w-pragma-messages" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-#warnings</key>
-    <name>clang-diagnostic-#warnings</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#w-warnings" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-pragma-clang-attribute</key>
     <name>clang-diagnostic-pragma-clang-attribute</name>
     <description>
@@ -29454,6 +32364,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-clang-attribute" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pragma-once-outside-header</key>
+    <name>clang-diagnostic-pragma-once-outside-header</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma once in main file</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-once-outside-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -29482,6 +32405,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-pack-suspicious-include" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pragma-system-header-outside-header</key>
+    <name>clang-diagnostic-pragma-system-header-outside-header</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #pragma system_header ignored in main file</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-system-header-outside-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -29574,6 +32510,543 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-pre-c++14-compat</key>
+    <name>clang-diagnostic-pre-c++14-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-14-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++14-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c++14-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-14-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++17-compat</key>
+    <name>clang-diagnostic-pre-c++17-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-17-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++17-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c++17-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
+<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
+<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
+<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
+<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
+<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
+<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
+<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
+<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
+<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
+<li>warning: hexadecimal floating literals are incompatible with C++ standards before C++17</li>
+<li>warning: inline variables are incompatible with C++ standards before C++17</li>
+<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
+<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
+<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
+<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
+<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
+<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-17-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++20-compat</key>
+    <name>clang-diagnostic-pre-c++20-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
+<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
+<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
+<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
+<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-20-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++20-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c++20-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
+<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
+<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
+<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
+<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
+<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
+<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
+<li>warning: designated initializers are incompatible with C++ standards before C++20</li>
+<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
+<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
+<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
+<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
+<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
+<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
+<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
+<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
+<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
+<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
+<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-20-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++23-compat</key>
+    <name>clang-diagnostic-pre-c++23-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-23-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++23-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c++23-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-23-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++26-compat</key>
+    <name>clang-diagnostic-pre-c++26-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-26-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++26-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c++26-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-26-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++2b-compat</key>
+    <name>clang-diagnostic-pre-c++2b-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2b-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++2b-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c++2b-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2b-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++2c-compat</key>
+    <name>clang-diagnostic-pre-c++2c-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2c-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++2c-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c++2c-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2c-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c11-compat</key>
+    <name>clang-diagnostic-pre-c11-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' is incompatible with C standards before C11</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c11-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c11-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c11-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' is incompatible with C standards before C11</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c23-compat</key>
+    <name>clang-diagnostic-pre-c23-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #embed is incompatible with C standards before C23</li>
+<li>warning: #warning is incompatible with C standards before C23</li>
+<li>warning: '%0' is incompatible with C standards before C23</li>
+<li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
+<li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
+<li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
+<li>warning: [[]] attributes are incompatible with C standards before C23</li>
+<li>warning: binary integer literals are incompatible with C standards before C23</li>
+<li>warning: digit separators are incompatible with C standards before C23</li>
+<li>warning: label at end of compound statement is incompatible with C standards before C23</li>
+<li>warning: label followed by a declaration is incompatible with C standards before C23</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C standards before C23</li>
+<li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
+<li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
+<li>warning: use of an empty initializer is incompatible with C standards before C23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c23-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c23-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c23-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #embed is incompatible with C standards before C23</li>
+<li>warning: #warning is incompatible with C standards before C23</li>
+<li>warning: '%0' is incompatible with C standards before C23</li>
+<li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
+<li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
+<li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
+<li>warning: [[]] attributes are incompatible with C standards before C23</li>
+<li>warning: binary integer literals are incompatible with C standards before C23</li>
+<li>warning: digit separators are incompatible with C standards before C23</li>
+<li>warning: label at end of compound statement is incompatible with C standards before C23</li>
+<li>warning: label followed by a declaration is incompatible with C standards before C23</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C standards before C23</li>
+<li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
+<li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
+<li>warning: use of an empty initializer is incompatible with C standards before C23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c23-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c2x-compat</key>
+    <name>clang-diagnostic-pre-c2x-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #embed is incompatible with C standards before C23</li>
+<li>warning: #warning is incompatible with C standards before C23</li>
+<li>warning: '%0' is incompatible with C standards before C23</li>
+<li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
+<li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
+<li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
+<li>warning: [[]] attributes are incompatible with C standards before C23</li>
+<li>warning: binary integer literals are incompatible with C standards before C23</li>
+<li>warning: digit separators are incompatible with C standards before C23</li>
+<li>warning: label at end of compound statement is incompatible with C standards before C23</li>
+<li>warning: label followed by a declaration is incompatible with C standards before C23</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C standards before C23</li>
+<li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
+<li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
+<li>warning: use of an empty initializer is incompatible with C standards before C23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c2x-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c2x-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #embed is incompatible with C standards before C23</li>
+<li>warning: #warning is incompatible with C standards before C23</li>
+<li>warning: '%0' is incompatible with C standards before C23</li>
+<li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
+<li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
+<li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
+<li>warning: [[]] attributes are incompatible with C standards before C23</li>
+<li>warning: binary integer literals are incompatible with C standards before C23</li>
+<li>warning: digit separators are incompatible with C standards before C23</li>
+<li>warning: label at end of compound statement is incompatible with C standards before C23</li>
+<li>warning: label followed by a declaration is incompatible with C standards before C23</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C standards before C23</li>
+<li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
+<li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
+<li>warning: use of an empty initializer is incompatible with C standards before C23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2x-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c2y-compat</key>
+    <name>clang-diagnostic-pre-c2y-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%select{--|++}0' on an object of complex type is incompatible with C standards before C2y</li>
+<li>warning: 'alignof' on an incomplete array type is incompatible with C standards before C2y</li>
+<li>warning: passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2y-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c2y-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c2y-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%select{--|++}0' on an object of complex type is incompatible with C standards before C2y</li>
+<li>warning: 'alignof' on an incomplete array type is incompatible with C standards before C2y</li>
+<li>warning: passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2y-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-openmp-51-compat</key>
+    <name>clang-diagnostic-pre-openmp-51-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: specifying OpenMP directives with [[]] is incompatible with OpenMP standards before OpenMP 5.1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-openmp-51-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-predefined-identifier-outside-function</key>
+    <name>clang-diagnostic-predefined-identifier-outside-function</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: predefined identifier is only valid inside function</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpredefined-identifier-outside-function" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-private-extern</key>
     <name>clang-diagnostic-private-extern</name>
     <description>
@@ -29585,6 +33058,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprivate-extern" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-private-header</key>
+    <name>clang-diagnostic-private-header</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: use of private header from outside its module: '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprivate-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-private-module</key>
@@ -29684,6 +33170,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-protocol-property-synthesis-ambiguity</key>
+    <name>clang-diagnostic-protocol-property-synthesis-ambiguity</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: property %select{of type %1|with attribute '%1'|without attribute '%1'|with getter %1|with setter %1}0 was selected for synthesis</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprotocol-property-synthesis-ambiguity" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-psabi</key>
+    <name>clang-diagnostic-psabi</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: AVX vector %select{return|argument}0 of type %1 without '%2' enabled changes the ABI</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpsabi" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-ptrauth-null-pointers</key>
     <name>clang-diagnostic-ptrauth-null-pointers</name>
     <description>
@@ -29698,29 +33210,28 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-call-to-pure-virtual-from-ctor-dtor</key>
-    <name>clang-diagnostic-call-to-pure-virtual-from-ctor-dtor</name>
+    <key>clang-diagnostic-qualified-void-return-type</key>
+    <name>clang-diagnostic-qualified-void-return-type</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: call to pure virtual member function %0 has undefined behavior; overrides of %0 in subclasses are not available in the %select{constructor|destructor}1 of %2</li>
+<li>warning: function cannot return qualified void type %0</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcall-to-pure-virtual-from-ctor-dtor" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wqualified-void-return-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-rtti</key>
-    <name>clang-diagnostic-rtti</name>
+    <key>clang-diagnostic-quoted-include-in-framework-header</key>
+    <name>clang-diagnostic-quoted-include-in-framework-header</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: dynamic_cast will not work since RTTI data is disabled by %select{-fno-rtti-data|/GR-}0</li>
-<li>warning: typeid will not work since RTTI data is disabled by %select{-fno-rtti-data|/GR-}0</li>
+<li>warning: double-quoted include "%0" in framework header, expected angle-bracketed instead</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrtti" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wquoted-include-in-framework-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -29780,6 +33291,46 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-readonly-iboutlet-property</key>
+    <name>clang-diagnostic-readonly-iboutlet-property</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: readonly IBOutlet property %0 when auto-synthesized may not work correctly with 'nib' loader</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreadonly-iboutlet-property" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-receiver-expr</key>
+    <name>clang-diagnostic-receiver-expr</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: receiver type %0 is not 'id' or interface pointer, consider casting it to 'id'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreceiver-expr" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-receiver-forward-class</key>
+    <name>clang-diagnostic-receiver-forward-class</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: receiver %0 is a forward class and corresponding @interface may not exist</li>
+<li>warning: receiver type %0 for instance message is a forward declaration</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreceiver-forward-class" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-redeclared-class-member</key>
     <name>clang-diagnostic-redeclared-class-member</name>
     <description>
@@ -29793,6 +33344,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-redundant-consteval-if</key>
+    <name>clang-diagnostic-redundant-consteval-if</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: consteval if is always true in an %select{unevaluated|immediate}0 context</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wredundant-consteval-if" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-redundant-move</key>
     <name>clang-diagnostic-redundant-move</name>
     <description>
@@ -29802,6 +33366,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wredundant-move" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-redundant-parens</key>
+    <name>clang-diagnostic-redundant-parens</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: redundant parentheses surrounding declarator</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wredundant-parens" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -29888,15 +33465,28 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-reserved-macro-identifier</key>
-    <name>clang-diagnostic-reserved-macro-identifier</name>
+    <key>clang-diagnostic-requires-expression</key>
+    <name>clang-diagnostic-requires-expression</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: macro name is a reserved identifier</li>
+<li>warning: this requires expression will only be checked for syntactic validity; did you intend to place it in a nested requirement? (add another 'requires' before the expression)</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreserved-macro-identifier" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrequires-expression" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-requires-super-attribute</key>
+    <name>clang-diagnostic-requires-super-attribute</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 attribute cannot be applied to %select{methods in protocols|dealloc}1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrequires-super-attribute" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -29926,6 +33516,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreserved-identifier" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-reserved-macro-identifier</key>
+    <name>clang-diagnostic-reserved-macro-identifier</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: macro name is a reserved identifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreserved-macro-identifier" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -29967,6 +33570,34 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrestrict-expansion" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-retained-language-linkage</key>
+    <name>clang-diagnostic-retained-language-linkage</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: friend function %0 retaining previous language linkage is an extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wretained-language-linkage" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-return-local-addr</key>
+    <name>clang-diagnostic-return-local-addr</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{address of|reference to}0 stack memory associated with %select{local variable|parameter|compound literal}2 %1 returned</li>
+<li>warning: returning %select{address of|reference to}0 local temporary object</li>
+<li>warning: returning address of label, which is local</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-local-addr" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -30051,6 +33682,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-rewrite-not-bool</key>
+    <name>clang-diagnostic-rewrite-not-bool</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++20 requires return type of selected 'operator==' function for rewritten '%1' comparison to be 'bool', not %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrewrite-not-bool" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-round-trip-cc1-args</key>
     <name>clang-diagnostic-round-trip-cc1-args</name>
     <description>
@@ -30060,6 +33704,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rround-trip-cc1-args" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-rtti</key>
+    <name>clang-diagnostic-rtti</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: dynamic_cast will not work since RTTI data is disabled by %select{-fno-rtti-data|/GR-}0</li>
+<li>warning: typeid will not work since RTTI data is disabled by %select{-fno-rtti-data|/GR-}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrtti" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -30078,6 +33736,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-sarif-format-unstable</key>
+    <name>clang-diagnostic-sarif-format-unstable</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: diagnostic formatting in SARIF mode is currently unstable</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsarif-format-unstable" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-search-path-usage</key>
+    <name>clang-diagnostic-search-path-usage</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>remark: search path used: '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rsearch-path-usage" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-section</key>
     <name>clang-diagnostic-section</name>
     <description>
@@ -30089,19 +33773,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsection" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-cast-of-sel-type</key>
-    <name>clang-diagnostic-cast-of-sel-type</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: cast of type %0 to %1 is deprecated; use sel_getName instead</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-of-sel-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -30210,6 +33881,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsentinel" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-sequence-point</key>
+    <name>clang-diagnostic-sequence-point</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: multiple unsequenced modifications to %0</li>
+<li>warning: unsequenced modification and access to %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsequence-point" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -30329,6 +34014,45 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-shift-count-negative</key>
+    <name>clang-diagnostic-shift-count-negative</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: shift count is negative</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-count-negative" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-shift-count-overflow</key>
+    <name>clang-diagnostic-shift-count-overflow</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: shift count &gt;= width of type</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-count-overflow" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-shift-negative-value</key>
+    <name>clang-diagnostic-shift-negative-value</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: shifting a negative signed value is undefined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-negative-value" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-shift-op-parentheses</key>
     <name>clang-diagnostic-shift-op-parentheses</name>
     <description>
@@ -30338,6 +34062,32 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-op-parentheses" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-shift-overflow</key>
+    <name>clang-diagnostic-shift-overflow</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: signed shift result (%0) requires %1 bits to represent, but %2 only has %3 bits</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-overflow" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-shift-sign-overflow</key>
+    <name>clang-diagnostic-shift-sign-overflow</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: signed shift result (%0) sets the sign bit of the shift expression's type (%1) and becomes negative</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-sign-overflow" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -30396,6 +34146,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-signed-unsigned-wchar</key>
+    <name>clang-diagnostic-signed-unsigned-wchar</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' cannot be signed or unsigned</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsigned-unsigned-wchar" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-single-bit-bitfield-constant-conversion</key>
     <name>clang-diagnostic-single-bit-bitfield-constant-conversion</name>
     <description>
@@ -30435,6 +34198,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-sizeof-array-div</key>
+    <name>clang-diagnostic-sizeof-array-div</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: expression does not compute the number of elements in this array; element type is %0, not %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsizeof-array-div" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-sizeof-pointer-div</key>
+    <name>clang-diagnostic-sizeof-pointer-div</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' will return the size of the pointer, not the array itself</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsizeof-pointer-div" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-sizeof-pointer-memaccess</key>
     <name>clang-diagnostic-sizeof-pointer-memaccess</name>
     <description>
@@ -30445,6 +34234,71 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsizeof-pointer-memaccess" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-slash-u-filename</key>
+    <name>clang-diagnostic-slash-u-filename</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '/U%0' treated as the '/U' option</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wslash-u-filename" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-slh-asm-goto</key>
+    <name>clang-diagnostic-slh-asm-goto</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: speculative load hardening does not protect functions with asm goto</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wslh-asm-goto" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-sloc-usage</key>
+    <name>clang-diagnostic-sloc-usage</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>remark: source manager location address space usage:</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rsloc-usage" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-sometimes-uninitialized</key>
+    <name>clang-diagnostic-sometimes-uninitialized</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: variable %0 is %select{used|captured}1 uninitialized whenever %select{'%3' condition is %select{true|false}4|'%3' loop %select{is entered|exits because its condition is false}4|'%3' loop %select{condition is true|exits because its condition is false}4|switch %3 is taken|its declaration is reached|%3 is called}2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsometimes-uninitialized" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-source-mgr</key>
+    <name>clang-diagnostic-source-mgr</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsource-mgr" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -30497,6 +34351,45 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-spirv-compat</key>
+    <name>clang-diagnostic-spirv-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: sampler initializer has invalid %0 bits</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wspirv-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-stack-exhausted</key>
+    <name>clang-diagnostic-stack-exhausted</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: stack nearly exhausted; compilation time may suffer, and crashes due to stack overflow are likely</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstack-exhausted" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-stack-protector</key>
+    <name>clang-diagnostic-stack-protector</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: unable to protect inline asm that clobbers stack pointer against stack clash</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstack-protector" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-static-float-init</key>
     <name>clang-diagnostic-static-float-init</name>
     <description>
@@ -30525,6 +34418,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-static-inline-explicit-instantiation</key>
+    <name>clang-diagnostic-static-inline-explicit-instantiation</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ignoring '%select{static|inline}0' keyword on explicit template instantiation</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstatic-inline-explicit-instantiation" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-static-local-in-inline</key>
     <name>clang-diagnostic-static-local-in-inline</name>
     <description>
@@ -30536,6 +34442,59 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstatic-local-in-inline" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-static-self-init</key>
+    <name>clang-diagnostic-static-self-init</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: static variable %0 is suspiciously used within its own initialization</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstatic-self-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-stdlibcxx-not-found</key>
+    <name>clang-diagnostic-stdlibcxx-not-found</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: include path for libstdc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstdlibcxx-not-found" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-strict-potentially-direct-selector</key>
+    <name>clang-diagnostic-strict-potentially-direct-selector</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: @selector expression formed with potentially direct selector %0</li>
+<li>warning: @selector expression formed with potentially direct selector %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrict-potentially-direct-selector" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-strict-primary-template-shadow</key>
+    <name>clang-diagnostic-strict-primary-template-shadow</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration of %0 shadows template parameter</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrict-primary-template-shadow" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-strict-prototypes</key>
@@ -30631,6 +34590,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-strlcpy-strlcat-size</key>
+    <name>clang-diagnostic-strlcpy-strlcat-size</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: size argument in %0 call appears to be size of the source; expected the size of the destination</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrlcpy-strlcat-size" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-strncat-size</key>
     <name>clang-diagnostic-strncat-size</name>
     <description>
@@ -30642,6 +34614,32 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrncat-size" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-suggest-destructor-override</key>
+    <name>clang-diagnostic-suggest-destructor-override</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %sub{warn_destructor_marked_not_override_overriding}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsuggest-destructor-override" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-suggest-override</key>
+    <name>clang-diagnostic-suggest-override</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %sub{warn_function_marked_not_override_overriding}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsuggest-override" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -30782,6 +34780,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-sync-fetch-and-nand-semantics-changed</key>
+    <name>clang-diagnostic-sync-fetch-and-nand-semantics-changed</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: the semantics of this intrinsic changed with GCC version 4.4 - the newer semantics are provided here</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsync-fetch-and-nand-semantics-changed" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-target-clones-mixed-specifiers</key>
     <name>clang-diagnostic-target-clones-mixed-specifiers</name>
     <description>
@@ -30870,6 +34881,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-tautological-constant-out-of-range-compare</key>
+    <name>clang-diagnostic-tautological-constant-out-of-range-compare</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: result of comparison of %select{constant %0|true|false}1 with %select{expression of type %2|boolean expression}3 is always %4</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-constant-out-of-range-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-tautological-negation-compare</key>
     <name>clang-diagnostic-tautological-negation-compare</name>
     <description>
@@ -30893,19 +34917,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-objc-bool-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-tautological-constant-out-of-range-compare</key>
-    <name>clang-diagnostic-tautological-constant-out-of-range-compare</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: result of comparison of %select{constant %0|true|false}1 with %select{expression of type %2|boolean expression}3 is always %4</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-constant-out-of-range-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -31012,6 +35023,58 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-value-range-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-tcb-enforcement</key>
+    <name>clang-diagnostic-tcb-enforcement</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: calling %0 is a violation of trusted computing base '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtcb-enforcement" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-template-in-declaration-name</key>
+    <name>clang-diagnostic-template-in-declaration-name</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'template' cannot be used after a declarative nested name specifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtemplate-in-declaration-name" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-tentative-definition-array</key>
+    <name>clang-diagnostic-tentative-definition-array</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: tentative array definition assumed to have one element</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtentative-definition-array" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-tentative-definition-incomplete-type</key>
+    <name>clang-diagnostic-tentative-definition-incomplete-type</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: tentative definition of variable with internal linkage has incomplete non-array type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtentative-definition-incomplete-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -31238,6 +35301,45 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-typedef-redefinition</key>
+    <name>clang-diagnostic-typedef-redefinition</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: redefinition of typedef %0 is a C11 feature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtypedef-redefinition" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-typename-missing</key>
+    <name>clang-diagnostic-typename-missing</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: missing 'typename' prior to dependent type name '%0%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtypename-missing" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unable-to-open-stats-file</key>
+    <name>clang-diagnostic-unable-to-open-stats-file</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: unable to open statistics output file '%0': '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunable-to-open-stats-file" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-unaligned-access</key>
     <name>clang-diagnostic-unaligned-access</name>
     <description>
@@ -31247,6 +35349,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunaligned-access" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unaligned-qualifier-implicit-cast</key>
+    <name>clang-diagnostic-unaligned-qualifier-implicit-cast</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: implicit cast from type %0 to type %1 drops __unaligned qualifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunaligned-qualifier-implicit-cast" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -31278,6 +35393,71 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-undef</key>
+    <name>clang-diagnostic-undef</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is not defined, evaluates to 0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundef" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-undef-prefix</key>
+    <name>clang-diagnostic-undef-prefix</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is not defined, evaluates to 0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundef-prefix" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-undefined-arm-streaming</key>
+    <name>clang-diagnostic-undefined-arm-streaming</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: builtin call has undefined behaviour when called from a %0 function</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-streaming" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-undefined-arm-za</key>
+    <name>clang-diagnostic-undefined-arm-za</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: builtin call is not valid when calling from a function without active ZA state</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-za" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-undefined-arm-zt0</key>
+    <name>clang-diagnostic-undefined-arm-zt0</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: builtin call is not valid when calling from a function without active ZT0 state</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-zt0" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-undefined-bool-conversion</key>
     <name>clang-diagnostic-undefined-bool-conversion</name>
     <description>
@@ -31301,6 +35481,45 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-func-template" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-undefined-inline</key>
+    <name>clang-diagnostic-undefined-inline</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: inline function %q0 is not defined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-inline" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-undefined-internal</key>
+    <name>clang-diagnostic-undefined-internal</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{function|variable}0 %q1 has internal linkage but is not defined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-internal" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-undefined-internal-type</key>
+    <name>clang-diagnostic-undefined-internal-type</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++ requires a definition in this translation unit for %select{function|variable}0 %q1 because its type does not have linkage</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-internal-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -31408,6 +35627,45 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-unicode-homoglyph</key>
+    <name>clang-diagnostic-unicode-homoglyph</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: treating Unicode character &lt;U+%0&gt; as an identifier character rather than as '%1' symbol</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-homoglyph" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unicode-whitespace</key>
+    <name>clang-diagnostic-unicode-whitespace</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: treating Unicode character as whitespace</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-whitespace" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unicode-zero-width</key>
+    <name>clang-diagnostic-unicode-zero-width</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: identifier contains Unicode character &lt;U+%0&gt; that is invisible in some environments</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-zero-width" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-uninitialized</key>
     <name>clang-diagnostic-uninitialized</name>
     <description>
@@ -31439,45 +35697,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wuninitialized-const-reference" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-conditional-uninitialized</key>
-    <name>clang-diagnostic-conditional-uninitialized</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: variable %0 may be uninitialized when %select{used here|captured by block}1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconditional-uninitialized" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-sometimes-uninitialized</key>
-    <name>clang-diagnostic-sometimes-uninitialized</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: variable %0 is %select{used|captured}1 uninitialized whenever %select{'%3' condition is %select{true|false}4|'%3' loop %select{is entered|exits because its condition is false}4|'%3' loop %select{condition is true|exits because its condition is false}4|switch %3 is taken|its declaration is reached|%3 is called}2</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsometimes-uninitialized" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-static-self-init</key>
-    <name>clang-diagnostic-static-self-init</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: static variable %0 is suspiciously used within its own initialization</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstatic-self-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -31519,6 +35738,46 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-attributes" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unknown-cuda-version</key>
+    <name>clang-diagnostic-unknown-cuda-version</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: CUDA version %0 is only partially supported</li>
+<li>warning: CUDA version%0 is newer than the latest%select{| partially}1 supported version %2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-cuda-version" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unknown-directives</key>
+    <name>clang-diagnostic-unknown-directives</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: invalid preprocessing directive%select{|, did you mean '#%1'?}0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-directives" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unknown-escape-sequence</key>
+    <name>clang-diagnostic-unknown-escape-sequence</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: unknown escape sequence '\%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-escape-sequence" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -31620,6 +35879,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunneeded-member-function" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unqualified-std-cast-call</key>
+    <name>clang-diagnostic-unqualified-std-cast-call</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: unqualified call to '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunqualified-std-cast-call" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -31793,6 +36065,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-unsupported-availability-guard</key>
+    <name>clang-diagnostic-unsupported-availability-guard</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{@available|__builtin_available}0 does not guard availability here; use if (%select{@available|__builtin_available}0) instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-availability-guard" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-unsupported-cb</key>
     <name>clang-diagnostic-unsupported-cb</name>
     <description>
@@ -31802,6 +36087,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-cb" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unsupported-dll-base-class-template</key>
+    <name>clang-diagnostic-unsupported-dll-base-class-template</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: propagating dll attribute to %select{already instantiated|explicitly specialized}0 base class template without dll attribute is not supported</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-dll-base-class-template" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -31873,6 +36171,32 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-target-opt" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unsupported-visibility</key>
+    <name>clang-diagnostic-unsupported-visibility</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: target does not support 'protected' visibility; using 'default'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-visibility" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unusable-partial-specialization</key>
+    <name>clang-diagnostic-unusable-partial-specialization</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{class|variable}0 template partial specialization contains %select{a template parameter|template parameters}1 that cannot be deduced; this partial specialization will never be used</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunusable-partial-specialization" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-unused</key>
@@ -32068,6 +36392,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-unused-local-typedefs</key>
+    <name>clang-diagnostic-unused-local-typedefs</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: unused %select{typedef|type alias}0 %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-local-typedefs" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-unused-macros</key>
+    <name>clang-diagnostic-unused-macros</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: macro is not used</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-macros" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-unused-member-function</key>
     <name>clang-diagnostic-unused-member-function</name>
     <description>
@@ -32188,6 +36538,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-unused-volatile-lvalue</key>
+    <name>clang-diagnostic-unused-volatile-lvalue</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: expression result unused; assign into a variable to force a volatile load</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-volatile-lvalue" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-used-but-marked-unused</key>
     <name>clang-diagnostic-used-but-marked-unused</name>
     <description>
@@ -32197,19 +36560,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wused-but-marked-unused" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-search-path-usage</key>
-    <name>clang-diagnostic-search-path-usage</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>remark: search path used: '%0'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rsearch-path-usage" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -32236,6 +36586,104 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wuser-defined-warnings" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-varargs</key>
+    <name>clang-diagnostic-varargs</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: passing %select{an object that undergoes default argument promotion|an object of reference type|a parameter declared with the 'register' keyword}0 to 'va_start' has undefined behavior</li>
+<li>warning: second argument to 'va_arg' is of promotable type %0; this va_arg has undefined behavior because arguments will be promoted to %1</li>
+<li>warning: second argument to 'va_start' is not the last named parameter</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvarargs" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-variadic-macros</key>
+    <name>clang-diagnostic-variadic-macros</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: __VA_OPT__ can only appear in the expansion of a variadic macro</li>
+<li>warning: named variadic macros are a GNU extension</li>
+<li>warning: variadic macros are a C99 feature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvariadic-macros" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-vec-elem-size</key>
+    <name>clang-diagnostic-vec-elem-size</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: vector operands do not have the same elements sizes (%0 and %1)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvec-elem-size" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-vector-conversion</key>
+    <name>clang-diagnostic-vector-conversion</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: incompatible vector types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvector-conversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-vector-conversions</key>
+    <name>clang-diagnostic-vector-conversions</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: incompatible vector types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvector-conversions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-vexing-parse</key>
+    <name>clang-diagnostic-vexing-parse</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: empty parentheses interpreted as a function declaration</li>
+<li>warning: parentheses were disambiguated as a function declaration</li>
+<li>warning: parentheses were disambiguated as redundant parentheses around declaration of variable named %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvexing-parse" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-visibility</key>
+    <name>clang-diagnostic-visibility</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration of %0 will not be visible outside of this function</li>
+<li>warning: redefinition of %0 will not be visible outside of this function</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvisibility" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -32305,91 +36753,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-varargs</key>
-    <name>clang-diagnostic-varargs</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: passing %select{an object that undergoes default argument promotion|an object of reference type|a parameter declared with the 'register' keyword}0 to 'va_start' has undefined behavior</li>
-<li>warning: second argument to 'va_arg' is of promotable type %0; this va_arg has undefined behavior because arguments will be promoted to %1</li>
-<li>warning: second argument to 'va_start' is not the last named parameter</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvarargs" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-variadic-macros</key>
-    <name>clang-diagnostic-variadic-macros</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: __VA_OPT__ can only appear in the expansion of a variadic macro</li>
-<li>warning: named variadic macros are a GNU extension</li>
-<li>warning: variadic macros are a C99 feature</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvariadic-macros" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-vector-conversion</key>
-    <name>clang-diagnostic-vector-conversion</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: incompatible vector types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvector-conversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-vexing-parse</key>
-    <name>clang-diagnostic-vexing-parse</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: empty parentheses interpreted as a function declaration</li>
-<li>warning: parentheses were disambiguated as a function declaration</li>
-<li>warning: parentheses were disambiguated as redundant parentheses around declaration of variable named %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvexing-parse" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-visibility</key>
-    <name>clang-diagnostic-visibility</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: declaration of %0 will not be visible outside of this function</li>
-<li>warning: redefinition of %0 will not be visible outside of this function</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvisibility" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-void-ptr-dereference</key>
-    <name>clang-diagnostic-void-ptr-dereference</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ISO C does not allow indirection on operand of type %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvoid-ptr-dereference" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-void-pointer-to-enum-cast</key>
     <name>clang-diagnostic-void-pointer-to-enum-cast</name>
     <description>
@@ -32417,6 +36780,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-void-ptr-dereference</key>
+    <name>clang-diagnostic-void-ptr-dereference</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C does not allow indirection on operand of type %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvoid-ptr-dereference" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-wasm-exception-spec</key>
     <name>clang-diagnostic-wasm-exception-spec</name>
     <description>
@@ -32426,6 +36802,32 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wwasm-exception-spec" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-weak-template-vtables</key>
+    <name>clang-diagnostic-weak-template-vtables</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: this warning is no longer in use and will be removed in the next release</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wweak-template-vtables" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-weak-vtables</key>
+    <name>clang-diagnostic-weak-vtables</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wweak-vtables" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -32440,6 +36842,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wwritable-strings" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-write-strings</key>
+    <name>clang-diagnostic-write-strings</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++11 does not allow conversion from string literal to %0</li>
+<li>warning: conversion from string literal to %0 is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wwrite-strings" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -32459,3370 +36875,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-zero-length-array</key>
-    <name>clang-diagnostic-zero-length-array</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: zero size arrays are an extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wzero-length-array" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-msvc-not-found</key>
-    <name>clang-diagnostic-msvc-not-found</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: unable to find a Visual Studio installation; try running Clang from a developer command prompt</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmsvc-not-found" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-darwin-sdk-settings</key>
-    <name>clang-diagnostic-darwin-sdk-settings</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: SDK settings were ignored as 'SDKSettings.json' could not be parsed</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdarwin-sdk-settings" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-stdlibcxx-not-found</key>
-    <name>clang-diagnostic-stdlibcxx-not-found</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: include path for libstdc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstdlibcxx-not-found" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-sarif-format-unstable</key>
-    <name>clang-diagnostic-sarif-format-unstable</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: diagnostic formatting in SARIF mode is currently unstable</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsarif-format-unstable" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-missing-multilib</key>
-    <name>clang-diagnostic-missing-multilib</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: no multilib found matching flags: %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-multilib" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-android-unversioned-fallback</key>
-    <name>clang-diagnostic-android-unversioned-fallback</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: using unversioned Android target directory %0 for target %1; unversioned directories will not be used in Clang 19 -- provide a versioned directory for the target version or lower instead</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wandroid-unversioned-fallback" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-override-module</key>
-    <name>clang-diagnostic-override-module</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: overriding the module target triple with %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverride-module" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unable-to-open-stats-file</key>
-    <name>clang-diagnostic-unable-to-open-stats-file</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: unable to open statistics output file '%0': '%1'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunable-to-open-stats-file" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-analyzer-incompatible-plugin</key>
-    <name>clang-diagnostic-analyzer-incompatible-plugin</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: checker plugin '%0' is not compatible with this version of the analyzer</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wanalyzer-incompatible-plugin" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-module-file-config-mismatch</key>
-    <name>clang-diagnostic-module-file-config-mismatch</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: module file %0 cannot be loaded due to a configuration mismatch with the current compilation</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodule-file-config-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-div-by-zero</key>
-    <name>clang-diagnostic-div-by-zero</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{remainder|division}0 by zero is undefined</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdiv-by-zero" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-eager-load-cxx-named-modules</key>
-    <name>clang-diagnostic-eager-load-cxx-named-modules</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: the form '-fmodule-file=&lt;BMI-path&gt;' is deprecated for standard C++ named modules;consider to use '-fmodule-file=&lt;module-name&gt;=&lt;BMI-path&gt;' instead</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#weager-load-cxx-named-modules" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-psabi</key>
-    <name>clang-diagnostic-psabi</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: AVX vector %select{return|argument}0 of type %1 without '%2' enabled changes the ABI</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpsabi" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-backslash-newline-escape</key>
-    <name>clang-diagnostic-backslash-newline-escape</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: backslash and newline separated by space</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbackslash-newline-escape" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-dollar-in-identifier-extension</key>
-    <name>clang-diagnostic-dollar-in-identifier-extension</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '$' in identifier</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdollar-in-identifier-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-language-extension-token</key>
-    <name>clang-diagnostic-language-extension-token</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: extension used</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wlanguage-extension-token" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-invalid-utf8</key>
-    <name>clang-diagnostic-invalid-utf8</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: invalid UTF-8 in comment</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-utf8" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unicode-whitespace</key>
-    <name>clang-diagnostic-unicode-whitespace</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: treating Unicode character as whitespace</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-whitespace" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unicode-homoglyph</key>
-    <name>clang-diagnostic-unicode-homoglyph</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: treating Unicode character &lt;U+%0&gt; as an identifier character rather than as '%1' symbol</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-homoglyph" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unicode-zero-width</key>
-    <name>clang-diagnostic-unicode-zero-width</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: identifier contains Unicode character &lt;U+%0&gt; that is invisible in some environments</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunicode-zero-width" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-mathematical-notation-identifier-extension</key>
-    <name>clang-diagnostic-mathematical-notation-identifier-extension</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: mathematical notation character &lt;U+%0&gt; in an identifier is a Clang extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmathematical-notation-identifier-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++1z-compat-mangling</key>
-    <name>clang-diagnostic-c++1z-compat-mangling</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat-mangling" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-delimited-escape-sequence-extension</key>
-    <name>clang-diagnostic-delimited-escape-sequence-extension</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{delimited|named}0 escape sequences are a %select{Clang|C++23}1 extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdelimited-escape-sequence-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unknown-escape-sequence</key>
-    <name>clang-diagnostic-unknown-escape-sequence</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: unknown escape sequence '\%0'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-escape-sequence" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-invalid-unevaluated-string</key>
-    <name>clang-diagnostic-invalid-unevaluated-string</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: encoding prefix '%0' on an unevaluated string literal has no effect%select{| and is incompatible with c++2c}1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-unevaluated-string" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-include-next-outside-header</key>
-    <name>clang-diagnostic-include-next-outside-header</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #include_next in primary source file; will search from start of include path</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winclude-next-outside-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-include-next-absolute-path</key>
-    <name>clang-diagnostic-include-next-absolute-path</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #include_next in file found relative to primary source file or found by absolute path; will search from start of include path</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winclude-next-absolute-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-nonportable-include-path</key>
-    <name>clang-diagnostic-nonportable-include-path</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: non-portable path to file '%0'; specified path differs in case from file name on disk</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-include-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-nonportable-system-include-path</key>
-    <name>clang-diagnostic-nonportable-system-include-path</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: non-portable path to file '%0'; specified path differs in case from file name on disk</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-system-include-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pragma-once-outside-header</key>
-    <name>clang-diagnostic-pragma-once-outside-header</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #pragma once in main file</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-once-outside-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pragma-system-header-outside-header</key>
-    <name>clang-diagnostic-pragma-system-header-outside-header</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #pragma system_header ignored in main file</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpragma-system-header-outside-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-disabled-macro-expansion</key>
-    <name>clang-diagnostic-disabled-macro-expansion</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: disabled expansion of recursive macro</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdisabled-macro-expansion" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c2x-compat</key>
-    <name>clang-diagnostic-pre-c2x-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #embed is incompatible with C standards before C23</li>
-<li>warning: #warning is incompatible with C standards before C23</li>
-<li>warning: '%0' is incompatible with C standards before C23</li>
-<li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
-<li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
-<li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
-<li>warning: [[]] attributes are incompatible with C standards before C23</li>
-<li>warning: binary integer literals are incompatible with C standards before C23</li>
-<li>warning: digit separators are incompatible with C standards before C23</li>
-<li>warning: label at end of compound statement is incompatible with C standards before C23</li>
-<li>warning: label followed by a declaration is incompatible with C standards before C23</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C standards before C23</li>
-<li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
-<li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
-<li>warning: use of an empty initializer is incompatible with C standards before C23</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unused-macros</key>
-    <name>clang-diagnostic-unused-macros</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: macro is not used</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-macros" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-undef</key>
-    <name>clang-diagnostic-undef</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0 is not defined, evaluates to 0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundef" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-undef-prefix</key>
-    <name>clang-diagnostic-undef-prefix</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0 is not defined, evaluates to 0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundef-prefix" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-macro-redefinition</key>
-    <name>clang-diagnostic-objc-macro-redefinition</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ignoring redefinition of Objective-C qualifier macro</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-macro-redefinition" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-import-preprocessor-directive-pedantic</key>
-    <name>clang-diagnostic-import-preprocessor-directive-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #import is a language extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimport-preprocessor-directive-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-embedded-directive</key>
-    <name>clang-diagnostic-embedded-directive</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: embedding a directive within macro arguments has undefined behavior</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wembedded-directive" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unknown-directives</key>
-    <name>clang-diagnostic-unknown-directives</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: invalid preprocessing directive%select{|, did you mean '#%1'?}0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-directives" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-invalid-token-paste</key>
-    <name>clang-diagnostic-invalid-token-paste</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: pasting formed '%0', an invalid preprocessing token</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-token-paste" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-date-time</key>
-    <name>clang-diagnostic-date-time</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: expansion of date or time macro is not reproducible</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdate-time" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-private-header</key>
-    <name>clang-diagnostic-private-header</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: use of private header from outside its module: '%0'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprivate-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c2x-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c2x-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #embed is incompatible with C standards before C23</li>
-<li>warning: #warning is incompatible with C standards before C23</li>
-<li>warning: '%0' is incompatible with C standards before C23</li>
-<li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
-<li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
-<li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
-<li>warning: [[]] attributes are incompatible with C standards before C23</li>
-<li>warning: binary integer literals are incompatible with C standards before C23</li>
-<li>warning: digit separators are incompatible with C standards before C23</li>
-<li>warning: label at end of compound statement is incompatible with C standards before C23</li>
-<li>warning: label followed by a declaration is incompatible with C standards before C23</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C standards before C23</li>
-<li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
-<li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
-<li>warning: use of an empty initializer is incompatible with C standards before C23</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2x-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-include-angled-in-module-purview</key>
-    <name>clang-diagnostic-include-angled-in-module-purview</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '#include &lt;filename&gt;' attaches the declarations to the named module '%0', which is not usually intended; consider moving that directive before the module declaration</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winclude-angled-in-module-purview" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-header-guard</key>
-    <name>clang-diagnostic-header-guard</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0 is used as a header guard here, followed by #define of a different macro</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wheader-guard" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-empty-translation-unit</key>
-    <name>clang-diagnostic-empty-translation-unit</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ISO C requires a translation unit to contain at least one declaration</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wempty-translation-unit" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-nullability-extension</key>
-    <name>clang-diagnostic-nullability-extension</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: type nullability specifier %0 is a Clang extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnullability-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-fixed-enum-extension</key>
-    <name>clang-diagnostic-fixed-enum-extension</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: enumeration types with a fixed underlying type are a Clang extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfixed-enum-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-elaborated-enum-base</key>
-    <name>clang-diagnostic-elaborated-enum-base</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: non-defining declaration of enumeration with a fixed underlying type is only permitted as a standalone declaration%select{|; missing list of enumerators?}0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#welaborated-enum-base" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-elaborated-enum-class</key>
-    <name>clang-diagnostic-elaborated-enum-class</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: reference to enumeration must use 'enum' not 'enum %select{struct|class}0'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#welaborated-enum-class" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-microsoft-exists</key>
-    <name>clang-diagnostic-microsoft-exists</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: dependent %select{__if_not_exists|__if_exists}0 declarations are ignored</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmicrosoft-exists" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-generic-type-extension</key>
-    <name>clang-diagnostic-generic-type-extension</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: passing a type argument as the first operand to '_Generic' is a Clang extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgeneric-type-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-missing-selector-name</key>
-    <name>clang-diagnostic-missing-selector-name</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0 used as the name of the previous parameter rather than as part of the selector</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-selector-name" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-auto-storage-class</key>
-    <name>clang-diagnostic-auto-storage-class</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'auto' storage class specifier is not permitted in C++11, and will not be supported in future releases</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wauto-storage-class" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++98-c++11-compat</key>
-    <name>clang-diagnostic-c++98-c++11-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
-<li>warning: digit separators are incompatible with C++ standards before C++14</li>
-<li>warning: generic lambdas are incompatible with C++11</li>
-<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
-<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
-<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
-<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable templates are incompatible with C++ standards before C++14</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-empty-decomposition</key>
-    <name>clang-diagnostic-empty-decomposition</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ISO C++17 does not allow a decomposition group to be empty</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wempty-decomposition" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-arc-bridge-casts-disallowed-in-nonarc</key>
-    <name>clang-diagnostic-arc-bridge-casts-disallowed-in-nonarc</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%0' casts have no effect when not using ARC</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-bridge-casts-disallowed-in-nonarc" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-ambiguous-ellipsis</key>
-    <name>clang-diagnostic-ambiguous-ellipsis</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '...' in this location creates a C-style varargs function%select{, not a function parameter pack|}0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wambiguous-ellipsis" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-anonymous-pack-parens</key>
-    <name>clang-diagnostic-anonymous-pack-parens</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ISO C++11 requires a parenthesized pack declaration to have a name</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wanonymous-pack-parens" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-cxx-attribute-extension</key>
-    <name>clang-diagnostic-cxx-attribute-extension</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ISO C++ does not allow %select{an attribute list|%0}1 to appear here</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcxx-attribute-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-requires-expression</key>
-    <name>clang-diagnostic-requires-expression</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: this requires expression will only be checked for syntactic validity; did you intend to place it in a nested requirement? (add another 'requires' before the expression)</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrequires-expression" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-missing-template-arg-list-after-template-kw</key>
-    <name>clang-diagnostic-missing-template-arg-list-after-template-kw</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: a template argument list is expected after a name prefixed by the template keyword</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-template-arg-list-after-template-kw" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-static-inline-explicit-instantiation</key>
-    <name>clang-diagnostic-static-inline-explicit-instantiation</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ignoring '%select{static|inline}0' keyword on explicit template instantiation</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstatic-inline-explicit-instantiation" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-concepts-ts-compat</key>
-    <name>clang-diagnostic-concepts-ts-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ISO C++20 does not permit the 'bool' keyword after 'concept'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconcepts-ts-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-duplicate-enum</key>
-    <name>clang-diagnostic-duplicate-enum</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: element %0 has been implicitly assigned %1 which another element has been assigned</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-enum" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-comma</key>
-    <name>clang-diagnostic-comma</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: possible misuse of comma operator here</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcomma" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-predefined-identifier-outside-function</key>
-    <name>clang-diagnostic-predefined-identifier-outside-function</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: predefined identifier is only valid inside function</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpredefined-identifier-outside-function" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-interrupt-service-routine</key>
-    <name>clang-diagnostic-interrupt-service-routine</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: interrupt service routine should only call a function with attribute 'no_caller_saved_registers'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winterrupt-service-routine" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++98-c++11-compat-pedantic</key>
-    <name>clang-diagnostic-c++98-c++11-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
-<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
-<li>warning: digit separators are incompatible with C++ standards before C++14</li>
-<li>warning: generic lambdas are incompatible with C++11</li>
-<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
-<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
-<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
-<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable templates are incompatible with C++ standards before C++14</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-auto-decl-extensions</key>
-    <name>clang-diagnostic-auto-decl-extensions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: type inference of a declaration other than a plain identifier with optional trailing attributes is a Clang extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wauto-decl-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-excessive-regsave</key>
-    <name>clang-diagnostic-excessive-regsave</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{interrupt service routine|function with attribute 'no_caller_saved_registers'}0 should only call a function with attribute 'no_caller_saved_registers' or be compiled with '-mgeneral-regs-only'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexcessive-regsave" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-arm-interrupt-vfp-clobber</key>
-    <name>clang-diagnostic-arm-interrupt-vfp-clobber</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: interrupt service routine with vfp enabled may clobber the interruptee's vfp state</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warm-interrupt-vfp-clobber" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-redundant-parens</key>
-    <name>clang-diagnostic-redundant-parens</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: redundant parentheses surrounding declarator</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wredundant-parens" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-out-of-scope-function</key>
-    <name>clang-diagnostic-out-of-scope-function</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: use of out-of-scope declaration of %0%select{| whose type is not compatible with that of an implicit declaration}1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wout-of-scope-function" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-binding-in-condition</key>
-    <name>clang-diagnostic-binding-in-condition</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ISO C++17 does not permit structured binding declaration in a condition</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbinding-in-condition" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-incomplete-setjmp-declaration</key>
-    <name>clang-diagnostic-incomplete-setjmp-declaration</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: declaration of built-in function '%0' requires the declaration of the 'jmp_buf' type, commonly provided in the header &lt;setjmp.h&gt;</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincomplete-setjmp-declaration" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-incompatible-library-redeclaration</key>
-    <name>clang-diagnostic-incompatible-library-redeclaration</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: incompatible redeclaration of library function %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-library-redeclaration" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-strlcpy-strlcat-size</key>
-    <name>clang-diagnostic-strlcpy-strlcat-size</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: size argument in %0 call appears to be size of the source; expected the size of the destination</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrlcpy-strlcat-size" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-memsize-comparison</key>
-    <name>clang-diagnostic-memsize-comparison</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: size argument in %0 call is a comparison</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmemsize-comparison" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++98-c++11-c++14-compat</key>
-    <name>clang-diagnostic-c++98-c++11-c++14-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
-<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
-<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
-<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
-<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
-<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
-<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
-<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
-<li>warning: inline variables are incompatible with C++ standards before C++17</li>
-<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
-<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
-<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
-<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
-<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
-<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-assume</key>
-    <name>clang-diagnostic-assume</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: assumption is ignored because it contains (potential) side-effects</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wassume" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-builtin-memcpy-chk-size</key>
-    <name>clang-diagnostic-builtin-memcpy-chk-size</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%0' will always overflow; destination buffer has size %1, but size argument is %2</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbuiltin-memcpy-chk-size" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-non-c-typedef-for-linkage</key>
-    <name>clang-diagnostic-non-c-typedef-for-linkage</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: anonymous non-C-compatible type given name for linkage purposes by %select{typedef|alias}0 declaration; add a tag name here</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnon-c-typedef-for-linkage" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-duplicate-protocol</key>
-    <name>clang-diagnostic-duplicate-protocol</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: duplicate protocol definition of %0 is ignored</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-protocol" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-incompatible-property-type</key>
-    <name>clang-diagnostic-incompatible-property-type</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: property type %0 is incompatible with type %1 inherited from %2</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-property-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-protocol-property-synthesis-ambiguity</key>
-    <name>clang-diagnostic-protocol-property-synthesis-ambiguity</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: property %select{of type %1|with attribute '%1'|without attribute '%1'|with getter %1|with setter %1}0 was selected for synthesis</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprotocol-property-synthesis-ambiguity" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-incomplete-implementation</key>
-    <name>clang-diagnostic-incomplete-implementation</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: method definition for %0 not found</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincomplete-implementation" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-property-implicit-mismatch</key>
-    <name>clang-diagnostic-objc-property-implicit-mismatch</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: primary property declaration is implicitly strong while redeclaration in class extension is weak</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-implicit-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-atomic-property-with-user-defined-accessor</key>
-    <name>clang-diagnostic-atomic-property-with-user-defined-accessor</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: writable atomic property %0 cannot pair a synthesized %select{getter|setter}1 with a user defined %select{getter|setter}2</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-property-with-user-defined-accessor" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-property-matches-cocoa-ownership-rule</key>
-    <name>clang-diagnostic-objc-property-matches-cocoa-ownership-rule</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: property follows Cocoa naming convention for returning 'owned' objects</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-matches-cocoa-ownership-rule" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</key>
-    <name>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
-<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
-<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
-<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
-<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
-<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
-<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
-<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
-<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
-<li>warning: hexadecimal floating literals are incompatible with C++ standards before C++17</li>
-<li>warning: inline variables are incompatible with C++ standards before C++17</li>
-<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
-<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
-<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
-<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
-<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
-<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-protocol-property-synthesis</key>
-    <name>clang-diagnostic-objc-protocol-property-synthesis</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: auto property synthesis will not synthesize property %0 declared in protocol %1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-protocol-property-synthesis" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-autosynthesis-property-ivar-name-match</key>
-    <name>clang-diagnostic-objc-autosynthesis-property-ivar-name-match</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: autosynthesized property %0 will use %select{|synthesized}1 instance variable %2, not existing instance variable %3</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-autosynthesis-property-ivar-name-match" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-missing-property-synthesis</key>
-    <name>clang-diagnostic-objc-missing-property-synthesis</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: auto property synthesis is synthesizing property not explicitly synthesized</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-missing-property-synthesis" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-arc-performSelector-leaks</key>
-    <name>clang-diagnostic-arc-performSelector-leaks</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: performSelector may cause a leak because its selector is unknown</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warc-performSelector-leaks" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-implicit-retain-self</key>
-    <name>clang-diagnostic-implicit-retain-self</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-retain-self" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-readonly-iboutlet-property</key>
-    <name>clang-diagnostic-readonly-iboutlet-property</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: readonly IBOutlet property %0 when auto-synthesized may not work correctly with 'nib' loader</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreadonly-iboutlet-property" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-messaging-id</key>
-    <name>clang-diagnostic-objc-messaging-id</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: messaging unqualified id</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-messaging-id" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-invalid-static-assert-message</key>
-    <name>clang-diagnostic-invalid-static-assert-message</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: the message in this static assertion is not a constant expression</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-static-assert-message" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-redundant-consteval-if</key>
-    <name>clang-diagnostic-redundant-consteval-if</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: consteval if is always true in an %select{unevaluated|immediate}0 context</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wredundant-consteval-if" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-friend-enum</key>
-    <name>clang-diagnostic-friend-enum</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: elaborated enum specifier cannot be declared as a friend</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfriend-enum" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat</key>
-    <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
-<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
-<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
-<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
-<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
-<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
-<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
-<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
-<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
-<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
-<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
-<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-weak-vtables</key>
-    <name>clang-diagnostic-weak-vtables</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0 has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wweak-vtables" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-weak-template-vtables</key>
-    <name>clang-diagnostic-weak-template-vtables</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: this warning is no longer in use and will be removed in the next release</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wweak-template-vtables" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-missing-exception-spec</key>
-    <name>clang-diagnostic-missing-exception-spec</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0 is missing exception specification '%1'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-exception-spec" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-injected-class-name</key>
-    <name>clang-diagnostic-injected-class-name</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ISO C++ specifies that qualified reference to %0 is a constructor name rather than a %select{template name|type}1 in this context, despite preceding %select{'typename'|'template'}2 keyword</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winjected-class-name" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-dtor-typedef</key>
-    <name>clang-diagnostic-dtor-typedef</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: destructor cannot be declared using a %select{typedef|type alias}1 %0 of the class name</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdtor-typedef" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-constexpr-not-const</key>
-    <name>clang-diagnostic-constexpr-not-const</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconstexpr-not-const" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-invalid-constexpr</key>
-    <name>clang-diagnostic-invalid-constexpr</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{constexpr|consteval}1 %select{function|constructor}0 never produces a constant expression</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-constexpr" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-auto-var-id</key>
-    <name>clang-diagnostic-auto-var-id</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'auto' deduced as 'id' in declaration of %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wauto-var-id" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-undefined-arm-streaming</key>
-    <name>clang-diagnostic-undefined-arm-streaming</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: builtin call has undefined behaviour when called from a %0 function</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-streaming" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-undefined-arm-za</key>
-    <name>clang-diagnostic-undefined-arm-za</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: builtin call is not valid when calling from a function without active ZA state</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-za" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-undefined-arm-zt0</key>
-    <name>clang-diagnostic-undefined-arm-zt0</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: builtin call is not valid when calling from a function without active ZT0 state</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-zt0" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</key>
-    <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
-<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
-<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
-<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
-<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
-<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: designated initializers are incompatible with C++ standards before C++20</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
-<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
-<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
-<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
-<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
-<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
-<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
-<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-vec-elem-size</key>
-    <name>clang-diagnostic-vec-elem-size</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: vector operands do not have the same elements sizes (%0 and %1)</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvec-elem-size" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-dictionary-duplicate-keys</key>
-    <name>clang-diagnostic-objc-dictionary-duplicate-keys</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: duplicate key in dictionary literal</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-dictionary-duplicate-keys" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-alloca</key>
-    <name>clang-diagnostic-alloca</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: use of function %0 is discouraged; there is no way to check for failure but failure may still occur, resulting in a possibly exploitable security vulnerability</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walloca" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-alloca-with-align-alignof</key>
-    <name>clang-diagnostic-alloca-with-align-alignof</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: second argument to __builtin_alloca_with_align is supposed to be in bits</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walloca-with-align-alignof" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-non-power-of-two-alignment</key>
-    <name>clang-diagnostic-non-power-of-two-alignment</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: requested alignment is not a power of 2</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnon-power-of-two-alignment" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-builtin-assume-aligned-alignment</key>
-    <name>clang-diagnostic-builtin-assume-aligned-alignment</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: requested alignment must be %0 bytes or smaller; maximum alignment assumed</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbuiltin-assume-aligned-alignment" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-cmse-union-leak</key>
-    <name>clang-diagnostic-cmse-union-leak</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: passing union across security boundary via %select{parameter %1|return value}0 may leak information</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcmse-union-leak" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-dll-attribute-on-redeclaration</key>
-    <name>clang-diagnostic-dll-attribute-on-redeclaration</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: redeclaration of %q0 should not add %q1 attribute</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdll-attribute-on-redeclaration" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-dllimport-static-field-def</key>
-    <name>clang-diagnostic-dllimport-static-field-def</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: definition of dllimport static field</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdllimport-static-field-def" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-invalid-initializer-from-system-header</key>
-    <name>clang-diagnostic-invalid-initializer-from-system-header</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: invalid constructor from class in system header, should not be explicit</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-initializer-from-system-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c++2c-compat</key>
-    <name>clang-diagnostic-pre-c++2c-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
-<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
-<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
-<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
-<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2c-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unsupported-dll-base-class-template</key>
-    <name>clang-diagnostic-unsupported-dll-base-class-template</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: propagating dll attribute to %select{already instantiated|explicitly specialized}0 base class template without dll attribute is not supported</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-dll-base-class-template" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-encode-type</key>
-    <name>clang-diagnostic-encode-type</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: encoding of %0 type is incomplete because %1 component has unknown encoding</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wencode-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-gnu-inline-cpp-without-extern</key>
-    <name>clang-diagnostic-gnu-inline-cpp-without-extern</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'gnu_inline' attribute without 'extern' in C++ treated as externally available, this changed in Clang 10</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-inline-cpp-without-extern" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-missing-prototype-for-cc</key>
-    <name>clang-diagnostic-missing-prototype-for-cc</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: function with no prototype cannot use the %0 calling convention</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-prototype-for-cc" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unsupported-availability-guard</key>
-    <name>clang-diagnostic-unsupported-availability-guard</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{@available|__builtin_available}0 does not guard availability here; use if (%select{@available|__builtin_available}0) instead</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-availability-guard" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-ignored-availability-without-sdk-settings</key>
-    <name>clang-diagnostic-ignored-availability-without-sdk-settings</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0 availability is ignored without a valid 'SDKSettings.json' in the SDK</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-availability-without-sdk-settings" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pointer-compare</key>
-    <name>clang-diagnostic-pointer-compare</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: comparing a pointer to a null character constant; did you mean to compare to %select{NULL|(void *)0}0?</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-sizeof-pointer-div</key>
-    <name>clang-diagnostic-sizeof-pointer-div</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%0' will return the size of the pointer, not the array itself</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsizeof-pointer-div" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-sizeof-array-div</key>
-    <name>clang-diagnostic-sizeof-array-div</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: expression does not compute the number of elements in this array; element type is %0, not %1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsizeof-array-div" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-attribute-packed-for-bitfield</key>
-    <name>clang-diagnostic-attribute-packed-for-bitfield</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'packed' attribute was ignored on bit-fields with single-byte alignment in older versions of GCC and Clang</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wattribute-packed-for-bitfield" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c++2c-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c++2c-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
-<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
-<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
-<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
-<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2c-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unsupported-visibility</key>
-    <name>clang-diagnostic-unsupported-visibility</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: target does not support 'protected' visibility; using 'default'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsupported-visibility" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-invalid-no-builtin-names</key>
-    <name>clang-diagnostic-invalid-no-builtin-names</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%0' is not a valid builtin name for %1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-no-builtin-names" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-requires-super-attribute</key>
-    <name>clang-diagnostic-requires-super-attribute</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0 attribute cannot be applied to %select{methods in protocols|dealloc}1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrequires-super-attribute" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-ambiguous-reversed-operator</key>
-    <name>clang-diagnostic-ambiguous-reversed-operator</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ISO C++20 considers use of overloaded operator '%0' (with operand types %1 and %2) to be ambiguous despite there being a unique best viable function%select{ with non-reversed arguments|}3</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wambiguous-reversed-operator" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-rewrite-not-bool</key>
-    <name>clang-diagnostic-rewrite-not-bool</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ISO C++20 requires return type of selected 'operator==' function for rewritten '%1' comparison to be 'bool', not %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrewrite-not-bool" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-strict-primary-template-shadow</key>
-    <name>clang-diagnostic-strict-primary-template-shadow</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: declaration of %0 shadows template parameter</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrict-primary-template-shadow" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unqualified-std-cast-call</key>
-    <name>clang-diagnostic-unqualified-std-cast-call</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: unqualified call to '%0'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunqualified-std-cast-call" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-invalid-partial-specialization</key>
-    <name>clang-diagnostic-invalid-partial-specialization</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{class|variable}0 template partial specialization is not more specialized than the primary template</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-partial-specialization" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unusable-partial-specialization</key>
-    <name>clang-diagnostic-unusable-partial-specialization</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{class|variable}0 template partial specialization contains %select{a template parameter|template parameters}1 that cannot be deduced; this partial specialization will never be used</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunusable-partial-specialization" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-instantiation-after-specialization</key>
-    <name>clang-diagnostic-instantiation-after-specialization</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: explicit instantiation of %0 that occurs after an explicit specialization has no effect</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winstantiation-after-specialization" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++0x-narrowing</key>
-    <name>clang-diagnostic-c++0x-narrowing</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-narrowing" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-typename-missing</key>
-    <name>clang-diagnostic-typename-missing</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: missing 'typename' prior to dependent type name '%0%1'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtypename-missing" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-missing-prototypes</key>
-    <name>clang-diagnostic-missing-prototypes</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: no previous prototype for function %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-prototypes" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-missing-variable-declarations</key>
-    <name>clang-diagnostic-missing-variable-declarations</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: no previous extern declaration for non-static variable %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-variable-declarations" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-undefined-internal</key>
-    <name>clang-diagnostic-undefined-internal</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{function|variable}0 %q1 has internal linkage but is not defined</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-internal" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-undefined-internal-type</key>
-    <name>clang-diagnostic-undefined-internal-type</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ISO C++ requires a definition in this translation unit for %select{function|variable}0 %q1 because its type does not have linkage</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-internal-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-undefined-inline</key>
-    <name>clang-diagnostic-undefined-inline</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: inline function %q0 is not defined</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-inline" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-typedef-redefinition</key>
-    <name>clang-diagnostic-typedef-redefinition</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: redefinition of typedef %0 is a C11 feature</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtypedef-redefinition" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-retained-language-linkage</key>
-    <name>clang-diagnostic-retained-language-linkage</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: friend function %0 retaining previous language linkage is an extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wretained-language-linkage" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-forward-class-redefinition</key>
-    <name>clang-diagnostic-objc-forward-class-redefinition</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: redefinition of forward class %0 of a typedef name of an object type is ignored</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-forward-class-redefinition" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-interface-ivars</key>
-    <name>clang-diagnostic-objc-interface-ivars</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: declaration of instance variables in the interface is deprecated</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-interface-ivars" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-narrowing</key>
-    <name>clang-diagnostic-narrowing</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnarrowing" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-extern-initializer</key>
-    <name>clang-diagnostic-extern-initializer</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'extern' variable has an initializer</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextern-initializer" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-braced-scalar-init</key>
-    <name>clang-diagnostic-braced-scalar-init</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: braces around %select{scalar |}0initializer</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbraced-scalar-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-many-braces-around-scalar-init</key>
-    <name>clang-diagnostic-many-braces-around-scalar-init</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: too many braces around %select{scalar |}0initializer</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmany-braces-around-scalar-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-complex-component-init</key>
-    <name>clang-diagnostic-complex-component-init</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: complex initialization specifying real and imaginary components is an extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcomplex-component-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-qualified-void-return-type</key>
-    <name>clang-diagnostic-qualified-void-return-type</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: function cannot return qualified void type %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wqualified-void-return-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-explicit-ownership-type</key>
-    <name>clang-diagnostic-explicit-ownership-type</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: method parameter of type %0 with no explicit ownership</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexplicit-ownership-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-atomic-access</key>
-    <name>clang-diagnostic-atomic-access</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: accessing a member of an atomic structure or union is undefined behavior</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-access" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-float-equal</key>
-    <name>clang-diagnostic-float-equal</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: comparing floating point with == or != is unsafe</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfloat-equal" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-shift-negative-value</key>
-    <name>clang-diagnostic-shift-negative-value</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: shifting a negative signed value is undefined</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-negative-value" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-shift-count-negative</key>
-    <name>clang-diagnostic-shift-count-negative</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: shift count is negative</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-count-negative" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++0x-compat</key>
-    <name>clang-diagnostic-c++0x-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
-<li>warning: #warning is incompatible with C++ standards before C++23</li>
-<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
-<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
-<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
-<li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
-<li>warning: '%0' is a keyword in C++11</li>
-<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
-<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
-<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
-<li>warning: 'auto' storage class specifier is redundant and incompatible with C++11</li>
-<li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
-<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
-<li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
-<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
-<li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
-<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
-<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
-<li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
-<li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
-<li>warning: consteval if is incompatible with C++ standards before C++23</li>
-<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
-<li>warning: constexpr if is incompatible with C++ standards before C++17</li>
-<li>warning: constexpr on lambda expressions is incompatible with C++ standards before C++17</li>
-<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
-<li>warning: conversion from string literal to %0 is deprecated</li>
-<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
-<li>warning: decomposition declarations are incompatible with C++ standards before C++17</li>
-<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
-<li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
-<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-<li>warning: digit separators are incompatible with C++ standards before C++14</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
-<li>warning: explicit instantiation cannot be 'inline'</li>
-<li>warning: explicit instantiation of %0 must occur at global scope</li>
-<li>warning: explicit instantiation of %0 not in a namespace enclosing %1</li>
-<li>warning: explicit instantiation of %q0 must occur in namespace %1</li>
-<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
-<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
-<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: generic lambdas are incompatible with C++11</li>
-<li>warning: identifier after literal will be treated as a reserved user-defined literal suffix in C++11</li>
-<li>warning: identifier after literal will be treated as a user-defined literal suffix in C++11</li>
-<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
-<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
-<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
-<li>warning: inline variables are incompatible with C++ standards before C++17</li>
-<li>warning: integer literal is too large to be represented in type 'long' and is subject to undefined behavior under C++98, interpreting as 'unsigned long'; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
-<li>warning: integer literal is too large to be represented in type 'long', interpreting as 'unsigned long' per C++98; this literal will %select{have type 'long long'|be ill-formed}0 in C++11 onwards</li>
-<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
-<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
-<li>warning: nested namespace definition is incompatible with C++ standards before C++17</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list</li>
-<li>warning: non-constant-expression cannot be narrowed from type %0 to %1 in initializer list in C++11</li>
-<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: non-type template parameters declared with %0 are incompatible with C++ standards before C++17</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
-<li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
-<li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
-<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
-<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
-<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
-<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
-<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
-<li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list</li>
-<li>warning: type %0 cannot be narrowed to %1 in initializer list in C++11</li>
-<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: unicode literals are incompatible with C++ standards before C++17</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
-<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
-<li>warning: use of multiple declarators in a single using declaration is incompatible with C++ standards before C++17</li>
-<li>warning: use of right-shift operator ('&gt;&gt;') in template argument will require parentheses in C++11</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
-<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable templates are incompatible with C++ standards before C++14</li>
-<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-shift-count-overflow</key>
-    <name>clang-diagnostic-shift-count-overflow</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: shift count &gt;= width of type</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-count-overflow" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-shift-overflow</key>
-    <name>clang-diagnostic-shift-overflow</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: signed shift result (%0) requires %1 bits to represent, but %2 only has %3 bits</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-overflow" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-shift-sign-overflow</key>
-    <name>clang-diagnostic-shift-sign-overflow</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: signed shift result (%0) sets the sign bit of the shift expression's type (%1) and becomes negative</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wshift-sign-overflow" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-constant-logical-operand</key>
-    <name>clang-diagnostic-constant-logical-operand</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: use of logical '%0' with constant operand</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconstant-logical-operand" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-extra-qualification</key>
-    <name>clang-diagnostic-extra-qualification</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: extra qualification on member %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextra-qualification" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-tentative-definition-incomplete-type</key>
-    <name>clang-diagnostic-tentative-definition-incomplete-type</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: tentative definition of variable with internal linkage has incomplete non-array type %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtentative-definition-incomplete-type" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-tentative-definition-array</key>
-    <name>clang-diagnostic-tentative-definition-array</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: tentative array definition assumed to have one element</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtentative-definition-array" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-gnu-array-member-paren-init</key>
-    <name>clang-diagnostic-gnu-array-member-paren-init</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: parenthesized initialization of a member array is a GNU extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-array-member-paren-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-address-of-packed-member</key>
-    <name>clang-diagnostic-address-of-packed-member</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: taking address of packed member %0 of class or structure %q1 may result in an unaligned pointer value</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waddress-of-packed-member" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-align-mismatch</key>
-    <name>clang-diagnostic-align-mismatch</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: passing %0-byte aligned argument to %1-byte aligned parameter %2%select{| of %4}3 may result in an unaligned pointer access</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walign-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++1z-compat</key>
-    <name>clang-diagnostic-c++1z-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
-<li>warning: #warning is incompatible with C++ standards before C++23</li>
-<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
-<li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
-<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
-<li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
-<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
-<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
-<li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
-<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
-<li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
-<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
-<li>warning: consteval if is incompatible with C++ standards before C++23</li>
-<li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
-<li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
-<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
-<li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
-<li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
-<li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
-<li>warning: explicit(bool) is incompatible with C++ standards before C++20</li>
-<li>warning: explicitly defaulting this %sub{select_special_member_kind}0 with a type different from the implicit type is incompatible with C++ standards before C++20</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: incrementing expression of type bool is deprecated and incompatible with C++17</li>
-<li>warning: initialized lambda capture packs are incompatible with C++ standards before C++20</li>
-<li>warning: inline nested namespace definition is incompatible with C++ standards before C++20</li>
-<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
-<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
-<li>warning: member using declaration naming a non-member enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
-<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
-<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
-<li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
-<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
-<li>warning: use of function template name with no prior function template declaration in function call with explicit template arguments is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-<li>warning: using declaration naming a scoped enumerator is incompatible with C++ standards before C++20</li>
-<li>warning: using enum declaration is incompatible with C++ standards before C++20</li>
-<li>warning: virtual constexpr functions are incompatible with C++ standards before C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pointer-integer-compare</key>
-    <name>clang-diagnostic-pointer-integer-compare</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: comparison between pointer and integer (%0 and %1)</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-integer-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-circular-container</key>
-    <name>clang-diagnostic-objc-circular-container</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: adding %0 to %1 might cause circular dependency in container</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-circular-container" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-unsafe-perform-selector</key>
-    <name>clang-diagnostic-objc-unsafe-perform-selector</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0 is incompatible with selectors that return a %select{struct|union|vector}1 type</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-unsafe-perform-selector" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-cast-qual-unrelated</key>
-    <name>clang-diagnostic-cast-qual-unrelated</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ISO C++ does not allow %select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|functional-style cast|}0 from %1 to %2 because it casts away qualifiers, even though the source and destination types are unrelated</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-qual-unrelated" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-mismatched-new-delete</key>
-    <name>clang-diagnostic-mismatched-new-delete</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'delete%select{|[]}0' applied to a pointer that was allocated with 'new%select{[]|}0'; did you mean 'delete%select{[]|}0'?</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmismatched-new-delete" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-ambiguous-delete</key>
-    <name>clang-diagnostic-ambiguous-delete</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: multiple suitable %0 functions for %1; no 'operator delete' function will be invoked if initialization throws an exception</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wambiguous-delete" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-deprecated-altivec-src-compat</key>
-    <name>clang-diagnostic-deprecated-altivec-src-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: current handling of vector bool and vector pixel types in this context are deprecated; the default behaviour will soon change to that implied by the '-altivec-compat=xl' option</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-altivec-src-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-deprecate-lax-vec-conv-all</key>
-    <name>clang-diagnostic-deprecate-lax-vec-conv-all</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: implicit conversion between vector types ('%0' and '%1') is deprecated; in the future, the behavior implied by '-fno-lax-vector-conversions' will be the default</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecate-lax-vec-conv-all" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-jump-seh-finally</key>
-    <name>clang-diagnostic-jump-seh-finally</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: jump out of __finally block has undefined behavior</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wjump-seh-finally" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-template-in-declaration-name</key>
-    <name>clang-diagnostic-template-in-declaration-name</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'template' cannot be used after a declarative nested name specifier</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtemplate-in-declaration-name" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++2a-compat</key>
-    <name>clang-diagnostic-c++2a-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
-<li>warning: #warning is incompatible with C++ standards before C++23</li>
-<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
-<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
-<li>warning: '%0' is a keyword in C++20</li>
-<li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
-<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
-<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
-<li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
-<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
-<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
-<li>warning: consteval if is incompatible with C++ standards before C++23</li>
-<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
-<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
-<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
-<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
-<li>warning: taking address of non-addressable standard library function is incompatible with C++20</li>
-<li>warning: this expression will be parsed as explicit(bool) in C++20</li>
-<li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
-<li>warning: use of implicit 'typename' is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-alias-template-in-declaration-name</key>
-    <name>clang-diagnostic-alias-template-in-declaration-name</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: a declarative nested name specifier cannot name an alias template</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walias-template-in-declaration-name" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-idiomatic-parentheses</key>
-    <name>clang-diagnostic-idiomatic-parentheses</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: using the result of an assignment as a condition without parentheses</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#widiomatic-parentheses" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pointer-sign</key>
-    <name>clang-diagnostic-pointer-sign</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2 converts between pointers to integer types %select{with different sign|where one is of the unique plain 'char' type and the other is not}3</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-sign" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-incompatible-function-pointer-types-strict</key>
-    <name>clang-diagnostic-incompatible-function-pointer-types-strict</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: incompatible function pointer types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-function-pointer-types-strict" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-atomic-memory-ordering</key>
-    <name>clang-diagnostic-atomic-memory-ordering</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{|success |failure }0memory order argument to atomic operation is invalid</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-memory-ordering" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-atomic-implicit-seq-cst</key>
-    <name>clang-diagnostic-atomic-implicit-seq-cst</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: implicit use of sequentially-consistent atomic may incur stronger memory barriers than necessary</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#watomic-implicit-seq-cst" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-gpu-maybe-wrong-side</key>
-    <name>clang-diagnostic-gpu-maybe-wrong-side</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: capture host side class data member by this pointer in device or host device lambda function may result in invalid memory access if this pointer is not accessible on device side</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgpu-maybe-wrong-side" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-nvcc-compat</key>
-    <name>clang-diagnostic-nvcc-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: target-attribute based function overloads are not supported by NVCC and will be treated as a function redeclaration:new declaration is %select{__device__|__global__|__host__|__host__ __device__}0 function, old declaration is %select{__device__|__global__|__host__|__host__ __device__}1 function</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnvcc-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-cast-calling-convention</key>
-    <name>clang-diagnostic-cast-calling-convention</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: cast between incompatible calling conventions '%0' and '%1'; calls through this pointer may abort at runtime</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-calling-convention" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pointer-type-mismatch</key>
-    <name>clang-diagnostic-pointer-type-mismatch</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: pointer type mismatch%diff{ ($ and $)|}0,1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-type-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++2a-compat-pedantic</key>
-    <name>clang-diagnostic-c++2a-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
-<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
-<li>warning: #warning is incompatible with C++ standards before C++23</li>
-<li>warning: #warning is incompatible with C++ standards before C++23</li>
-<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
-<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
-<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
-<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
-<li>warning: '%0' is a keyword in C++20</li>
-<li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
-<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
-<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
-<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
-<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
-<li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
-<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
-<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
-<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
-<li>warning: consteval if is incompatible with C++ standards before C++23</li>
-<li>warning: consteval if is incompatible with C++ standards before C++23</li>
-<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
-<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
-<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
-<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
-<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
-<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
-<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
-<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
-<li>warning: taking address of non-addressable standard library function is incompatible with C++20</li>
-<li>warning: this expression will be parsed as explicit(bool) in C++20</li>
-<li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
-<li>warning: use of implicit 'typename' is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-conditional-type-mismatch</key>
-    <name>clang-diagnostic-conditional-type-mismatch</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: pointer/integer type mismatch in conditional expression%diff{ ($ and $)|}0,1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconditional-type-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unused-volatile-lvalue</key>
-    <name>clang-diagnostic-unused-volatile-lvalue</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: expression result unused; assign into a variable to force a volatile load</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-volatile-lvalue" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-missing-constinit</key>
-    <name>clang-diagnostic-missing-constinit</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'constinit' specifier missing on initializing declaration of %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-constinit" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-abstract-vbase-init</key>
-    <name>clang-diagnostic-abstract-vbase-init</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: initializer for virtual base class %0 of abstract class %1 will never be used</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wabstract-vbase-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-nested-anon-types</key>
-    <name>clang-diagnostic-nested-anon-types</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: anonymous types declared in an anonymous %select{struct|union}0 are an extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnested-anon-types" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-inaccessible-base</key>
-    <name>clang-diagnostic-inaccessible-base</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: direct base %0 is inaccessible due to ambiguity:%1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winaccessible-base" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-inline-new-delete</key>
-    <name>clang-diagnostic-inline-new-delete</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: replacement function %0 cannot be declared 'inline'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winline-new-delete" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-multiple-move-vbase</key>
-    <name>clang-diagnostic-multiple-move-vbase</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: defaulted move assignment operator of %0 will move assign virtual base class %1 multiple times</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmultiple-move-vbase" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++23-default-comp-relaxed-constexpr</key>
-    <name>clang-diagnostic-c++23-default-comp-relaxed-constexpr</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is a C++23 extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-default-comp-relaxed-constexpr" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-implicit-exception-spec-mismatch</key>
-    <name>clang-diagnostic-implicit-exception-spec-mismatch</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: function previously declared with an %select{explicit|implicit}0 exception specification redeclared with an %select{implicit|explicit}0 exception specification</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-exception-spec-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-CFString-literal</key>
-    <name>clang-diagnostic-CFString-literal</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: input conversion stopped due to an input byte that does not belong to the input codeset UTF-8</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wCFString-literal" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-return-local-addr</key>
-    <name>clang-diagnostic-return-local-addr</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{address of|reference to}0 stack memory associated with %select{local variable|parameter|compound literal}2 %1 returned</li>
-<li>warning: returning %select{address of|reference to}0 local temporary object</li>
-<li>warning: returning address of label, which is local</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-local-addr" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-assign-enum</key>
-    <name>clang-diagnostic-assign-enum</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: integer constant not in range of enumerated type %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wassign-enum" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-argument-outside-range</key>
-    <name>clang-diagnostic-argument-outside-range</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: argument value %0 is outside the valid range [%1, %2]</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wargument-outside-range" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-argument-undefined-behaviour</key>
-    <name>clang-diagnostic-argument-undefined-behaviour</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: argument value %0 will result in undefined behaviour</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wargument-undefined-behaviour" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-nonportable-vector-initialization</key>
-    <name>clang-diagnostic-nonportable-vector-initialization</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: vector initializers are not compatible with NEON intrinsics in big endian mode</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-vector-initialization" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-sync-fetch-and-nand-semantics-changed</key>
-    <name>clang-diagnostic-sync-fetch-and-nand-semantics-changed</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: the semantics of this intrinsic changed with GCC version 4.4 - the newer semantics are provided here</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsync-fetch-and-nand-semantics-changed" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-signed-unsigned-wchar</key>
-    <name>clang-diagnostic-signed-unsigned-wchar</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%0' cannot be signed or unsigned</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsigned-unsigned-wchar" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-direct-ivar-access</key>
-    <name>clang-diagnostic-direct-ivar-access</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: instance variable %0 is being directly accessed</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdirect-ivar-access" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unaligned-qualifier-implicit-cast</key>
-    <name>clang-diagnostic-unaligned-qualifier-implicit-cast</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: implicit cast from type %0 to type %1 drops __unaligned qualifier</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunaligned-qualifier-implicit-cast" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-module-import-in-extern-c</key>
-    <name>clang-diagnostic-module-import-in-extern-c</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: import of C++ module '%0' appears within extern "C" language linkage specification</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodule-import-in-extern-c" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-modules-import-nested-redundant</key>
-    <name>clang-diagnostic-modules-import-nested-redundant</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: redundant #include of module '%0' appears within %1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodules-import-nested-redundant" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-export-using-directive</key>
-    <name>clang-diagnostic-export-using-directive</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ISO C++20 does not permit using directive to be exported</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexport-using-directive" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-experimental-header-units</key>
-    <name>clang-diagnostic-experimental-header-units</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: the implementation of header units is in an experimental phase</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexperimental-header-units" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-modules-ambiguous-internal-linkage</key>
-    <name>clang-diagnostic-modules-ambiguous-internal-linkage</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: ambiguous use of internal linkage declaration %0 defined in multiple modules</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodules-ambiguous-internal-linkage" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-zero-as-null-pointer-constant</key>
     <name>clang-diagnostic-zero-as-null-pointer-constant</name>
     <description>
@@ -35836,1068 +36888,17 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-tcb-enforcement</key>
-    <name>clang-diagnostic-tcb-enforcement</name>
+    <key>clang-diagnostic-zero-length-array</key>
+    <name>clang-diagnostic-zero-length-array</name>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: calling %0 is a violation of trusted computing base '%1'</li>
+<li>warning: zero size arrays are an extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtcb-enforcement" target="_blank">Diagnostic flags in Clang</a></p>]]>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wzero-length-array" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
-  <rule>
-    <key>clang-diagnostic-openacc-self-if-potential-conflict</key>
-    <name>clang-diagnostic-openacc-self-if-potential-conflict</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: OpenACC construct 'self' has no effect when an 'if' clause evaluates to true</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenacc-self-if-potential-conflict" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-openacc-deprecated-clause-alias</key>
-    <name>clang-diagnostic-openacc-deprecated-clause-alias</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: OpenACC clause name '%0' is a deprecated clause name and is now an alias for '%1'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenacc-deprecated-clause-alias" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pch-vfs-diff</key>
-    <name>clang-diagnostic-pch-vfs-diff</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: PCH was compiled with different VFS overlay files than are currently in use</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpch-vfs-diff" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pch-date-time</key>
-    <name>clang-diagnostic-pch-date-time</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{precompiled header|module}0 uses __DATE__ or __TIME__</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpch-date-time" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-override-init</key>
-    <name>clang-diagnostic-override-init</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
-<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
-<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverride-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-effc++</key>
-    <name>clang-diagnostic-effc++</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0 has virtual functions but non-virtual destructor</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#weffc-" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c2x-compat</key>
-    <name>clang-diagnostic-c2x-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%0' is a keyword in C23</li>
-<li>warning: type of UTF-8 string literal will change from array of char to array of char8_t in C23</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc2x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-sequence-point</key>
-    <name>clang-diagnostic-sequence-point</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: multiple unsequenced modifications to %0</li>
-<li>warning: unsequenced modification and access to %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsequence-point" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-address</key>
-    <name>clang-diagnostic-address</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: address of %select{'%1'|function '%1'|array '%1'|lambda function pointer conversion operator}0 will always evaluate to 'true'</li>
-<li>warning: comparison of %select{address of|function|array}0 '%1' %select{not |}2equal to a null pointer is always %select{true|false}2</li>
-<li>warning: comparison of nonnull %select{function call|parameter}0 '%1' %select{not |}2equal to a null pointer is '%select{true|false}2' on first encounter</li>
-<li>warning: nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter</li>
-<li>warning: result of comparison against %select{a string literal|@encode}0 is unspecified (use an explicit string comparison function instead)</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waddress" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-CL4</key>
-    <name>clang-diagnostic-CL4</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #pragma execution_character_set expected '%0'</li>
-<li>warning: #pragma execution_character_set expected 'push' or 'pop'</li>
-<li>warning: #pragma execution_character_set invalid value '%0', only 'UTF-8' is supported</li>
-<li>warning: #pragma warning expected '%0'</li>
-<li>warning: #pragma warning expected 'push', 'pop', 'default', 'disable', 'error', 'once', 'suppress', 1, 2, 3, or 4</li>
-<li>warning: #pragma warning expected a warning number</li>
-<li>warning: #pragma warning(push, level) requires a level between 0 and 4</li>
-<li>warning: %0</li>
-<li>warning: %0 has C-linkage specified, but returns incomplete type %1 which could be incompatible with C</li>
-<li>warning: %0 has C-linkage specified, but returns user-defined type %1 which is incompatible with C</li>
-<li>warning: %0 has lower precedence than %1; %1 will be evaluated first</li>
-<li>warning: %2 defined as %select{a struct|an interface|a class}0%select{| template}1 here but previously declared as %select{a struct|an interface|a class}3%select{| template}1; this is valid, but may result in linker errors under the Microsoft C++ ABI</li>
-<li>warning: %plural{1:enumeration value %1 not handled in switch|2:enumeration values %1 and %2 not handled in switch|3:enumeration values %1, %2, and %3 not handled in switch|:%0 enumeration values not handled in switch: %1, %2, %3...}0</li>
-<li>warning: %q0 hides overloaded virtual %select{function|functions}1</li>
-<li>warning: %select{aligning a value|the result of checking whether a value is aligned}0 to 1 byte is %select{a no-op|always true}0</li>
-<li>warning: %select{delete|destructor}0 called on %1 that is abstract but has non-virtual destructor</li>
-<li>warning: %select{delete|destructor}0 called on non-final %1 that has virtual functions but non-virtual destructor</li>
-<li>warning: %select{equality|inequality|relational|three-way}0 comparison result unused</li>
-<li>warning: %select{field width|precision}0 used with '%1' conversion specifier, resulting in undefined behavior</li>
-<li>warning: %select{field|base class}0 %1 will be initialized after %select{field|base}2 %3</li>
-<li>warning: %select{function|variable}0 %1 is not needed and will not be emitted</li>
-<li>warning: %select{self-|array }0comparison always evaluates to %select{a constant|true|false|'std::strong_ordering::equal'}1</li>
-<li>warning: %select{struct|interface|class}0%select{| template}1 %2 was previously declared as a %select{struct|interface|class}3%select{| template}1; this is valid, but may result in linker errors under the Microsoft C++ ABI</li>
-<li>warning: %select{values of type|enum values with underlying type}2 '%0' should not be used as format arguments; add an explicit cast to %1 instead</li>
-<li>warning: %select{void function|void method|constructor|destructor}1 %0 should not return a value</li>
-<li>warning: %select{|empty }0%select{struct|union}1 has size 0 in C, %select{size 1|non-zero size}2 in C++</li>
-<li>warning: %sub{subst_format_overflow}0,1,2</li>
-<li>warning: %sub{subst_format_overflow}0,1,2</li>
-<li>warning: %sub{subst_format_truncation}0,1,2</li>
-<li>warning: %sub{subst_format_truncation}0,1,2</li>
-<li>warning: '%%n' specifier not supported on this platform</li>
-<li>warning: '%0' is not a valid object format flag</li>
-<li>warning: '%0' qualifier on function type %1 has no effect</li>
-<li>warning: '%0' qualifier on omitted return type %1 has no effect</li>
-<li>warning: '%0' qualifier on reference type %1 has no effect</li>
-<li>warning: '%0' type qualifier%s1 on return type %plural{1:has|:have}1 no effect</li>
-<li>warning: '%0' within '%1'</li>
-<li>warning: '%select{*|.*}0' specified field %select{width|precision}0 is missing a matching 'int' argument</li>
-<li>warning: '&amp;&amp;' of a value and its negation always evaluates to false</li>
-<li>warning: '&amp;&amp;' within '||'</li>
-<li>warning: '-fuse-ld=' taking a path is deprecated; use '--ld-path=' instead</li>
-<li>warning: '/*' within block comment</li>
-<li>warning: 'static' function %0 declared in header file should be declared 'static inline'</li>
-<li>warning: 'this' pointer cannot be null in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0</li>
-<li>warning: '||' of a value and its negation always evaluates to true</li>
-<li>warning: // comments are not allowed in this language</li>
-<li>warning: ARC %select{unused|__unsafe_unretained|__strong|__weak|__autoreleasing}0 lifetime qualifier on return type is ignored</li>
-<li>warning: ISO C++ requires field designators to be specified in declaration order; field %1 will be initialized after field %0</li>
-<li>warning: add explicit braces to avoid dangling else</li>
-<li>warning: adding %0 to a string does not append to the string</li>
-<li>warning: all paths through this function will call itself</li>
-<li>warning: angle-bracketed include &lt;%0&gt; cannot be aliased to double-quoted include "%1"</li>
-<li>warning: argument %0 of type %1 with mismatched bound</li>
-<li>warning: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension</li>
-<li>warning: array section %select{lower bound|length}0 is of type 'char'</li>
-<li>warning: array subscript is of type 'char'</li>
-<li>warning: assigning %select{field|instance variable}0 to itself</li>
-<li>warning: base class %0 is uninitialized when used here to access %q1</li>
-<li>warning: bitwise comparison always evaluates to %select{false|true}0</li>
-<li>warning: bitwise negation of a boolean expression%select{;| always evaluates to 'true';}0 did you mean logical negation?</li>
-<li>warning: bitwise or with non-zero value always evaluates to true</li>
-<li>warning: block pointer variable %0 is %select{uninitialized|null}1 when captured by block</li>
-<li>warning: call to undeclared function %0; ISO C99 and later do not support implicit function declarations</li>
-<li>warning: call to undeclared library function '%0' with type %1; ISO C99 and later do not support implicit function declarations</li>
-<li>warning: calling '%0' with a nonzero argument is unsafe</li>
-<li>warning: cannot mix positional and non-positional arguments in format string</li>
-<li>warning: case value not in enumerated type %0</li>
-<li>warning: cast %diff{from $ to $ |}0,1converts to incompatible function type</li>
-<li>warning: cast of type %0 to %1 is deprecated; use sel_getName instead</li>
-<li>warning: comparison of %select{address of|function|array}0 '%1' %select{not |}2equal to a null pointer is always %select{true|false}2</li>
-<li>warning: comparison of integers of different signs: %0 and %1</li>
-<li>warning: comparison of nonnull %select{function call|parameter}0 '%1' %select{not |}2equal to a null pointer is '%select{true|false}2' on first encounter</li>
-<li>warning: comparisons like 'X&lt;=Y&lt;=Z' don't have their mathematical meaning</li>
-<li>warning: container access result unused - container access should not be used for side effects</li>
-<li>warning: convenience initializer missing a 'self' call to another initializer</li>
-<li>warning: convenience initializer should not invoke an initializer on 'super'</li>
-<li>warning: converting the enum constant to a boolean</li>
-<li>warning: converting the result of '&lt;&lt;' to a boolean always evaluates to %select{false|true}0</li>
-<li>warning: converting the result of '&lt;&lt;' to a boolean; did you mean '(%0) != 0'?</li>
-<li>warning: converting the result of '?:' with integer constants to a boolean always evaluates to 'true'</li>
-<li>warning: data argument not used by format string</li>
-<li>warning: data argument position '%0' exceeds the number of data arguments (%1)</li>
-<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared copy %select{assignment operator|constructor}1</li>
-<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided copy %select{assignment operator|constructor}1</li>
-<li>warning: designated initializer invoked a non-designated initializer</li>
-<li>warning: designated initializer missing a 'super' call to a designated initializer of the super class</li>
-<li>warning: designated initializer should only invoke a designated initializer on 'super'</li>
-<li>warning: double-quoted include "%0" cannot be aliased to angle-bracketed include &lt;%1&gt;</li>
-<li>warning: empty initialization statement of '%select{if|switch|range-based for}0' has no effect</li>
-<li>warning: equality comparison with extraneous parentheses</li>
-<li>warning: escaped newline between */ characters at block comment end</li>
-<li>warning: expected 'ON' or 'OFF' or 'DEFAULT' in pragma</li>
-<li>warning: expected end of directive in pragma</li>
-<li>warning: explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1</li>
-<li>warning: explicitly assigning value of variable of type %0 to itself%select{|; did you mean to assign to member %2?}1</li>
-<li>warning: explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1</li>
-<li>warning: explicitly moving variable of type %0 to itself%select{|; did you mean to move to member %2?}1</li>
-<li>warning: expression result unused</li>
-<li>warning: expression result unused; should this cast be to 'void'?</li>
-<li>warning: expression with side effects has no effect in an unevaluated context</li>
-<li>warning: expression with side effects will be evaluated despite being used as an operand to 'typeid'</li>
-<li>warning: field %0 can overwrite instance variable %1 with variable sized type %2 in superclass %3</li>
-<li>warning: field %0 is uninitialized when used here</li>
-<li>warning: field %0 with variable sized type %1 is not visible to subclasses and can conflict with their instance variables</li>
-<li>warning: field %select{width|precision}0 should have type %1, but argument has type %2</li>
-<li>warning: flag '%0' is ignored when flag '%1' is present</li>
-<li>warning: flag '%0' results in undefined behavior with '%1' conversion specifier</li>
-<li>warning: format specifies type %0 but the argument has %select{type|underlying type}2 %1</li>
-<li>warning: format string contains '\0' within the string body</li>
-<li>warning: format string is empty</li>
-<li>warning: format string is not a string literal (potentially insecure)</li>
-<li>warning: format string is not null-terminated</li>
-<li>warning: format string missing</li>
-<li>warning: format string should not be a wide string</li>
-<li>warning: ignored trigraph would end block comment</li>
-<li>warning: ignoring return value of function declared with %0 attribute</li>
-<li>warning: ignoring return value of function declared with %0 attribute</li>
-<li>warning: ignoring return value of function declared with %0 attribute: %1</li>
-<li>warning: ignoring temporary created by a constructor declared with %0 attribute</li>
-<li>warning: ignoring temporary created by a constructor declared with %0 attribute: %1</li>
-<li>warning: implicit declaration of function %0</li>
-<li>warning: implicitly declaring library function '%0' with type %1</li>
-<li>warning: incomplete format specifier</li>
-<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
-<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
-<li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
-<li>warning: initializer order does not match the declaration order</li>
-<li>warning: invalid conversion specifier '%0'</li>
-<li>warning: invalid position specified for %select{field width|field precision}0</li>
-<li>warning: ivar %0 which backs the property is not referenced in this property's accessor</li>
-<li>warning: lambda capture %0 is not %select{used|required to be captured for this use}1</li>
-<li>warning: left operand of comma operator has no effect</li>
-<li>warning: length modifier '%0' results in undefined behavior or no effect with '%1' conversion specifier</li>
-<li>warning: logical not is only applied to the left hand side of this %select{comparison|bitwise operator}0</li>
-<li>warning: loop variable %0 %diff{of type $ binds to a temporary constructed from type $|binds to a temporary constructed from a different type}1,2</li>
-<li>warning: loop variable %0 creates a copy from type %1</li>
-<li>warning: method has no return type specified; defaults to 'id'</li>
-<li>warning: method override for the designated initializer of the superclass %objcinstance0 not found</li>
-<li>warning: method possibly missing a [super %0] call</li>
-<li>warning: misleading indentation; statement is not part of the previous '%select{if|else|for|while}0'</li>
-<li>warning: missing field %0 initializer</li>
-<li>warning: missing field %0 initializer</li>
-<li>warning: missing object format flag</li>
-<li>warning: more '%%' conversions than data arguments</li>
-<li>warning: moving a local object in a return statement prevents copy elision</li>
-<li>warning: moving a temporary object prevents copy elision</li>
-<li>warning: multi-character character constant</li>
-<li>warning: multi-line // comment</li>
-<li>warning: no closing ']' for '%%[' in scanf format string</li>
-<li>warning: non-void %select{function|method}1 %0 should return a value</li>
-<li>warning: non-void %select{function|method}1 %0 should return a value</li>
-<li>warning: non-void coroutine does not return a value</li>
-<li>warning: non-void coroutine does not return a value in all control paths</li>
-<li>warning: non-void function does not return a value</li>
-<li>warning: non-void function does not return a value in all control paths</li>
-<li>warning: non-void lambda does not return a value</li>
-<li>warning: non-void lambda does not return a value in all control paths</li>
-<li>warning: not packing field %0 as it is non-POD for the purposes of layout</li>
-<li>warning: null passed to a callee that requires a non-null argument</li>
-<li>warning: null returned from %select{function|method}0 that requires a non-null return value</li>
-<li>warning: object format flags cannot be used with '%0' conversion specifier</li>
-<li>warning: operator '%0' has lower precedence than '%1'; '%1' will be evaluated first</li>
-<li>warning: operator '?:' has lower precedence than '%0'; '%0' will be evaluated first</li>
-<li>warning: operator '?:' has lower precedence than '%0'; '%0' will be evaluated first</li>
-<li>warning: overflow converting case value to switch condition type (%0 to %1)</li>
-<li>warning: overlapping comparisons always evaluate to %select{false|true}0</li>
-<li>warning: overloaded operator %select{&gt;&gt;|&lt;&lt;}0 has higher precedence than comparison operator</li>
-<li>warning: parameter %0 set but not used</li>
-<li>warning: parameter %0 was not declared, defaults to 'int'; ISO C99 and later do not support implicit int</li>
-<li>warning: performing pointer arithmetic on a null pointer has undefined behavior%select{| if the offset is nonzero}0</li>
-<li>warning: performing pointer subtraction with a null pointer %select{has|may have}0 undefined behavior</li>
-<li>warning: position arguments in format strings start counting at 1 (not 0)</li>
-<li>warning: pragma STDC FENV_ROUND is not supported</li>
-<li>warning: pragma diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'</li>
-<li>warning: pragma diagnostic expected option name (e.g. "-Wundef")</li>
-<li>warning: pragma diagnostic pop could not pop, no matching push</li>
-<li>warning: pragma include_alias expected '%0'</li>
-<li>warning: pragma include_alias expected include filename</li>
-<li>warning: private field %0 is not used</li>
-<li>warning: redundant move in return statement</li>
-<li>warning: reference %0 is not yet bound to a value when used here</li>
-<li>warning: reference %0 is not yet bound to a value when used within its own initialization</li>
-<li>warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; comparison may be assumed to always evaluate to %select{true|false}0</li>
-<li>warning: result of comparison of %select{constant %0|true|false}1 with %select{expression of type %2|boolean expression}3 is always %4</li>
-<li>warning: result of comparison of %select{constant %0|true|false}1 with %select{expression of type %2|boolean expression}3 is always %4</li>
-<li>warning: result of comparison of constant %0 with expression of type 'BOOL' is always %1, as the only well defined values for 'BOOL' are YES and NO</li>
-<li>warning: semicolon before method body is ignored</li>
-<li>warning: sizeof on array function parameter will return size of %0 instead of %1</li>
-<li>warning: sizeof on pointer operation will return size of %0 instead of %1</li>
-<li>warning: static variable %0 is suspiciously used within its own initialization</li>
-<li>warning: suggest braces around initialization of subobject</li>
-<li>warning: suspicious concatenation of string literals in an array initialization; did you mean to separate the elements with a comma?</li>
-<li>warning: switch condition has boolean value</li>
-<li>warning: trigraph converted to '%0' character</li>
-<li>warning: trigraph ends block comment</li>
-<li>warning: trigraph ignored</li>
-<li>warning: type specifier missing, defaults to 'int'</li>
-<li>warning: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int</li>
-<li>warning: unexpected token in pragma diagnostic</li>
-<li>warning: unknown pragma ignored</li>
-<li>warning: unknown pragma in STDC namespace</li>
-<li>warning: unused %select{typedef|type alias}0 %1</li>
-<li>warning: unused function %0</li>
-<li>warning: unused label %0</li>
-<li>warning: unused parameter %0</li>
-<li>warning: unused variable %0</li>
-<li>warning: unused variable %0</li>
-<li>warning: use of __private_extern__ on a declaration may not produce external symbol private to the linkage unit and is deprecated</li>
-<li>warning: use of bitwise '%0' with boolean operands</li>
-<li>warning: use of unknown builtin %0</li>
-<li>warning: using '%%P' format specifier with an Objective-C pointer results in dumping runtime object structure, not object value</li>
-<li>warning: using '%%P' format specifier without precision</li>
-<li>warning: using '%0' format specifier annotation outside of os_log()/os_trace()</li>
-<li>warning: using '%0' format specifier, but argument has boolean value</li>
-<li>warning: using the result of an assignment as a condition without parentheses</li>
-<li>warning: variable %0 is %select{decremented|incremented}1 both in the loop header and in the loop body</li>
-<li>warning: variable %0 is %select{used|captured}1 uninitialized whenever %select{'%3' condition is %select{true|false}4|'%3' loop %select{is entered|exits because its condition is false}4|'%3' loop %select{condition is true|exits because its condition is false}4|switch %3 is taken|its declaration is reached|%3 is called}2</li>
-<li>warning: variable %0 is uninitialized when %select{used here|captured by block}1</li>
-<li>warning: variable %0 is uninitialized when passed as a const reference argument here</li>
-<li>warning: variable %0 is uninitialized when used within its own initialization</li>
-<li>warning: variable %0 set but not used</li>
-<li>warning: variable length arrays in C++ are a Clang extension</li>
-<li>warning: variable length arrays in C++ are a Clang extension</li>
-<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
-<li>warning: variable length arrays in C++ are a Clang extension; did you mean to use 'static_assert'?</li>
-<li>warning: variable%select{s| %1|s %1 and %2|s %1, %2, and %3|s %1, %2, %3, and %4}0 used in loop condition not modified in loop body</li>
-<li>warning: zero field width in scanf format string is unused</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wCL4" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-endif-labels</key>
-    <name>clang-diagnostic-endif-labels</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: extra tokens at end of #%0 directive</li>
-<li>warning: extra tokens at the end of '#pragma omp %0' are ignored</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wendif-labels" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-cpp</key>
-    <name>clang-diagnostic-cpp</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcpp" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-comments</key>
-    <name>clang-diagnostic-comments</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '/*' within block comment</li>
-<li>warning: // comments are not allowed in this language</li>
-<li>warning: escaped newline between */ characters at block comment end</li>
-<li>warning: multi-line // comment</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcomments" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-conversion-null</key>
-    <name>clang-diagnostic-conversion-null</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: implicit conversion of %select{NULL|nullptr}0 constant to %1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconversion-null" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-bool-conversions</key>
-    <name>clang-diagnostic-bool-conversions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true</li>
-<li>warning: address of %select{'%1'|function '%1'|array '%1'|lambda function pointer conversion operator}0 will always evaluate to 'true'</li>
-<li>warning: initialization of pointer of type %0 to null from a constant boolean expression</li>
-<li>warning: nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter</li>
-<li>warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; pointer may be assumed to always convert to true</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbool-conversions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-int-conversions</key>
-    <name>clang-diagnostic-int-conversions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: incompatible integer to pointer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
-<li>warning: incompatible pointer to integer conversion %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2%select{|; dereference with *|; take the address with &amp;|; remove *|; remove &amp;}3</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wint-conversions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-vector-conversions</key>
-    <name>clang-diagnostic-vector-conversions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: incompatible vector types %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wvector-conversions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unused-local-typedefs</key>
-    <name>clang-diagnostic-unused-local-typedefs</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: unused %select{typedef|type alias}0 %1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunused-local-typedefs" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++0x-extensions</key>
-    <name>clang-diagnostic-c++0x-extensions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{defaulted|deleted}0 function definitions are a C++11 extension</li>
-<li>warning: '%0' keyword is a C++11 extension</li>
-<li>warning: 'auto' type specifier is a C++11 extension</li>
-<li>warning: 'long long' is a C++11 extension</li>
-<li>warning: 'template' keyword outside of a template</li>
-<li>warning: 'typename' occurs outside of a template</li>
-<li>warning: [[]] attributes are a C++11 extension</li>
-<li>warning: alias declarations are a C++11 extension</li>
-<li>warning: commas at the end of enumerator lists are a C++11 extension</li>
-<li>warning: default member initializer for non-static data member is a C++11 extension</li>
-<li>warning: default template arguments for a function template are a C++11 extension</li>
-<li>warning: enumeration types with a fixed underlying type are a C++11 extension</li>
-<li>warning: explicit conversion functions are a C++11 extension</li>
-<li>warning: extern templates are a C++11 extension</li>
-<li>warning: extra ';' outside of a function is a C++11 extension</li>
-<li>warning: generalized initializer lists are a C++11 extension</li>
-<li>warning: implicit conversion from array size expression of type %0 to %select{integral|enumeration}1 type %2 is a C++11 extension</li>
-<li>warning: inline namespaces are a C++11 feature</li>
-<li>warning: lambdas are a C++11 extension</li>
-<li>warning: non-class friend type %0 is a C++11 extension</li>
-<li>warning: non-type template argument referring to %select{function|object}0 %1 with internal linkage is a C++11 extension</li>
-<li>warning: range-based for loop is a C++11 extension</li>
-<li>warning: reference qualifiers on functions are a C++11 extension</li>
-<li>warning: rvalue references are a C++11 extension</li>
-<li>warning: scoped enumerations are a C++11 extension</li>
-<li>warning: static data member %0 in union is a C++11 extension</li>
-<li>warning: unelaborated friend declaration is a C++11 extension; specify '%select{struct|interface|union|class|enum}0' to befriend %1</li>
-<li>warning: use of enumeration in a nested name specifier is a C++11 extension</li>
-<li>warning: variadic templates are a C++11 extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-0x-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++1y-extensions</key>
-    <name>clang-diagnostic-c++1y-extensions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'decltype(auto)' type specifier is a C++14 extension</li>
-<li>warning: binary integer literals are a C++14 extension</li>
-<li>warning: initialized lambda captures are a C++14 extension</li>
-<li>warning: multiple return statements in constexpr function is a C++14 extension</li>
-<li>warning: type definition in a constexpr %select{function|constructor}0 is a C++14 extension</li>
-<li>warning: use of the %0 attribute is a C++14 extension</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++14 extension</li>
-<li>warning: variable declaration in a constexpr %select{function|constructor}0 is a C++14 extension</li>
-<li>warning: variable templates are a C++14 extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1y-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-deprecated-copy-dtor</key>
-    <name>clang-diagnostic-deprecated-copy-dtor</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared destructor</li>
-<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided destructor</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-copy-dtor" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++1z-extensions</key>
-    <name>clang-diagnostic-c++1z-extensions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%select{if|switch}0' initialization statements are a C++17 extension</li>
-<li>warning: 'begin' and 'end' returning different types (%0 and %1) is a C++17 extension</li>
-<li>warning: 'constexpr' on lambda expressions is a C++17 extension</li>
-<li>warning: 'static_assert' with no message is a C++17 extension</li>
-<li>warning: ISO C++ standards before C++17 do not allow new expression for type %0 to use list-initialization</li>
-<li>warning: attributes on %select{a namespace|an enumerator}0 declaration are a C++17 extension</li>
-<li>warning: capture of '*this' by copy is a C++17 extension</li>
-<li>warning: constexpr if is a C++17 extension</li>
-<li>warning: decomposition declarations are a C++17 extension</li>
-<li>warning: default scope specifier for attributes is a C++17 extension</li>
-<li>warning: hexadecimal floating literals are a C++17 feature</li>
-<li>warning: inline variables are a C++17 extension</li>
-<li>warning: nested namespace definition is a C++17 extension; define each namespace separately</li>
-<li>warning: pack expansion of using declaration is a C++17 extension</li>
-<li>warning: pack fold expression is a C++17 extension</li>
-<li>warning: template template parameter using 'typename' is a C++17 extension</li>
-<li>warning: use of multiple declarators in a single using declaration is a C++17 extension</li>
-<li>warning: use of the %0 attribute is a C++17 extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++2a-extensions</key>
-    <name>clang-diagnostic-c++2a-extensions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: aggregate initialization of type %0 from a parenthesized list of values is a C++20 extension</li>
-<li>warning: captured structured bindings are a C++20 extension</li>
-<li>warning: constexpr constructor that does not initialize all members is a C++20 extension</li>
-<li>warning: constexpr union constructor that does not initialize any member is a C++20 extension</li>
-<li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is a C++20 extension</li>
-<li>warning: default member initializer for bit-field is a C++20 extension</li>
-<li>warning: defaulted comparison operators are a C++20 extension</li>
-<li>warning: designated initializers are a C++20 extension</li>
-<li>warning: explicit capture of 'this' with a capture default of '=' is a C++20 extension</li>
-<li>warning: explicit template parameter list for lambdas is a C++20 extension</li>
-<li>warning: explicit(bool) is a C++20 extension</li>
-<li>warning: function try block in constexpr %select{function|constructor}0 is a C++20 extension</li>
-<li>warning: initialized lambda pack captures are a C++20 extension</li>
-<li>warning: inline nested namespace definition is a C++20 extension</li>
-<li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is a C++20 extension</li>
-<li>warning: missing 'typename' prior to dependent type name %0%1; implicit 'typename' is a C++20 extension</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is a C++20 extension</li>
-<li>warning: range-based for loop initialization statements are a C++20 extension</li>
-<li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is a C++20 extension</li>
-<li>warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension</li>
-<li>warning: use of the %0 attribute is a C++20 extension</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++20 extension</li>
-<li>warning: using declaration naming a scoped enumerator is a C++20 extension</li>
-<li>warning: using enum declaration is a C++20 extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++2b-extensions</key>
-    <name>clang-diagnostic-c++2b-extensions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{an attribute specifier sequence|%0}1 in this position is a C++23 extension</li>
-<li>warning: 'size_t' suffix for literals is a C++23 extension</li>
-<li>warning: alias declaration in this context is a C++23 extension</li>
-<li>warning: consteval if is a C++23 extension</li>
-<li>warning: declaring overloaded %0 as 'static' is a C++23 extension</li>
-<li>warning: definition of a %select{static|thread_local}1 variable in a constexpr %select{function|constructor}0 is a C++23 extension</li>
-<li>warning: label at end of compound statement is a C++23 extension</li>
-<li>warning: lambda without a parameter clause is a C++23 extension</li>
-<li>warning: static lambdas are a C++23 extension</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is a C++23 extension</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is a C++23 extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2b-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++2c-extensions</key>
-    <name>clang-diagnostic-c++2c-extensions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning:  '%0' in a raw string literal delimiter is a C++2c extension</li>
-<li>warning: '= delete' with a message is a C++2c extension</li>
-<li>warning: an attribute specifier sequence attached to a structured binding declaration is a C++2c extension</li>
-<li>warning: pack indexing is a C++2c extension</li>
-<li>warning: placeholder variables are a C++2c extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2c-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c2x-extensions</key>
-    <name>clang-diagnostic-c2x-extensions</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #embed is a %select{C23|Clang}0 extension</li>
-<li>warning: '_BitInt' suffix for literals is a C23 extension</li>
-<li>warning: '_Static_assert' with no message is a C23 extension</li>
-<li>warning: 'nullptr' is a C23 extension</li>
-<li>warning: [[]] attributes are a C23 extension</li>
-<li>warning: binary integer literals are a C23 extension</li>
-<li>warning: defining a type within '%select{__builtin_offsetof|offsetof}0' is a C23 extension</li>
-<li>warning: label at end of compound statement is a C23 extension</li>
-<li>warning: label followed by a declaration is a C23 extension</li>
-<li>warning: omitting the parameter name in a function definition is a C23 extension</li>
-<li>warning: passing no argument for the '...' parameter of a variadic macro is a C23 extension</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is a C23 extension</li>
-<li>warning: use of an empty initializer is a C23 extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc2x-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-msvc-include</key>
-    <name>clang-diagnostic-msvc-include</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #include resolved using non-portable Microsoft search rules as: %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmsvc-include" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-frame-larger-than=</key>
-    <name>clang-diagnostic-frame-larger-than=</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0</li>
-<li>warning: stack frame size (%0) exceeds limit (%1) in '%2'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wframe-larger-than=" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-spirv-compat</key>
-    <name>clang-diagnostic-spirv-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: sampler initializer has invalid %0 bits</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wspirv-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-integer-overflow</key>
-    <name>clang-diagnostic-integer-overflow</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: overflow in expression; result is %0 with type %1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winteger-overflow" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-fixed-point-overflow</key>
-    <name>clang-diagnostic-fixed-point-overflow</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: overflow in expression; result is %0 with type %1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfixed-point-overflow" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-partial-availability</key>
-    <name>clang-diagnostic-partial-availability</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0 is only available %select{|in %4 environment }3on %1 %2 or newer</li>
-<li>warning: %0 is only available %select{|in %4 environment }3on %1 %2 or newer</li>
-<li>warning: %0 is unavailable</li>
-<li>warning: %0 is unavailable</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpartial-availability" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-enum-constexpr-conversion</key>
-    <name>clang-diagnostic-enum-constexpr-conversion</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: integer value %0 is outside the valid range of values [%1, %2] for the enumeration type %3</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wenum-constexpr-conversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-constant-evaluated</key>
-    <name>clang-diagnostic-constant-evaluated</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '%0' will always evaluate to 'true' in a manifestly constant-evaluated expression</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconstant-evaluated" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-stack-exhausted</key>
-    <name>clang-diagnostic-stack-exhausted</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: stack nearly exhausted; compilation time may suffer, and crashes due to stack overflow are likely</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstack-exhausted" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-higher-precision-fp</key>
-    <name>clang-diagnostic-higher-precision-fp</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: higher precision floating-point type size has the same size than floating-point type size</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whigher-precision-fp" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-nan-infinity-disabled</key>
-    <name>clang-diagnostic-nan-infinity-disabled</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: use of %select{infinity|NaN}0%select{| via a macro}1 is undefined behavior due to the currently enabled floating-point options</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnan-infinity-disabled" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-stack-protector</key>
-    <name>clang-diagnostic-stack-protector</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: unable to protect inline asm that clobbers stack pointer against stack clash</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstack-protector" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-slh-asm-goto</key>
-    <name>clang-diagnostic-slh-asm-goto</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: speculative load hardening does not protect functions with asm goto</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wslh-asm-goto" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-duplicate-category-definition</key>
-    <name>clang-diagnostic-objc-duplicate-category-definition</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: duplicate definition of category %1 on interface %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-duplicate-category-definition" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-invalid-feature-combination</key>
-    <name>clang-diagnostic-invalid-feature-combination</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: invalid feature combination: %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-feature-combination" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-knl-knm-isa-support-removed</key>
-    <name>clang-diagnostic-knl-knm-isa-support-removed</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: KNL, KNM related Intel Xeon Phi CPU's specific ISA's supports will be removed in LLVM 19.</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wknl-knm-isa-support-removed" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-sloc-usage</key>
-    <name>clang-diagnostic-sloc-usage</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>remark: source manager location address space usage:</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rsloc-usage" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-apinotes</key>
-    <name>clang-diagnostic-apinotes</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %0</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wapinotes" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-nonportable-private-apinotes-path</key>
-    <name>clang-diagnostic-nonportable-private-apinotes-path</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: private API notes file for module '%0' should be named '%0_private.apinotes', not '%1'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-private-apinotes-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-nonportable-private-system-apinotes-path</key>
-    <name>clang-diagnostic-nonportable-private-system-apinotes-path</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: private API notes file for module '%0' should be named '%0_private.apinotes', not '%1'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-private-system-apinotes-path" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-poison-system-directories</key>
-    <name>clang-diagnostic-poison-system-directories</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: include location '%0' is unsafe for cross-compilation</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpoison-system-directories" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-overriding-option</key>
-    <name>clang-diagnostic-overriding-option</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: overriding '%0' option with '%1'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverriding-option" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-overriding-t-option</key>
-    <name>clang-diagnostic-overriding-t-option</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: overriding '%0' option with '%1'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverriding-t-option" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-missing-sysroot</key>
-    <name>clang-diagnostic-missing-sysroot</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: no such sysroot directory: '%0'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-sysroot" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-incompatible-sysroot</key>
-    <name>clang-diagnostic-incompatible-sysroot</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: using sysroot for '%0' but targeting '%1'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-sysroot" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-debug-compression-unavailable</key>
-    <name>clang-diagnostic-debug-compression-unavailable</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: cannot compress debug sections (%0 not enabled)</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdebug-compression-unavailable" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-delayed-template-parsing-in-cxx20</key>
-    <name>clang-diagnostic-delayed-template-parsing-in-cxx20</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: -fdelayed-template-parsing is deprecated after C++20</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdelayed-template-parsing-in-cxx20" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-slash-u-filename</key>
-    <name>clang-diagnostic-slash-u-filename</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '/U%0' treated as the '/U' option</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wslash-u-filename" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-  </rule>
+
 </rules>

--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -87,7 +87,6 @@ const auto c2 = absl::MakeCleanup(std::function&lt;void()&gt;([] {}));</code></p
 const absl::Cleanup c2 = std::function&lt;void()&gt;([] {});</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/abseil/cleanup-ctad.html" target="_blank">clang.llvm.org</a></p>]]>
-      <![CDATA[]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -644,11 +643,13 @@ d *= static_cast&lt;int64_t&gt;(a);</code></pre>
 <pre class="c++"><code>// The following code will produce a warning because this ID-dependent
 // variable is used in a loop condition statement.
 int ThreadID = get_local_id(0);
+
 // The following loop will produce a warning because the loop condition
 // statement depends on an ID-dependent variable.
 for (int i = 0; i &lt; ThreadID; ++i) {
   std::cout &lt;&lt; i &lt;&lt; std::endl;
 }
+
 // The following loop will not produce a warning, because the ID-dependent
 // variable is not used in the loop condition statement.
 for (int i = 0; i &lt; 100; ++i) {
@@ -1193,8 +1194,7 @@ while (TEMP_FAILURE_RETRY(read(STDIN_FILENO, cs, sizeof(cs))) != 0) {
     <key>boost-use-ranges</key>
     <name>boost-use-ranges</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - boost-use-ranges</p>
 </div>
 <h1 id="boost-use-ranges">boost-use-ranges</h1>
@@ -1235,9 +1235,7 @@ auto AreSame = boost::range::equal(Items1, Items2);</code></pre>
 <pre class="c++"><code>boost::range::find(Items | boost::adaptors::reversed, 0);</code></pre>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/boost/use-ranges.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/boost/use-ranges.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -1659,6 +1657,7 @@ public:
 
   int memberToBeCopied = 0;
 };
+
 class X2 : public Copyable {
   X2(const X2 &amp;other) {} // Copyable(other) is missing
 };</code></pre>
@@ -1684,8 +1683,7 @@ class X2 : public Copyable {
     <key>bugprone-crtp-constructor-accessibility</key>
     <name>bugprone-crtp-constructor-accessibility</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - bugprone-crtp-constructor-accessibility</p>
 </div>
 <h1 id="bugprone-crtp-constructor-accessibility">bugprone-crtp-constructor-accessibility</h1>
@@ -1745,9 +1743,7 @@ CRTP&lt;int&gt; AlsoCompileTimeError;</code></pre>
 </ul>
 <p>The check also suggests a fix-its in some cases.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/crtp-constructor-accessibility.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/crtp-constructor-accessibility.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -1824,6 +1820,7 @@ FILE *open(const char *Dir, const char *Name, Flags Mode) { /* ... */ }</code></
 <p>More elaborate and type-safe constructs, such as opaque typedefs or strong types should be used instead, to prevent a mistaken order of arguments.</p>
 <pre class="c++"><code>struct Coord2D { int X; int Y; };
 void drawPoint(const Coord2D Pos) { /* ... */ }
+
 FILE *open(const Path &amp;Dir, const Filename &amp;Name, Flags Mode) { /* ... */ }</code></pre>
 <p>Due to the potentially elaborate refactoring and API-breaking that is necessary to strengthen the type safety of a project, no automatic fix-its are offered.</p>
 <h2 id="options">Options</h2>
@@ -1896,11 +1893,14 @@ void compare(const char *CharBuf, std::string String) { /* ... */ }</code></pre>
 <p>None of the following cases produce a diagnostic:</p>
 <pre class="c++"><code>int printf(const char *Format, ...) { /* ... */ }
 int someOldCFunction() { /* ... */ }
+
 template &lt;typename T, typename U&gt;
 int add(T X, U Y) { return X + Y };
+
 void theseAreNotWarnedAbout() {
     printf(&quot;%d %d\n&quot;, 1, 2);   // Two ints passed, they could be swapped.
     someOldCFunction(1, 2, 3); // Similarly, multiple ints passed.
+
     add(1, 2); // Instantiates &#39;add&lt;int, int&gt;&#39;, but that&#39;s not a user-defined function.
 }</code></pre>
 <p>Due to the limitation above, parameters which type are further dependent upon template instantiations to <em>prove</em> that they mix with another parameter's is not diagnosed.</p>
@@ -1908,13 +1908,16 @@ void theseAreNotWarnedAbout() {
 struct Vector {
   typedef T element_type;
 };
+
 // Diagnosed: Explicit instantiation was done by the user, we can prove it
 // is the same type.
 void instantiated(int A, Vector&lt;int&gt;::element_type B) { /* ... */ }
+
 // Diagnosed: The two parameter types are exactly the same.
 template &lt;typename T&gt;
 void exact(typename Vector&lt;T&gt;::element_type A,
            typename Vector&lt;T&gt;::element_type B) { /* ... */ }
+
 // Skipped: The two parameters are both &#39;T&#39; but we cannot prove this
 // without actually instantiating.
 template &lt;typename T&gt;
@@ -1923,14 +1926,17 @@ void falseNegative(T A, typename Vector&lt;T&gt;::element_type B) { /* ... */ }<
 <pre class="c++"><code>struct String {
     String(const char *Buf);
 };
+
 struct StringView {
     StringView(const char *Buf);
     operator const char *() const;
 };
+
 // Skipped: Directly swapping expressions of the two type cannot mix.
 // (Note: StringView -&gt; const char * -&gt; String would be **two**
 // user-defined conversions, which is disallowed by the language.)
 void strs(String Str, StringView SV) { /* ... */ }
+
 // Diagnosed: StringView implicitly converts to and from a buffer.
 void cStr(StringView SV, const char *Buf() { /* ... */ }</code></pre>
 <h2>References</h2>
@@ -2121,7 +2127,7 @@ public:
   explicit Person(T&amp;&amp; n, int x = 1) {}
 
   // C3: perfect forwarding ctor guarded with enable_if
-  template&lt;typename T, typename X = enable_if_t&lt;is_special&lt;T&gt;,void&gt;&gt;
+  template&lt;typename T, typename X = enable_if_t&lt;is_special&lt;T&gt;, void&gt;&gt;
   explicit Person(T&amp;&amp; n) {}
 
   // C4: variadic perfect forwarding ctor guarded with enable_if
@@ -2187,9 +2193,11 @@ public:
 <pre class="c++"><code>long mul(int a, int b) {
   return a * b; // warning: performing an implicit widening conversion to type &#39;long&#39; of a multiplication performed in type &#39;int&#39;
 }
+
 char* ptr_add(char *base, int a, int b) {
   return base + a * b; // warning: result of multiplication in type &#39;int&#39; is used as a pointer offset after an implicit widening conversion to type &#39;ssize_t&#39;
 }
+
 char ptr_subscript(char *base, int a, int b) {
   return base[a * b]; // warning: result of multiplication in type &#39;int&#39; is used as a pointer offset after an implicit widening conversion to type &#39;ssize_t&#39;
 }</code></pre>
@@ -2797,7 +2805,8 @@ void process(EStatus status) {
 </ul>
 <dl>
 <dt>[1] It is possible to overflow:</dt>
-<dd><ul>
+<dd>
+<ul>
 <li>If the capacity of the destination array is unknown.</li>
 <li>If the given length is equal to the destination array's capacity.</li>
 </ul>
@@ -2918,8 +2927,7 @@ struct C: public B {
     <key>bugprone-pointer-arithmetic-on-polymorphic-object</key>
     <name>bugprone-pointer-arithmetic-on-polymorphic-object</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - bugprone-pointer-arithmetic-on-polymorphic-object</p>
 </div>
 <h1 id="bugprone-pointer-arithmetic-on-polymorphic-object">bugprone-pointer-arithmetic-on-polymorphic-object</h1>
@@ -2963,9 +2971,7 @@ void foo() {
 <h2 id="references">References</h2>
 <p>This check corresponds to the SEI Cert rule <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/CTR56-CPP.+Do+not+use+pointer+arithmetic+on+polymorphic+objects">CTR56-CPP. Do not use pointer arithmetic on polymorphic objects</a>.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -3078,7 +3084,7 @@ if (onFire) {
   #define cool__macro // also this
 }
 int _g(); // disallowed in global namespace only</code></pre>
-<p>The check can also be inverted, i.e. it can be configured to flag any identifier that is _<a href="">not</a> a reserved identifier. This mode is for use by e.g. standard library implementors, to ensure they don't infringe on the user namespace.</p>
+<p>The check can also be inverted, i.e. it can be configured to flag any identifier that is _<a href="http://clang.llvm.org/extra/clang-tidy/checks/">not</a> a reserved identifier. This mode is for use by e.g. standard library implementors, to ensure they don't infringe on the user namespace.</p>
 <p>This check does not (yet) check for other reserved names, e.g. macro names identical to language keywords, and names specifically reserved by language standards, e.g. C++ 'zombie names' and C future library directions.</p>
 <p>This check corresponds to CERT C Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/c/DCL37-C.+Do+not+declare+or+define+a+reserved+identifier">DCL37-C. Do not declare or define a reserved identifier</a> as well as its C++ counterpart, <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL51-CPP.+Do+not+declare+or+define+a+reserved+identifier">DCL51-CPP. Do not declare or define a reserved identifier</a>.</p>
 <h2 id="options">Options</h2>
@@ -3099,8 +3105,7 @@ int _g(); // disallowed in global namespace only</code></pre>
     <key>bugprone-return-const-ref-from-parameter</key>
     <name>bugprone-return-const-ref-from-parameter</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - bugprone-return-const-ref-from-parameter</p>
 </div>
 <h1 id="bugprone-return-const-ref-from-parameter">bugprone-return-const-ref-from-parameter</h1>
@@ -3120,9 +3125,7 @@ const S &amp;fn(const S &amp;a) {
 const S&amp; s = fn(S{1});
 s.v; // use after free</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/return-const-ref-from-parameter.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/return-const-ref-from-parameter.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -3142,7 +3145,9 @@ s.v; // use after free</code></pre>
 //                     ^ warning: shared pointer to non-array is initialized with array [bugprone-shared-ptr-array-mismatch]
 std::shared_ptr&lt;Foo&gt; x1(new Foo), x2(new Foo[10]); // no replacement
 //                                   ^ warning: shared pointer to non-array is initialized with array [bugprone-shared-ptr-array-mismatch]
+
 std::shared_ptr&lt;Foo&gt; x3(new Foo[10], [](const Foo *ptr) { delete[] ptr; }); // no warning
+
 struct S {
   std::shared_ptr&lt;Foo&gt; x(new Foo[10]); // no replacement in this case
   //                     ^ warning: shared pointer to non-array is initialized with array [bugprone-shared-ptr-array-mismatch]
@@ -3181,10 +3186,12 @@ struct S {
 <p>Selects which set of functions is considered as asynchronous-safe (and therefore allowed in signal handlers). It can be set to the following values:</p>
 <dl>
 <dt><code>minimal</code></dt>
-<dd><p>Selects a minimal set that is defined in the CERT SIG30-C rule. and includes functions <code>abort()</code>, <code>_Exit()</code>, <code>quick_exit()</code> and <code>signal()</code>.</p>
+<dd>
+<p>Selects a minimal set that is defined in the CERT SIG30-C rule. and includes functions <code>abort()</code>, <code>_Exit()</code>, <code>quick_exit()</code> and <code>signal()</code>.</p>
 </dd>
 <dt><code>POSIX</code></dt>
-<dd><p>Selects a larger set of functions that is listed in POSIX.1-2017 (see <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_04_03">this link</a> for more information). The following functions are included: <code>_Exit</code>, <code>_exit</code>, <code>abort</code>, <code>accept</code>, <code>access</code>, <code>aio_error</code>, <code>aio_return</code>, <code>aio_suspend</code>, <code>alarm</code>, <code>bind</code>, <code>cfgetispeed</code>, <code>cfgetospeed</code>, <code>cfsetispeed</code>, <code>cfsetospeed</code>, <code>chdir</code>, <code>chmod</code>, <code>chown</code>, <code>clock_gettime</code>, <code>close</code>, <code>connect</code>, <code>creat</code>, <code>dup</code>, <code>dup2</code>, <code>execl</code>, <code>execle</code>, <code>execv</code>, <code>execve</code>, <code>faccessat</code>, <code>fchdir</code>, <code>fchmod</code>, <code>fchmodat</code>, <code>fchown</code>, <code>fchownat</code>, <code>fcntl</code>, <code>fdatasync</code>, <code>fexecve</code>, <code>ffs</code>, <code>fork</code>, <code>fstat</code>, <code>fstatat</code>, <code>fsync</code>, <code>ftruncate</code>, <code>futimens</code>, <code>getegid</code>, <code>geteuid</code>, <code>getgid</code>, <code>getgroups</code>, <code>getpeername</code>, <code>getpgrp</code>, <code>getpid</code>, <code>getppid</code>, <code>getsockname</code>, <code>getsockopt</code>, <code>getuid</code>, <code>htonl</code>, <code>htons</code>, <code>kill</code>, <code>link</code>, <code>linkat</code>, <code>listen</code>, <code>longjmp</code>, <code>lseek</code>, <code>lstat</code>, <code>memccpy</code>, <code>memchr</code>, <code>memcmp</code>, <code>memcpy</code>, <code>memmove</code>, <code>memset</code>, <code>mkdir</code>, <code>mkdirat</code>, <code>mkfifo</code>, <code>mkfifoat</code>, <code>mknod</code>, <code>mknodat</code>, <code>ntohl</code>, <code>ntohs</code>, <code>open</code>, <code>openat</code>, <code>pause</code>, <code>pipe</code>, <code>poll</code>, <code>posix_trace_event</code>, <code>pselect</code>, <code>pthread_kill</code>, <code>pthread_self</code>, <code>pthread_sigmask</code>, <code>quick_exit</code>, <code>raise</code>, <code>read</code>, <code>readlink</code>, <code>readlinkat</code>, <code>recv</code>, <code>recvfrom</code>, <code>recvmsg</code>, <code>rename</code>, <code>renameat</code>, <code>rmdir</code>, <code>select</code>, <code>sem_post</code>, <code>send</code>, <code>sendmsg</code>, <code>sendto</code>, <code>setgid</code>, <code>setpgid</code>, <code>setsid</code>, <code>setsockopt</code>, <code>setuid</code>, <code>shutdown</code>, <code>sigaction</code>, <code>sigaddset</code>, <code>sigdelset</code>, <code>sigemptyset</code>, <code>sigfillset</code>, <code>sigismember</code>, <code>siglongjmp</code>, <code>signal</code>, <code>sigpause</code>, <code>sigpending</code>, <code>sigprocmask</code>, <code>sigqueue</code>, <code>sigset</code>, <code>sigsuspend</code>, <code>sleep</code>, <code>sockatmark</code>, <code>socket</code>, <code>socketpair</code>, <code>stat</code>, <code>stpcpy</code>, <code>stpncpy</code>, <code>strcat</code>, <code>strchr</code>, <code>strcmp</code>, <code>strcpy</code>, <code>strcspn</code>, <code>strlen</code>, <code>strncat</code>, <code>strncmp</code>, <code>strncpy</code>, <code>strnlen</code>, <code>strpbrk</code>, <code>strrchr</code>, <code>strspn</code>, <code>strstr</code>, <code>strtok_r</code>, <code>symlink</code>, <code>symlinkat</code>, <code>tcdrain</code>, <code>tcflow</code>, <code>tcflush</code>, <code>tcgetattr</code>, <code>tcgetpgrp</code>, <code>tcsendbreak</code>, <code>tcsetattr</code>, <code>tcsetpgrp</code>, <code>time</code>, <code>timer_getoverrun</code>, <code>timer_gettime</code>, <code>timer_settime</code>, <code>times</code>, <code>umask</code>, <code>uname</code>, <code>unlink</code>, <code>unlinkat</code>, <code>utime</code>, <code>utimensat</code>, <code>utimes</code>, <code>wait</code>, <code>waitpid</code>, <code>wcpcpy</code>, <code>wcpncpy</code>, <code>wcscat</code>, <code>wcschr</code>, <code>wcscmp</code>, <code>wcscpy</code>, <code>wcscspn</code>, <code>wcslen</code>, <code>wcsncat</code>, <code>wcsncmp</code>, <code>wcsncpy</code>, <code>wcsnlen</code>, <code>wcspbrk</code>, <code>wcsrchr</code>, <code>wcsspn</code>, <code>wcsstr</code>, <code>wcstok</code>, <code>wmemchr</code>, <code>wmemcmp</code>, <code>wmemcpy</code>, <code>wmemmove</code>, <code>wmemset</code>, <code>write</code></p>
+<dd>
+<p>Selects a larger set of functions that is listed in POSIX.1-2017 (see <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_04_03">this link</a> for more information). The following functions are included: <code>_Exit</code>, <code>_exit</code>, <code>abort</code>, <code>accept</code>, <code>access</code>, <code>aio_error</code>, <code>aio_return</code>, <code>aio_suspend</code>, <code>alarm</code>, <code>bind</code>, <code>cfgetispeed</code>, <code>cfgetospeed</code>, <code>cfsetispeed</code>, <code>cfsetospeed</code>, <code>chdir</code>, <code>chmod</code>, <code>chown</code>, <code>clock_gettime</code>, <code>close</code>, <code>connect</code>, <code>creat</code>, <code>dup</code>, <code>dup2</code>, <code>execl</code>, <code>execle</code>, <code>execv</code>, <code>execve</code>, <code>faccessat</code>, <code>fchdir</code>, <code>fchmod</code>, <code>fchmodat</code>, <code>fchown</code>, <code>fchownat</code>, <code>fcntl</code>, <code>fdatasync</code>, <code>fexecve</code>, <code>ffs</code>, <code>fork</code>, <code>fstat</code>, <code>fstatat</code>, <code>fsync</code>, <code>ftruncate</code>, <code>futimens</code>, <code>getegid</code>, <code>geteuid</code>, <code>getgid</code>, <code>getgroups</code>, <code>getpeername</code>, <code>getpgrp</code>, <code>getpid</code>, <code>getppid</code>, <code>getsockname</code>, <code>getsockopt</code>, <code>getuid</code>, <code>htonl</code>, <code>htons</code>, <code>kill</code>, <code>link</code>, <code>linkat</code>, <code>listen</code>, <code>longjmp</code>, <code>lseek</code>, <code>lstat</code>, <code>memccpy</code>, <code>memchr</code>, <code>memcmp</code>, <code>memcpy</code>, <code>memmove</code>, <code>memset</code>, <code>mkdir</code>, <code>mkdirat</code>, <code>mkfifo</code>, <code>mkfifoat</code>, <code>mknod</code>, <code>mknodat</code>, <code>ntohl</code>, <code>ntohs</code>, <code>open</code>, <code>openat</code>, <code>pause</code>, <code>pipe</code>, <code>poll</code>, <code>posix_trace_event</code>, <code>pselect</code>, <code>pthread_kill</code>, <code>pthread_self</code>, <code>pthread_sigmask</code>, <code>quick_exit</code>, <code>raise</code>, <code>read</code>, <code>readlink</code>, <code>readlinkat</code>, <code>recv</code>, <code>recvfrom</code>, <code>recvmsg</code>, <code>rename</code>, <code>renameat</code>, <code>rmdir</code>, <code>select</code>, <code>sem_post</code>, <code>send</code>, <code>sendmsg</code>, <code>sendto</code>, <code>setgid</code>, <code>setpgid</code>, <code>setsid</code>, <code>setsockopt</code>, <code>setuid</code>, <code>shutdown</code>, <code>sigaction</code>, <code>sigaddset</code>, <code>sigdelset</code>, <code>sigemptyset</code>, <code>sigfillset</code>, <code>sigismember</code>, <code>siglongjmp</code>, <code>signal</code>, <code>sigpause</code>, <code>sigpending</code>, <code>sigprocmask</code>, <code>sigqueue</code>, <code>sigset</code>, <code>sigsuspend</code>, <code>sleep</code>, <code>sockatmark</code>, <code>socket</code>, <code>socketpair</code>, <code>stat</code>, <code>stpcpy</code>, <code>stpncpy</code>, <code>strcat</code>, <code>strchr</code>, <code>strcmp</code>, <code>strcpy</code>, <code>strcspn</code>, <code>strlen</code>, <code>strncat</code>, <code>strncmp</code>, <code>strncpy</code>, <code>strnlen</code>, <code>strpbrk</code>, <code>strrchr</code>, <code>strspn</code>, <code>strstr</code>, <code>strtok_r</code>, <code>symlink</code>, <code>symlinkat</code>, <code>tcdrain</code>, <code>tcflow</code>, <code>tcflush</code>, <code>tcgetattr</code>, <code>tcgetpgrp</code>, <code>tcsendbreak</code>, <code>tcsetattr</code>, <code>tcsetpgrp</code>, <code>time</code>, <code>timer_getoverrun</code>, <code>timer_gettime</code>, <code>timer_settime</code>, <code>times</code>, <code>umask</code>, <code>uname</code>, <code>unlink</code>, <code>unlinkat</code>, <code>utime</code>, <code>utimensat</code>, <code>utimes</code>, <code>wait</code>, <code>waitpid</code>, <code>wcpcpy</code>, <code>wcpncpy</code>, <code>wcscat</code>, <code>wcschr</code>, <code>wcscmp</code>, <code>wcscpy</code>, <code>wcscspn</code>, <code>wcslen</code>, <code>wcsncat</code>, <code>wcsncmp</code>, <code>wcsncpy</code>, <code>wcsnlen</code>, <code>wcspbrk</code>, <code>wcsrchr</code>, <code>wcsspn</code>, <code>wcsstr</code>, <code>wcstok</code>, <code>wmemchr</code>, <code>wmemcmp</code>, <code>wmemcpy</code>, <code>wmemmove</code>, <code>wmemset</code>, <code>write</code></p>
 <p>The function <code>quick_exit</code> is not included in the POSIX list but it is included here in the set of safe functions.</p>
 </dd>
 </dl>
@@ -3682,17 +3689,6 @@ flag |=
 #include &quot;Pterodactyl.h&quot;    // OK, .h files tend not to have definitions.
 #include &quot;Velociraptor.cpp&quot; // Warning, filename is suspicious.
 #include_next &lt;stdio.c&gt;     // Warning, filename is suspicious.</code></pre>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>HeaderFileExtensions</p>
-<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">HeaderFileExtensions</span>.</p>
-<p>Default value: <code>";h;hh;hpp;hxx"</code> A semicolon-separated list of filename extensions of header files (the filename extensions should not contain a "." prefix). For extension-less header files, use an empty string or leave an empty string between ";" if there are other filename extensions.</p>
-</div>
-<div class="option">
-<p>ImplementationFileExtensions</p>
-<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">ImplementationFileExtensions</span>.</p>
-<p>Default value: <code>"c;cc;cpp;cxx"</code> Likewise, a semicolon-separated list of filename extensions of implementation files.</p>
-</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-include.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -3714,6 +3710,7 @@ flag |=
 <p>Objects with the same value may not have the same object representation. This may be caused by padding or floating-point types.</p>
 <p>See also: <a href="https://wiki.sei.cmu.edu/confluence/display/c/EXP42-C.+Do+not+compare+padding+data">EXP42-C. Do not compare padding data</a> and <a href="https://wiki.sei.cmu.edu/confluence/display/c/FLP37-C.+Do+not+use+object+representations+to+compare+floating-point+values">FLP37-C. Do not use object representations to compare floating-point values</a></p>
 <p>This check is also related to and partially overlaps the CERT C++ Coding Standard rules <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP57-CPP.+Prefer+special+member+functions+and+overloaded+operators+to+C+Standard+Library+functions">OOP57-CPP. Prefer special member functions and overloaded operators to C Standard Library functions</a> and <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/EXP62-CPP.+Do+not+access+the+bits+of+an+object+representation+that+are+not+part+of+the+object%27s+value+representation">EXP62-CPP. Do not access the bits of an object representation that are not part of the object's value representation</a></p>
+<p><span class="title-ref">cert-exp42-c</span> redirects here as an alias of this check.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-memory-comparison.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -3890,7 +3887,7 @@ Token t = readNextToken();</code></pre>
 if (!strcmp(...))      // Won&#39;t warn
 if (strcmp(...) != 0)  // Won&#39;t warn</code></pre>
 <p>Checks that compare function results (i.e., <code>strcmp</code>) are compared to valid constant. The resulting value is</p>
-<pre class=""><code>&lt;  0    when lower than,
+<pre><code>&lt;  0    when lower than,
 &gt;  0    when greater than,
 == 0    when equals.</code></pre>
 <p>A common mistake is to compare the result to <span class="title-ref">1</span> or <span class="title-ref">-1</span>.</p>
@@ -3920,8 +3917,7 @@ if (strcmp(...) != 0)  // Won&#39;t warn</code></pre>
     <key>bugprone-suspicious-stringview-data-usage</key>
     <name>bugprone-suspicious-stringview-data-usage</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - bugprone-suspicious-stringview-data-usage</p>
 </div>
 <h1 id="bugprone-suspicious-stringview-data-usage">bugprone-suspicious-stringview-data-usage</h1>
@@ -3947,9 +3943,7 @@ void something(std::string_view sv) {
 <p>Specifies methods, functions, or classes where the result of <code>.data()</code> is passed to. Allows to exclude such calls from the analysis. Accepts a semicolon-separated list of names or regular expressions matching these entities. Default value is: empty string.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-stringview-data-usage.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-stringview-data-usage.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -4333,6 +4327,7 @@ int *f2() noexcept {
   }
   // ...
 }
+
 int *f3() noexcept {
   int *p = new (std::nothrow) int[1000]; // no warning: &quot;nothrow&quot; is used
   // ...
@@ -4483,7 +4478,8 @@ struct S {
 <p>Checks for functions that have safer, more secure replacements available, or are considered deprecated due to design flaws. The check heavily relies on the functions from the <strong>Annex K.</strong> "Bounds-checking interfaces" of C11.</p>
 <dl>
 <dt>The check implements the following rules from the CERT C Coding Standard:</dt>
-<dd><ul>
+<dd>
+<ul>
 <li>Recommendation <a href="https://wiki.sei.cmu.edu/confluence/display/c/MSC24-C.+Do+not+use+deprecated+or+obsolescent+functions">MSC24-C. Do not use deprecated or obsolescent functions</a>.</li>
 <li>Rule <a href="https://wiki.sei.cmu.edu/confluence/display/c/MSC33-C.+Do+not+pass+invalid+data+to+the+asctime%28%29+function">MSC33-C. Do not pass invalid data to the asctime() function</a>.</li>
 </ul>
@@ -4507,7 +4503,7 @@ struct S {
 <li><code>setbuf</code>, suggested replacement: <code>setvbuf</code></li>
 </ul>
 </blockquote>
-<p>If <a href="unsafe-functions.html#cmdoption-arg-ReportMoreUnsafeFunctions">ReportMoreUnsafeFunctions</a> is enabled, the following functions are also checked:</p>
+<p>If <a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/unsafe-functions.html#cmdoption-arg-ReportMoreUnsafeFunctions">ReportMoreUnsafeFunctions</a> is enabled, the following functions are also checked:</p>
 <blockquote>
 <ul>
 <li><code>bcmp</code>, suggested replacement: <code>memcmp</code></li>
@@ -4678,7 +4674,7 @@ MyObject foo = future1.get();
 <h2 id="options">Options</h2>
 <div class="option">
 <p>CheckedFunctions</p>
-<p>Semicolon-separated list of functions to check. The function is checked if the name and scope matches, with any arguments. By default the following functions are checked: <code>std::async, std::launder, std::remove, std::remove_if, std::unique, std::unique_ptr::release, std::basic_string::empty, std::vector::empty, std::back_inserter, std::distance, std::find, std::find_if, std::inserter, std::lower_bound, std::make_pair, std::map::count, std::map::find, std::map::lower_bound, std::multimap::equal_range, std::multimap::upper_bound, std::set::count, std::set::find, std::setfill, std::setprecision, std::setw, std::upper_bound, std::vector::at, bsearch, ferror, feof, isalnum, isalpha, isblank, iscntrl, isdigit, isgraph, islower, isprint, ispunct, isspace, isupper, iswalnum, iswprint, iswspace, isxdigit, memchr, memcmp, strcmp, strcoll, strncmp, strpbrk, strrchr, strspn, strstr, wcscmp, access, bind, connect, difftime, dlsym, fnmatch, getaddrinfo, getopt, htonl, htons, iconv_open, inet_addr, isascii, isatty, mmap, newlocale, openat, pathconf, pthread_equal, pthread_getspecific, pthread_mutex_trylock, readdir, readlink, recvmsg, regexec, scandir, semget, setjmp, shm_open, shmget, sigismember, strcasecmp, strsignal, ttyname</code></p>
+<p>Semicolon-separated list of functions to check. This parameter supports regexp. The function is checked if the name and scope matches, with any arguments. By default the following functions are checked: <code>^::std::async$, ^::std::launder$, ^::std::remove$, ^::std::remove_if$, ^::std::unique$, ^::std::unique_ptr::release$, ^::std::basic_string::empty$, ^::std::vector::empty$, ^::std::back_inserter$, ^::std::distance$, ^::std::find$, ^::std::find_if$, ^::std::inserter$, ^::std::lower_bound$, ^::std::make_pair$, ^::std::map::count$, ^::std::map::find$, ^::std::map::lower_bound$, ^::std::multimap::equal_range$, ^::std::multimap::upper_bound$, ^::std::set::count$, ^::std::set::find$, ^::std::setfill$, ^::std::setprecision$, ^::std::setw$, ^::std::upper_bound$, ^::std::vector::at$, ^::bsearch$, ^::ferror$, ^::feof$, ^::isalnum$, ^::isalpha$, ^::isblank$, ^::iscntrl$, ^::isdigit$, ^::isgraph$, ^::islower$, ^::isprint$, ^::ispunct$, ^::isspace$, ^::isupper$, ^::iswalnum$, ^::iswprint$, ^::iswspace$, ^::isxdigit$, ^::memchr$, ^::memcmp$, ^::strcmp$, ^::strcoll$, ^::strncmp$, ^::strpbrk$, ^::strrchr$, ^::strspn$, ^::strstr$, ^::wcscmp$, ^::access$, ^::bind$, ^::connect$, ^::difftime$, ^::dlsym$, ^::fnmatch$, ^::getaddrinfo$, ^::getopt$, ^::htonl$, ^::htons$, ^::iconv_open$, ^::inet_addr$, isascii$, isatty$, ^::mmap$, ^::newlocale$, ^::openat$, ^::pathconf$, ^::pthread_equal$, ^::pthread_getspecific$, ^::pthread_mutex_trylock$, ^::readdir$, ^::readlink$, ^::recvmsg$, ^::regexec$, ^::scandir$, ^::semget$, ^::setjmp$, ^::shm_open$, ^::shmget$, ^::sigismember$, ^::strcasecmp$, ^::strsignal$, ^::ttyname$</code></p>
 <ul>
 <li><code>std::async()</code>. Not using the return value makes the call synchronous.</li>
 <li><code>std::launder()</code>. Not using the return value usually means that the function interface was misunderstood by the programmer. Only the returned pointer is "laundered", not the argument.</li>
@@ -4759,7 +4755,7 @@ if (i == 2) {
   IS_INITIALIZED(str);
   std::cout &lt;&lt; str;
 }</code></pre>
-<p>The check will not output a warning in this case because passing the object to a function as a non-const pointer or reference counts as a reinitialization (see section <a href="#reinitialization">Reinitialization</a> below).</p>
+<p>The check will not output a warning in this case because passing the object to a function as a non-const pointer or reference counts as a reinitialization (see section <a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/use-after-move.html#reinitialization">Reinitialization</a> below).</p>
 <h2 id="unsequenced-moves-uses-and-reinitializations">Unsequenced moves, uses, and reinitializations</h2>
 <p>In many cases, C++ does not make any guarantees about the order in which sub-expressions of a statement are evaluated. This means that in code like the following, it is not guaranteed whether the use will happen before or after the move:</p>
 <pre class="c++"><code>void f(int i, std::vector&lt;int&gt; v);
@@ -4783,7 +4779,7 @@ std::string str = &quot;&quot;;
 f(std::move(str));</code></pre>
 <p>The check will assume that the last line causes a move, even though, in this particular case, it does not. Again, this is intentional.</p>
 <p>There is one special case: A call to <code>std::move</code> inside a <code>try_emplace</code> call is conservatively assumed not to move. This is to avoid spurious warnings, as the check has no way to reason about the <code>bool</code> returned by <code>try_emplace</code>.</p>
-<p>When analyzing the order in which moves, uses and reinitializations happen (see section <a href="#unsequenced-moves-uses-and-reinitializations">Unsequenced moves, uses, and reinitializations</a>), the move is assumed to occur in whichever function the result of the <code>std::move</code> is passed to.</p>
+<p>When analyzing the order in which moves, uses and reinitializations happen (see section <a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/use-after-move.html#unsequenced-moves-uses-and-reinitializations">Unsequenced moves, uses, and reinitializations</a>), the move is assumed to occur in whichever function the result of the <code>std::move</code> is passed to.</p>
 <p>The check also handles perfect-forwarding with <code>std::forward</code> so the following code will also trigger a use-after-move warning.</p>
 <pre class="c++"><code>void consume(int);
 
@@ -4882,8 +4878,7 @@ struct Derived : Base {
     <key>cert-ctr56-cpp</key>
     <name>cert-ctr56-cpp</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - cert-ctr56-cpp</p>
 </div>
 <div class="meta" data-http-equiv=refresh="5;URL=../bugprone/pointer-arithmetic-on-polymorphic-object.html">
@@ -4893,9 +4888,7 @@ struct Derived : Base {
 <p>The <span class="title-ref">cert-ctr56-cpp</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-pointer-arithmetic-on-polymorphic-object
 &lt;../bugprone/pointer-arithmetic-on-polymorphic-object&gt;</code> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/ctr56-cpp.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/ctr56-cpp.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -5041,24 +5034,30 @@ struct Derived : Base {
 <pre class="c++"><code>namespace std {
   int x; // warning: modification of &#39;std&#39; namespace can result in undefined behavior [cert-dcl58-cpp]
 }
+
 namespace posix::a { // warning: modification of &#39;posix&#39; namespace can result in undefined behavior
 }
+
 template &lt;&gt;
 struct ::std::hash&lt;long&gt; { // warning: modification of &#39;std&#39; namespace can result in undefined behavior
   unsigned long operator()(const long &amp;K) const {
     return K;
   }
 };
+
 struct MyData { long data; };
+
 template &lt;&gt;
 struct ::std::hash&lt;MyData&gt; { // no warning: specialization with user-defined type
   unsigned long operator()(const MyData &amp;K) const {
     return K.data;
   }
 };
+
 namespace std {
   template &lt;&gt;
   void swap&lt;bool&gt;(bool &amp;a, bool &amp;b); // warning: modification of &#39;std&#39; namespace can result in undefined behavior
+
   template &lt;&gt;
   bool less&lt;void&gt;::operator()&lt;MyData &amp;&amp;, MyData &amp;&amp;&gt;(MyData &amp;&amp;, MyData &amp;&amp;) const { // warning: modification of &#39;std&#39; namespace can result in undefined behavior
     return true;
@@ -5414,6 +5413,7 @@ void func(const char *buff) {
     <name>cert-exp42-c</name>
     <description>
       <![CDATA[<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/suspicious-memory-comparison.html">
+
 </div>
 <h1 id="cert-exp42-c">cert-exp42-c</h1>
 <p>The <span class="title-ref">cert-exp42-c</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-suspicious-memory-comparison &lt;../bugprone/suspicious-memory-comparison&gt;</code> for more information.</p>
@@ -5458,6 +5458,7 @@ void func(const char *buff) {
     <name>cert-flp37-c</name>
     <description>
       <![CDATA[<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/suspicious-memory-comparison.html">
+
 </div>
 <h1 id="cert-flp37-c">cert-flp37-c</h1>
 <p>The <span class="title-ref">cert-flp37-c</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-suspicious-memory-comparison &lt;../bugprone/suspicious-memory-comparison&gt;</code> for more information.</p>
@@ -5470,8 +5471,7 @@ void func(const char *buff) {
     <key>cert-int09-c</key>
     <name>cert-int09-c</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - cert-int09-c</p>
 </div>
 <div class="meta" data-http-equiv=refresh="5;URL=../readability/enum-initial-value.html">
@@ -5480,9 +5480,7 @@ void func(const char *buff) {
 <h1 id="cert-int09-c">cert-int09-c</h1>
 <p>The <span class="title-ref">cert-int09-c</span> check is an alias, please see <code class="interpreted-text" role="doc">readability-enum-initial-value &lt;../readability/enum-initial-value&gt;</code> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/int09-c.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/int09-c.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -6050,8 +6048,7 @@ void func(const char *buff) {
     <key>clang-analyzer-cplusplus.ArrayDelete</key>
     <name>clang-analyzer-cplusplus.ArrayDelete</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-cplusplus.ArrayDelete</p>
 </div>
 <div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-arraydelete">
@@ -6061,9 +6058,7 @@ void func(const char *buff) {
 <p>Reports destructions of arrays of polymorphic objects that are destructed as their base class.</p>
 <p>The <span class="title-ref">clang-analyzer-cplusplus.ArrayDelete</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-arraydelete">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.ArrayDelete.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.ArrayDelete.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -6092,9 +6087,12 @@ void func(const char *buff) {
       <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-cplusplus.Move</p>
 </div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-move">
+
+</div>
 <h1 id="clang-analyzer-cplusplus.move">clang-analyzer-cplusplus.Move</h1>
 <p>Find use-after-move bugs in C++.</p>
-<p>The clang-analyzer-cplusplus.Move check is an alias of Clang Static Analyzer cplusplus.Move.</p>
+<p>The <span class="title-ref">clang-analyzer-cplusplus.Move</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-move">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.Move.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -6494,8 +6492,7 @@ void func(const char *buff) {
     <key>clang-analyzer-optin.taint.TaintedAlloc</key>
     <name>clang-analyzer-optin.taint.TaintedAlloc</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-optin.taint.TaintedAlloc</p>
 </div>
 <div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-taintedalloc">
@@ -6505,9 +6502,7 @@ void func(const char *buff) {
 <p>Check for memory allocations, where the size parameter might be a tainted (attacker controlled) value.</p>
 <p>The <span class="title-ref">clang-analyzer-optin.taint.TaintedAlloc</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-taintedalloc">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.taint.TaintedAlloc.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.taint.TaintedAlloc.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -7298,17 +7293,14 @@ void func(const char *buff) {
     <key>clang-analyzer-security.PutenvStackArray</key>
     <name>clang-analyzer-security.PutenvStackArray</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-security.PutenvStackArray</p>
 </div>
 <h1 id="clang-analyzer-security.putenvstackarray">clang-analyzer-security.PutenvStackArray</h1>
 <p>Finds calls to the function 'putenv' which pass a pointer to an automatic (stack-allocated) array as the argument.</p>
 <p>The clang-analyzer-security.PutenvStackArray check is an alias of Clang Static Analyzer security.PutenvStackArray.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.PutenvStackArray.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.PutenvStackArray.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -7316,17 +7308,14 @@ void func(const char *buff) {
     <key>clang-analyzer-security.SetgidSetuidOrder</key>
     <name>clang-analyzer-security.SetgidSetuidOrder</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-security.SetgidSetuidOrder</p>
 </div>
 <h1 id="clang-analyzer-security.setgidsetuidorder">clang-analyzer-security.SetgidSetuidOrder</h1>
 <p>Warn on possible reversed order of 'setgid(getgid()))' and 'setuid(getuid())' (CERT: POS36-C).</p>
 <p>The clang-analyzer-security.SetgidSetuidOrder check is an alias of Clang Static Analyzer security.SetgidSetuidOrder.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.SetgidSetuidOrder.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.SetgidSetuidOrder.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -7352,8 +7341,7 @@ void func(const char *buff) {
     <key>clang-analyzer-unix.BlockInCriticalSection</key>
     <name>clang-analyzer-unix.BlockInCriticalSection</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-unix.BlockInCriticalSection</p>
 </div>
 <div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-blockincriticalsection">
@@ -7363,9 +7351,7 @@ void func(const char *buff) {
 <p>Check for calls to blocking functions inside a critical section.</p>
 <p>The <span class="title-ref">clang-analyzer-unix.BlockInCriticalSection</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-blockincriticalsection">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.BlockInCriticalSection.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.BlockInCriticalSection.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -7499,8 +7485,7 @@ void func(const char *buff) {
     <key>clang-analyzer-unix.Stream</key>
     <name>clang-analyzer-unix.Stream</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - clang-analyzer-unix.Stream</p>
 </div>
 <div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-stream">
@@ -7510,9 +7495,7 @@ void func(const char *buff) {
 <p>Check stream handling functions.</p>
 <p>The <span class="title-ref">clang-analyzer-unix.Stream</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-stream">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.Stream.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.Stream.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -7762,7 +7745,7 @@ struct Foo {
   int* x;
   std::unique_ptr&lt;int&gt; x;
   std::shared_ptr&lt;int&gt; x;
-  gsl::not_null&lt;int&gt; x;
+  gsl::not_null&lt;int*&gt; x;
 };
 
 // Bad, rvalue reference member
@@ -8195,7 +8178,8 @@ void wrapper_function2(F&amp;&amp; f) {
 <p>This check implements <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es46-avoid-lossy-narrowing-truncating-arithmetic-conversions">ES.46</a> from the C++ Core Guidelines.</p>
 <dl>
 <dt>We enforce only part of the guideline, more specifically, we flag narrowing conversions from:</dt>
-<dd><ul>
+<dd>
+<ul>
 <li>an integer to a narrower integer (e.g. <code>char</code> to <code>unsigned char</code>) if WarnOnIntegerNarrowingConversion Option is set,</li>
 <li>an integer to a narrower floating-point (e.g. <code>uint64_t</code> to <code>float</code>) if WarnOnIntegerToFloatingPointNarrowingConversion Option is set,</li>
 <li>a floating-point to an integer (e.g. <code>double</code> to <code>int</code>),</li>
@@ -8203,7 +8187,8 @@ void wrapper_function2(F&amp;&amp; f) {
 </ul>
 </dd>
 <dt>This check will flag:</dt>
-<dd><ul>
+<dd>
+<ul>
 <li>All narrowing conversions that are not marked by an explicit cast (c-style or <code>static_cast</code>). For example: <code>int i = 0; i += 0.1;</code>, <code>void f(int); f(0.1);</code>,</li>
 <li>All applications of binary operators with a narrowing conversions. For example: <code>int i; i+= 0.1;</code>.</li>
 </ul>
@@ -8575,22 +8560,6 @@ public:
     return;
   m = mm;
 }</code></pre>
-<div class="option">
-<p>UseAssignment</p>
-<p>Note: this option is deprecated, to be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the <span class="title-ref">UseAssignment</span> option from <code class="interpreted-text" role="doc">cppcoreguidelines-use-default-member-init &lt;../cppcoreguidelines/use-default-member-init&gt;</code> instead.</p>
-<p>If this option is set to <span class="title-ref">true</span> (by default <span class="title-ref">UseAssignment</span> from <code class="interpreted-text" role="doc">modernize-use-default-member-init
-&lt;../modernize/use-default-member-init&gt;</code> will be used), the check will initialize members with an assignment. In this case the fix of the first example looks like this:</p>
-</div>
-<pre class="c++"><code>class C {
-  int n = 1;
-  int m;
-public:
-  C() {
-    if (dice())
-      return;
-    m = 1;
-  }
-};</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/prefer-member-initializer.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -8664,7 +8633,7 @@ public:
 <p>Imposes limitations on the use of <code>const_cast</code> within C++ code. It depends on the <code class="interpreted-text" role="option">StrictMode</code> option setting to determine whether it should flag all instances of <code>const_cast</code> or only those that remove either <code>const</code> or <code>volatile</code> qualifier.</p>
 <p>Modifying a variable that has been declared as <code>const</code> in C++ is generally considered undefined behavior, and this remains true even when using <code>const_cast</code>. In C++, the <code>const</code> qualifier indicates that a variable is intended to be read-only, and the compiler enforces this by disallowing any attempts to change the value of that variable.</p>
 <p>Removing the <code>volatile</code> qualifier in C++ can have serious consequences. This qualifier indicates that a variable's value can change unpredictably, and removing it may lead to undefined behavior, optimization problems, and debugging challenges. It's essential to retain the <code>volatile</code> qualifier in situations where the variable's volatility is a crucial aspect of program correctness and reliability.</p>
-<p>This rule is part of the <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-constcast">Type safety (Type 3)</a> profile and <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es50-dont-cast-away-const">ES.50: Don't cast away const</a> rule from the C++ Core Guidelines.</p>
+<p>This rule is part of the <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-constcast">Type safety (Type 3)</a> profile and <a href="https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es50-dont-cast-away-const">ES.50: Don’t cast away const</a> rule from the C++ Core Guidelines.</p>
 <h2 id="options">Options</h2>
 <div class="option">
 <p>StrictMode</p>
@@ -8916,11 +8885,18 @@ struct C {
 </div>
 <div class="option">
 <p>AllowMissingMoveFunctionsWhenCopyIsDeleted</p>
-<p>When set to <span class="title-ref">true</span> (default is <span class="title-ref">false</span>), this check doesn't flag classes which define deleted copy operations but don't define move operations. This flag is related to Google C++ Style Guide <a href="https://google.github.io/styleguide/cppguide.html#Copyable_Movable_Types">https://google.github.io/styleguide/cppguide.html#Copyable_Movable_Types</a>. With this option enabled, the following class won't be flagged:</p>
+<p>When set to <span class="title-ref">true</span> (default is <span class="title-ref">false</span>), this check doesn't flag classes which define deleted copy operations but don't define move operations. This flag is related to Google C++ Style Guide <a href="https://google.github.io/styleguide/cppguide.html#Copyable_Movable_Types">Copyable and Movable Types</a>. With this option enabled, the following class won't be flagged:</p>
 <pre class="c++"><code>struct A {
   A(const A&amp;) = delete;
   A&amp; operator=(const A&amp;) = delete;
   ~A();
+};</code></pre>
+</div>
+<div class="option">
+<p>AllowImplicitlyDeletedCopyOrMove</p>
+<p>When set to <span class="title-ref">true</span> (default is <span class="title-ref">false</span>), this check doesn't flag classes which implicitly delete copy or move operations. With this option enabled, the following class won't be flagged:</p>
+<pre class="c++"><code>struct A : boost::noncopyable {
+  ~A() { std::cout &lt;&lt; &quot;dtor\n&quot;; }
 };</code></pre>
 </div>
 <h2>References</h2>
@@ -8965,6 +8941,7 @@ struct C {
 protected:
   virtual ~Foo(){}
 };
+
 class Bar {         // NOK, public destructor should be virtual
   virtual void f();
 public:
@@ -8976,6 +8953,7 @@ public:
 protected:
   ~Foo(){}
 };
+
 class Bar {         // OK, destructor is now virtual
   virtual void f();
 public:
@@ -9264,12 +9242,6 @@ auto fn(const T1 &amp;lhs, const T2 &amp;rhs) -&gt; decltype(lhs + rhs) {
 <p>Finds anonymous namespaces in headers.</p>
 <p><a href="https://google.github.io/styleguide/cppguide.html#Namespaces">https://google.github.io/styleguide/cppguide.html#Namespaces</a></p>
 <p>Corresponding cpplint.py check name: <span class="title-ref">build/namespaces</span>.</p>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>HeaderFileExtensions</p>
-<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">HeaderFileExtensions</span>.</p>
-<p>A comma-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is "h,hh,hpp,hxx". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. E.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
-</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/build-namespaces.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -9361,12 +9333,6 @@ bool f() {
 <h1 id="google-global-names-in-headers">google-global-names-in-headers</h1>
 <p>Flag global namespace pollution in header files. Right now it only triggers on <code>using</code> declarations and directives.</p>
 <p>The relevant style guide section is <a href="https://google.github.io/styleguide/cppguide.html#Namespaces">https://google.github.io/styleguide/cppguide.html#Namespaces</a>.</p>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>HeaderFileExtensions</p>
-<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">HeaderFileExtensions</span>.</p>
-<p>A comma-separated list of filename extensions of header files (the filename extensions should not contain "." prefix). Default is "h". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. E.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
-</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/google/global-names-in-headers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -10298,8 +10264,7 @@ switch(i) {}</code></pre>
     <key>linuxkernel-must-check-errs</key>
     <name>linuxkernel-must-check-errs</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - linuxkernel-must-check-errs</p>
 </div>
 <h1 id="linuxkernel-must-check-errs">linuxkernel-must-check-errs</h1>
@@ -10315,33 +10280,7 @@ void *fn() { ERR_PTR(-EINVAL); }
 /* An invalid use of fn. */
 fn();</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/linuxkernel/must-check-errs.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>linuxkernel-must-use-errs</key>
-    <name>linuxkernel-must-use-errs</name>
-    <description>
-      <![CDATA[<div class="title">
-<p>clang-tidy - linuxkernel-must-use-errs</p>
-</div>
-<h1 id="linuxkernel-must-use-errs">linuxkernel-must-use-errs</h1>
-<p>Checks Linux kernel code to see if it uses the results from the functions in <code>linux/err.h</code>. Also checks to see if code uses the results from functions that directly return a value from one of these error functions.</p>
-<p>This is important in the Linux kernel because <code>ERR_PTR</code>, <code>PTR_ERR</code>, <code>IS_ERR</code>, <code>IS_ERR_OR_NULL</code>, <code>ERR_CAST</code>, and <code>PTR_ERR_OR_ZERO</code> return values must be checked, since positive pointers and negative error codes are being used in the same context. These functions are marked with <code>__attribute__((warn_unused_result))</code>, but some kernel versions do not have this warning enabled for clang.</p>
-<p>Examples:</p>
-<pre class="c"><code>/* Trivial unused call to an ERR function */
-PTR_ERR_OR_ZERO(some_function_call());
-
-/* A function that returns ERR_PTR. */
-void *fn() { ERR_PTR(-EINVAL); }
-
-/* An invalid use of fn. */
-fn();</code></pre>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/linuxkernel/must-use-errs.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/linuxkernel/must-check-errs.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -10371,12 +10310,6 @@ fn();</code></pre>
 </div>
 <h1 id="llvm-header-guard">llvm-header-guard</h1>
 <p>Finds and fixes header guards that do not adhere to LLVM style.</p>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>HeaderFileExtensions</p>
-<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">HeaderFileExtensions</span>.</p>
-<p>A comma-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is "h,hh,hpp,hxx". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. E.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
-</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/llvm/header-guard.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -10651,7 +10584,7 @@ namespace LIBC_NAMESPACE_DECL {
 <p>Warn about confusable identifiers, i.e. identifiers that are visually close to each other, but use different Unicode characters. This detects a potential attack described in <a href="https://www.cve.org/CVERecord?id=CVE-2021-42574">CVE-2021-42574</a>.</p>
 <p>Example:</p>
 <pre class="text"><code>int fo; // Initial character is U+0066 (LATIN SMALL LETTER F).
-int fo; // Initial character is U+1D41F (MATHEMATICAL BOLD SMALL F) not U+0066 (LATIN SMALL LETTER F).</code></pre>
+int 𝐟o; // Initial character is U+1D41F (MATHEMATICAL BOLD SMALL F) not U+0066 (LATIN SMALL LETTER F).</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/confusable-identifiers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -10953,17 +10886,6 @@ constexpr int f10() { return 0; } // OK: constexpr function implies inline.
 template &lt;class T&gt;
 constexpr T pi = T(3.1415926L);</code></pre>
 <p>When <code class="interpreted-text" role="program">clang-tidy</code> is invoked with the <span class="title-ref">--fix-notes</span> option, this check provides fixes that automatically add the <code>inline</code> keyword to discovered functions. Please note that the addition of the <code>inline</code> keyword to variables is not currently supported by this check.</p>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>HeaderFileExtensions</p>
-<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">HeaderFileExtensions</span>.</p>
-<p>A comma-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is "h,hh,hpp,hxx". For header files without an extension, use an empty string (if there are no other desired extensions) or leave an empty element in the list. E.g., "h,hh,hpp,hxx," (note the trailing comma).</p>
-</div>
-<div class="option">
-<p>UseHeaderFileExtension</p>
-<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. The check will unconditionally use the global option <span class="title-ref">HeaderFileExtensions</span>.</p>
-<p>When <span class="title-ref">true</span>, the check will use the file extension to distinguish header files. Default is <span class="title-ref">true</span>.</p>
-</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/definitions-in-headers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -11057,9 +10979,9 @@ Baz baz; // warning: missing include &quot;baz.h&quot;</code></pre>
 
 int main() {
     bool isAdmin = false;
-    /* } if (isAdmin) begin admins only */
+    /*‮ } ⁦if (isAdmin)⁩ ⁦ begin admins only */
         std::cout &lt;&lt; &quot;You are an admin.\n&quot;;
-    /* end admins only { */
+    /* end admins only ‮ { ⁦*/
     return 0;
 }</code></pre>
 <h2>References</h2>
@@ -11079,13 +11001,13 @@ int main() {
 <p>An example of such misleading code follows:</p>
 <pre class="text"><code>#include &lt;stdio.h&gt;
 
-short int N = (short int)0;
-short int l = (short int)12345;
+short int א = (short int)0;
+short int ג = (short int)12345;
 
 int main() {
-  int N = N; // a local variable, set to zero?
-  printf(&quot;l is %d\n&quot;, l);
-  printf(&quot;N is %d\n&quot;, N);
+  int א = ג; // a local variable, set to zero?
+  printf(&quot;ג is %d\n&quot;, ג);
+  printf(&quot;א is %d\n&quot;, א);
 }</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/misleading-identifier.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -11249,7 +11171,8 @@ void f(const int_ptr ptr) {
 <p>Finds violations of the rule "Throw by value, catch by reference" presented for example in "C++ Coding Standards" by H. Sutter and A. Alexandrescu, as well as the CERT C++ Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/ERR61-CPP.+Catch+exceptions+by+lvalue+reference">ERR61-CPP. Catch exceptions by lvalue reference</a>.</p>
 <dl>
 <dt>Exceptions:</dt>
-<dd><ul>
+<dd>
+<ul>
 <li>Throwing string literals will not be flagged despite being a pointer. They are not susceptible to slicing and the usage of string literals is idiomatic.</li>
 <li>Catching character pointers (<code>char</code>, <code>wchar_t</code>, unicode character types) will not be flagged to allow catching string literals.</li>
 <li>Moved named values will not be flagged as not throwing an anonymous temporary. In this case we can be sure that the user knows that the object can't be accessed outside catch blocks handling the error.</li>
@@ -11385,17 +11308,11 @@ static void staticFunctionA() { /*some code that doesn&#39;t use `i`*/ }</code><
 </div>
 <h1 id="misc-unused-using-decls">misc-unused-using-decls</h1>
 <p>Finds unused <code>using</code> declarations.</p>
-<p>Unused <code>using</code><span class="title-ref"> declarations in header files will not be diagnosed since these using declarations are part of the header's public API. Allowed header file extensions can be configured via the `HeaderFileExtensions</span> option (see below).</p>
+<p>Unused <code>using</code><span class="title-ref"> declarations in header files will not be diagnosed since these using declarations are part of the header's public API. Allowed header file extensions can be configured via the global option `HeaderFileExtensions</span>.</p>
 <p>Example:</p>
 <pre class="c++"><code>// main.cpp
 namespace n { class C; }
 using n::C;  // Never actually used.</code></pre>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>HeaderFileExtensions</p>
-<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">HeaderFileExtensions</span>.</p>
-<p>A semicolon-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is "h,hh,hpp,hxx". For extension-less header files, use an empty string or leave an empty string between "," if there are other filename extensions.</p>
-</div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/unused-using-decls.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -11413,7 +11330,7 @@ using n::C;  // Never actually used.</code></pre>
 <p>Anonymous namespaces are the "superior alternative" according to the C++ Standard. <code>static</code> was proposed for deprecation, but later un-deprecated to keep C compatibility [1]. <code>static</code> is an overloaded term with different meanings in different contexts, so it can create confusion.</p>
 <p>The following uses of <code>static</code> will <em>not</em> be diagnosed:</p>
 <ul>
-<li>Functions or variables in header files, since anonymous namespaces in headers is considered an antipattern. Allowed header file extensions can be configured via the <span class="title-ref">HeaderFileExtensions</span> option (see below).</li>
+<li>Functions or variables in header files, since anonymous namespaces in headers is considered an antipattern. Allowed header file extensions can be configured via the global option <span class="title-ref">HeaderFileExtensions</span>.</li>
 <li><code>const</code> or <code>constexpr</code> variables, since they already have implicit internal linkage in C++.</li>
 </ul>
 <p>Examples:</p>
@@ -11426,12 +11343,6 @@ namespace {
   void foo();
   int x;
 } // namespace</code></pre>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>HeaderFileExtensions</p>
-<p>Note: this option is deprecated, it will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19. Please use the global configuration option <span class="title-ref">HeaderFileExtensions</span>.</p>
-<p>A semicolon-separated list of filename extensions of header files (the filename extensions should not include "." prefix). Default is ";h;hh;hpp;hxx". For extension-less header files, using an empty string or leaving an empty string between ";" if there are other filename extensions.</p>
-</div>
 <p>[1] <a href="https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1012">Undeprecating static</a></p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/use-anonymous-namespace.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -11442,8 +11353,7 @@ namespace {
     <key>misc-use-internal-linkage</key>
     <name>misc-use-internal-linkage</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - misc-use-internal-linkage</p>
 </div>
 <h1 id="misc-use-internal-linkage">misc-use-internal-linkage</h1>
@@ -11467,17 +11377,17 @@ extern int v2;</code></pre>
 <p>Selects what kind of a fix the check should provide. The default is <span class="title-ref">UseStatic</span>.</p>
 <dl>
 <dt><code>None</code></dt>
-<dd><p>Don't fix automatically.</p>
+<dd>
+<p>Don't fix automatically.</p>
 </dd>
 <dt><code>UseStatic</code></dt>
-<dd><p>Add <code>static</code> for internal linkage variable and function.</p>
+<dd>
+<p>Add <code>static</code> for internal linkage variable and function.</p>
 </dd>
 </dl>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/use-internal-linkage.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/use-internal-linkage.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -11725,23 +11635,31 @@ extern &quot;C&quot; {
 <p>Detects usage of the deprecated member types of <code>std::ios_base</code> and replaces those that have a non-deprecated equivalent.</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Deprecated member type</th>
 <th>Replacement</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>std::ios_base::io_state</code></td>
 <td><code>std::ios_base::iostate</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>std::ios_base::open_mode</code></td>
 <td><code>std::ios_base::openmode</code></td>
 </tr>
-<tr class="odd">
-<td><p><code>std::ios_base::seek_dir</code> <code>std::ios_base::streamoff</code> <code>std::ios_base::streampos</code></p></td>
-<td><p><code>std::ios_base::seekdir</code></p></td>
+<tr>
+<td><code>std::ios_base::seek_dir</code></td>
+<td><code>std::ios_base::seekdir</code></td>
+</tr>
+<tr>
+<td><code>std::ios_base::streamoff</code></td>
+<td></td>
+</tr>
+<tr>
+<td><code>std::ios_base::streampos</code></td>
+<td></td>
 </tr>
 </tbody>
 </table>
@@ -12089,8 +12007,7 @@ my_ptr = std::make_unique&lt;MyPair&gt;(1, 2);</code></pre>
     <key>modernize-min-max-use-initializer-list</key>
     <name>modernize-min-max-use-initializer-list</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - modernize-min-max-use-initializer-list</p>
 </div>
 <h1 id="modernize-min-max-use-initializer-list">modernize-min-max-use-initializer-list</h1>
@@ -12117,9 +12034,7 @@ my_ptr = std::make_unique&lt;MyPair&gt;(1, 2);</code></pre>
 <p>An integer specifying the size (in bytes) above which trivial types are ignored. Default is <span class="title-ref">32</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/min-max-use-initializer-list.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/min-max-use-initializer-list.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -12222,7 +12137,7 @@ public:
 +  C(std::string S) : S(std::move(S)) {}
 };</code></pre>
 <div class="seealso">
-<p>For more information about the pass-by-value idiom, read: <a href="">Want Speed? Pass by Value</a>.</p>
+<p>For more information about the pass-by-value idiom, read: <a href="http://clang.llvm.org/extra/clang-tidy/checks/">Want Speed? Pass by Value</a>.</p>
 </div>
 <h2 id="options">Options</h2>
 <div class="option">
@@ -12292,35 +12207,36 @@ const char *const RegEx{R&quot;(\w\([a-z]\))&quot;};</code></pre>
 <p>Find and remove redundant <code>void</code> argument lists.</p>
 <dl>
 <dt>Examples:</dt>
-<dd><table>
+<dd>
+<table>
 <thead>
-<tr class="header">
+<tr>
 <th>Initial code</th>
 <th>Code with applied fixes</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>int f(void);</code></td>
 <td><code>int f();</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>int (*f(void))(void);</code></td>
 <td><code>int (*f())();</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>typedef int (*f_t(void))(void);</code></td>
 <td><code>typedef int (*f_t())();</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>void (C::*p)(void);</code></td>
 <td><code>void (C::*p)();</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>C::C(void) {}</code></td>
 <td><code>C::C() {}</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>C::~C(void) {}</code></td>
 <td><code>C::~C() {}</code></td>
 </tr>
@@ -12814,6 +12730,29 @@ struct my_class {};</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>modernize-use-default</key>
+    <name>modernize-use-default</name>
+    <description>
+      <![CDATA[<dl>
+<dt>orphan</dt>
+<dd>
+
+</dd>
+</dl>
+<div class="title">
+<p>clang-tidy - modernize-use-default</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../modernize/use-equals-default.html">
+
+</div>
+<h1 id="modernize-use-default">modernize-use-default</h1>
+<p>This check has been renamed to <code class="interpreted-text" role="doc">modernize-use-equals-default &lt;../modernize/use-equals-default&gt;</code>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-default.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>modernize-use-default-member-init</key>
     <name>modernize-use-default-member-init</name>
     <description>
@@ -12867,8 +12806,7 @@ struct A {
     <key>modernize-use-designated-initializers</key>
     <name>modernize-use-designated-initializers</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - modernize-use-designated-initializers</p>
 </div>
 <h1 id="modernize-use-designated-initializers">modernize-use-designated-initializers</h1>
@@ -12876,11 +12814,11 @@ struct A {
 <p>With plain initializer lists, it is very easy to introduce bugs when adding new fields in the middle of a struct or class type. The same confusion might arise when changing the order of fields.</p>
 <p>C++20 supports the designated initializer syntax for aggregate types. By applying it, we can always be sure that aggregates are constructed correctly, because every variable being initialized is referenced by its name.</p>
 <p>Example:</p>
-<pre class=""><code>struct S { int i, j; };</code></pre>
+<pre><code>struct S { int i, j; };</code></pre>
 <p>is an aggregate type that should be initialized as</p>
-<pre class=""><code>S s{.i = 1, .j = 2};</code></pre>
+<pre><code>S s{.i = 1, .j = 2};</code></pre>
 <p>instead of</p>
-<pre class=""><code>S s{1, 2};</code></pre>
+<pre><code>S s{1, 2};</code></pre>
 <p>which could easily become an issue when <code>i</code> and <code>j</code> are swapped in the declaration of <code>S</code>.</p>
 <p>Even when compiling in a language version older than C++20, depending on your compiler, designated initializers are potentially supported. Therefore, the check is by default restricted to C99/C++20 and above. Check out the options <code>-Wc99-designator</code> to get support for mixed designators in initializer list in C and <code>-Wc++20-designator</code> for support of designated initializers in older C++ language modes.</p>
 <h2 id="options">Options</h2>
@@ -12905,31 +12843,7 @@ struct A {
 <p>When set to <span class="title-ref">false</span>, the check will not restrict itself to C++20 and above. The default value is <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-designated-initializers.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>modernize-use-default</key>
-    <name>modernize-use-default</name>
-    <description>
-      <![CDATA[<dl>
-<dt>orphan</dt>
-<dd>
-</dd>
-</dl>
-<div class="title">
-<p>clang-tidy - modernize-use-default</p>
-</div>
-<div class="meta" data-http-equiv=refresh="5;URL=../modernize/use-equals-default.html">
-
-</div>
-<h1 id="modernize-use-default">modernize-use-default</h1>
-<p>This check has been renamed to <code class="interpreted-text" role="doc">modernize-use-equals-default &lt;../modernize/use-equals-default&gt;</code>.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-default.html" target="_blank">clang.llvm.org</a></p>]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-designated-initializers.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -13240,7 +13154,7 @@ struct bar {
 <p>clang-tidy - modernize-use-nullptr</p>
 </div>
 <h1 id="modernize-use-nullptr">modernize-use-nullptr</h1>
-<p>The check converts the usage of null pointer constants (e.g. <code>NULL</code>, <code>0</code>) to use the new C++11 <code>nullptr</code> keyword.</p>
+<p>The check converts the usage of null pointer constants (e.g. <code>NULL</code>, <code>0</code>) to use the new C++11 and C23 <code>nullptr</code> keyword.</p>
 <h2 id="example">Example</h2>
 <pre class="c++"><code>void assignment() {
   char *a = NULL;
@@ -13296,7 +13210,7 @@ void assignment() {
 <h1 id="modernize-use-override">modernize-use-override</h1>
 <p>Adds <code>override</code> (introduced in C++11) to overridden virtual functions and removes <code>virtual</code> from those functions as it is not required.</p>
 <p><code>virtual</code> on non base class implementations was used to help indicate to the user that a function was virtual. C++ compilers did not use the presence of this to signify an overridden function.</p>
-<p>In C++ 11 <code>override</code> and <code>final</code> keywords were introduced to allow overridden functions to be marked appropriately. Their presence allows compilers to verify that an overridden function correctly overrides a base class implementation.</p>
+<p>In C++11 <code>override</code> and <code>final</code> keywords were introduced to allow overridden functions to be marked appropriately. Their presence allows compilers to verify that an overridden function correctly overrides a base class implementation.</p>
 <p>This can be useful as compilers can generate a compile time error when:</p>
 <blockquote>
 <ul>
@@ -13340,8 +13254,7 @@ void assignment() {
     <key>modernize-use-ranges</key>
     <name>modernize-use-ranges</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - modernize-use-ranges</p>
 </div>
 <h1 id="modernize-use-ranges">modernize-use-ranges</h1>
@@ -13376,9 +13289,7 @@ auto AreSame = std::ranges::equal(Items1, Items2);</code></pre>
 <pre class="c++"><code>std::ranges::find(Items | std::views::reverse, 0);</code></pre>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-ranges.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-ranges.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -13390,12 +13301,14 @@ auto AreSame = std::ranges::equal(Items1, Items2);</code></pre>
 <p>clang-tidy - modernize-use-starts-ends-with</p>
 </div>
 <h1 id="modernize-use-starts-ends-with">modernize-use-starts-ends-with</h1>
-<p>Checks whether a <code>find</code> or <code>rfind</code> result is compared with 0 and suggests replacing with <code>starts_with</code> when the method exists in the class. Notably, this will work with <code>std::string</code> and <code>std::string_view</code>.</p>
+<p>Checks for common roundabout ways to express <code>starts_with</code> and <code>ends_with</code> and suggests replacing with <code>starts_with</code> when the method is available. Notably, this will work with <code>std::string</code> and <code>std::string_view</code>.</p>
 <pre class="c++"><code>std::string s = &quot;...&quot;;
 if (s.find(&quot;prefix&quot;) == 0) { /* do something */ }
-if (s.rfind(&quot;prefix&quot;, 0) == 0) { /* do something */ }</code></pre>
+if (s.rfind(&quot;prefix&quot;, 0) == 0) { /* do something */ }
+if (s.compare(0, strlen(&quot;prefix&quot;), &quot;prefix&quot;) == 0) { /* do something */ }</code></pre>
 <p>becomes</p>
 <pre class="c++"><code>std::string s = &quot;...&quot;;
+if (s.starts_with(&quot;prefix&quot;)) { /* do something */ }
 if (s.starts_with(&quot;prefix&quot;)) { /* do something */ }
 if (s.starts_with(&quot;prefix&quot;)) { /* do something */ }</code></pre>
 <h2>References</h2>
@@ -13407,8 +13320,7 @@ if (s.starts_with(&quot;prefix&quot;)) { /* do something */ }</code></pre>
     <key>modernize-use-std-format</key>
     <name>modernize-use-std-format</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - modernize-use-std-format</p>
 </div>
 <h1 id="modernize-use-std-format">modernize-use-std-format</h1>
@@ -13417,7 +13329,7 @@ if (s.starts_with(&quot;prefix&quot;)) { /* do something */ }</code></pre>
 <pre class="c++"><code>return absl::StrFormat(&quot;The %s is %3d&quot;, description.c_str(), value);</code></pre>
 <p>into:</p>
 <pre class="c++"><code>return std::format(&quot;The {} is {:3}&quot;, description, value);</code></pre>
-<p>The check uses the same format-string-conversion algorithm as <a href="../modernize/use-std-print.html">modernize-use-std-print</a> and its shortcomings are described in the documentation for that check.</p>
+<p>The check uses the same format-string-conversion algorithm as <a href="http://clang.llvm.org/extra/clang-tidy/checks/../modernize/use-std-print.html">modernize-use-std-print</a> and its shortcomings are described in the documentation for that check.</p>
 <h2 id="options">Options</h2>
 <div class="option">
 <p>StrictMode</p>
@@ -13443,9 +13355,7 @@ return strprintf(&quot;%d %u\n&quot;, i, u);</code></pre>
 <p>The header that must be included for the declaration of <span class="title-ref">ReplacementFormatFunction</span> so that a <code>#include</code> directive can be added if required. If <span class="title-ref">ReplacementFormatFunction</span> is <span class="title-ref">std::format</span> then this option will default to <code>&lt;format&gt;</code>, otherwise this option will default to nothing and no <code>#include</code> directive will be added.</p>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-std-format.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-std-format.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -13916,7 +13826,7 @@ MPI_Send(&amp;buf, 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);</code></pre>
 <li>yyyy + ww : Calendar year specified with week of a week year (unless YYYY is also specified).
 <ul>
 <li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">yyyy-ww</span>;<br />
-Output string: <span class="title-ref">2014-01</span> (Wrong because it's not the first week of 2014)</div></li>
+Output string: <span class="title-ref">2014-01</span> (Wrong because it’s not the first week of 2014)</div></li>
 <li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">dd-MM-yyyy (ww-YYYY)</span>;<br />
 Output string: <span class="title-ref">29-12-2014 (01-2015)</span> (This is correct)</div></li>
 </ul></li>
@@ -13938,35 +13848,35 @@ Output string: <span class="title-ref">05-2014</span> (Wrong because it reads as
 <li>YYYY + QQ : Week year specified with quarter of normal year (unless yyyy is also specified).
 <ul>
 <li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-QQ</span><br />
-Output string: <span class="title-ref">2015-04</span> (Wrong because it's not the 4th quarter of 2015)</div></li>
+Output string: <span class="title-ref">2015-04</span> (Wrong because it’s not the 4th quarter of 2015)</div></li>
 <li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (QQ-yyyy)</span><br />
 Output string: <span class="title-ref">01-2015 (04-2014)</span> (This is correct)</div></li>
 </ul></li>
 <li>YYYY + MM : Week year specified with Month of a calendar year (unless yyyy is also specified).
 <ul>
 <li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-MM</span><br />
-Output string: <span class="title-ref">2015-12</span> (Wrong because it's not the 12th month of 2015)</div></li>
+Output string: <span class="title-ref">2015-12</span> (Wrong because it’s not the 12th month of 2015)</div></li>
 <li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (MM-yyyy)</span><br />
 Output string: <span class="title-ref">01-2015 (12-2014)</span> (This is correct)</div></li>
 </ul></li>
 <li>YYYY + DD : Week year with day of a calendar year (unless yyyy is also specified).
 <ul>
 <li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-DD</span><br />
-Output string: <span class="title-ref">2015-363</span> (Wrong because it's not the 363rd day of 2015)</div></li>
+Output string: <span class="title-ref">2015-363</span> (Wrong because it’s not the 363rd day of 2015)</div></li>
 <li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (DD-yyyy)</span><br />
 Output string: <span class="title-ref">01-2015 (363-2014)</span> (This is correct)</div></li>
 </ul></li>
 <li>YYYY + WW : Week year with week of a calendar year (unless yyyy is also specified).
 <ul>
 <li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-WW</span><br />
-Output string: <span class="title-ref">2015-05</span> (Wrong because it's not the 5th week of 2015)</div></li>
+Output string: <span class="title-ref">2015-05</span> (Wrong because it’s not the 5th week of 2015)</div></li>
 <li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (WW-MM-yyyy)</span><br />
 Output string: <span class="title-ref">01-2015 (05-12-2014)</span> (This is correct)</div></li>
 </ul></li>
 <li>YYYY + F : Week year with day of week in a calendar month (unless yyyy is also specified).
 <ul>
 <li><div class="line-block"><strong>Example 1:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">YYYY-ww-F-EE</span><br />
-Output string: <span class="title-ref">2015-01-5-Mon</span> (Wrong because it's not the 5th Monday of January in 2015)</div></li>
+Output string: <span class="title-ref">2015-01-5-Mon</span> (Wrong because it’s not the 5th Monday of January in 2015)</div></li>
 <li><div class="line-block"><strong>Example 2:</strong> Input Date: <span class="title-ref">29 December 2014</span> ; Format String: <span class="title-ref">ww-YYYY (F-EE-MM-yyyy)</span><br />
 Output string: <span class="title-ref">01-2015 (5-Mon-12-2014)</span> (This is correct)</div></li>
 </ul></li>
@@ -14264,6 +14174,7 @@ str.find(&#39;A&#39;);</code></pre>
       <![CDATA[<dl>
 <dt>orphan</dt>
 <dd>
+
 </dd>
 </dl>
 <div class="title">
@@ -14873,13 +14784,13 @@ int NestInFalse = condition1 ? true1 : condition2 ? true2 : false1;</code></pre>
 <p>Finds return statements with <code>void</code> values used within functions with <code>void</code> result types.</p>
 <p>A function with a <code>void</code> return type is intended to perform a task without producing a return value. Return statements with expressions could lead to confusion and may miscommunicate the function's intended behavior.</p>
 <p>Example:</p>
-<pre class=""><code>void g();
+<pre><code>void g();
 void f() {
     // ...
     return g();
 }</code></pre>
 <p>In a long function body, the <code>return</code> statement suggests that the function returns a value. However, <code>return g();</code> is a combination of two statements that should be written as</p>
-<pre class=""><code>g();
+<pre><code>g();
 return;</code></pre>
 <p>to make clear that <code>g()</code> is called and immediately afterwards the function returns (nothing).</p>
 <p>In C, the same issue is detected by the compiler if the <code>-Wpedantic</code> mode is enabled.</p>
@@ -14890,7 +14801,7 @@ return;</code></pre>
 </div>
 <div class="option">
 <p>StrictMode</p>
-<p>The value <span class="title-ref">false</span> specifies that a direct return statement shall be excluded from the analysis if it is the only statement not contained in a block like <code>if (cond) return g();</code>. The default value is <span class="title-ref">true</span>.</p>
+<p>The value <span class="title-ref">false</span> specifies that a direct return statement shall be excluded from the analysis if it is the only statement not contained in a block, like <code>if (cond) return g();</code>. The default value is <span class="title-ref">true</span>.</p>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-return-with-void-value.html" target="_blank">clang.llvm.org</a></p>]]>
@@ -14983,42 +14894,42 @@ const Clazz* foo();</code></pre>
 <p>clang-tidy - readability-container-contains</p>
 </div>
 <h1 id="readability-container-contains">readability-container-contains</h1>
-<p>Finds usages of <code>container.count()</code> and <code>container.find() == container.end()</code> which should be replaced by a call to the <code>container.contains()</code> method introduced in C++ 20.</p>
+<p>Finds usages of <code>container.count()</code> and <code>container.find() == container.end()</code> which should be replaced by a call to the <code>container.contains()</code> method introduced in C++20.</p>
 <p>Whether an element is contained inside a container should be checked with <code>contains</code> instead of <code>count</code>/<code>find</code> because <code>contains</code> conveys the intent more clearly. Furthermore, for containers which permit multiple entries per key (<code>multimap</code>, <code>multiset</code>, ...), <code>contains</code> is more efficient than <code>count</code> because <code>count</code> has to do unnecessary additional work.</p>
 <p>Examples:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Initial expression</th>
 <th>Result</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>myMap.find(x) == myMap.end()</code></td>
 <td><code>!myMap.contains(x)</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>myMap.find(x) != myMap.end()</code></td>
 <td><code>myMap.contains(x)</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>if (myMap.count(x))</code></td>
 <td><code>if (myMap.contains(x))</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>bool exists = myMap.count(x)</code></td>
 <td><code>bool exists = myMap.contains(x)</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>bool exists = myMap.count(x) &gt; 0</code></td>
 <td><code>bool exists = myMap.contains(x)</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>bool exists = myMap.count(x) &gt;= 1</code></td>
 <td><code>bool exists = myMap.contains(x)</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>bool missing = myMap.count(x) == 0</code></td>
 <td><code>bool missing = !myMap.contains(x)</code></td>
 </tr>
@@ -15207,8 +15118,7 @@ if (p)
     <key>readability-enum-initial-value</key>
     <name>readability-enum-initial-value</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - readability-enum-initial-value</p>
 </div>
 <h1 id="readability-enum-initial-value">readability-enum-initial-value</h1>
@@ -15273,9 +15183,7 @@ enum E {    // Invalid, e1, e3, and e5 are not explicitly initialized.
   g2 = 3,</code></pre>
 </div>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/enum-initial-value.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/enum-initial-value.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -15371,7 +15279,7 @@ enum E {    // Invalid, e1, e3, and e5 are not explicitly initialized.
 <li><p>Apple Block Declaration</p></li>
 </ul>
 <h3 id="nesting-increment">Nesting increment</h3>
-<p>This is where the previous basic building block, <a href="#nesting-level">Nesting level</a>, matters. The following structures increase the function's Cognitive Complexity metric by the current <a href="#nesting-level">Nesting level</a>:</p>
+<p>This is where the previous basic building block, <a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/function-cognitive-complexity.html#nesting-level">Nesting level</a>, matters. The following structures increase the function's Cognitive Complexity metric by the current <a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/function-cognitive-complexity.html#nesting-level">Nesting level</a>:</p>
 <ul>
 <li><p>Conditional operators:</p>
 <blockquote>
@@ -15414,7 +15322,8 @@ enum E {    // Invalid, e1, e3, and e5 are not explicitly initialized.
 <h2 id="limitations">Limitations</h2>
 <dl>
 <dt>The metric is implemented with two notable exceptions:</dt>
-<dd><ul>
+<dd>
+<ul>
 <li><span class="title-ref">preprocessor conditionals</span> (<code>#ifdef</code>, <code>#if</code>, <code>#elif</code>, <code>#else</code>, <code>#endif</code>) are not accounted for.</li>
 <li><span class="title-ref">each method in a recursion cycle</span> is not accounted for. It can't be fully implemented, because cross-translational-unit analysis would be needed, which is currently not possible in clang-tidy.</li>
 </ul>
@@ -15488,10 +15397,7 @@ enum E {    // Invalid, e1, e3, and e5 are not explicitly initialized.
 <div class="option">
 <p>MinimumVariableNameLength</p>
 <p>All variables (other than loop counter, exception names and function parameters) are expected to have at least a length of <span class="title-ref">MinimumVariableNameLength</span> (default is <span class="title-ref">3</span>). Setting it to <span class="title-ref">0</span> or <span class="title-ref">1</span> disables the check entirely.</p>
-<pre class="c++"><code>int doubler(int x)   // warns that x is too short
-{
-   return 2 * x;
-}</code></pre>
+<pre class="c++"><code>int i = 42;    // warns that &#39;i&#39; is too short</code></pre>
 <p>This check does not have any fix suggestions in the general case since variable names have semantic value.</p>
 </div>
 <div class="option">
@@ -15501,7 +15407,10 @@ enum E {    // Invalid, e1, e3, and e5 are not explicitly initialized.
 <div class="option">
 <p>MinimumParameterNameLength</p>
 <p>All function parameter names are expected to have a length of at least <span class="title-ref">MinimumParameterNameLength</span> (default is <span class="title-ref">3</span>). Setting it to <span class="title-ref">0</span> or <span class="title-ref">1</span> disables the check entirely.</p>
-<pre class="c++"><code>int i = 42;    // warns that &#39;i&#39; is too short</code></pre>
+<pre class="c++"><code>int doubler(int x)   // warns that x is too short
+{
+   return 2 * x;
+}</code></pre>
 <p>This check does not have any fix suggestions in the general case since variable names have semantic value.</p>
 </div>
 <div class="option">
@@ -15564,14 +15473,14 @@ catch (const std::exception&amp; e) {
 <p>Casing types include:</p>
 <blockquote>
 <ul>
-<li><code>lower_case</code>,</li>
-<li><code>UPPER_CASE</code>,</li>
-<li><code>camelBack</code>,</li>
-<li><code>CamelCase</code>,</li>
-<li><code>camel_Snake_Back</code>,</li>
-<li><code>Camel_Snake_Case</code>,</li>
-<li><code>aNy_CasE</code>,</li>
-<li><code>Leading_upper_snake_case</code>.</li>
+<li><code>lower_case</code></li>
+<li><code>UPPER_CASE</code></li>
+<li><code>camelBack</code></li>
+<li><code>CamelCase</code></li>
+<li><code>camel_Snake_Back</code></li>
+<li><code>Camel_Snake_Case</code></li>
+<li><code>aNy_CasE</code></li>
+<li><code>Leading_upper_snake_case</code></li>
 </ul>
 </blockquote>
 <p>It also supports a fixed prefix and suffix that will be prepended or appended to the identifiers, regardless of the casing.</p>
@@ -17504,7 +17413,7 @@ public:
 <p>The following table is the default mapping table of Hungarian Notation which maps Decl to its prefix string. You can also have your own style in config file.</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Primitive Type</th>
 <th></th>
 <th></th>
@@ -17514,7 +17423,7 @@ public:
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><blockquote>
 <p>Type</p>
 </blockquote></td>
@@ -17524,15 +17433,15 @@ public:
 <td>Type</td>
 <td>Prefix</td>
 </tr>
-<tr class="even">
-<td>=================</td>
-<td>==============</td>
-<td>======================</td>
-<td>==============</td>
-<td>==============</td>
-<td>==============</td>
+<tr>
+<td><hr /></td>
+<td><hr /></td>
+<td><hr /></td>
+<td><hr /></td>
+<td><hr /></td>
+<td><hr /></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>int8_t</td>
 <td>i8</td>
 <td>signed int</td>
@@ -17540,7 +17449,7 @@ public:
 <td>BOOL</td>
 <td>b</td>
 </tr>
-<tr class="even">
+<tr>
 <td>int16_t</td>
 <td>i16</td>
 <td>signed short</td>
@@ -17548,7 +17457,7 @@ public:
 <td>BOOLEAN</td>
 <td>b</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>int32_t</td>
 <td>i32</td>
 <td>signed short int</td>
@@ -17556,7 +17465,7 @@ public:
 <td>BYTE</td>
 <td>by</td>
 </tr>
-<tr class="even">
+<tr>
 <td>int64_t</td>
 <td>i64</td>
 <td>signed long long int</td>
@@ -17564,7 +17473,7 @@ public:
 <td>CHAR</td>
 <td>c</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>uint8_t</td>
 <td>u8</td>
 <td>signed long long</td>
@@ -17572,7 +17481,7 @@ public:
 <td>UCHAR</td>
 <td>uc</td>
 </tr>
-<tr class="even">
+<tr>
 <td>uint16_t</td>
 <td>u16</td>
 <td>signed long int</td>
@@ -17580,7 +17489,7 @@ public:
 <td>SHORT</td>
 <td>s</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>uint32_t</td>
 <td>u32</td>
 <td>signed long</td>
@@ -17588,7 +17497,7 @@ public:
 <td>USHORT</td>
 <td>us</td>
 </tr>
-<tr class="even">
+<tr>
 <td>uint64_t</td>
 <td>u64</td>
 <td>signed</td>
@@ -17596,7 +17505,7 @@ public:
 <td>WORD</td>
 <td>w</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>char8_t</td>
 <td>c8</td>
 <td>unsigned long long int</td>
@@ -17604,7 +17513,7 @@ public:
 <td>DWORD</td>
 <td>dw</td>
 </tr>
-<tr class="even">
+<tr>
 <td>char16_t</td>
 <td>c16</td>
 <td>unsigned long long</td>
@@ -17612,7 +17521,7 @@ public:
 <td>DWORD32</td>
 <td>dw32</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>char32_t</td>
 <td>c32</td>
 <td>unsigned long int</td>
@@ -17620,7 +17529,7 @@ public:
 <td>DWORD64</td>
 <td>dw64</td>
 </tr>
-<tr class="even">
+<tr>
 <td>float</td>
 <td>f</td>
 <td>unsigned long</td>
@@ -17628,7 +17537,7 @@ public:
 <td>LONG</td>
 <td>l</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>double</td>
 <td>d</td>
 <td>unsigned short int</td>
@@ -17636,7 +17545,7 @@ public:
 <td>ULONG</td>
 <td>ul</td>
 </tr>
-<tr class="even">
+<tr>
 <td>char</td>
 <td>c</td>
 <td>unsigned short</td>
@@ -17644,7 +17553,7 @@ public:
 <td>ULONG32</td>
 <td>ul32</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>bool</td>
 <td>b</td>
 <td>unsigned int</td>
@@ -17652,7 +17561,7 @@ public:
 <td>ULONG64</td>
 <td>ul64</td>
 </tr>
-<tr class="even">
+<tr>
 <td>_Bool</td>
 <td>b</td>
 <td>unsigned char</td>
@@ -17660,7 +17569,7 @@ public:
 <td>ULONGLONG</td>
 <td>ull</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>int</td>
 <td>i</td>
 <td>unsigned</td>
@@ -17668,7 +17577,7 @@ public:
 <td>HANDLE</td>
 <td>h</td>
 </tr>
-<tr class="even">
+<tr>
 <td>size_t</td>
 <td>n</td>
 <td>long long int</td>
@@ -17676,7 +17585,7 @@ public:
 <td>INT</td>
 <td>i</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>short</td>
 <td>s</td>
 <td>long double</td>
@@ -17684,7 +17593,7 @@ public:
 <td>INT8</td>
 <td>i8</td>
 </tr>
-<tr class="even">
+<tr>
 <td>signed</td>
 <td>i</td>
 <td>long long</td>
@@ -17692,7 +17601,7 @@ public:
 <td>INT16</td>
 <td>i16</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>unsigned</td>
 <td>u</td>
 <td>long int</td>
@@ -17700,7 +17609,7 @@ public:
 <td>INT32</td>
 <td>i32</td>
 </tr>
-<tr class="even">
+<tr>
 <td>long</td>
 <td>l</td>
 <td>long</td>
@@ -17708,7 +17617,7 @@ public:
 <td>INT64</td>
 <td>i64</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>long long</td>
 <td>ll</td>
 <td>ptrdiff_t</td>
@@ -17716,32 +17625,77 @@ public:
 <td>UINT</td>
 <td>ui</td>
 </tr>
-<tr class="even">
-<td><p>unsigned long long double ptrdiff_t wchar_t short int short</p></td>
-<td><p>ul ld p wc si s</p></td>
-<td><p>void</p></td>
-<td><p><em>none</em></p></td>
-<td><p>UINT8 UINT16 UINT32 UINT64 PVOID</p></td>
-<td><p>u8 u16 u32 u64 p</p></td>
+<tr>
+<td>unsigned long</td>
+<td>ul</td>
+<td>void</td>
+<td><em>none</em></td>
+<td>UINT8</td>
+<td>u8</td>
+</tr>
+<tr>
+<td>long double</td>
+<td>ld</td>
+<td></td>
+<td></td>
+<td>UINT16</td>
+<td>u16</td>
+</tr>
+<tr>
+<td>ptrdiff_t</td>
+<td>p</td>
+<td></td>
+<td></td>
+<td>UINT32</td>
+<td>u32</td>
+</tr>
+<tr>
+<td>wchar_t</td>
+<td>wc</td>
+<td></td>
+<td></td>
+<td>UINT64</td>
+<td>u64</td>
+</tr>
+<tr>
+<td>short int</td>
+<td>si</td>
+<td></td>
+<td></td>
+<td>PVOID</td>
+<td>p</td>
+</tr>
+<tr>
+<td>short</td>
+<td>s</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
 </tr>
 </tbody>
 </table>
 <p><strong>There are more trivial options for Hungarian Notation:</strong></p>
 <dl>
 <dt><strong>HungarianNotation.General.</strong>*</dt>
-<dd><p>Options are not belonging to any specific Decl.</p>
+<dd>
+<p>Options are not belonging to any specific Decl.</p>
 </dd>
 <dt><strong>HungarianNotation.CString.</strong>*</dt>
-<dd><p>Options for NULL-terminated string.</p>
+<dd>
+<p>Options for NULL-terminated string.</p>
 </dd>
 <dt><strong>HungarianNotation.DerivedType.</strong>*</dt>
-<dd><p>Options for derived types.</p>
+<dd>
+<p>Options for derived types.</p>
 </dd>
 <dt><strong>HungarianNotation.PrimitiveType.</strong>*</dt>
-<dd><p>Options for primitive types.</p>
+<dd>
+<p>Options for primitive types.</p>
 </dd>
 <dt><strong>HungarianNotation.UserDefinedType.</strong>*</dt>
-<dd><p>Options for user-defined types.</p>
+<dd>
+<p>Options for user-defined types.</p>
 </dd>
 </dl>
 <h2 id="options-for-hungarian-notation">Options for Hungarian Notation</h2>
@@ -17776,16 +17730,20 @@ public:
 <p>Before:</p>
 <pre class="c++"><code>// Array
 int DataArray[2] = {0};
+
 // Pointer
 void *DataBuffer = NULL;
+
 // FunctionPointer
 typedef void (*FUNC_PTR)();
 FUNC_PTR FuncPtr = NULL;</code></pre>
 <p>After:</p>
 <pre class="c++"><code>// Array
 int aDataArray[2] = {0};
+
 // Pointer
 void *pDataBuffer = NULL;
+
 // FunctionPointer
 typedef void (*FUNC_PTR)();
 FUNC_PTR fnFuncPtr = NULL;</code></pre>
@@ -17808,21 +17766,25 @@ FUNC_PTR fnFuncPtr = NULL;</code></pre>
 <p>Before:</p>
 <pre class="c++"><code>// CharPointer
 const char *NamePtr = &quot;Name&quot;;
+
 // CharArray
 const char NameArray[] = &quot;Name&quot;;
 
 // WideCharPointer
 const wchar_t *WideNamePtr = L&quot;Name&quot;;
+
 // WideCharArray
 const wchar_t WideNameArray[] = L&quot;Name&quot;;</code></pre>
 <p>After:</p>
 <pre class="c++"><code>// CharPointer
 const char *szNamePtr = &quot;Name&quot;;
+
 // CharArray
 const char szNameArray[] = &quot;Name&quot;;
 
 // WideCharPointer
 const wchar_t *wszWideNamePtr = L&quot;Name&quot;;
+
 // WideCharArray
 const wchar_t wszWideNameArray[] = L&quot;Name&quot;;</code></pre>
 <div class="option">
@@ -17871,6 +17833,7 @@ DWORD    dwValueDword = 0;</code></pre>
       <![CDATA[<dl>
 <dt>orphan</dt>
 <dd>
+
 </dd>
 </dl>
 <div class="title">
@@ -18274,8 +18237,7 @@ public:
     <key>readability-math-missing-parentheses</key>
     <name>readability-math-missing-parentheses</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - readability-math-missing-parentheses</p>
 </div>
 <h1 id="readability-math-missing-parentheses">readability-math-missing-parentheses</h1>
@@ -18286,9 +18248,7 @@ public:
 <p>After:</p>
 <pre class="c++"><code>int x = 1 + (2 * 3) - (4 / 5);</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/math-missing-parentheses.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/math-missing-parentheses.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -18341,7 +18301,8 @@ if (cond1)
 }</code></pre>
 <dl>
 <dt>The check warns about such unusual syntax for readability reasons:</dt>
-<dd><ul>
+<dd>
+<ul>
 <li>There are programmers that are not familiar with this unusual syntax.</li>
 <li>It is possible that variables are mixed up.</li>
 </ul>
@@ -18440,53 +18401,53 @@ void f4(int *p) {
 <table>
 <caption>Token Representation Mapping Table</caption>
 <thead>
-<tr class="header">
+<tr>
 <th>Traditional</th>
 <th>Alternative</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>&amp;&amp;</code></td>
 <td><code>and</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>&amp;=</code></td>
 <td><code>and_eq</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>&amp;</code></td>
 <td><code>bitand</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>|</code></td>
 <td><code>bitor</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>~</code></td>
 <td><code>compl</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>!</code></td>
 <td><code>not</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>!=</code></td>
 <td><code>not_eq</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>||</code></td>
 <td><code>or</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>|=</code></td>
 <td><code>or_eq</code></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>^</code></td>
 <td><code>xor</code></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>^=</code></td>
 <td><code>xor_eq</code></td>
 </tr>
@@ -18966,139 +18927,139 @@ const Point&amp; p = { 1, 2 };</code></pre>
 <p>Examples:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Initial expression</th>
 <th>Result</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>if (b == true)</code></td>
 <td><blockquote>
 <p><code>if (b)</code></p>
 </blockquote></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>if (b == false)</code></td>
 <td><blockquote>
 <p><code>if (!b)</code></p>
 </blockquote></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>if (b &amp;&amp; true)</code></td>
 <td><blockquote>
 <p><code>if (b)</code></p>
 </blockquote></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>if (b &amp;&amp; false)</code></td>
 <td><blockquote>
 <p><code>if (false)</code></p>
 </blockquote></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>if (b || true)</code></td>
 <td><blockquote>
 <p><code>if (true)</code></p>
 </blockquote></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>if (b || false)</code></td>
 <td><blockquote>
 <p><code>if (b)</code></p>
 </blockquote></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>e ? true : false</code></td>
 <td><blockquote>
 <p><code>e</code></p>
 </blockquote></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>e ? false : true</code></td>
 <td><blockquote>
 <p><code>!e</code></p>
 </blockquote></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>if (true) t(); else f();</code></td>
 <td><blockquote>
 <p><code>t();</code></p>
 </blockquote></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>if (false) t(); else f();</code></td>
 <td><blockquote>
 <p><code>f();</code></p>
 </blockquote></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>if (e) return true; else return false;</code></td>
 <td><blockquote>
 <p><code>return e;</code></p>
 </blockquote></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>if (e) return false; else return true;</code></td>
 <td><blockquote>
 <p><code>return !e;</code></p>
 </blockquote></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>if (e) b = true; else b = false;</code></td>
 <td><blockquote>
 <p><code>b = e;</code></p>
 </blockquote></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>if (e) b = false; else b = true;</code></td>
 <td><blockquote>
 <p><code>b = !e;</code></p>
 </blockquote></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>if (e) return true; return false;</code></td>
 <td><blockquote>
 <p><code>return e;</code></p>
 </blockquote></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>if (e) return false; return true;</code></td>
 <td><blockquote>
 <p><code>return !e;</code></p>
 </blockquote></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>!(!a || b)</code></td>
 <td><blockquote>
 <p><code>a &amp;&amp; !b</code></p>
 </blockquote></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>!(a || !b)</code></td>
 <td><blockquote>
 <p><code>!a &amp;&amp; b</code></p>
 </blockquote></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>!(!a || !b)</code></td>
 <td><blockquote>
 <p><code>a &amp;&amp; b</code></p>
 </blockquote></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>!(!a &amp;&amp; b)</code></td>
 <td><blockquote>
 <p><code>a || !b</code></p>
 </blockquote></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>!(a &amp;&amp; !b)</code></td>
 <td><blockquote>
 <p><code>!a || b</code></p>
 </blockquote></td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>!(!a &amp;&amp; !b)</code></td>
 <td><blockquote>
 <p><code>a || b</code></p>
@@ -19108,7 +19069,8 @@ const Point&amp; p = { 1, 2 };</code></pre>
 </table>
 <dl>
 <dt>The resulting expression <code>e</code> is modified as follows:</dt>
-<dd><ol type="1">
+<dd>
+<ol type="1">
 <li>Unnecessary parentheses around the expression are removed.</li>
 <li>Negated applications of <code>!</code> are eliminated.</li>
 <li>Negated applications of comparison operators are changed to use the opposite condition.</li>
@@ -19119,7 +19081,8 @@ const Point&amp; p = { 1, 2 };</code></pre>
 </ol>
 </dd>
 <dt>Examples:</dt>
-<dd><ol type="1">
+<dd>
+<ol type="1">
 <li><p>The ternary assignment <code>bool b = (i &lt; 0) ? true : false;</code> has redundant parentheses and becomes <code>bool b = i &lt; 0;</code>.</p></li>
 <li><p>The conditional return <code>if (!b) return false; return true;</code> has an implied double negation and becomes <code>return b;</code>.</p></li>
 <li><p>The conditional return <code>if (i &lt; 0) return false; return true;</code> becomes <code>return i &gt;= 0;</code>.</p>
@@ -19152,10 +19115,10 @@ const Point&amp; p = { 1, 2 };</code></pre>
 <p>SimplifyDeMorganRelaxed</p>
 <p>If <span class="title-ref">true</span>, <code class="interpreted-text" role="option">SimplifyDeMorgan</code> will also transform negated conjunctions and disjunctions where there is no negation on either operand. This option has no effect if <code class="interpreted-text" role="option">SimplifyDeMorgan</code> is <span class="title-ref">false</span>. Default is <span class="title-ref">false</span>.</p>
 <p>When Enabled:</p>
-<pre class=""><code>bool X = !(A &amp;&amp; B)
+<pre><code>bool X = !(A &amp;&amp; B)
 bool Y = !(A || B)</code></pre>
 <p>Would be transformed to:</p>
-<pre class=""><code>bool X = !A || !B
+<pre><code>bool X = !A || !B
 bool Y = !A &amp;&amp; !B</code></pre>
 </div>
 <h2>References</h2>
@@ -19214,6 +19177,7 @@ C::foo();
 C::x;
 C::E1;
 C::E2;</code></pre>
+<p>The <span class="title-ref">--fix</span> commandline option provides default support for safe fixes, whereas <span class="title-ref">--fix-notes</span> enables fixes that may replace expressions with side effects, potentially altering the program's behavior.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/static-accessed-through-instance.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
@@ -19252,8 +19216,9 @@ C::E2;</code></pre>
 <h1 id="readability-string-compare">readability-string-compare</h1>
 <p>Finds string comparisons using the compare method.</p>
 <p>A common mistake is to use the string's <code>compare</code> method instead of using the equality or inequality operators. The compare method is intended for sorting functions and thus returns a negative number, a positive number or zero depending on the lexicographical relationship between the strings compared. If an equality or inequality check can suffice, that is recommended. This is recommended to avoid the risk of incorrect interpretation of the return value and to simplify the code. The string equality and inequality operators can also be faster than the <code>compare</code> method due to early termination.</p>
-<p>Examples:</p>
-<pre class="c++"><code>std::string str1{&quot;a&quot;};
+<h2 id="example">Example</h2>
+<pre class="c++"><code>// The same rules apply to std::string_view.
+std::string str1{&quot;a&quot;};
 std::string str2{&quot;b&quot;};
 
 // use str1 != str2 instead.
@@ -19343,10 +19308,10 @@ foo(b, src);</code></pre>
 <p>The Levenshtein distance is translated into a similarity percentage by dividing it with the length of the <em>longer</em> string, and taking its complement with regards to <span class="title-ref">100</span>%. For example, given <code>something</code> and <code>anything</code>, the distance is <span class="title-ref">4</span> edits, and the similarity percentage is <span class="title-ref">100</span>% <span class="title-ref">- 4 / 9 = 55.55...</span>%.</p>
 <p>This heuristic can be configured with <code class="interpreted-text" role="ref">bounds&lt;opt_Bounds&gt;</code>. The default bounds are: below <span class="title-ref">50</span>% dissimilar and above <span class="title-ref">66</span>% similar. This heuristic is case-sensitive.</p>
 <h3 id="jaro--winkler-distance-as-jarowinkler">Jaro--Winkler distance (as <span class="title-ref">JaroWinkler</span>)</h3>
-<p>The <a href="http://en.wikipedia.org/wiki/Jaro-Winkler_distance">Jaro--Winkler distance</a> is an edit distance like the Levenshtein distance. It is calculated from the amount of common characters that are sufficiently close to each other in position, and to-be-changed characters. The original definition of Jaro has been extended by Winkler to weigh prefix similarities more. The similarity percentage is expressed as an average of the common and non-common characters against the length of both strings.</p>
+<p>The <a href="http://en.wikipedia.org/wiki/Jaro–Winkler_distance">Jaro--Winkler distance</a> is an edit distance like the Levenshtein distance. It is calculated from the amount of common characters that are sufficiently close to each other in position, and to-be-changed characters. The original definition of Jaro has been extended by Winkler to weigh prefix similarities more. The similarity percentage is expressed as an average of the common and non-common characters against the length of both strings.</p>
 <p>This heuristic can be configured with <code class="interpreted-text" role="ref">bounds&lt;opt_Bounds&gt;</code>. The default bounds are: below <span class="title-ref">75</span>% dissimilar and above <span class="title-ref">85</span>% similar. This heuristic is case-insensitive.</p>
-<h3 id="sorensen--dice-coefficient-as-dice">Sorensen--Dice coefficient (as <span class="title-ref">Dice</span>)</h3>
-<p>The <a href="http://en.wikipedia.org/wiki/Sorensen-Dice_coefficient">Sorensen--Dice coefficient</a> was originally defined to measure the similarity of two sets. Formally, the coefficient is calculated by dividing <span class="title-ref">2 * #(intersection)</span> with <span class="title-ref">#(set1) + #(set2)</span>, where <span class="title-ref">#()</span> is the cardinality function of sets. This metric is applied to strings by creating bigrams (substring sequences of length 2) of the two strings and using the set of bigrams for the two strings as the two sets.</p>
+<h3 id="sørensen--dice-coefficient-as-dice">Sørensen--Dice coefficient (as <span class="title-ref">Dice</span>)</h3>
+<p>The <a href="http://en.wikipedia.org/wiki/Sørensen–Dice_coefficient">Sørensen--Dice coefficient</a> was originally defined to measure the similarity of two sets. Formally, the coefficient is calculated by dividing <span class="title-ref">2 * #(intersection)</span> with <span class="title-ref">#(set1) + #(set2)</span>, where <span class="title-ref">#()</span> is the cardinality function of sets. This metric is applied to strings by creating bigrams (substring sequences of length 2) of the two strings and using the set of bigrams for the two strings as the two sets.</p>
 <p>This heuristic can be configured with <code class="interpreted-text" role="ref">bounds&lt;opt_Bounds&gt;</code>. The default bounds are: below <span class="title-ref">60</span>% dissimilar and above <span class="title-ref">70</span>% similar. This heuristic is case-insensitive.</p>
 <h2 id="options">Options</h2>
 <div class="option">
@@ -19512,7 +19477,7 @@ auto x = 1U; // OK, suffix is uppercase.
 <p>clang-tidy - readability-use-anyofallof</p>
 </div>
 <h1 id="readability-use-anyofallof">readability-use-anyofallof</h1>
-<p>Finds range-based for loops that can be replaced by a call to <code>std::any_of</code> or <code>std::all_of</code>. In C++ 20 mode, suggests <code>std::ranges::any_of</code> or <code>std::ranges::all_of</code>.</p>
+<p>Finds range-based for loops that can be replaced by a call to <code>std::any_of</code> or <code>std::all_of</code>. In C++20 mode, suggests <code>std::ranges::any_of</code> or <code>std::ranges::all_of</code>.</p>
 <p>Example:</p>
 <pre class="c++"><code>bool all_even(std::vector&lt;int&gt; V) {
   for (int I : V) {
@@ -19532,8 +19497,7 @@ auto x = 1U; // OK, suffix is uppercase.
     <key>readability-use-std-min-max</key>
     <name>readability-use-std-min-max</name>
     <description>
-      <![CDATA[
-      <div class="title">
+      <![CDATA[<div class="title">
 <p>clang-tidy - readability-use-std-min-max</p>
 </div>
 <h1 id="readability-use-std-min-max">readability-use-std-min-max</h1>
@@ -19550,12 +19514,10 @@ auto x = 1U; // OK, suffix is uppercase.
   a = std::max(a, b);
 }</code></pre>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/use-std-min-max.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/use-std-min-max.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>INFO</severity>
-  </rule>
+    </rule>
   <rule>
     <key>zircon-temporary-objects</key>
     <name>zircon-temporary-objects</name>
@@ -19602,16 +19564,16 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-aarch64-sme-attributes</key>
     <name>clang-diagnostic-aarch64-sme-attributes</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: %select{returning|passing}0 a VL-dependent argument %select{from|to}0 a function with a different streaming-mode is undefined behaviour when the streaming and non-streaming vector lengths are different at runtime</li>
-  <li>warning: %select{returning|passing}0 a VL-dependent argument %select{from|to}0 a locally streaming function is undefined behaviour when the streaming and non-streaming vector lengths are different at runtime</li>
-  <li>warning: always_inline function %1 and its caller %0 have mismatching %2 attributes, inlining may change runtime behaviour</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waarch64-sme-attributes" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{returning|passing}0 a VL-dependent argument %select{from|to}0 a function with a different streaming-mode is undefined behaviour when the streaming and non-streaming vector lengths are different at runtime</li>
+<li>warning: %select{returning|passing}0 a VL-dependent argument %select{from|to}0 a locally streaming function is undefined behaviour when the streaming and non-streaming vector lengths are different at runtime</li>
+<li>warning: always_inline function %1 and its caller %0 have mismatching %2 attributes, inlining may change runtime behaviour</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waarch64-sme-attributes" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -19850,6 +19812,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: cast of type %0 to %1 is deprecated; use sel_getName instead</li>
 <li>warning: comparison of %select{address of|function|array}0 '%1' %select{not |}2equal to a null pointer is always %select{true|false}2</li>
 <li>warning: comparison of nonnull %select{function call|parameter}0 '%1' %select{not |}2equal to a null pointer is '%select{true|false}2' on first encounter</li>
+<li>warning: comparisons like 'X&lt;=Y&lt;=Z' don't have their mathematical meaning</li>
 <li>warning: container access result unused - container access should not be used for side effects</li>
 <li>warning: convenience initializer missing a 'self' call to another initializer</li>
 <li>warning: convenience initializer should not invoke an initializer on 'super'</li>
@@ -19972,6 +19935,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: use of __private_extern__ on a declaration may not produce external symbol private to the linkage unit and is deprecated</li>
 <li>warning: use of bitwise '%0' with boolean operands</li>
 <li>warning: use of unknown builtin %0</li>
+<li>warning: using '%%P' format specifier with an Objective-C pointer results in dumping runtime object structure, not object value</li>
 <li>warning: using '%%P' format specifier without precision</li>
 <li>warning: using '%0' format specifier annotation outside of os_log()/os_trace()</li>
 <li>warning: using '%0' format specifier, but argument has boolean value</li>
@@ -20133,6 +20097,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %0 attribute ignored for field of type %1</li>
 <li>warning: %0 attribute ignored on a non-definition declaration</li>
 <li>warning: %0 attribute ignored on inline function</li>
+<li>warning: %0 attribute ignored on local class%select{| member}1</li>
 <li>warning: %0 attribute ignored when parsing type</li>
 <li>warning: %0 attribute is deprecated and ignored in %1</li>
 <li>warning: %0 attribute is ignored because %1 is not a function pointer</li>
@@ -20165,6 +20130,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'deprecated' attribute on anonymous namespace ignored</li>
 <li>warning: 'dllexport' attribute ignored on explicit instantiation definition</li>
 <li>warning: 'gnu_inline' attribute requires function to be marked 'inline', attribute ignored</li>
+<li>warning: 'hybrid_patchable' is ignored on functions without external linkage</li>
 <li>warning: 'internal_linkage' attribute on a non-static local variable is ignored</li>
 <li>warning: 'mig_server_routine' attribute only applies to routines that return a kern_return_t</li>
 <li>warning: 'nocf_check' attribute ignored; use -fcf-protection to enable the attribute</li>
@@ -20277,6 +20243,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: feature cannot be %select{introduced|deprecated|obsoleted}0 in %1 version %2 before it was %select{introduced|deprecated|obsoleted}3 in version %4; attribute ignored</li>
 <li>warning: ignoring availability attribute %select{on '+load' method|with constructor attribute|with destructor attribute}0</li>
 <li>warning: only 'unavailable' and 'deprecated' are supported for Swift availability</li>
+<li>warning: unknown environment %0 in availability macro</li>
 <li>warning: unknown platform %0 in availability macro</li>
 <li>warning: use same version number separators '_' or '.'; as in 'major[.minor[.subminor]]'</li>
 </ul>
@@ -20345,8 +20312,8 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>remark: %0</li>
-<li>remark: %0; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'.</li>
-<li>remark: %0; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied!</li>
+<li>remark: %0; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'</li>
+<li>remark: %0; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop; if the arrays will always be independent, specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments -- erroneous results will occur if these options are incorrectly applied</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#rpass-analysis" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -20399,6 +20366,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: -mtocdata option is ignored for %0 because %1</li>
 <li>warning: call to '%0' declared with 'warning' attribute: %1</li>
 </ul>
 <h2>References</h2>
@@ -20426,7 +20394,6 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: binary integer literals are a C++14 extension</li>
-<li>warning: binary integer literals are a GNU extension</li>
 <li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
 </ul>
 <h2>References</h2>
@@ -20498,6 +20465,7 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: '_BitInt' in %select{C17 and earlier|C++}0 is a Clang extension</li>
+<li>warning: '_BitInt' suffix for literals is a Clang extension</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbit-int-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -20563,7 +20531,7 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true</li>
-<li>warning: address of%select{| function| array}0 '%1' will always evaluate to 'true'</li>
+<li>warning: address of %select{'%1'|function '%1'|array '%1'|lambda function pointer conversion operator}0 will always evaluate to 'true'</li>
 <li>warning: initialization of pointer of type %0 to null from a constant boolean expression</li>
 <li>warning: nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter</li>
 <li>warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; pointer may be assumed to always convert to true</li>
@@ -20590,14 +20558,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-bounds-safety-counted-by-elt-type-unknown-size</key>
     <name>clang-diagnostic-bounds-safety-counted-by-elt-type-unknown-size</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: '%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}4' %select{cannot|should not}3 be applied to %select{a pointer with pointee|an array with element}0 of unknown size because %1 is %select{an incomplete type|a sizeless type|a function type|a struct type with a flexible array member%select{|. This will be an error in a future compiler version}3}2</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbounds-safety-counted-by-elt-type-unknown-size" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}4' %select{cannot|should not}3 be applied to %select{a pointer with pointee|an array with element}0 of unknown size because %1 is %select{an incomplete type|a sizeless type|a function type|a struct type with a flexible array member%select{|. This will be an error in a future compiler version}3}2</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbounds-safety-counted-by-elt-type-unknown-size" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -20665,13 +20633,17 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #embed is a %select{C23|Clang}0 extension</li>
 <li>warning: '_BitInt' suffix for literals is a C23 extension</li>
 <li>warning: '_Static_assert' with no message is a C23 extension</li>
 <li>warning: 'nullptr' is a C23 extension</li>
 <li>warning: [[]] attributes are a C23 extension</li>
+<li>warning: binary integer literals are a C23 extension</li>
+<li>warning: defining a type within '%select{__builtin_offsetof|offsetof}0' is a C23 extension</li>
 <li>warning: label at end of compound statement is a C23 extension</li>
 <li>warning: label followed by a declaration is a C23 extension</li>
 <li>warning: omitting the parameter name in a function definition is a C23 extension</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is a C23 extension</li>
 <li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is a C23 extension</li>
 <li>warning: use of an empty initializer is a C23 extension</li>
 </ul>
@@ -20687,6 +20659,7 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: '%0' is a keyword in C23</li>
+<li>warning: type of UTF-8 string literal will change from array of char to array of char8_t in C23</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc23-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -20696,16 +20669,16 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-c2y-extensions</key>
     <name>clang-diagnostic-c2y-extensions</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: '%select{--|++}0' on an object of complex type is a C2y extension</li>
-  <li>warning: 'alignof' on an incomplete array type is a C2y extension</li>
-  <li>warning: passing a type argument as the first operand to '_Generic' is a C2y extension</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc2y-extensions" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%select{--|++}0' on an object of complex type is a C2y extension</li>
+<li>warning: 'alignof' on an incomplete array type is a C2y extension</li>
+<li>warning: passing a type argument as the first operand to '_Generic' is a C2y extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc2y-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -20773,27 +20746,27 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-pre-c11-compat</key>
     <name>clang-diagnostic-pre-c11-compat</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: '%0' is incompatible with C standards before C11</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c11-compat" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' is incompatible with C standards before C11</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c11-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-pre-c11-compat-pedantic</key>
     <name>clang-diagnostic-pre-c11-compat-pedantic</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: '%0' is incompatible with C standards before C11</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%0' is incompatible with C standards before C11</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -20802,15 +20775,18 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #embed is incompatible with C standards before C23</li>
 <li>warning: #warning is incompatible with C standards before C23</li>
 <li>warning: '%0' is incompatible with C standards before C23</li>
 <li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
 <li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
 <li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
 <li>warning: [[]] attributes are incompatible with C standards before C23</li>
+<li>warning: binary integer literals are incompatible with C standards before C23</li>
 <li>warning: digit separators are incompatible with C standards before C23</li>
 <li>warning: label at end of compound statement is incompatible with C standards before C23</li>
 <li>warning: label followed by a declaration is incompatible with C standards before C23</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C standards before C23</li>
 <li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
 <li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
 <li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
@@ -20827,15 +20803,18 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #embed is incompatible with C standards before C23</li>
 <li>warning: #warning is incompatible with C standards before C23</li>
 <li>warning: '%0' is incompatible with C standards before C23</li>
 <li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
 <li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
 <li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
 <li>warning: [[]] attributes are incompatible with C standards before C23</li>
+<li>warning: binary integer literals are incompatible with C standards before C23</li>
 <li>warning: digit separators are incompatible with C standards before C23</li>
 <li>warning: label at end of compound statement is incompatible with C standards before C23</li>
 <li>warning: label followed by a declaration is incompatible with C standards before C23</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C standards before C23</li>
 <li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
 <li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
 <li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
@@ -20849,31 +20828,31 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-pre-c2y-compat</key>
     <name>clang-diagnostic-pre-c2y-compat</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: '%select{--|++}0' on an object of complex type is incompatible with C standards before C2y</li>
-  <li>warning: 'alignof' on an incomplete array type is incompatible with C standards before C2y</li>
-  <li>warning: passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2y-compat" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%select{--|++}0' on an object of complex type is incompatible with C standards before C2y</li>
+<li>warning: 'alignof' on an incomplete array type is incompatible with C standards before C2y</li>
+<li>warning: passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2y-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-pre-c2y-compat-pedantic</key>
     <name>clang-diagnostic-pre-c2y-compat-pedantic</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: '%select{--|++}0' on an object of complex type is incompatible with C standards before C2y</li>
-  <li>warning: 'alignof' on an incomplete array type is incompatible with C standards before C2y</li>
-  <li>warning: passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2y-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '%select{--|++}0' on an object of complex type is incompatible with C standards before C2y</li>
+<li>warning: 'alignof' on an incomplete array type is incompatible with C standards before C2y</li>
+<li>warning: passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2y-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -20903,7 +20882,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'typename' occurs outside of a template</li>
 <li>warning: [[]] attributes are a C++11 extension</li>
 <li>warning: alias declarations are a C++11 extension</li>
-<li>warning: befriending enumeration type %0 is a C++11 extension</li>
 <li>warning: commas at the end of enumerator lists are a C++11 extension</li>
 <li>warning: default member initializer for non-static data member is a C++11 extension</li>
 <li>warning: default template arguments for a function template are a C++11 extension</li>
@@ -20914,6 +20892,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: generalized initializer lists are a C++11 extension</li>
 <li>warning: implicit conversion from array size expression of type %0 to %select{integral|enumeration}1 type %2 is a C++11 extension</li>
 <li>warning: inline namespaces are a C++11 feature</li>
+<li>warning: lambdas are a C++11 extension</li>
 <li>warning: non-class friend type %0 is a C++11 extension</li>
 <li>warning: non-type template argument referring to %select{function|object}0 %1 with internal linkage is a C++11 extension</li>
 <li>warning: range-based for loop is a C++11 extension</li>
@@ -20936,14 +20915,16 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
 <li>warning: '%0' is a keyword in C++11</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'auto' storage class specifier is redundant and incompatible with C++11</li>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
@@ -20952,8 +20933,10 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
@@ -20971,7 +20954,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
 <li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: digit separators are incompatible with C++ standards before C++14</li>
 <li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
@@ -21005,7 +20987,9 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: return type deduction is incompatible with C++ standards before C++14</li>
 <li>warning: static lambdas are incompatible with C++ standards before C++23</li>
@@ -21053,11 +21037,13 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
@@ -21067,6 +21053,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '%0' is a keyword in C++11</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'auto' storage class specifier is redundant and incompatible with C++11</li>
@@ -21082,12 +21070,16 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
 <li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
 <li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
@@ -21118,8 +21110,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: designated initializers are incompatible with C++ standards before C++20</li>
@@ -21178,8 +21168,12 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: return type deduction is incompatible with C++ standards before C++14</li>
@@ -21284,7 +21278,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
@@ -21420,20 +21414,24 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
@@ -21446,7 +21444,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
 <li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
 <li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
@@ -21465,7 +21462,9 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: template template parameter using 'typename' is incompatible with C++ standards before C++17</li>
@@ -21491,6 +21490,8 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
@@ -21503,6 +21504,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
@@ -21515,11 +21518,15 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
 <li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
@@ -21544,8 +21551,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: designated initializers are incompatible with C++ standards before C++20</li>
@@ -21585,8 +21590,12 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: static lambdas are incompatible with C++ standards before C++23</li>
@@ -21668,17 +21677,21 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
 <li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
@@ -21686,7 +21699,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
 <li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
 <li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
@@ -21702,7 +21714,9 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
@@ -21738,6 +21752,8 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
@@ -21748,6 +21764,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
@@ -21757,8 +21775,12 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
@@ -21773,8 +21795,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: designated initializers are incompatible with C++ standards before C++20</li>
@@ -21805,8 +21825,12 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: static lambdas are incompatible with C++ standards before C++23</li>
@@ -21855,6 +21879,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: inline nested namespace definition is a C++20 extension</li>
 <li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is a C++20 extension</li>
 <li>warning: missing 'typename' prior to dependent type name %0%1; implicit 'typename' is a C++20 extension</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is a C++20 extension</li>
 <li>warning: range-based for loop initialization statements are a C++20 extension</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is a C++20 extension</li>
 <li>warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension</li>
@@ -21887,23 +21912,27 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: '%0' is a keyword in C++20</li>
 <li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
 <li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 <li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: taking address of non-addressable standard library function is incompatible with C++20</li>
 <li>warning: this expression will be parsed as explicit(bool) in C++20</li>
@@ -21923,6 +21952,8 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
@@ -21931,6 +21962,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: '%0' is a keyword in C++20</li>
 <li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
@@ -21940,18 +21973,22 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
 <li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 <li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: taking address of non-addressable standard library function is incompatible with C++20</li>
@@ -22007,14 +22044,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-c++23-attribute-extensions</key>
     <name>clang-diagnostic-c++23-attribute-extensions</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: use of the %0 attribute is a C++23 extension</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-attribute-extensions" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: use of the %0 attribute is a C++23 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-attribute-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -22033,18 +22070,18 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-c++23-compat</key>
     <name>clang-diagnostic-c++23-compat</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
-  <li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
-  <li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
-  <li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
-  <li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-compat" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -22053,6 +22090,10 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is a C++2c extension</li>
+<li>warning: '= delete' with a message is a C++2c extension</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is a C++2c extension</li>
+<li>warning: pack indexing is a C++2c extension</li>
 <li>warning: placeholder variables are a C++2c extension</li>
 </ul>
 <h2>References</h2>
@@ -22063,15 +22104,15 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-c++2c-compat</key>
     <name>clang-diagnostic-c++2c-compat</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: cannot delete expression with pointer-to-'void' type %0</li>
-  <li>warning: deleting pointer to incomplete type %0 is incompatible with C++2c and may cause undefined behavior</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2c-compat" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: cannot delete expression with pointer-to-'void' type %0</li>
+<li>warning: deleting pointer to incomplete type %0 is incompatible with C++2c and may cause undefined behavior</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2c-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -22080,6 +22121,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{anonymous struct|union}0 member %1 with a non-trivial %sub{select_special_member_kind}2 is incompatible with C++98</li>
@@ -22091,6 +22133,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '%0' type specifier is incompatible with C++98</li>
 <li>warning: '&lt;::' is treated as digraph '&lt;:' (aka '[') followed by ':' in C++98</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
 <li>warning: 'alignas' is incompatible with C++98</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'auto' type specifier is incompatible with C++98</li>
@@ -22107,10 +22150,11 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: alias declarations are incompatible with C++98</li>
 <li>warning: alignof expressions are incompatible with C++98</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
 <li>warning: befriending %1 without '%select{struct|interface|union|class|enum}0' keyword is incompatible with C++98</li>
-<li>warning: befriending enumeration type %0 is incompatible with C++98</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: consecutive right angle brackets are incompatible with C++98 (use '&gt; &gt;')</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
@@ -22128,7 +22172,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
 <li>warning: default template arguments for a function template are incompatible with C++98</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: delegating constructors are incompatible with C++98</li>
 <li>warning: digit separators are incompatible with C++ standards before C++14</li>
@@ -22171,8 +22214,10 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: passing object of trivial but non-POD type %0 through variadic %select{function|block|method|constructor}1 is incompatible with C++98</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop is incompatible with C++98</li>
 <li>warning: raw string literals are incompatible with C++98</li>
@@ -22262,6 +22307,8 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
 <li>warning: #line number greater than 32767 is incompatible with C++98</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
@@ -22281,6 +22328,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '&lt;::' is treated as digraph '&lt;:' (aka '[') followed by ':' in C++98</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
 <li>warning: 'alignas' is incompatible with C++98</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
@@ -22306,15 +22355,18 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: alias declarations are incompatible with C++98</li>
 <li>warning: alignof expressions are incompatible with C++98</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
 <li>warning: attributes on %select{a namespace|an enumerator}0 declaration are incompatible with C++ standards before C++17</li>
 <li>warning: befriending %1 without '%select{struct|interface|union|class|enum}0' keyword is incompatible with C++98</li>
-<li>warning: befriending enumeration type %0 is incompatible with C++98</li>
 <li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
 <li>warning: cast between pointer-to-function and pointer-to-object is incompatible with C++98</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: commas at the end of enumerator lists are incompatible with C++98</li>
@@ -22346,8 +22398,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: default template arguments for a function template are incompatible with C++98</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: delegating constructors are incompatible with C++98</li>
@@ -22419,9 +22469,13 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
 <li>warning: passing object of trivial but non-POD type %0 through variadic %select{function|block|method|constructor}1 is incompatible with C++98</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: range-based for loop is incompatible with C++98</li>
@@ -22641,6 +22695,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
@@ -22680,6 +22735,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
@@ -22742,7 +22798,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
@@ -22786,7 +22841,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
@@ -22805,6 +22859,10 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
 <li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 </ul>
 <h2>References</h2>
@@ -22818,6 +22876,10 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
 <li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 </ul>
 <h2>References</h2>
@@ -22873,14 +22935,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-cast-function-type-mismatch</key>
     <name>clang-diagnostic-cast-function-type-mismatch</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: cast %diff{from $ to $ |}0,1converts to incompatible function type</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-function-type-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: cast %diff{from $ to $ |}0,1converts to incompatible function type</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-function-type-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -23118,7 +23180,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %sub{select_arith_conv_kind}0 different enumeration types%diff{ ($ and $)|}1,2 is deprecated</li>
 <li>warning: %sub{select_arith_conv_kind}0 different enumeration types%diff{ ($ and $)|}1,2 is deprecated</li>
 <li>warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true</li>
-<li>warning: address of%select{| function| array}0 '%1' will always evaluate to 'true'</li>
+<li>warning: address of %select{'%1'|function '%1'|array '%1'|lambda function pointer conversion operator}0 will always evaluate to 'true'</li>
 <li>warning: assigning value of signed enum type %1 to unsigned bit-field %0; negative enumerators of enum %1 will be converted to positive values</li>
 <li>warning: bit-field %0 is not wide enough to store all enumerators of %1</li>
 <li>warning: expression which evaluates to zero treated as a null pointer constant of type %0</li>
@@ -23142,6 +23204,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: implicit conversion of %select{NULL|nullptr}0 constant to %1</li>
 <li>warning: implicit conversion of out of range value from %0 to %1 is undefined</li>
 <li>warning: implicit conversion of out of range value from %0 to %1 is undefined</li>
+<li>warning: implicit conversion truncates vector: %0 to %1</li>
 <li>warning: implicit conversion turns floating-point number into integer: %0 to %1</li>
 <li>warning: implicit conversion turns string literal into bool: %0 to %1</li>
 <li>warning: implicit conversion turns vector to scalar: %0 to %1</li>
@@ -23187,7 +23250,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <ul>
 <li>warning: %0 is required to declare the member 'unhandled_exception()' when exceptions are enabled</li>
 <li>warning: 'for co_await' belongs to CoroutineTS instead of C++20, which is deprecated</li>
-<li>warning: return type of 'coroutine_handle&lt;&gt;::address should be 'void*' (have %0) in order to get capability with existing async C API.</li>
+<li>warning: return type of 'coroutine_handle&lt;&gt;::address should be 'void*' (have %0) in order to get capability with existing async C API</li>
 <li>warning: this coroutine may be split into pieces; not every piece is guaranteed to be inlined</li>
 <li>warning: under -fcoro-aligned-allocation, the non-aligned allocation function for the promise type %0 has higher precedence than the global aligned allocation function</li>
 </ul>
@@ -23285,7 +23348,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: dxv not found. Resulting DXIL will not be validated or signed for use in release environments.</li>
+<li>warning: dxv not found; resulting DXIL will not be validated or signed for use in release environment</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdxil-validation" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -23298,7 +23361,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{address of|reference to}0 stack memory associated with %select{local variable|parameter}2 %1 returned</li>
+<li>warning: %select{address of|reference to}0 stack memory associated with %select{local variable|parameter|compound literal}2 %1 returned</li>
 <li>warning: %select{reference|backing array for 'std::initializer_list'}2 %select{|subobject of }1member %0 %select{binds to|is}2 a temporary object whose lifetime is shorter than the lifetime of the constructed object</li>
 <li>warning: %select{temporary %select{whose address is used as value of|%select{|implicitly }2bound to}4 %select{%select{|reference }4member of local variable|local %select{variable|reference}4}1|array backing %select{initializer list subobject of local variable|local initializer list}1}0 %select{%3 |}2will be destroyed at the end of the full-expression</li>
 <li>warning: array backing %select{initializer list subobject of the allocated object|the allocated initializer list}0 will be destroyed at the end of the full-expression</li>
@@ -23306,6 +23369,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: initializing pointer member %0 to point to a temporary object whose lifetime is shorter than the lifetime of the constructed object</li>
 <li>warning: initializing pointer member %0 with the stack address of %select{variable|parameter}2 %1</li>
 <li>warning: lifetime extension of %select{temporary|backing array of initializer list}0 created by aggregate initialization using a default member initializer is not yet supported; lifetime of %select{temporary|backing array}0 will end at the end of the full-expression</li>
+<li>warning: object backing the pointer %0 will be destroyed at the end of the full-expression</li>
+<li>warning: object backing the pointer %0 will be destroyed at the end of the full-expression</li>
 <li>warning: object backing the pointer will be destroyed at the end of the full-expression</li>
 <li>warning: returning %select{address of|reference to}0 local temporary object</li>
 <li>warning: returning address of label, which is local</li>
@@ -23319,27 +23384,27 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-dangling-assignment</key>
     <name>clang-diagnostic-dangling-assignment</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: object backing the pointer %0 will be destroyed at the end of the full-expression</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdangling-assignment" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: object backing the pointer %0 will be destroyed at the end of the full-expression</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdangling-assignment" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-dangling-assignment-gsl</key>
     <name>clang-diagnostic-dangling-assignment-gsl</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: object backing the pointer %0 will be destroyed at the end of the full-expression</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdangling-assignment-gsl" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: object backing the pointer %0 will be destroyed at the end of the full-expression</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdangling-assignment-gsl" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -23472,7 +23537,7 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: cannot delete expression with pointer-to-'void' type %0</li>
-<li>warning: deleting pointer to incomplete type %0 may cause undefined behavior</li>
+<li>warning: deleting pointer to incomplete type %0 is incompatible with C++2c and may cause undefined behavior</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdelete-incomplete" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -23526,11 +23591,12 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'depend' clause for 'ordered' is deprecated; use 'doacross' instead</li>
 <li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
 <li>warning: -O4 is equivalent to -O3</li>
-<li>warning: Use of 'long' with '__vector' is deprecated</li>
 <li>warning: access declarations are deprecated; use using declarations instead</li>
 <li>warning: applying attribute %0 to a declaration is deprecated; apply it to the type instead</li>
+<li>warning: argument '%0' is deprecated%select{|, use '%2' instead}1</li>
 <li>warning: argument '%0' is deprecated, %1</li>
-<li>warning: argument '%0' is deprecated, use '%1' instead</li>
+<li>warning: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations</li>
+<li>warning: argument '-fno-relaxed-template-template-args' is deprecated</li>
 <li>warning: builtin %0 is deprecated; use %1 instead</li>
 <li>warning: comparison between two arrays is deprecated; to compare array addresses, use unary '+' to decay operands to pointers</li>
 <li>warning: conversion from string literal to %0 is deprecated</li>
@@ -23551,6 +23617,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: the '[[_Noreturn]]' attribute spelling is deprecated in C23; use '[[noreturn]]' instead</li>
 <li>warning: top-level comma expression in array subscript is deprecated in C++20 and unsupported in C++23</li>
 <li>warning: treating '%0' input as '%1' when in C++ mode, this behavior is deprecated</li>
+<li>warning: use of 'long' with '__vector' is deprecated</li>
 <li>warning: use of C-style parameters in Objective-C method declarations is deprecated</li>
 <li>warning: use of result of assignment to object of volatile-qualified type %0 is deprecated</li>
 <li>warning: volatile qualifier in structured binding declaration is deprecated</li>
@@ -23848,14 +23915,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-deprecated-no-relaxed-template-template-args</key>
     <name>clang-diagnostic-deprecated-no-relaxed-template-template-args</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: argument '-fno-relaxed-template-template-args' is deprecated</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-no-relaxed-template-template-args" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: argument '-fno-relaxed-template-template-args' is deprecated</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-no-relaxed-template-template-args" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -23875,14 +23942,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-deprecated-ofast</key>
     <name>clang-diagnostic-deprecated-ofast</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-ofast" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-ofast" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -24449,14 +24516,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-explicit-specialization-storage-class</key>
     <name>clang-diagnostic-explicit-specialization-storage-class</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: explicit specialization cannot have a storage class</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexplicit-specialization-storage-class" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: explicit specialization cannot have a storage class</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexplicit-specialization-storage-class" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -24485,7 +24552,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '-fuse-ld=' taking a path is deprecated; use '--ld-path=' instead</li>
 <li>warning: ARC %select{unused|__unsafe_unretained|__strong|__weak|__autoreleasing}0 lifetime qualifier on return type is ignored</li>
 <li>warning: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension</li>
-<li>warning: call to function without interrupt attribute could clobber interruptee's VFP registers</li>
+<li>warning: cast %diff{from $ to $ |}0,1converts to incompatible function type</li>
 <li>warning: comparison of integers of different signs: %0 and %1</li>
 <li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared copy %select{assignment operator|constructor}1</li>
 <li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided copy %select{assignment operator|constructor}1</li>
@@ -24494,6 +24561,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
 <li>warning: initializer %select{partially |}0overrides prior initialization of this subobject</li>
 <li>warning: method has no return type specified; defaults to 'id'</li>
+<li>warning: missing field %0 initializer</li>
 <li>warning: missing field %0 initializer</li>
 <li>warning: parameter %0 set but not used</li>
 <li>warning: performing pointer arithmetic on a null pointer has undefined behavior%select{| if the offset is nonzero}0</li>
@@ -24554,14 +24622,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-extractapi-misuse</key>
     <name>clang-diagnostic-extractapi-misuse</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: missing symbol graph output directory, defaulting to working directory</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextractapi-misuse" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: missing symbol graph output directory, defaulting to working directory</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextractapi-misuse" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -24726,6 +24794,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: null returned from %select{function|method}0 that requires a non-null return value</li>
 <li>warning: object format flags cannot be used with '%0' conversion specifier</li>
 <li>warning: position arguments in format strings start counting at 1 (not 0)</li>
+<li>warning: using '%%P' format specifier with an Objective-C pointer results in dumping runtime object structure, not object value</li>
 <li>warning: using '%%P' format specifier without precision</li>
 <li>warning: using '%0' format specifier annotation outside of os_log()/os_trace()</li>
 <li>warning: using '%0' format specifier, but argument has boolean value</li>
@@ -24874,14 +24943,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-format-signedness</key>
     <name>clang-diagnostic-format-signedness</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: format specifies type %0 but the argument has %select{type|underlying type}2 %1</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-signedness" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: format specifies type %0 but the argument has %select{type|underlying type}2 %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-signedness" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -25065,17 +25134,17 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-function-effects</key>
     <name>clang-diagnostic-function-effects</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: attribute '%0' on function does not match previous declaration</li>
-  <li>warning: attribute '%0' on overriding function does not match base declaration</li>
-  <li>warning: attribute '%0' should not be added via type conversion</li>
-  <li>warning: effects conflict when merging declarations; kept '%0', discarded '%1'</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfunction-effects" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: attribute '%0' on function does not match previous declaration</li>
+<li>warning: attribute '%0' on overriding function does not match base declaration</li>
+<li>warning: attribute '%0' should not be added via type conversion</li>
+<li>warning: effects conflict when merging declarations; kept '%0', discarded '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfunction-effects" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -25104,6 +25173,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: use of the %0 attribute is a C++14 extension</li>
 <li>warning: use of the %0 attribute is a C++17 extension</li>
 <li>warning: use of the %0 attribute is a C++20 extension</li>
+<li>warning: use of the %0 attribute is a C++23 extension</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfuture-attribute-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -25139,11 +25209,9 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension</li>
 <li>warning: arithmetic on%select{ a|}0 pointer%select{|s}0 to void is a GNU extension</li>
 <li>warning: arithmetic on%select{ a|}0 pointer%select{|s}0 to%select{ the|}2 function type%select{|s}2 %1%select{| and %3}2 is a GNU extension</li>
-<li>warning: binary integer literals are a GNU extension</li>
 <li>warning: cast to union type is a GNU extension</li>
 <li>warning: class member cannot be redeclared</li>
 <li>warning: complex integer types are a GNU extension</li>
-<li>warning: defining a type within '%select{__builtin_offsetof|offsetof}0' is a Clang extension</li>
 <li>warning: empty %select{struct|union}0 is a GNU extension</li>
 <li>warning: expression is not an %select{integer|integral}0 constant expression; folding it to a constant is a GNU extension</li>
 <li>warning: field %0 with variable sized type %1 not at the end of a struct or class is a GNU extension</li>
@@ -25154,7 +25222,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: in-class initializer for static data member is not a constant expression; folding it to a constant is a GNU extension</li>
 <li>warning: in-class initializer for static data member of type %0 is a GNU extension</li>
 <li>warning: initialization of an array %diff{of type $ from a compound literal of type $|from a compound literal}0,1 is a GNU extension</li>
-<li>warning: must specify at least one argument for '...' parameter of variadic macro</li>
 <li>warning: redeclaration of already-defined enum %0 is a GNU extension</li>
 <li>warning: string literal operator templates are a GNU extension</li>
 <li>warning: subscript of a pointer to void is a GNU extension</li>
@@ -25575,7 +25642,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: must specify at least one argument for '...' parameter of variadic macro</li>
 <li>warning: token pasting of ',' and __VA_ARGS__ is a GNU extension</li>
 </ul>
 <h2>References</h2>
@@ -25663,15 +25729,15 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-hlsl-availability</key>
     <name>clang-diagnostic-hlsl-availability</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: %0 is only available %select{|in %4 environment }3on %1 %2 or newer</li>
-  <li>warning: %0 is unavailable</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whlsl-availability" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %0 is only available %select{|in %4 environment }3on %1 %2 or newer</li>
+<li>warning: %0 is unavailable</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whlsl-availability" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>CRITICAL</severity>
     </rule>
   <rule>
@@ -25690,14 +25756,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-mix-packoffset</key>
     <name>clang-diagnostic-mix-packoffset</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: cannot mix packoffset elements with nonpackoffset elements in a cbuffer</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmix-packoffset" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: cannot mix packoffset elements with nonpackoffset elements in a cbuffer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmix-packoffset" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -25726,6 +25792,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %0 attribute ignored for field of type %1</li>
 <li>warning: %0 attribute ignored on a non-definition declaration</li>
 <li>warning: %0 attribute ignored on inline function</li>
+<li>warning: %0 attribute ignored on local class%select{| member}1</li>
 <li>warning: %0 attribute ignored when parsing type</li>
 <li>warning: %0 attribute is deprecated and ignored in %1</li>
 <li>warning: %0 attribute is ignored because %1 is not a function pointer</li>
@@ -25758,6 +25825,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'deprecated' attribute on anonymous namespace ignored</li>
 <li>warning: 'dllexport' attribute ignored on explicit instantiation definition</li>
 <li>warning: 'gnu_inline' attribute requires function to be marked 'inline', attribute ignored</li>
+<li>warning: 'hybrid_patchable' is ignored on functions without external linkage</li>
 <li>warning: 'internal_linkage' attribute on a non-static local variable is ignored</li>
 <li>warning: 'mig_server_routine' attribute only applies to routines that return a kern_return_t</li>
 <li>warning: 'nocf_check' attribute ignored; use -fcf-protection to enable the attribute</li>
@@ -26116,6 +26184,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: higher order bits are zeroes after implicit conversion</li>
 <li>warning: implicit conversion from integral type %0 to 'BOOL'</li>
 <li>warning: implicit conversion loses integer precision: %0 to %1</li>
+<li>warning: implicit conversion loses integer precision: %0 to %1</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wimplicit-int-conversion" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -26352,26 +26421,26 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-installapi-violation</key>
     <name>clang-diagnostic-installapi-violation</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: declaration '%0' is %select{weak defined|thread local}1, but symbol is not in dynamic library</li>
-  <li>warning: declaration '%0' is marked %select{available|unavailable}1, but symbol is %select{not |}2exported in dynamic library</li>
-  <li>warning: declaration has external linkage, but dynamic library doesn't have symbol '%0'</li>
-  <li>warning: declaration has external linkage, but symbol has internal linkage in dynamic library '%0'</li>
-  <li>warning: dynamic library symbol '%0' is %select{weak defined|thread local}1, but its declaration is not</li>
-  <li>warning: glob '%0' did not match any header file</li>
-  <li>warning: no declaration was found for exported symbol '%0' in dynamic library</li>
-  <li>warning: no such excluded %select{public|private}0 header file: '%1'</li>
-  <li>warning: platform does not match: '%0' (provided) vs '%1' (found)</li>
-  <li>warning: runpath search paths do not match: '%0' (provided) vs '%1' (found)</li>
-  <li>warning: runpath search paths missing from %0: '%1'</li>
-  <li>warning: symbol exported in dynamic library, but marked hidden in declaration '%0'</li>
-  <li>warning: violations found for %0</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winstallapi-violation" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration '%0' is %select{weak defined|thread local}1, but symbol is not in dynamic library</li>
+<li>warning: declaration '%0' is marked %select{available|unavailable}1, but symbol is %select{not |}2exported in dynamic library</li>
+<li>warning: declaration has external linkage, but dynamic library doesn't have symbol '%0'</li>
+<li>warning: declaration has external linkage, but symbol has internal linkage in dynamic library '%0'</li>
+<li>warning: dynamic library symbol '%0' is %select{weak defined|thread local}1, but its declaration is not</li>
+<li>warning: glob '%0' did not match any header file</li>
+<li>warning: no declaration was found for exported symbol '%0' in dynamic library</li>
+<li>warning: no such excluded %select{public|private}0 header file: '%1'</li>
+<li>warning: platform does not match: '%0' (provided) vs '%1' (found)</li>
+<li>warning: runpath search paths do not match: '%0' (provided) vs '%1' (found)</li>
+<li>warning: runpath search paths missing from %0: '%1'</li>
+<li>warning: symbol exported in dynamic library, but marked hidden in declaration '%0'</li>
+<li>warning: violations found for %0</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winstallapi-violation" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -26724,9 +26793,9 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'main' is not allowed to be declared _Noreturn</li>
 <li>warning: 'main' is not allowed to be declared variadic</li>
 <li>warning: 'main' should not be declared static</li>
-<li>warning: ISO C++ does not allow 'main' to be used by a program</li>
 <li>warning: bool literal returned from 'main'</li>
 <li>warning: only one parameter on 'main' declaration</li>
+<li>warning: referring to 'main' within an expression is a Clang extension</li>
 <li>warning: variable named 'main' with external linkage has undefined behavior</li>
 </ul>
 <h2>References</h2>
@@ -27373,7 +27442,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: Potential performance regression from use of __builtin_expect(): Annotation was correct on %0 of profiled executions.</li>
+<li>warning: potential performance regression from use of __builtin_expect(): annotation was correct on %0 of profiled executions</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmisexpect" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -27465,14 +27534,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-missing-designated-field-initializers</key>
     <name>clang-diagnostic-missing-designated-field-initializers</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: missing field %0 initializer</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-designated-field-initializers" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: missing field %0 initializer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-designated-field-initializers" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -27481,6 +27550,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: missing field %0 initializer</li>
 <li>warning: missing field %0 initializer</li>
 </ul>
 <h2>References</h2>
@@ -27491,14 +27561,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-missing-include-dirs</key>
     <name>clang-diagnostic-missing-include-dirs</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: no such include directory: '%0'</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-include-dirs" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: no such include directory: '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-include-dirs" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -27811,6 +27881,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: use of __private_extern__ on a declaration may not produce external symbol private to the linkage unit and is deprecated</li>
 <li>warning: use of bitwise '%0' with boolean operands</li>
 <li>warning: use of unknown builtin %0</li>
+<li>warning: using '%%P' format specifier with an Objective-C pointer results in dumping runtime object structure, not object value</li>
 <li>warning: using '%%P' format specifier without precision</li>
 <li>warning: using '%0' format specifier annotation outside of os_log()/os_trace()</li>
 <li>warning: using '%0' format specifier, but argument has boolean value</li>
@@ -27964,7 +28035,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %sub{select_arith_conv_kind}0 different enumeration types%diff{ ($ and $)|}1,2 is deprecated</li>
 <li>warning: %sub{select_arith_conv_kind}0 different enumeration types%diff{ ($ and $)|}1,2 is deprecated</li>
 <li>warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true</li>
-<li>warning: address of%select{| function| array}0 '%1' will always evaluate to 'true'</li>
+<li>warning: address of %select{'%1'|function '%1'|array '%1'|lambda function pointer conversion operator}0 will always evaluate to 'true'</li>
 <li>warning: assigning value of signed enum type %1 to unsigned bit-field %0; negative enumerators of enum %1 will be converted to positive values</li>
 <li>warning: bit-field %0 is not wide enough to store all enumerators of %1</li>
 <li>warning: comparison of integers of different signs: %0 and %1</li>
@@ -27990,6 +28061,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: implicit conversion of %select{NULL|nullptr}0 constant to %1</li>
 <li>warning: implicit conversion of out of range value from %0 to %1 is undefined</li>
 <li>warning: implicit conversion of out of range value from %0 to %1 is undefined</li>
+<li>warning: implicit conversion truncates vector: %0 to %1</li>
 <li>warning: implicit conversion turns floating-point number into integer: %0 to %1</li>
 <li>warning: implicit conversion turns string literal into bool: %0 to %1</li>
 <li>warning: implicit conversion turns vector to scalar: %0 to %1</li>
@@ -28789,7 +28861,8 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: OpenACC directives not yet implemented, pragma ignored</li>
+<li>warning: OpenACC clause '%0' not yet implemented, clause ignored</li>
+<li>warning: OpenACC construct '%0' not yet implemented, pragma ignored</li>
 <li>warning: unexpected '#pragma acc ...' in program</li>
 </ul>
 <h2>References</h2>
@@ -28840,8 +28913,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: OpenMP loop iteration variable cannot have more than 64 bits size and will be narrowed</li>
 <li>warning: OpenMP offloading target '%0' is similar to target '%1' already specified; will be ignored</li>
 <li>warning: OpenMP only allows an ordered construct with the simd clause nested in a simd construct</li>
-<li>warning: Type %0 is not trivially copyable and not guaranteed to be mapped correctly</li>
-<li>warning: Type %0 is not trivially copyable and not guaranteed to be mapped correctly</li>
 <li>warning: aligned clause will be ignored because the requested alignment is not a power of 2</li>
 <li>warning: allocate directive specifies %select{default|'%1'}0 allocator while previously used %select{default|'%3'}2</li>
 <li>warning: allocator with the 'thread' trait access has unspecified behavior on '%0' directive</li>
@@ -28864,6 +28935,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: the context selector '%0' in context set '%1' requires a context property defined in parentheses; selector ignored</li>
 <li>warning: the context selector '%0' in the context set '%1' cannot have a score ('%2'); score ignored</li>
 <li>warning: the context selector '%0' is not valid for the context set '%1'; selector ignored</li>
+<li>warning: type %0 is not trivially copyable and not guaranteed to be mapped correctly</li>
+<li>warning: type %0 is not trivially copyable and not guaranteed to be mapped correctly</li>
 <li>warning: unexpected '#pragma omp ...' in program</li>
 <li>warning: valid %0 clauses start with %1; %select{token|tokens}2 will be ignored</li>
 <li>warning: variant function in '#pragma omp declare variant' is itself marked as '#pragma omp declare variant'</li>
@@ -28951,7 +29024,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: Type %0 is not trivially copyable and not guaranteed to be mapped correctly</li>
+<li>warning: type %0 is not trivially copyable and not guaranteed to be mapped correctly</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenmp-mapping" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -28978,9 +29051,9 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: OpenMP offloading target '%0' is similar to target '%1' already specified; will be ignored</li>
-<li>warning: Type %0 is not trivially copyable and not guaranteed to be mapped correctly</li>
 <li>warning: declaration is not declared in any declare target region</li>
 <li>warning: declaration marked as declare target after first use, it may lead to incorrect results</li>
+<li>warning: type %0 is not trivially copyable and not guaranteed to be mapped correctly</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenmp-target" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -29026,7 +29099,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '%0' does not support '-moutline'; flag ignored</li>
 <li>warning: -fjmc works only for ELF; option ignored</li>
 <li>warning: /arm64EC has been overridden by specified target: %0; option ignored</li>
-<li>warning: The warning option '-%0' is not supported</li>
 <li>warning: ignoring '%0' as it conflicts with that implied by '%1' (%2)</li>
 <li>warning: ignoring '%0' option as it cannot be used with %select{implicit usage of|}1 -mabicalls and the N64 ABI</li>
 <li>warning: ignoring '%0' option as it is not currently supported for processor '%1'</li>
@@ -29037,6 +29109,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: option '%0' was ignored by the %1 toolchain, using '-fPIC'</li>
 <li>warning: option '-ffine-grained-bitfield-accesses' cannot be enabled together with a sanitizer; flag ignored</li>
 <li>warning: the argument '%0' is not supported for option '%1'. Mapping to '%1%2'</li>
+<li>warning: the library '%0=%1' is not supported, OpenMP will not be enabled</li>
+<li>warning: the warning option '-%0' is not supported</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woption-ignored" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -29209,6 +29283,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '%0' within '%1'</li>
 <li>warning: '&amp;&amp;' within '||'</li>
 <li>warning: add explicit braces to avoid dangling else</li>
+<li>warning: comparisons like 'X&lt;=Y&lt;=Z' don't have their mathematical meaning</li>
 <li>warning: equality comparison with extraneous parentheses</li>
 <li>warning: logical not is only applied to the left hand side of this %select{comparison|bitwise operator}0</li>
 <li>warning: operator '%0' has lower precedence than '%1'; '%1' will be evaluated first</li>
@@ -29291,7 +29366,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: address of%select{| function| array}0 '%1' will always evaluate to 'true'</li>
+<li>warning: address of %select{'%1'|function '%1'|array '%1'|lambda function pointer conversion operator}0 will always evaluate to 'true'</li>
 <li>warning: nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter</li>
 </ul>
 <h2>References</h2>
@@ -29432,7 +29507,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '#pragma comment %0' ignored</li>
 <li>warning: '#pragma init_seg' is only supported when targeting a Microsoft environment</li>
 <li>warning: OpenCL extension %0 unknown or does not require pragma - ignoring</li>
-<li>warning: Setting the floating point evaluation method to `source` on a target without SSE is not supported.</li>
 <li>warning: angle-bracketed include &lt;%0&gt; cannot be aliased to double-quoted include "%1"</li>
 <li>warning: double-quoted include "%0" cannot be aliased to angle-bracketed include &lt;%1&gt;</li>
 <li>warning: expected #pragma pack parameter to be '1', '2', '4', '8', or '16'</li>
@@ -29478,6 +29552,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: pragma include_alias expected '%0'</li>
 <li>warning: pragma include_alias expected include filename</li>
 <li>warning: pragma pop_macro could not pop '%0', no matching push_macro</li>
+<li>warning: setting the floating point evaluation method to `source` on a target without SSE is not supported</li>
 <li>warning: the current #pragma pack alignment value is modified in the included file</li>
 <li>warning: undeclared variable %0 used as an argument for '#pragma unused'</li>
 <li>warning: unexpected argument '%0' to '#pragma %1'%select{|; expected %3}2</li>
@@ -29611,15 +29686,15 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-ptrauth-null-pointers</key>
     <name>clang-diagnostic-ptrauth-null-pointers</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: authenticating a null pointer will almost certainly trap</li>
-  <li>warning: signing a null pointer will yield a non-null pointer</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wptrauth-null-pointers" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: authenticating a null pointer will almost certainly trap</li>
+<li>warning: signing a null pointer will yield a non-null pointer</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wptrauth-null-pointers" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -29898,16 +29973,16 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-return-mismatch</key>
     <name>clang-diagnostic-return-mismatch</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: %select{void function|void method|constructor|destructor}1 %0 should not return a value</li>
-  <li>warning: non-void %select{function|method}1 %0 should return a value</li>
-  <li>warning: non-void %select{function|method}1 %0 should return a value</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{void function|void method|constructor|destructor}1 %0 should not return a value</li>
+<li>warning: non-void %select{function|method}1 %0 should return a value</li>
+<li>warning: non-void %select{function|method}1 %0 should return a value</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>CRITICAL</severity>
     </rule>
   <rule>
@@ -29916,7 +29991,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{address of|reference to}0 stack memory associated with %select{local variable|parameter}2 %1 returned</li>
+<li>warning: %select{address of|reference to}0 stack memory associated with %select{local variable|parameter|compound literal}2 %1 returned</li>
 <li>warning: returning %select{address of|reference to}0 local temporary object</li>
 <li>warning: returning address of label, which is local</li>
 </ul>
@@ -30144,7 +30219,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: Received warning after diagnostic serialization teardown was underway: %0</li>
+<li>warning: received warning after diagnostic serialization teardown was underway: %0</li>
 <li>warning: unable to merge a subprocess's serialized diagnostics</li>
 <li>warning: unable to open file %0 for serializing diagnostics (%1)</li>
 </ul>
@@ -30379,7 +30454,8 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: OpenACC directives not yet implemented, pragma ignored</li>
+<li>warning: OpenACC clause '%0' not yet implemented, clause ignored</li>
+<li>warning: OpenACC construct '%0' not yet implemented, pragma ignored</li>
 <li>warning: unexpected '#pragma acc ...' in program</li>
 </ul>
 <h2>References</h2>
@@ -30698,7 +30774,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: __sync builtin operation MUST have natural alignment (consider using __atomic).</li>
+<li>warning: __sync builtin operation must have natural alignment (consider using __atomic)</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wsync-alignment" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -30960,13 +31036,13 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %select{reading|writing}3 the value pointed to by %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
 <li>warning: %select{reading|writing}3 variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
 <li>warning: %select{reading|writing}3 variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
-<li>warning: Cycle in acquired_before/after dependencies, starting with '%0'</li>
 <li>warning: acquiring %0 '%1' that is already held</li>
 <li>warning: calling function %0 requires negative capability '%1'</li>
 <li>warning: calling function %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
 <li>warning: calling function %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
 <li>warning: cannot call function '%1' while %0 '%2' is held</li>
 <li>warning: cannot resolve lock expression</li>
+<li>warning: cycle in acquired_before/after dependencies, starting with '%0'</li>
 <li>warning: expecting %0 '%1' to be held at start of each loop</li>
 <li>warning: expecting %0 '%1' to be held at the end of function</li>
 <li>warning: ignoring %0 attribute because its argument is invalid</li>
@@ -30996,12 +31072,12 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %select{reading|writing}1 variable %0 requires holding %select{any mutex|any mutex exclusively}1</li>
 <li>warning: %select{reading|writing}3 the value pointed to by %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
 <li>warning: %select{reading|writing}3 variable %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
-<li>warning: Cycle in acquired_before/after dependencies, starting with '%0'</li>
 <li>warning: acquiring %0 '%1' that is already held</li>
 <li>warning: calling function %0 requires negative capability '%1'</li>
 <li>warning: calling function %1 requires holding %0 %select{'%2'|'%2' exclusively}3</li>
 <li>warning: cannot call function '%1' while %0 '%2' is held</li>
 <li>warning: cannot resolve lock expression</li>
+<li>warning: cycle in acquired_before/after dependencies, starting with '%0'</li>
 <li>warning: expecting %0 '%1' to be held at start of each loop</li>
 <li>warning: expecting %0 '%1' to be held at the end of function</li>
 <li>warning: releasing %0 '%1' that was not held</li>
@@ -31288,8 +31364,10 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %0 is only available on %1 %2 or newer</li>
-<li>warning: %0 is only available on %1 %2 or newer</li>
+<li>warning: %0 is only available %select{|in %4 environment }3on %1 %2 or newer</li>
+<li>warning: %0 is only available %select{|in %4 environment }3on %1 %2 or newer</li>
+<li>warning: %0 is unavailable</li>
+<li>warning: %0 is unavailable</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunguarded-availability" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -31302,7 +31380,8 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %0 is only available on %1 %2 or newer</li>
+<li>warning: %0 is only available %select{|in %4 environment }3on %1 %2 or newer</li>
+<li>warning: %0 is unavailable</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunguarded-availability-new" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -31651,6 +31730,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <ul>
 <li>warning: %0 is an %select{unsafe pointer used for buffer access|unsafe buffer that does not perform bounds checks}1</li>
 <li>warning: %select{unsafe pointer operation|unsafe pointer arithmetic|unsafe buffer access|function introduces unsafe buffer manipulation|unsafe invocation of span::data}0</li>
+<li>warning: the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsafe-buffer-usage" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -31660,14 +31740,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-unsafe-buffer-usage-in-container</key>
     <name>clang-diagnostic-unsafe-buffer-usage-in-container</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsafe-buffer-usage-in-container" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsafe-buffer-usage-in-container" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -31869,6 +31949,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: argument '%0' requires profile-guided optimization information</li>
 <li>warning: argument '%0' requires profile-guided optimization information</li>
 <li>warning: argument unused during compilation: '%0'</li>
+<li>warning: ignoring '-f%select{no-|}0raw-string-literals', which is only valid for C and C++ standards before C++11</li>
 <li>warning: ignoring -fdiscard-value-names for LLVM Bitcode</li>
 <li>warning: ignoring -fverify-debuginfo-preserve-export=%0 because -fverify-debuginfo-preserve wasn't enabled</li>
 <li>warning: ignoring invalid /arch: argument '%0'; for %select{64|32}1-bit expected one of %2</li>
@@ -32461,7 +32542,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: Using unversioned Android target directory %0 for target %1. Unversioned directories will not be used in Clang 19. Provide a versioned directory for the target version or lower instead.</li>
+<li>warning: using unversioned Android target directory %0 for target %1; unversioned directories will not be used in Clang 19 -- provide a versioned directory for the target version or lower instead</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wandroid-unversioned-fallback" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -32812,15 +32893,18 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #embed is incompatible with C standards before C23</li>
 <li>warning: #warning is incompatible with C standards before C23</li>
 <li>warning: '%0' is incompatible with C standards before C23</li>
 <li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
 <li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
 <li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
 <li>warning: [[]] attributes are incompatible with C standards before C23</li>
+<li>warning: binary integer literals are incompatible with C standards before C23</li>
 <li>warning: digit separators are incompatible with C standards before C23</li>
 <li>warning: label at end of compound statement is incompatible with C standards before C23</li>
 <li>warning: label followed by a declaration is incompatible with C standards before C23</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C standards before C23</li>
 <li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
 <li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
 <li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
@@ -32967,15 +33051,18 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #embed is incompatible with C standards before C23</li>
 <li>warning: #warning is incompatible with C standards before C23</li>
 <li>warning: '%0' is incompatible with C standards before C23</li>
 <li>warning: '...' as the only parameter of a function is incompatible with C standards before C23</li>
 <li>warning: '_BitInt' suffix for literals is incompatible with C standards before C23</li>
 <li>warning: '_Static_assert' with no message is incompatible with C standards before C23</li>
 <li>warning: [[]] attributes are incompatible with C standards before C23</li>
+<li>warning: binary integer literals are incompatible with C standards before C23</li>
 <li>warning: digit separators are incompatible with C standards before C23</li>
 <li>warning: label at end of compound statement is incompatible with C standards before C23</li>
 <li>warning: label followed by a declaration is incompatible with C standards before C23</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C standards before C23</li>
 <li>warning: specifying character '%0' with a universal character name is incompatible with C standards before C23</li>
 <li>warning: universal character name referring to a control character is incompatible with C standards before C23</li>
 <li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C standards before C23</li>
@@ -33233,14 +33320,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-missing-template-arg-list-after-template-kw</key>
     <name>clang-diagnostic-missing-template-arg-list-after-template-kw</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: a template argument list is expected after a name prefixed by the template keyword</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-template-arg-list-after-template-kw" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: a template argument list is expected after a name prefixed by the template keyword</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-template-arg-list-after-template-kw" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>CRITICAL</severity>
     </rule>
   <rule>
@@ -33374,14 +33461,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-arm-interrupt-vfp-clobber</key>
     <name>clang-diagnostic-arm-interrupt-vfp-clobber</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: interrupt service routine with vfp enabled may clobber the interruptee's vfp state</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warm-interrupt-vfp-clobber" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: interrupt service routine with vfp enabled may clobber the interruptee's vfp state</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warm-interrupt-vfp-clobber" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -33429,7 +33516,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: declaration of built-in function '%0' requires the declaration of the 'jmp_buf' type, commonly provided in the header &lt;setjmp.h&gt;.</li>
+<li>warning: declaration of built-in function '%0' requires the declaration of the 'jmp_buf' type, commonly provided in the header &lt;setjmp.h&gt;</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wincomplete-setjmp-declaration" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -33510,7 +33597,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: the argument to %0 has side effects that will be discarded</li>
+<li>warning: assumption is ignored because it contains (potential) side-effects</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wassume" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -33785,14 +33872,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-friend-enum</key>
     <name>clang-diagnostic-friend-enum</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: elaborated enum specifier cannot be declared as a friend</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfriend-enum" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: elaborated enum specifier cannot be declared as a friend</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfriend-enum" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -33805,6 +33892,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
@@ -33987,6 +34075,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
@@ -34154,6 +34243,10 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
 <li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 </ul>
 <h2>References</h2>
@@ -34297,6 +34390,10 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
 <li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 </ul>
 <h2>References</h2>
@@ -34372,14 +34469,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-strict-primary-template-shadow</key>
     <name>clang-diagnostic-strict-primary-template-shadow</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: declaration of %0 shadows template parameter</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrict-primary-template-shadow" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: declaration of %0 shadows template parameter</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrict-primary-template-shadow" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>CRITICAL</severity>
     </rule>
   <rule>
@@ -34440,7 +34537,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
@@ -34592,7 +34689,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1 in C++11</li>
@@ -34744,14 +34841,16 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
-<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
+<li>warning: %select{case value|enumerator value|non-type template argument|array size|explicit specifier argument|noexcept specifier argument|call to 'size()'|call to 'data()'}0 %select{cannot be narrowed from type %2 to %3|evaluates to %2, which cannot be narrowed to type %3}1</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: %select{if|switch}0 initialization statements are incompatible with C++ standards before C++17</li>
 <li>warning: '%0' is a keyword in C++11</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'auto' storage class specifier is redundant and incompatible with C++11</li>
 <li>warning: 'begin' and 'end' returning different types (%0 and %1) is incompatible with C++ standards before C++17</li>
@@ -34760,8 +34859,10 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
 <li>warning: 'static_assert' with no message is incompatible with C++ standards before C++17</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
 <li>warning: by value capture of '*this' is incompatible with C++ standards before C++17</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
 <li>warning: class template argument deduction is incompatible with C++ standards before C++17%select{|; for compatibility, use explicit type name %1}0</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
 <li>warning: constant expression evaluates to %0 which cannot be narrowed to type %1</li>
@@ -34779,7 +34880,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
 <li>warning: default scope specifier for attributes is incompatible with C++ standards before C++17</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: digit separators are incompatible with C++ standards before C++14</li>
 <li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
@@ -34813,7 +34913,9 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: pack expansion using declaration is incompatible with C++ standards before C++17</li>
 <li>warning: pack fold expression is incompatible with C++ standards before C++17</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: return type deduction is incompatible with C++ standards before C++14</li>
 <li>warning: static lambdas are incompatible with C++ standards before C++23</li>
@@ -34923,14 +35025,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-tentative-definition-array</key>
     <name>clang-diagnostic-tentative-definition-array</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: tentative array definition assumed to have one element</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtentative-definition-array" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: tentative array definition assumed to have one element</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtentative-definition-array" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -34978,17 +35080,21 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{default construction|assignment}0 of lambda is incompatible with C++ standards before C++20</li>
 <li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: '&lt;=&gt;' operator is incompatible with C++ standards before C++20</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'char8_t' type specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'register' storage class specifier is deprecated and incompatible with C++17</li>
 <li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
 <li>warning: captured structured bindings are incompatible with C++ standards before C++20</li>
+<li>warning: class template argument deduction for alias templates is incompatible with C++ standards before C++20</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: constexpr constructor that does not initialize all members is incompatible with C++ standards before C++20</li>
 <li>warning: constexpr union constructor that does not initialize any member is incompatible with C++ standards before C++20</li>
@@ -34996,7 +35102,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: decomposition declaration declared %plural{1:'%1'|:with '%1' specifiers}0 is incompatible with C++ standards before C++20</li>
 <li>warning: default member initializer for bit-field is incompatible with C++ standards before C++20</li>
 <li>warning: defaulted comparison operators are incompatible with C++ standards before C++20</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: explicit capture of 'this' with a capture default of '=' is incompatible with C++ standards before C++20</li>
 <li>warning: explicit template parameter list for lambdas is incompatible with C++ standards before C++20</li>
@@ -35012,7 +35117,9 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: member using declaration naming non-class '%0' enumerator is incompatible with C++ standards before C++20</li>
 <li>warning: non-type template parameter of type %0 is incompatible with C++ standards before C++20</li>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
 <li>warning: passing no argument for the '...' parameter of a variadic macro is incompatible with C++ standards before C++20</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 <li>warning: range-based for loop initialization statements are incompatible with C++ standards before C++20</li>
 <li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++20</li>
@@ -35113,7 +35220,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: Current handling of vector bool and vector pixel types in this context are deprecated. The default behaviour will soon change to that implied by the '-altivec-compat=xl' option</li>
+<li>warning: current handling of vector bool and vector pixel types in this context are deprecated; the default behaviour will soon change to that implied by the '-altivec-compat=xl' option</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-altivec-src-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -35126,7 +35233,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: Implicit conversion between vector types ('%0' and '%1') is deprecated. In the future, the behavior implied by '-fno-lax-vector-conversions' will be the default.</li>
+<li>warning: implicit conversion between vector types ('%0' and '%1') is deprecated; in the future, the behavior implied by '-fno-lax-vector-conversions' will be the default</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecate-lax-vec-conv-all" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -35149,14 +35256,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-template-in-declaration-name</key>
     <name>clang-diagnostic-template-in-declaration-name</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: 'template' cannot be used after a declarative nested name specifier</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtemplate-in-declaration-name" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'template' cannot be used after a declarative nested name specifier</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtemplate-in-declaration-name" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -35165,23 +35272,27 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
 <li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: '%0' is a keyword in C++20</li>
 <li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
 <li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
 <li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 <li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: taking address of non-addressable standard library function is incompatible with C++20</li>
 <li>warning: this expression will be parsed as explicit(bool) in C++20</li>
@@ -35198,14 +35309,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-alias-template-in-declaration-name</key>
     <name>clang-diagnostic-alias-template-in-declaration-name</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: a declarative nested name specifier cannot name an alias template</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walias-template-in-declaration-name" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: a declarative nested name specifier cannot name an alias template</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walias-template-in-declaration-name" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -35289,14 +35400,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-nvcc-compat</key>
     <name>clang-diagnostic-nvcc-compat</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: target-attribute based function overloads are not supported by NVCC and will be treated as a function redeclaration:new declaration is %select{__device__|__global__|__host__|__host__ __device__}0 function, old declaration is %select{__device__|__global__|__host__|__host__ __device__}1 function</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnvcc-compat" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: target-attribute based function overloads are not supported by NVCC and will be treated as a function redeclaration:new declaration is %select{__device__|__global__|__host__|__host__ __device__}0 function, old declaration is %select{__device__|__global__|__host__|__host__ __device__}1 function</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnvcc-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -35331,6 +35442,8 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+<li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: #warning is incompatible with C++ standards before C++23</li>
 <li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
@@ -35339,6 +35452,8 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
 <li>warning: '%0' is a keyword in C++20</li>
 <li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+<li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
 <li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
@@ -35348,18 +35463,22 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
 <li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: consteval if is incompatible with C++ standards before C++23</li>
 <li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
 <li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
 <li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
 <li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: static lambdas are incompatible with C++ standards before C++23</li>
 <li>warning: taking address of non-addressable standard library function is incompatible with C++20</li>
@@ -35525,7 +35644,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %select{address of|reference to}0 stack memory associated with %select{local variable|parameter}2 %1 returned</li>
+<li>warning: %select{address of|reference to}0 stack memory associated with %select{local variable|parameter|compound literal}2 %1 returned</li>
 <li>warning: returning %select{address of|reference to}0 local temporary object</li>
 <li>warning: returning address of label, which is local</li>
 </ul>
@@ -35732,40 +35851,40 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-openacc-self-if-potential-conflict</key>
     <name>clang-diagnostic-openacc-self-if-potential-conflict</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: OpenACC construct 'self' has no effect when an 'if' clause evaluates to true</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenacc-self-if-potential-conflict" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: OpenACC construct 'self' has no effect when an 'if' clause evaluates to true</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenacc-self-if-potential-conflict" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-openacc-deprecated-clause-alias</key>
     <name>clang-diagnostic-openacc-deprecated-clause-alias</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: OpenACC clause name '%0' is a deprecated clause name and is now an alias for '%1'</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenacc-deprecated-clause-alias" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: OpenACC clause name '%0' is a deprecated clause name and is now an alias for '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenacc-deprecated-clause-alias" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-pch-vfs-diff</key>
     <name>clang-diagnostic-pch-vfs-diff</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: PCH was compiled with different VFS overlay files than are currently in use</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpch-vfs-diff" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: PCH was compiled with different VFS overlay files than are currently in use</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpch-vfs-diff" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -35816,6 +35935,7 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: '%0' is a keyword in C23</li>
+<li>warning: type of UTF-8 string literal will change from array of char to array of char8_t in C23</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc2x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -35842,7 +35962,7 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: address of%select{| function| array}0 '%1' will always evaluate to 'true'</li>
+<li>warning: address of %select{'%1'|function '%1'|array '%1'|lambda function pointer conversion operator}0 will always evaluate to 'true'</li>
 <li>warning: comparison of %select{address of|function|array}0 '%1' %select{not |}2equal to a null pointer is always %select{true|false}2</li>
 <li>warning: comparison of nonnull %select{function call|parameter}0 '%1' %select{not |}2equal to a null pointer is '%select{true|false}2' on first encounter</li>
 <li>warning: nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter</li>
@@ -35921,16 +36041,17 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: bitwise negation of a boolean expression%select{;| always evaluates to 'true';}0 did you mean logical negation?</li>
 <li>warning: bitwise or with non-zero value always evaluates to true</li>
 <li>warning: block pointer variable %0 is %select{uninitialized|null}1 when captured by block</li>
-<li>warning: call to function without interrupt attribute could clobber interruptee's VFP registers</li>
 <li>warning: call to undeclared function %0; ISO C99 and later do not support implicit function declarations</li>
 <li>warning: call to undeclared library function '%0' with type %1; ISO C99 and later do not support implicit function declarations</li>
 <li>warning: calling '%0' with a nonzero argument is unsafe</li>
 <li>warning: cannot mix positional and non-positional arguments in format string</li>
 <li>warning: case value not in enumerated type %0</li>
+<li>warning: cast %diff{from $ to $ |}0,1converts to incompatible function type</li>
 <li>warning: cast of type %0 to %1 is deprecated; use sel_getName instead</li>
 <li>warning: comparison of %select{address of|function|array}0 '%1' %select{not |}2equal to a null pointer is always %select{true|false}2</li>
 <li>warning: comparison of integers of different signs: %0 and %1</li>
 <li>warning: comparison of nonnull %select{function call|parameter}0 '%1' %select{not |}2equal to a null pointer is '%select{true|false}2' on first encounter</li>
+<li>warning: comparisons like 'X&lt;=Y&lt;=Z' don't have their mathematical meaning</li>
 <li>warning: container access result unused - container access should not be used for side effects</li>
 <li>warning: convenience initializer missing a 'self' call to another initializer</li>
 <li>warning: convenience initializer should not invoke an initializer on 'super'</li>
@@ -35998,6 +36119,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: method override for the designated initializer of the superclass %objcinstance0 not found</li>
 <li>warning: method possibly missing a [super %0] call</li>
 <li>warning: misleading indentation; statement is not part of the previous '%select{if|else|for|while}0'</li>
+<li>warning: missing field %0 initializer</li>
 <li>warning: missing field %0 initializer</li>
 <li>warning: missing object format flag</li>
 <li>warning: more '%%' conversions than data arguments</li>
@@ -36067,6 +36189,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: use of __private_extern__ on a declaration may not produce external symbol private to the linkage unit and is deprecated</li>
 <li>warning: use of bitwise '%0' with boolean operands</li>
 <li>warning: use of unknown builtin %0</li>
+<li>warning: using '%%P' format specifier with an Objective-C pointer results in dumping runtime object structure, not object value</li>
 <li>warning: using '%%P' format specifier without precision</li>
 <li>warning: using '%0' format specifier annotation outside of os_log()/os_trace()</li>
 <li>warning: using '%0' format specifier, but argument has boolean value</li>
@@ -36152,7 +36275,7 @@ Derived();             // and so temporary construction is okay</code></pre>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
 <li>warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true</li>
-<li>warning: address of%select{| function| array}0 '%1' will always evaluate to 'true'</li>
+<li>warning: address of %select{'%1'|function '%1'|array '%1'|lambda function pointer conversion operator}0 will always evaluate to 'true'</li>
 <li>warning: initialization of pointer of type %0 to null from a constant boolean expression</li>
 <li>warning: nonnull %select{function call|parameter}0 '%1' will evaluate to 'true' on first encounter</li>
 <li>warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; pointer may be assumed to always convert to true</li>
@@ -36216,7 +36339,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: 'typename' occurs outside of a template</li>
 <li>warning: [[]] attributes are a C++11 extension</li>
 <li>warning: alias declarations are a C++11 extension</li>
-<li>warning: befriending enumeration type %0 is a C++11 extension</li>
 <li>warning: commas at the end of enumerator lists are a C++11 extension</li>
 <li>warning: default member initializer for non-static data member is a C++11 extension</li>
 <li>warning: default template arguments for a function template are a C++11 extension</li>
@@ -36227,6 +36349,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: generalized initializer lists are a C++11 extension</li>
 <li>warning: implicit conversion from array size expression of type %0 to %select{integral|enumeration}1 type %2 is a C++11 extension</li>
 <li>warning: inline namespaces are a C++11 feature</li>
+<li>warning: lambdas are a C++11 extension</li>
 <li>warning: non-class friend type %0 is a C++11 extension</li>
 <li>warning: non-type template argument referring to %select{function|object}0 %1 with internal linkage is a C++11 extension</li>
 <li>warning: range-based for loop is a C++11 extension</li>
@@ -36330,6 +36453,7 @@ Derived();             // and so temporary construction is okay</code></pre>
 <li>warning: inline nested namespace definition is a C++20 extension</li>
 <li>warning: invoking a pointer to a 'const &amp;' member function on an rvalue is a C++20 extension</li>
 <li>warning: missing 'typename' prior to dependent type name %0%1; implicit 'typename' is a C++20 extension</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is a C++20 extension</li>
 <li>warning: range-based for loop initialization statements are a C++20 extension</li>
 <li>warning: uninitialized variable in a constexpr %select{function|constructor}0 is a C++20 extension</li>
 <li>warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension</li>
@@ -36372,6 +36496,10 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning:  '%0' in a raw string literal delimiter is a C++2c extension</li>
+<li>warning: '= delete' with a message is a C++2c extension</li>
+<li>warning: an attribute specifier sequence attached to a structured binding declaration is a C++2c extension</li>
+<li>warning: pack indexing is a C++2c extension</li>
 <li>warning: placeholder variables are a C++2c extension</li>
 </ul>
 <h2>References</h2>
@@ -36385,13 +36513,17 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
+<li>warning: #embed is a %select{C23|Clang}0 extension</li>
 <li>warning: '_BitInt' suffix for literals is a C23 extension</li>
 <li>warning: '_Static_assert' with no message is a C23 extension</li>
 <li>warning: 'nullptr' is a C23 extension</li>
 <li>warning: [[]] attributes are a C23 extension</li>
+<li>warning: binary integer literals are a C23 extension</li>
+<li>warning: defining a type within '%select{__builtin_offsetof|offsetof}0' is a C23 extension</li>
 <li>warning: label at end of compound statement is a C23 extension</li>
 <li>warning: label followed by a declaration is a C23 extension</li>
 <li>warning: omitting the parameter name in a function definition is a C23 extension</li>
+<li>warning: passing no argument for the '...' parameter of a variadic macro is a C23 extension</li>
 <li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is a C23 extension</li>
 <li>warning: use of an empty initializer is a C23 extension</li>
 </ul>
@@ -36472,8 +36604,10 @@ Derived();             // and so temporary construction is okay</code></pre>
     <description>
       <![CDATA[<p>Diagnostic text:</p>
 <ul>
-<li>warning: %0 is only available on %1 %2 or newer</li>
-<li>warning: %0 is only available on %1 %2 or newer</li>
+<li>warning: %0 is only available %select{|in %4 environment }3on %1 %2 or newer</li>
+<li>warning: %0 is only available %select{|in %4 environment }3on %1 %2 or newer</li>
+<li>warning: %0 is unavailable</li>
+<li>warning: %0 is unavailable</li>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpartial-availability" target="_blank">Diagnostic flags in Clang</a></p>]]>
@@ -36522,14 +36656,14 @@ Derived();             // and so temporary construction is okay</code></pre>
   <rule>
     <key>clang-diagnostic-higher-precision-fp</key>
     <name>clang-diagnostic-higher-precision-fp</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: higher precision floating-point type size has the same size than floating-point type size</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whigher-precision-fp" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: higher precision floating-point type size has the same size than floating-point type size</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whigher-precision-fp" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
     <severity>INFO</severity>
     </rule>
   <rule>

--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -19600,6 +19600,21 @@ Derived();             // and so temporary construction is okay</code></pre>
   <!-- Clang Diagnostic Rules -->
 
   <rule>
+    <key>clang-diagnostic-aarch64-sme-attributes</key>
+    <name>clang-diagnostic-aarch64-sme-attributes</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: %select{returning|passing}0 a VL-dependent argument %select{from|to}0 a function with a different streaming-mode is undefined behaviour when the streaming and non-streaming vector lengths are different at runtime</li>
+  <li>warning: %select{returning|passing}0 a VL-dependent argument %select{from|to}0 a locally streaming function is undefined behaviour when the streaming and non-streaming vector lengths are different at runtime</li>
+  <li>warning: always_inline function %1 and its caller %0 have mismatching %2 attributes, inlining may change runtime behaviour</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waarch64-sme-attributes" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-aix-compat</key>
     <name>clang-diagnostic-aix-compat</name>
     <description>
@@ -20560,6 +20575,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-bounds-safety-counted-by-elt-type-unknown-size</key>
+    <name>clang-diagnostic-bounds-safety-counted-by-elt-type-unknown-size</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: '%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}4' %select{cannot|should not}3 be applied to %select{a pointer with pointee|an array with element}0 of unknown size because %1 is %select{an incomplete type|a sizeless type|a function type|a struct type with a flexible array member%select{|. This will be an error in a future compiler version}3}2</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbounds-safety-counted-by-elt-type-unknown-size" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-branch-protection</key>
     <name>clang-diagnostic-branch-protection</name>
     <description>
@@ -20653,6 +20681,21 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-c2y-extensions</key>
+    <name>clang-diagnostic-c2y-extensions</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: '%select{--|++}0' on an object of complex type is a C2y extension</li>
+  <li>warning: 'alignof' on an incomplete array type is a C2y extension</li>
+  <li>warning: passing a type argument as the first operand to '_Generic' is a C2y extension</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc2y-extensions" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-c99-extensions</key>
     <name>clang-diagnostic-c99-extensions</name>
     <description>
@@ -20715,6 +20758,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-pre-c11-compat</key>
+    <name>clang-diagnostic-pre-c11-compat</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: '%0' is incompatible with C standards before C11</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c11-compat" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c11-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c11-compat-pedantic</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: '%0' is incompatible with C standards before C11</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-pre-c23-compat</key>
     <name>clang-diagnostic-pre-c23-compat</name>
     <description>
@@ -20762,6 +20831,36 @@ Derived();             // and so temporary construction is okay</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c23-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c2y-compat</key>
+    <name>clang-diagnostic-pre-c2y-compat</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: '%select{--|++}0' on an object of complex type is incompatible with C standards before C2y</li>
+  <li>warning: 'alignof' on an incomplete array type is incompatible with C standards before C2y</li>
+  <li>warning: passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2y-compat" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c2y-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c2y-compat-pedantic</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: '%select{--|++}0' on an object of complex type is incompatible with C standards before C2y</li>
+  <li>warning: 'alignof' on an incomplete array type is incompatible with C standards before C2y</li>
+  <li>warning: passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2y-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -21893,6 +21992,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++23-attribute-extensions</key>
+    <name>clang-diagnostic-c++23-attribute-extensions</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: use of the %0 attribute is a C++23 extension</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-attribute-extensions" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-c++23-lambda-attributes</key>
     <name>clang-diagnostic-c++23-lambda-attributes</name>
     <description>
@@ -21906,6 +22018,23 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++23-compat</key>
+    <name>clang-diagnostic-c++23-compat</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
+  <li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
+  <li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
+  <li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
+  <li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-compat" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-c++26-extensions</key>
     <name>clang-diagnostic-c++26-extensions</name>
     <description>
@@ -21916,6 +22045,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-26-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++2c-compat</key>
+    <name>clang-diagnostic-c++2c-compat</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: cannot delete expression with pointer-to-'void' type %0</li>
+  <li>warning: deleting pointer to incomplete type %0 is incompatible with C++2c and may cause undefined behavior</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2c-compat" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -22715,6 +22858,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-cast-function-type-mismatch</key>
+    <name>clang-diagnostic-cast-function-type-mismatch</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: cast %diff{from $ to $ |}0,1converts to incompatible function type</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-function-type-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-cast-function-type-strict</key>
     <name>clang-diagnostic-cast-function-type-strict</name>
     <description>
@@ -23145,6 +23301,32 @@ Derived();             // and so temporary construction is okay</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdangling" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-dangling-assignment</key>
+    <name>clang-diagnostic-dangling-assignment</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: object backing the pointer %0 will be destroyed at the end of the full-expression</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdangling-assignment" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-dangling-assignment-gsl</key>
+    <name>clang-diagnostic-dangling-assignment-gsl</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: object backing the pointer %0 will be destroyed at the end of the full-expression</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdangling-assignment-gsl" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -23651,6 +23833,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-deprecated-no-relaxed-template-template-args</key>
+    <name>clang-diagnostic-deprecated-no-relaxed-template-template-args</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: argument '-fno-relaxed-template-template-args' is deprecated</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-no-relaxed-template-template-args" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-deprecated-non-prototype</key>
     <name>clang-diagnostic-deprecated-non-prototype</name>
     <description>
@@ -23662,6 +23857,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-non-prototype" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecated-ofast</key>
+    <name>clang-diagnostic-deprecated-ofast</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-ofast" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -24226,6 +24434,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-explicit-specialization-storage-class</key>
+    <name>clang-diagnostic-explicit-specialization-storage-class</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: explicit specialization cannot have a storage class</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexplicit-specialization-storage-class" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-extern-c-compat</key>
     <name>clang-diagnostic-extern-c-compat</name>
     <description>
@@ -24315,6 +24536,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextra-tokens" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-extractapi-misuse</key>
+    <name>clang-diagnostic-extractapi-misuse</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: missing symbol graph output directory, defaulting to working directory</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextractapi-misuse" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -24625,6 +24859,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-format-signedness</key>
+    <name>clang-diagnostic-format-signedness</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: format specifies type %0 but the argument has %select{type|underlying type}2 %1</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-signedness" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-format-truncation</key>
     <name>clang-diagnostic-format-truncation</name>
     <description>
@@ -24800,6 +25047,22 @@ Derived();             // and so temporary construction is okay</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfunction-def-in-objc-container" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-function-effects</key>
+    <name>clang-diagnostic-function-effects</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: attribute '%0' on function does not match previous declaration</li>
+  <li>warning: attribute '%0' on overriding function does not match base declaration</li>
+  <li>warning: attribute '%0' should not be added via type conversion</li>
+  <li>warning: effects conflict when merging declarations; kept '%0', discarded '%1'</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfunction-effects" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -25385,6 +25648,20 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>CRITICAL</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-hlsl-availability</key>
+    <name>clang-diagnostic-hlsl-availability</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: %0 is only available %select{|in %4 environment }3on %1 %2 or newer</li>
+  <li>warning: %0 is unavailable</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whlsl-availability" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-hlsl-extensions</key>
     <name>clang-diagnostic-hlsl-extensions</name>
     <description>
@@ -25395,6 +25672,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whlsl-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-mix-packoffset</key>
+    <name>clang-diagnostic-mix-packoffset</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: cannot mix packoffset elements with nonpackoffset elements in a cbuffer</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmix-packoffset" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -26044,6 +26334,31 @@ Derived();             // and so temporary construction is okay</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winline-namespace-reopened-noninline" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-installapi-violation</key>
+    <name>clang-diagnostic-installapi-violation</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: declaration '%0' is %select{weak defined|thread local}1, but symbol is not in dynamic library</li>
+  <li>warning: declaration '%0' is marked %select{available|unavailable}1, but symbol is %select{not |}2exported in dynamic library</li>
+  <li>warning: declaration has external linkage, but dynamic library doesn't have symbol '%0'</li>
+  <li>warning: declaration has external linkage, but symbol has internal linkage in dynamic library '%0'</li>
+  <li>warning: dynamic library symbol '%0' is %select{weak defined|thread local}1, but its declaration is not</li>
+  <li>warning: glob '%0' did not match any header file</li>
+  <li>warning: no declaration was found for exported symbol '%0' in dynamic library</li>
+  <li>warning: no such excluded %select{public|private}0 header file: '%1'</li>
+  <li>warning: platform does not match: '%0' (provided) vs '%1' (found)</li>
+  <li>warning: runpath search paths do not match: '%0' (provided) vs '%1' (found)</li>
+  <li>warning: runpath search paths missing from %0: '%1'</li>
+  <li>warning: symbol exported in dynamic library, but marked hidden in declaration '%0'</li>
+  <li>warning: violations found for %0</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winstallapi-violation" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -27135,6 +27450,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-missing-designated-field-initializers</key>
+    <name>clang-diagnostic-missing-designated-field-initializers</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: missing field %0 initializer</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-designated-field-initializers" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-missing-field-initializers</key>
     <name>clang-diagnostic-missing-field-initializers</name>
     <description>
@@ -27145,6 +27473,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-field-initializers" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-missing-include-dirs</key>
+    <name>clang-diagnostic-missing-include-dirs</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: no such include directory: '%0'</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-include-dirs" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -29255,6 +29596,20 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-ptrauth-null-pointers</key>
+    <name>clang-diagnostic-ptrauth-null-pointers</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: authenticating a null pointer will almost certainly trap</li>
+  <li>warning: signing a null pointer will yield a non-null pointer</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wptrauth-null-pointers" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-call-to-pure-virtual-from-ctor-dtor</key>
     <name>clang-diagnostic-call-to-pure-virtual-from-ctor-dtor</name>
     <description>
@@ -29526,6 +29881,21 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrestrict-expansion" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-return-mismatch</key>
+    <name>clang-diagnostic-return-mismatch</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: %select{void function|void method|constructor|destructor}1 %0 should not return a value</li>
+  <li>warning: non-void %select{function|method}1 %0 should return a value</li>
+  <li>warning: non-void %select{function|method}1 %0 should return a value</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-return-stack-address</key>
@@ -31275,6 +31645,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-unsafe-buffer-usage-in-container</key>
+    <name>clang-diagnostic-unsafe-buffer-usage-in-container</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsafe-buffer-usage-in-container" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-unsequenced</key>
     <name>clang-diagnostic-unsequenced</name>
     <description>
@@ -32848,6 +33231,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-missing-template-arg-list-after-template-kw</key>
+    <name>clang-diagnostic-missing-template-arg-list-after-template-kw</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: a template argument list is expected after a name prefixed by the template keyword</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-template-arg-list-after-template-kw" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-static-inline-explicit-instantiation</key>
     <name>clang-diagnostic-static-inline-explicit-instantiation</name>
     <description>
@@ -32986,6 +33382,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexcessive-regsave" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-arm-interrupt-vfp-clobber</key>
+    <name>clang-diagnostic-arm-interrupt-vfp-clobber</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: interrupt service routine with vfp enabled may clobber the interruptee's vfp state</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warm-interrupt-vfp-clobber" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -33384,6 +33793,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wredundant-consteval-if" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-friend-enum</key>
+    <name>clang-diagnostic-friend-enum</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: elaborated enum specifier cannot be declared as a friend</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfriend-enum" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -33961,6 +34383,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-strict-primary-template-shadow</key>
+    <name>clang-diagnostic-strict-primary-template-shadow</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: declaration of %0 shadows template parameter</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrict-primary-template-shadow" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-unqualified-std-cast-call</key>
     <name>clang-diagnostic-unqualified-std-cast-call</name>
     <description>
@@ -34499,6 +34934,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-tentative-definition-array</key>
+    <name>clang-diagnostic-tentative-definition-array</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: tentative array definition assumed to have one element</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtentative-definition-array" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-gnu-array-member-paren-init</key>
     <name>clang-diagnostic-gnu-array-member-paren-init</name>
     <description>
@@ -34738,6 +35186,32 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-alias-template-in-declaration-name</key>
+    <name>clang-diagnostic-alias-template-in-declaration-name</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: a declarative nested name specifier cannot name an alias template</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walias-template-in-declaration-name" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-template-in-declaration-name</key>
+    <name>clang-diagnostic-template-in-declaration-name</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: 'template' cannot be used after a declarative nested name specifier</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtemplate-in-declaration-name" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-c++2a-compat</key>
     <name>clang-diagnostic-c++2a-compat</name>
     <description>
@@ -34823,6 +35297,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgpu-maybe-wrong-side" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-nvcc-compat</key>
+    <name>clang-diagnostic-nvcc-compat</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: target-attribute based function overloads are not supported by NVCC and will be treated as a function redeclaration:new declaration is %select{__device__|__global__|__host__|__host__ __device__}0 function, old declaration is %select{__device__|__global__|__host__|__host__ __device__}1 function</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnvcc-compat" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -35253,6 +35740,45 @@ Derived();             // and so temporary construction is okay</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtcb-enforcement" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-openacc-self-if-potential-conflict</key>
+    <name>clang-diagnostic-openacc-self-if-potential-conflict</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: OpenACC construct 'self' has no effect when an 'if' clause evaluates to true</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenacc-self-if-potential-conflict" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-openacc-deprecated-clause-alias</key>
+    <name>clang-diagnostic-openacc-deprecated-clause-alias</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: OpenACC clause name '%0' is a deprecated clause name and is now an alias for '%1'</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenacc-deprecated-clause-alias" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pch-vfs-diff</key>
+    <name>clang-diagnostic-pch-vfs-diff</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: PCH was compiled with different VFS overlay files than are currently in use</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpch-vfs-diff" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
     <severity>INFO</severity>
     </rule>
   <rule>
@@ -36007,6 +36533,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-higher-precision-fp</key>
+    <name>clang-diagnostic-higher-precision-fp</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: higher precision floating-point type size has the same size than floating-point type size</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whigher-precision-fp" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-nan-infinity-disabled</key>
     <name>clang-diagnostic-nan-infinity-disabled</name>
     <description>
@@ -36225,545 +36764,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdelayed-template-parsing-in-cxx20" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
-    <severity>INFO</severity>
-  </rule>
-  <rule>
-    <key>clang-diagnostic-aarch64-sme-attributes</key>
-    <name>clang-diagnostic-aarch64-sme-attributes</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: %select{returning|passing}0 a VL-dependent argument %select{from|to}0 a function with a different streaming-mode is undefined behaviour when the streaming and non-streaming vector lengths are different at runtime</li>
-  <li>warning: %select{returning|passing}0 a VL-dependent argument %select{from|to}0 a locally streaming function is undefined behaviour when the streaming and non-streaming vector lengths are different at runtime</li>
-  <li>warning: always_inline function %1 and its caller %0 have mismatching %2 attributes, inlining may change runtime behaviour</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#waarch64-sme-attributes" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-alias-template-in-declaration-name</key>
-    <name>clang-diagnostic-alias-template-in-declaration-name</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: a declarative nested name specifier cannot name an alias template</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walias-template-in-declaration-name" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-arm-interrupt-vfp-clobber</key>
-    <name>clang-diagnostic-arm-interrupt-vfp-clobber</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: interrupt service routine with vfp enabled may clobber the interruptee's vfp state</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#warm-interrupt-vfp-clobber" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-bounds-safety-counted-by-elt-type-unknown-size</key>
-    <name>clang-diagnostic-bounds-safety-counted-by-elt-type-unknown-size</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: '%select{counted_by|sized_by|counted_by_or_null|sized_by_or_null}4' %select{cannot|should not}3 be applied to %select{a pointer with pointee|an array with element}0 of unknown size because %1 is %select{an incomplete type|a sizeless type|a function type|a struct type with a flexible array member%select{|. This will be an error in a future compiler version}3}2</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbounds-safety-counted-by-elt-type-unknown-size" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++23-attribute-extensions</key>
-    <name>clang-diagnostic-c++23-attribute-extensions</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: use of the %0 attribute is a C++23 extension</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-attribute-extensions" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++23-compat</key>
-    <name>clang-diagnostic-c++23-compat</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning:  '%0' in a raw string literal delimiter is incompatible with standards before C++2c</li>
-  <li>warning: '= delete' with a message is incompatible with C++ standards before C++2c</li>
-  <li>warning: an attribute specifier sequence attached to a structured binding declaration is incompatible with C++ standards before C++2c</li>
-  <li>warning: pack indexing is incompatible with C++ standards before C++2c</li>
-  <li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-compat" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++2c-compat</key>
-    <name>clang-diagnostic-c++2c-compat</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: cannot delete expression with pointer-to-'void' type %0</li>
-  <li>warning: deleting pointer to incomplete type %0 is incompatible with C++2c and may cause undefined behavior</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2c-compat" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c2y-extensions</key>
-    <name>clang-diagnostic-c2y-extensions</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: '%select{--|++}0' on an object of complex type is a C2y extension</li>
-  <li>warning: 'alignof' on an incomplete array type is a C2y extension</li>
-  <li>warning: passing a type argument as the first operand to '_Generic' is a C2y extension</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc2y-extensions" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-cast-function-type-mismatch</key>
-    <name>clang-diagnostic-cast-function-type-mismatch</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: cast %diff{from $ to $ |}0,1converts to incompatible function type</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wcast-function-type-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-dangling-assignment</key>
-    <name>clang-diagnostic-dangling-assignment</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: object backing the pointer %0 will be destroyed at the end of the full-expression</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdangling-assignment" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-dangling-assignment-gsl</key>
-    <name>clang-diagnostic-dangling-assignment-gsl</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: object backing the pointer %0 will be destroyed at the end of the full-expression</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdangling-assignment-gsl" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-deprecated-no-relaxed-template-template-args</key>
-    <name>clang-diagnostic-deprecated-no-relaxed-template-template-args</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: argument '-fno-relaxed-template-template-args' is deprecated</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-no-relaxed-template-template-args" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-deprecated-ofast</key>
-    <name>clang-diagnostic-deprecated-ofast</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-ofast" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-explicit-specialization-storage-class</key>
-    <name>clang-diagnostic-explicit-specialization-storage-class</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: explicit specialization cannot have a storage class</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexplicit-specialization-storage-class" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-extractapi-misuse</key>
-    <name>clang-diagnostic-extractapi-misuse</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: missing symbol graph output directory, defaulting to working directory</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wextractapi-misuse" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-format-signedness</key>
-    <name>clang-diagnostic-format-signedness</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: format specifies type %0 but the argument has %select{type|underlying type}2 %1</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wformat-signedness" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-friend-enum</key>
-    <name>clang-diagnostic-friend-enum</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: elaborated enum specifier cannot be declared as a friend</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfriend-enum" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-function-effects</key>
-    <name>clang-diagnostic-function-effects</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: attribute '%0' on function does not match previous declaration</li>
-  <li>warning: attribute '%0' on overriding function does not match base declaration</li>
-  <li>warning: attribute '%0' should not be added via type conversion</li>
-  <li>warning: effects conflict when merging declarations; kept '%0', discarded '%1'</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfunction-effects" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-higher-precision-fp</key>
-    <name>clang-diagnostic-higher-precision-fp</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: higher precision floating-point type size has the same size than floating-point type size</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whigher-precision-fp" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-hlsl-availability</key>
-    <name>clang-diagnostic-hlsl-availability</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: %0 is only available %select{|in %4 environment }3on %1 %2 or newer</li>
-  <li>warning: %0 is unavailable</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#whlsl-availability" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-installapi-violation</key>
-    <name>clang-diagnostic-installapi-violation</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: declaration '%0' is %select{weak defined|thread local}1, but symbol is not in dynamic library</li>
-  <li>warning: declaration '%0' is marked %select{available|unavailable}1, but symbol is %select{not |}2exported in dynamic library</li>
-  <li>warning: declaration has external linkage, but dynamic library doesn't have symbol '%0'</li>
-  <li>warning: declaration has external linkage, but symbol has internal linkage in dynamic library '%0'</li>
-  <li>warning: dynamic library symbol '%0' is %select{weak defined|thread local}1, but its declaration is not</li>
-  <li>warning: glob '%0' did not match any header file</li>
-  <li>warning: no declaration was found for exported symbol '%0' in dynamic library</li>
-  <li>warning: no such excluded %select{public|private}0 header file: '%1'</li>
-  <li>warning: platform does not match: '%0' (provided) vs '%1' (found)</li>
-  <li>warning: runpath search paths do not match: '%0' (provided) vs '%1' (found)</li>
-  <li>warning: runpath search paths missing from %0: '%1'</li>
-  <li>warning: symbol exported in dynamic library, but marked hidden in declaration '%0'</li>
-  <li>warning: violations found for %0</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winstallapi-violation" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-missing-designated-field-initializers</key>
-    <name>clang-diagnostic-missing-designated-field-initializers</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: missing field %0 initializer</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-designated-field-initializers" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-missing-include-dirs</key>
-    <name>clang-diagnostic-missing-include-dirs</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: no such include directory: '%0'</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-include-dirs" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-missing-template-arg-list-after-template-kw</key>
-    <name>clang-diagnostic-missing-template-arg-list-after-template-kw</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: a template argument list is expected after a name prefixed by the template keyword</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmissing-template-arg-list-after-template-kw" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-mix-packoffset</key>
-    <name>clang-diagnostic-mix-packoffset</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: cannot mix packoffset elements with nonpackoffset elements in a cbuffer</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmix-packoffset" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-nvcc-compat</key>
-    <name>clang-diagnostic-nvcc-compat</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: target-attribute based function overloads are not supported by NVCC and will be treated as a function redeclaration:new declaration is %select{__device__|__global__|__host__|__host__ __device__}0 function, old declaration is %select{__device__|__global__|__host__|__host__ __device__}1 function</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wnvcc-compat" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-openacc-deprecated-clause-alias</key>
-    <name>clang-diagnostic-openacc-deprecated-clause-alias</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: OpenACC clause name '%0' is a deprecated clause name and is now an alias for '%1'</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenacc-deprecated-clause-alias" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-openacc-self-if-potential-conflict</key>
-    <name>clang-diagnostic-openacc-self-if-potential-conflict</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: OpenACC construct 'self' has no effect when an 'if' clause evaluates to true</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wopenacc-self-if-potential-conflict" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pch-vfs-diff</key>
-    <name>clang-diagnostic-pch-vfs-diff</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: PCH was compiled with different VFS overlay files than are currently in use</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpch-vfs-diff" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c11-compat</key>
-    <name>clang-diagnostic-pre-c11-compat</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: '%0' is incompatible with C standards before C11</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c11-compat" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c11-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c11-compat-pedantic</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: '%0' is incompatible with C standards before C11</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c2y-compat</key>
-    <name>clang-diagnostic-pre-c2y-compat</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: '%select{--|++}0' on an object of complex type is incompatible with C standards before C2y</li>
-  <li>warning: 'alignof' on an incomplete array type is incompatible with C standards before C2y</li>
-  <li>warning: passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2y-compat" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pre-c2y-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c2y-compat-pedantic</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: '%select{--|++}0' on an object of complex type is incompatible with C standards before C2y</li>
-  <li>warning: 'alignof' on an incomplete array type is incompatible with C standards before C2y</li>
-  <li>warning: passing a type argument as the first operand to '_Generic' is incompatible with C standards before C2y</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2y-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-ptrauth-null-pointers</key>
-    <name>clang-diagnostic-ptrauth-null-pointers</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: authenticating a null pointer will almost certainly trap</li>
-  <li>warning: signing a null pointer will yield a non-null pointer</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wptrauth-null-pointers" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-return-mismatch</key>
-    <name>clang-diagnostic-return-mismatch</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: %select{void function|void method|constructor|destructor}1 %0 should not return a value</li>
-  <li>warning: non-void %select{function|method}1 %0 should return a value</li>
-  <li>warning: non-void %select{function|method}1 %0 should return a value</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-mismatch" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-strict-primary-template-shadow</key>
-    <name>clang-diagnostic-strict-primary-template-shadow</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: declaration of %0 shadows template parameter</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wstrict-primary-template-shadow" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>CRITICAL</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-template-in-declaration-name</key>
-    <name>clang-diagnostic-template-in-declaration-name</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: 'template' cannot be used after a declarative nested name specifier</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtemplate-in-declaration-name" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-tentative-definition-array</key>
-    <name>clang-diagnostic-tentative-definition-array</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: tentative array definition assumed to have one element</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wtentative-definition-array" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-unsafe-buffer-usage-in-container</key>
-    <name>clang-diagnostic-unsafe-buffer-usage-in-container</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wunsafe-buffer-usage-in-container" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
     <severity>INFO</severity>
   </rule>
 </rules>

--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -1190,6 +1190,58 @@ while (TEMP_FAILURE_RETRY(read(STDIN_FILENO, cs, sizeof(cs))) != 0) {
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>boost-use-ranges</key>
+    <name>boost-use-ranges</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - boost-use-ranges</p>
+</div>
+<h1 id="boost-use-ranges">boost-use-ranges</h1>
+<p>Detects calls to standard library iterator algorithms that could be replaced with a Boost ranges version instead.</p>
+<h2 id="example">Example</h2>
+<pre class="c++"><code>auto Iter1 = std::find(Items.begin(), Items.end(), 0);
+auto AreSame = std::equal(Items1.cbegin(), Items1.cend(), std::begin(Items2),
+                          std::end(Items2));</code></pre>
+<p>Transforms to:</p>
+<pre class="c++"><code>auto Iter1 = boost::range::find(Items, 0);
+auto AreSame = boost::range::equal(Items1, Items2);</code></pre>
+<h2 id="supported-algorithms">Supported algorithms</h2>
+<p>Calls to the following std library algorithms are checked:</p>
+<p><code>std::accumulate</code>, <code>std::adjacent_difference</code>, <code>std::adjacent_find</code>, <code>std::all_of</code>, <code>std::any_of</code>, <code>std::binary_search</code>, <code>std::copy_backward</code>, <code>std::copy_if</code>, <code>std::copy</code>, <code>std::count_if</code>, <code>std::count</code>, <code>std::equal_range</code>, <code>std::equal</code>, <code>std::fill</code>, <code>std::find_end</code>, <code>std::find_first_of</code>, <code>std::find_if_not</code>, <code>std::find_if</code>, <code>std::find</code>, <code>std::for_each</code>, <code>std::generate</code>, <code>std::includes</code>, <code>std::iota</code>, <code>std::is_partitioned</code>, <code>std::is_permutation</code>, <code>std::is_sorted_until</code>, <code>std::is_sorted</code>, <code>std::lexicographical_compare</code>, <code>std::lower_bound</code>, <code>std::make_heap</code>, <code>std::max_element</code>, <code>std::merge</code>, <code>std::min_element</code>, <code>std::mismatch</code>, <code>std::next_permutation</code>, <code>std::none_of</code>, <code>std::parital_sum</code>, <code>std::partial_sort_copy</code>, <code>std::partition_copy</code>, <code>std::partition_point</code>, <code>std::partition</code>, <code>std::pop_heap</code>, <code>std::prev_permutation</code>, <code>std::push_heap</code>, <code>std::random_shuffle</code>, <code>std::reduce</code>, <code>std::remove_copy_if</code>, <code>std::remove_copy</code>, <code>std::remove_if</code>, <code>std::remove</code>, <code>std::replace_copy_if</code>, <code>std::replace_copy</code>, <code>std::replace_if</code>, <code>std::replace</code>, <code>std::reverse_copy</code>, <code>std::reverse</code>, <code>std::search</code>, <code>std::set_difference</code>, <code>std::set_intersection</code>, <code>std::set_symmetric_difference</code>, <code>std::set_union</code>, <code>std::sort_heap</code>, <code>std::sort</code>, <code>std::stable_partition</code>, <code>std::stable_sort</code>, <code>std::transform</code>, <code>std::unique_copy</code>, <code>std::unique</code>, <code>std::upper_bound</code>.</p>
+<p>The check will also look for the following functions from the <code>boost::algorithm</code> namespace:</p>
+<p><code>all_of_equal</code>, <code>any_of_equal</code>, <code>any_of</code>, <code>apply_permutation</code>, <code>apply_reverse_permutation</code>, <code>clamp_range</code>, <code>copy_if_until</code>, <code>copy_if_while</code>, <code>copy_if</code>, <code>copy_until</code>, <code>copy_while</code>, <code>find_backward</code>, <code>find_if_backward</code>, <code>find_if_not_backward</code>, <code>find_if_not</code>, <code>find_not_backward</code>, <code>hex_lower</code>, <code>hex</code>, <code>iota</code>, <code>all_of</code>, <code>is_decreasing</code>, <code>is_increasing</code>, <code>is_palindrome</code>, <code>is_partitioned_until</code>, <code>is_partitioned</code>, <code>is_permutation</code>, <code>is_sorted_until</code>, <code>is_sorted</code>, <code>is_strictly_decreasing</code>, <code>is_strictly_increasing</code>, <code>none_of_equal</code>, <code>none_of</code>, <code>one_of_equal</code>, <code>one_of</code>, <code>partition_copy</code>, <code>partition_point</code>, <code>reduce</code>, <code>unhex</code>.</p>
+<h2 id="reverse-iteration">Reverse Iteration</h2>
+<p>If calls are made using reverse iterators on containers, The code will be fixed using the <code>boost::adaptors::reverse</code> adaptor.</p>
+<pre class="c++"><code>auto AreSame = std::equal(Items1.rbegin(), Items1.rend(),
+                          std::crbegin(Items2), std::crend(Items2));</code></pre>
+<p>Transforms to:</p>
+<pre class="c++"><code>auto AreSame = boost::range::equal(boost::adaptors::reverse(Items1),
+                                   boost::adaptors::reverse(Items2));</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IncludeStyle</p>
+<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
+</div>
+<div class="option">
+<p>IncludeBoostSystem</p>
+<p>If <span class="title-ref">true</span> (default value) the boost headers are included as system headers with angle brackets (<span class="title-ref">#include &lt;boost.hpp&gt;</span>), otherwise quotes are used (<span class="title-ref">#include "boost.hpp"</span>).</p>
+</div>
+<div class="option">
+<p>UseReversePipe</p>
+<p>When <span class="title-ref">true</span> (default <span class="title-ref">false</span>), fixes which involve reverse ranges will use the pipe adaptor syntax instead of the function syntax.</p>
+<pre class="c++"><code>std::find(Items.rbegin(), Items.rend(), 0);</code></pre>
+<p>Transforms to:</p>
+<pre class="c++"><code>boost::range::find(Items | boost::adaptors::reversed, 0);</code></pre>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/boost/use-ranges.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>boost-use-to-string</key>
     <name>boost-use-to-string</name>
     <description>
@@ -1627,6 +1679,77 @@ class X2 : public Copyable {
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
+    </rule>
+  <rule>
+    <key>bugprone-crtp-constructor-accessibility</key>
+    <name>bugprone-crtp-constructor-accessibility</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-crtp-constructor-accessibility</p>
+</div>
+<h1 id="bugprone-crtp-constructor-accessibility">bugprone-crtp-constructor-accessibility</h1>
+<p>Detects error-prone Curiously Recurring Template Pattern usage, when the CRTP can be constructed outside itself and the derived class.</p>
+<p>The CRTP is an idiom, in which a class derives from a template class, where itself is the template argument. It should be ensured that if a class is intended to be a base class in this idiom, it can only be instantiated if the derived class is it's template argument.</p>
+<p>Example:</p>
+<pre class="c++"><code>template &lt;typename T&gt; class CRTP {
+private:
+  CRTP() = default;
+  friend T;
+};
+
+class Derived : CRTP&lt;Derived&gt; {};</code></pre>
+<p>Below can be seen some common mistakes that will allow the breaking of the idiom.</p>
+<p>If the constructor of a class intended to be used in a CRTP is public, then it allows users to construct that class on its own.</p>
+<p>Example:</p>
+<pre class="c++"><code>template &lt;typename T&gt; class CRTP {
+public:
+  CRTP() = default;
+};
+
+class Good : CRTP&lt;Good&gt; {};
+Good GoodInstance;
+
+CRTP&lt;int&gt; BadInstance;</code></pre>
+<p>If the constructor is protected, the possibility of an accidental instantiation is prevented, however it can fade an error, when a different class is used as the template parameter instead of the derived one.</p>
+<p>Example:</p>
+<pre class="c++"><code>template &lt;typename T&gt; class CRTP {
+protected:
+  CRTP() = default;
+};
+
+class Good : CRTP&lt;Good&gt; {};
+Good GoodInstance;
+
+class Bad : CRTP&lt;Good&gt; {};
+Bad BadInstance;</code></pre>
+<p>To ensure that no accidental instantiation happens, the best practice is to make the constructor private and declare the derived class as friend. Note that as a tradeoff, this also gives the derived class access to every other private members of the CRTP.</p>
+<p>Example:</p>
+<pre class="c++"><code>template &lt;typename T&gt; class CRTP {
+  CRTP() = default;
+  friend T;
+};
+
+class Good : CRTP&lt;Good&gt; {};
+Good GoodInstance;
+
+class Bad : CRTP&lt;Good&gt; {};
+Bad CompileTimeError;
+
+CRTP&lt;int&gt; AlsoCompileTimeError;</code></pre>
+<p>Limitations:</p>
+<ul>
+<li>The check is not supported below C++11</li>
+<li>The check does not handle when the derived class is passed as a variadic template argument</li>
+<li>Accessible functions that can construct the CRTP, like factory functions are not checked</li>
+</ul>
+<p>The check also suggests a fix-its in some cases.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/crtp-constructor-accessibility.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>bugprone-dangling-handle</key>
@@ -2792,6 +2915,61 @@ struct C: public B {
       </description>
     </rule>
   <rule>
+    <key>bugprone-pointer-arithmetic-on-polymorphic-object</key>
+    <name>bugprone-pointer-arithmetic-on-polymorphic-object</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-pointer-arithmetic-on-polymorphic-object</p>
+</div>
+<h1 id="bugprone-pointer-arithmetic-on-polymorphic-object">bugprone-pointer-arithmetic-on-polymorphic-object</h1>
+<p>Finds pointer arithmetic performed on classes that contain a virtual function.</p>
+<p>Pointer arithmetic on polymorphic objects where the pointer's static type is different from its dynamic type is undefined behavior, as the two types could have different sizes, and thus the vtable pointer could point to an invalid address.</p>
+<p>Finding pointers where the static type contains a virtual member function is a good heuristic, as the pointer is likely to point to a different, derived object.</p>
+<p>Example:</p>
+<pre class="c++"><code>struct Base {
+  virtual void ~Base();
+};
+
+struct Derived : public Base {};
+
+void foo() {
+  Base *b = new Derived[10];
+
+  b += 1;
+  // warning: pointer arithmetic on class that declares a virtual function can
+  // result in undefined behavior if the dynamic type differs from the
+  // pointer type
+
+  delete[] static_cast&lt;Derived*&gt;(b);
+}</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreInheritedVirtualFunctions</p>
+<p>When <span class="title-ref">true</span>, objects that only inherit a virtual function are not checked. Classes that do not declare a new virtual function are excluded by default, as they make up the majority of false positives. Default: <span class="title-ref">false</span>.</p>
+<pre class="c++"><code>void bar() {
+  Base *b = new Base[10];
+  b += 1; // warning, as Base declares a virtual destructor
+
+  delete[] b;
+
+  Derived *d = new Derived[10]; // Derived overrides the destructor, and
+                                // declares no other virtual functions
+  d += 1; // warning only if IgnoreVirtualDeclarationsOnly is set to false
+
+  delete[] d;
+}</code></pre>
+</div>
+<h2 id="references">References</h2>
+<p>This check corresponds to the SEI Cert rule <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/CTR56-CPP.+Do+not+use+pointer+arithmetic+on+polymorphic+objects">CTR56-CPP. Do not use pointer arithmetic on polymorphic objects</a>.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>bugprone-posix-return</key>
     <name>bugprone-posix-return</name>
     <description>
@@ -2916,6 +3094,37 @@ int _g(); // disallowed in global namespace only</code></pre>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/reserved-identifier.html" target="_blank">clang.llvm.org</a></p>]]>
       </description>
     <severity>MINOR</severity>
+    </rule>
+  <rule>
+    <key>bugprone-return-const-ref-from-parameter</key>
+    <name>bugprone-return-const-ref-from-parameter</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-return-const-ref-from-parameter</p>
+</div>
+<h1 id="bugprone-return-const-ref-from-parameter">bugprone-return-const-ref-from-parameter</h1>
+<p>Detects return statements that return a constant reference parameter as constant reference. This may cause use-after-free errors if the caller uses xvalues as arguments.</p>
+<p>In C++, constant reference parameters can accept xvalues which will be destructed after the call. When the function returns such a parameter also as constant reference, then the returned reference can be used after the object it refers to has been destroyed.</p>
+<h2 id="example">Example</h2>
+<pre class="c++"><code>struct S {
+  int v;
+  S(int);
+  ~S();
+};
+
+const S &amp;fn(const S &amp;a) {
+  return a;
+}
+
+const S&amp; s = fn(S{1});
+s.v; // use after free</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/return-const-ref-from-parameter.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>bugprone-shared-ptr-array-mismatch</key>
@@ -3706,6 +3915,43 @@ if (strcmp(...) != 0)  // Won&#39;t warn</code></pre>
       </description>
     <severity>MINOR</severity>
     <type>BUG</type>
+    </rule>
+  <rule>
+    <key>bugprone-suspicious-stringview-data-usage</key>
+    <name>bugprone-suspicious-stringview-data-usage</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - bugprone-suspicious-stringview-data-usage</p>
+</div>
+<h1 id="bugprone-suspicious-stringview-data-usage">bugprone-suspicious-stringview-data-usage</h1>
+<p>Identifies suspicious usages of <code>std::string_view::data()</code> that could lead to reading out-of-bounds data due to inadequate or incorrect string null termination.</p>
+<p>It warns when the result of <code>data()</code> is passed to a constructor or function without also passing the corresponding result of <code>size()</code> or <code>length()</code> member function. Such usage can lead to unintended behavior, particularly when assuming the data pointed to by <code>data()</code> is null-terminated.</p>
+<p>The absence of a <code>c_str()</code> method in <code>std::string_view</code> often leads developers to use <code>data()</code> as a substitute, especially when interfacing with C APIs that expect null-terminated strings. However, since <code>data()</code> does not guarantee null termination, this can result in unintended behavior if the API relies on proper null termination for correct string interpretation.</p>
+<p>In today's programming landscape, this scenario can occur when implicitly converting an <code>std::string_view</code> to an <code>std::string</code>. Since the constructor in <code>std::string</code> designed for string-view-like objects is <code>explicit</code>, attempting to pass an <code>std::string_view</code> to a function expecting an <code>std::string</code> will result in a compilation error. As a workaround, developers may be tempted to utilize the <code>.data()</code> method to achieve compilation, introducing potential risks.</p>
+<p>For instance:</p>
+<pre class="c++"><code>void printString(const std::string&amp; str) {
+  std::cout &lt;&lt; &quot;String: &quot; &lt;&lt; str &lt;&lt; std::endl;
+}
+
+void something(std::string_view sv) {
+  printString(sv.data());
+}</code></pre>
+<p>In this example, directly passing <code>sv</code> to the <code>printString</code> function would lead to a compilation error due to the explicit nature of the <code>std::string</code> constructor. Consequently, developers might opt for <code>sv.data()</code> to resolve the compilation error, albeit introducing potential hazards as discussed.</p>
+<div class="option">
+<p>StringViewTypes</p>
+<p>Option allows users to specify custom string view-like types for analysis. It accepts a semicolon-separated list of type names or regular expressions matching these types. Default value is: <span class="title-ref">::std::basic_string_view;::llvm::StringRef</span>.</p>
+</div>
+<div class="option">
+<p>AllowedCallees</p>
+<p>Specifies methods, functions, or classes where the result of <code>.data()</code> is passed to. Allows to exclude such calls from the analysis. Accepts a semicolon-separated list of names or regular expressions matching these entities. Default value is: empty string.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-stringview-data-usage.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>bugprone-swapped-arguments</key>
@@ -4633,6 +4879,27 @@ struct Derived : Base {
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>cert-ctr56-cpp</key>
+    <name>cert-ctr56-cpp</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-ctr56-cpp</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/pointer-arithmetic-on-polymorphic-object.html">
+
+</div>
+<h1 id="cert-ctr56-cpp">cert-ctr56-cpp</h1>
+<p>The <span class="title-ref">cert-ctr56-cpp</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-pointer-arithmetic-on-polymorphic-object
+&lt;../bugprone/pointer-arithmetic-on-polymorphic-object&gt;</code> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/ctr56-cpp.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>cert-dcl03-c</key>
     <name>cert-dcl03-c</name>
     <description>
@@ -5200,6 +5467,26 @@ void func(const char *buff) {
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>cert-int09-c</key>
+    <name>cert-int09-c</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - cert-int09-c</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=../readability/enum-initial-value.html">
+
+</div>
+<h1 id="cert-int09-c">cert-int09-c</h1>
+<p>The <span class="title-ref">cert-int09-c</span> check is an alias, please see <code class="interpreted-text" role="doc">readability-enum-initial-value &lt;../readability/enum-initial-value&gt;</code> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/int09-c.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>cert-mem57-cpp</key>
     <name>cert-mem57-cpp</name>
     <description>
@@ -5760,6 +6047,27 @@ void func(const char *buff) {
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-analyzer-cplusplus.ArrayDelete</key>
+    <name>clang-analyzer-cplusplus.ArrayDelete</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - clang-analyzer-cplusplus.ArrayDelete</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-arraydelete">
+
+</div>
+<h1 id="clang-analyzer-cplusplus.arraydelete">clang-analyzer-cplusplus.ArrayDelete</h1>
+<p>Reports destructions of arrays of polymorphic objects that are destructed as their base class.</p>
+<p>The <span class="title-ref">clang-analyzer-cplusplus.ArrayDelete</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-arraydelete">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.ArrayDelete.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-analyzer-cplusplus.InnerPointer</key>
     <name>clang-analyzer-cplusplus.InnerPointer</name>
     <description>
@@ -6179,6 +6487,27 @@ void func(const char *buff) {
 <p>The <span class="title-ref">clang-analyzer-optin.portability.UnixAPI</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-portability-unixapi">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.portability.UnixAPI.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-optin.taint.TaintedAlloc</key>
+    <name>clang-analyzer-optin.taint.TaintedAlloc</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - clang-analyzer-optin.taint.TaintedAlloc</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-taintedalloc">
+
+</div>
+<h1 id="clang-analyzer-optin.taint.taintedalloc">clang-analyzer-optin.taint.TaintedAlloc</h1>
+<p>Check for memory allocations, where the size parameter might be a tainted (attacker controlled) value.</p>
+<p>The <span class="title-ref">clang-analyzer-optin.taint.TaintedAlloc</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-taintedalloc">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.taint.TaintedAlloc.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -6966,6 +7295,42 @@ void func(const char *buff) {
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-analyzer-security.PutenvStackArray</key>
+    <name>clang-analyzer-security.PutenvStackArray</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - clang-analyzer-security.PutenvStackArray</p>
+</div>
+<h1 id="clang-analyzer-security.putenvstackarray">clang-analyzer-security.PutenvStackArray</h1>
+<p>Finds calls to the function 'putenv' which pass a pointer to an automatic (stack-allocated) array as the argument.</p>
+<p>The clang-analyzer-security.PutenvStackArray check is an alias of Clang Static Analyzer security.PutenvStackArray.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.PutenvStackArray.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-security.SetgidSetuidOrder</key>
+    <name>clang-analyzer-security.SetgidSetuidOrder</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - clang-analyzer-security.SetgidSetuidOrder</p>
+</div>
+<h1 id="clang-analyzer-security.setgidsetuidorder">clang-analyzer-security.SetgidSetuidOrder</h1>
+<p>Warn on possible reversed order of 'setgid(getgid()))' and 'setuid(getuid())' (CERT: POS36-C).</p>
+<p>The clang-analyzer-security.SetgidSetuidOrder check is an alias of Clang Static Analyzer security.SetgidSetuidOrder.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.SetgidSetuidOrder.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-analyzer-unix.API</key>
     <name>clang-analyzer-unix.API</name>
     <description>
@@ -6980,6 +7345,27 @@ void func(const char *buff) {
 <p>The <span class="title-ref">clang-analyzer-unix.API</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-api">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.API.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-unix.BlockInCriticalSection</key>
+    <name>clang-analyzer-unix.BlockInCriticalSection</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - clang-analyzer-unix.BlockInCriticalSection</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-blockincriticalsection">
+
+</div>
+<h1 id="clang-analyzer-unix.blockincriticalsection">clang-analyzer-unix.BlockInCriticalSection</h1>
+<p>Check for calls to blocking functions inside a critical section.</p>
+<p>The <span class="title-ref">clang-analyzer-unix.BlockInCriticalSection</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-blockincriticalsection">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.BlockInCriticalSection.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -7106,6 +7492,27 @@ void func(const char *buff) {
 <p>The <span class="title-ref">clang-analyzer-unix.StdCLibraryFunctions</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-stdclibraryfunctions">Clang Static Analyzer Available Checkers</a> for more information.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.StdCLibraryFunctions.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-analyzer-unix.Stream</key>
+    <name>clang-analyzer-unix.Stream</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - clang-analyzer-unix.Stream</p>
+</div>
+<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-stream">
+
+</div>
+<h1 id="clang-analyzer-unix.stream">clang-analyzer-unix.Stream</h1>
+<p>Check stream handling functions.</p>
+<p>The <span class="title-ref">clang-analyzer-unix.Stream</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-stream">Clang Static Analyzer Available Checkers</a> for more information.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.Stream.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -9888,6 +10295,33 @@ switch(i) {}</code></pre>
       </description>
     </rule>
   <rule>
+    <key>linuxkernel-must-check-errs</key>
+    <name>linuxkernel-must-check-errs</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - linuxkernel-must-check-errs</p>
+</div>
+<h1 id="linuxkernel-must-check-errs">linuxkernel-must-check-errs</h1>
+<p>Checks Linux kernel code to see if it uses the results from the functions in <code>linux/err.h</code>. Also checks to see if code uses the results from functions that directly return a value from one of these error functions.</p>
+<p>This is important in the Linux kernel because <code>ERR_PTR</code>, <code>PTR_ERR</code>, <code>IS_ERR</code>, <code>IS_ERR_OR_NULL</code>, <code>ERR_CAST</code>, and <code>PTR_ERR_OR_ZERO</code> return values must be checked, since positive pointers and negative error codes are being used in the same context. These functions are marked with <code>__attribute__((warn_unused_result))</code>, but some kernel versions do not have this warning enabled for clang.</p>
+<p>Examples:</p>
+<pre class="c"><code>/* Trivial unused call to an ERR function */
+PTR_ERR_OR_ZERO(some_function_call());
+
+/* A function that returns ERR_PTR. */
+void *fn() { ERR_PTR(-EINVAL); }
+
+/* An invalid use of fn. */
+fn();</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/linuxkernel/must-check-errs.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>linuxkernel-must-use-errs</key>
     <name>linuxkernel-must-use-errs</name>
     <description>
@@ -11005,6 +11439,49 @@ namespace {
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>misc-use-internal-linkage</key>
+    <name>misc-use-internal-linkage</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - misc-use-internal-linkage</p>
+</div>
+<h1 id="misc-use-internal-linkage">misc-use-internal-linkage</h1>
+<p>Detects variables and functions that can be marked as static or moved into an anonymous namespace to enforce internal linkage.</p>
+<p>Static functions and variables are scoped to a single file. Marking functions and variables as static helps to better remove dead code. In addition, it gives the compiler more information and allows for more aggressive optimizations.</p>
+<p>Example:</p>
+<pre class="c++"><code>int v1; // can be marked as static
+
+void fn1(); // can be marked as static
+
+namespace {
+  // already in anonymous namespace
+  int v2;
+  void fn2();
+}
+// already declared as extern
+extern int v2;</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>FixMode</p>
+<p>Selects what kind of a fix the check should provide. The default is <span class="title-ref">UseStatic</span>.</p>
+<dl>
+<dt><code>None</code></dt>
+<dd><p>Don't fix automatically.</p>
+</dd>
+<dt><code>UseStatic</code></dt>
+<dd><p>Add <code>static</code> for internal linkage variable and function.</p>
+</dd>
+</dl>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/use-internal-linkage.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>modernize-avoid-bind</key>
     <name>modernize-avoid-bind</name>
     <description>
@@ -11605,6 +12082,44 @@ my_ptr = std::make_unique&lt;MyPair&gt;(1, 2);</code></pre>
 </div>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/make-unique.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>modernize-min-max-use-initializer-list</key>
+    <name>modernize-min-max-use-initializer-list</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - modernize-min-max-use-initializer-list</p>
+</div>
+<h1 id="modernize-min-max-use-initializer-list">modernize-min-max-use-initializer-list</h1>
+<p>Replaces nested <code>std::min</code> and <code>std::max</code> calls with an initializer list where applicable.</p>
+<p>For instance, consider the following code:</p>
+<pre class="cpp"><code>int a = std::max(std::max(i, j), k);</code></pre>
+<p>The check will transform the above code to:</p>
+<pre class="cpp"><code>int a = std::max({i, j, k});</code></pre>
+<h1 id="performance-considerations">Performance Considerations</h1>
+<p>While this check simplifies the code and makes it more readable, it may cause performance degradation for non-trivial types due to the need to copy objects into the initializer list.</p>
+<p>To avoid this, it is recommended to use <span class="title-ref">std::ref</span> or <span class="title-ref">std::cref</span> for non-trivial types:</p>
+<pre class="cpp"><code>std::string b = std::max({std::ref(i), std::ref(j), std::ref(k)});</code></pre>
+<h1 id="options">Options</h1>
+<div class="option">
+<p>IncludeStyle</p>
+<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
+</div>
+<div class="option">
+<p>IgnoreNonTrivialTypes</p>
+<p>A boolean specifying whether to ignore non-trivial types. Default is <span class="title-ref">true</span>.</p>
+</div>
+<div class="option">
+<p>IgnoreTrivialTypesOfSizeAbove</p>
+<p>An integer specifying the size (in bytes) above which trivial types are ignored. Default is <span class="title-ref">32</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/min-max-use-initializer-list.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -12349,6 +12864,54 @@ struct A {
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>modernize-use-designated-initializers</key>
+    <name>modernize-use-designated-initializers</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - modernize-use-designated-initializers</p>
+</div>
+<h1 id="modernize-use-designated-initializers">modernize-use-designated-initializers</h1>
+<p>Finds initializer lists for aggregate types which could be written as designated initializers instead.</p>
+<p>With plain initializer lists, it is very easy to introduce bugs when adding new fields in the middle of a struct or class type. The same confusion might arise when changing the order of fields.</p>
+<p>C++20 supports the designated initializer syntax for aggregate types. By applying it, we can always be sure that aggregates are constructed correctly, because every variable being initialized is referenced by its name.</p>
+<p>Example:</p>
+<pre class=""><code>struct S { int i, j; };</code></pre>
+<p>is an aggregate type that should be initialized as</p>
+<pre class=""><code>S s{.i = 1, .j = 2};</code></pre>
+<p>instead of</p>
+<pre class=""><code>S s{1, 2};</code></pre>
+<p>which could easily become an issue when <code>i</code> and <code>j</code> are swapped in the declaration of <code>S</code>.</p>
+<p>Even when compiling in a language version older than C++20, depending on your compiler, designated initializers are potentially supported. Therefore, the check is by default restricted to C99/C++20 and above. Check out the options <code>-Wc99-designator</code> to get support for mixed designators in initializer list in C and <code>-Wc++20-designator</code> for support of designated initializers in older C++ language modes.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IgnoreMacros</p>
+<p>The value <span class="title-ref">false</span> specifies that components of initializer lists expanded from macros are not checked. The default value is <span class="title-ref">true</span>.</p>
+</div>
+<div class="option">
+<p>IgnoreSingleElementAggregates</p>
+<p>The value <span class="title-ref">false</span> specifies that even initializers for aggregate types with only a single element should be checked. The default value is <span class="title-ref">true</span>.</p>
+</div>
+<div class="option">
+<p>RestrictToPODTypes</p>
+<p>The value <span class="title-ref">true</span> specifies that only Plain Old Data (POD) types shall be checked. This makes the check applicable to even older C++ standards. The default value is <span class="title-ref">false</span>.</p>
+</div>
+<div class="option">
+<p>StrictCStandardCompliance</p>
+<p>When set to <span class="title-ref">false</span>, the check will not restrict itself to C99 and above. The default value is <span class="title-ref">true</span>.</p>
+</div>
+<div class="option">
+<p>StrictCppStandardCompliance</p>
+<p>When set to <span class="title-ref">false</span>, the check will not restrict itself to C++20 and above. The default value is <span class="title-ref">true</span>.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-designated-initializers.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>modernize-use-default</key>
     <name>modernize-use-default</name>
     <description>
@@ -12774,6 +13337,52 @@ void assignment() {
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>modernize-use-ranges</key>
+    <name>modernize-use-ranges</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - modernize-use-ranges</p>
+</div>
+<h1 id="modernize-use-ranges">modernize-use-ranges</h1>
+<p>Detects calls to standard library iterator algorithms that could be replaced with a ranges version instead.</p>
+<h2 id="example">Example</h2>
+<pre class="c++"><code>auto Iter1 = std::find(Items.begin(), Items.end(), 0);
+auto AreSame = std::equal(Items1.cbegin(), Items1.cend(),
+                          std::begin(Items2), std::end(Items2));</code></pre>
+<p>Transforms to:</p>
+<pre class="c++"><code>auto Iter1 = std::ranges::find(Items, 0);
+auto AreSame = std::ranges::equal(Items1, Items2);</code></pre>
+<h2 id="supported-algorithms">Supported algorithms</h2>
+<p>Calls to the following std library algorithms are checked:</p>
+<p><code>std::adjacent_find</code>, <code>std::all_of</code>, <code>std::any_of</code>, <code>std::binary_search</code>, <code>std::copy_backward</code>, <code>std::copy_if</code>, <code>std::copy</code>, <code>std::destroy</code>, <code>std::equal_range</code>, <code>std::equal</code>, <code>std::fill</code>, <code>std::find_end</code>, <code>std::find_if_not</code>, <code>std::find_if</code>, <code>std::find</code>, <code>std::for_each</code>, <code>std::generate</code>, <code>std::includes</code>, <code>std::inplace_merge</code>, <code>std::iota</code>, <code>std::is_heap_until</code>, <code>std::is_heap</code>, <code>std::is_partitioned</code>, <code>std::is_permutation</code>, <code>std::is_sorted_until</code>, <code>std::is_sorted</code>, <code>std::lexicographical_compare</code>, <code>std::lower_bound</code>, <code>std::make_heap</code>, <code>std::max_element</code>, <code>std::merge</code>, <code>std::min_element</code>, <code>std::minmax_element</code>, <code>std::mismatch</code>, <code>std::move_backward</code>, <code>std::move</code>, <code>std::next_permutation</code>, <code>std::none_of</code>, <code>std::partial_sort_copy</code>, <code>std::partition_copy</code>, <code>std::partition_point</code>, <code>std::partition</code>, <code>std::pop_heap</code>, <code>std::prev_permutation</code>, <code>std::push_heap</code>, <code>std::remove_copy_if</code>, <code>std::remove_copy</code>, <code>std::remove</code>, <code>std::remove_if</code>, <code>std::replace_if</code>, <code>std::replace</code>, <code>std::reverse_copy</code>, <code>std::reverse</code>, <code>std::rotate</code>, <code>std::rotate_copy</code>, <code>std::sample</code>, <code>std::search</code>, <code>std::set_difference</code>, <code>std::set_intersection</code>, <code>std::set_symmetric_difference</code>, <code>std::set_union</code>, <code>std::shift_left</code>, <code>std::shift_right</code>, <code>std::sort_heap</code>, <code>std::sort</code>, <code>std::stable_partition</code>, <code>std::stable_sort</code>, <code>std::transform</code>, <code>std::uninitialized_copy</code>, <code>std::uninitialized_default_construct</code>, <code>std::uninitialized_fill</code>, <code>std::uninitialized_move</code>, <code>std::uninitialized_value_construct</code>, <code>std::unique_copy</code>, <code>std::unique</code>, <code>std::upper_bound</code>.</p>
+<h2 id="reverse-iteration">Reverse Iteration</h2>
+<p>If calls are made using reverse iterators on containers, The code will be fixed using the <code>std::views::reverse</code> adaptor.</p>
+<pre class="c++"><code>auto AreSame = std::equal(Items1.rbegin(), Items1.rend(),
+                          std::crbegin(Items2), std::crend(Items2));</code></pre>
+<p>Transforms to:</p>
+<pre class="c++"><code>auto AreSame = std::ranges::equal(std::ranges::reverse_view(Items1),
+                                  std::ranges::reverse_view(Items2));</code></pre>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>IncludeStyle</p>
+<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
+</div>
+<div class="option">
+<p>UseReversePipe</p>
+<p>When <span class="title-ref">true</span> (default <span class="title-ref">false</span>), fixes which involve reverse ranges will use the pipe adaptor syntax instead of the function syntax.</p>
+<pre class="c++"><code>std::find(Items.rbegin(), Items.rend(), 0);</code></pre>
+<p>Transforms to:</p>
+<pre class="c++"><code>std::ranges::find(Items | std::views::reverse, 0);</code></pre>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-ranges.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>modernize-use-starts-ends-with</key>
     <name>modernize-use-starts-ends-with</name>
     <description>
@@ -12791,6 +13400,52 @@ if (s.starts_with(&quot;prefix&quot;)) { /* do something */ }
 if (s.starts_with(&quot;prefix&quot;)) { /* do something */ }</code></pre>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-starts-ends-with.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>modernize-use-std-format</key>
+    <name>modernize-use-std-format</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - modernize-use-std-format</p>
+</div>
+<h1 id="modernize-use-std-format">modernize-use-std-format</h1>
+<p>Converts calls to <code>absl::StrFormat</code>, or other functions via configuration options, to C++20's <code>std::format</code>, or another function via a configuration option, modifying the format string appropriately and removing now-unnecessary calls to <code>std::string::c_str()</code> and <code>std::string::data()</code>.</p>
+<p>For example, it turns lines like</p>
+<pre class="c++"><code>return absl::StrFormat(&quot;The %s is %3d&quot;, description.c_str(), value);</code></pre>
+<p>into:</p>
+<pre class="c++"><code>return std::format(&quot;The {} is {:3}&quot;, description, value);</code></pre>
+<p>The check uses the same format-string-conversion algorithm as <a href="../modernize/use-std-print.html">modernize-use-std-print</a> and its shortcomings are described in the documentation for that check.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>StrictMode</p>
+<p>When <span class="title-ref">true</span>, the check will add casts when converting from variadic functions and printing signed or unsigned integer types (including fixed-width integer types from <code>&lt;cstdint&gt;</code>, <code>ptrdiff_t</code>, <code>size_t</code> and <code>ssize_t</code>) as the opposite signedness to ensure that the output would matches that of a simple wrapper for <code>std::sprintf</code> that accepted a C-style variable argument list. For example, with <span class="title-ref">StrictMode</span> enabled,</p>
+<pre class="c++"><code>extern std::string strprintf(const char *format, ...);
+int i = -42;
+unsigned int u = 0xffffffff;
+return strprintf(&quot;%d %u\n&quot;, i, u);</code></pre>
+<p>would be converted to</p>
+<pre class="c++"><code>return std::format(&quot;{} {}\n&quot;, static_cast&lt;unsigned int&gt;(i), static_cast&lt;int&gt;(u));</code></pre>
+<p>to ensure that the output will continue to be the unsigned representation of -42 and the signed representation of 0xffffffff (often 4294967254 and -1 respectively). When <span class="title-ref">false</span> (which is the default), these casts will not be added which may cause a change in the output. Note that this option makes no difference for the default value of <span class="title-ref">StrFormatLikeFunctions</span> since <code>absl::StrFormat</code> takes a function parameter pack and is not a variadic function.</p>
+</div>
+<div class="option">
+<p>StrFormatLikeFunctions</p>
+<p>A semicolon-separated list of (fully qualified) function names to replace, with the requirement that the first parameter contains the printf-style format string and the arguments to be formatted follow immediately afterwards. The default value for this option is <span class="title-ref">absl::StrFormat</span>.</p>
+</div>
+<div class="option">
+<p>ReplacementFormatFunction</p>
+<p>The function that will be used to replace the function set by the <span class="title-ref">StrFormatLikeFunctions</span> option rather than the default <span class="title-ref">std::format</span>. It is expected that the function provides an interface that is compatible with <code>std::format</code>. A suitable candidate would be <span class="title-ref">fmt::format</span>.</p>
+</div>
+<div class="option">
+<p>FormatHeader</p>
+<p>The header that must be included for the declaration of <span class="title-ref">ReplacementFormatFunction</span> so that a <code>#include</code> directive can be added if required. If <span class="title-ref">ReplacementFormatFunction</span> is <span class="title-ref">std::format</span> then this option will default to <code>&lt;format&gt;</code>, otherwise this option will default to nothing and no <code>#include</code> directive will be added.</p>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-std-format.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -14545,6 +15200,82 @@ if (p)
 <p>This check helps to enforce this <a href="https://llvm.org/docs/CodingStandards.html#don-t-use-else-after-a-return">LLVM Coding Standards recommendation</a>.</p>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/else-after-return.html" target="_blank">clang.llvm.org</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>readability-enum-initial-value</key>
+    <name>readability-enum-initial-value</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-enum-initial-value</p>
+</div>
+<h1 id="readability-enum-initial-value">readability-enum-initial-value</h1>
+<p>Enforces consistent style for enumerators' initialization, covering three styles: none, first only, or all initialized explicitly.</p>
+<p>An inconsistent style and strictness to defining the initializing value of enumerators may cause issues if the enumeration is extended with new enumerators that obtain their integer representation implicitly.</p>
+<p>The following three cases are accepted:</p>
+<ol>
+<li><strong>No</strong> enumerators are explicit initialized.</li>
+<li>Exactly <strong>the first</strong> enumerator is explicit initialized.</li>
+<li><strong>All</strong> enumerators are explicit initialized.</li>
+</ol>
+<pre class="c++"><code>enum A {    // (1) Valid, none of enumerators are initialized.
+  a0,
+  a1,
+  a2,
+};
+
+enum B {    // (2) Valid, the first enumerator is initialized.
+  b0 = 0,
+  b1,
+  b2,
+};
+
+enum C {    // (3) Valid, all of enumerators are initialized.
+  c0 = 0,
+  c1 = 1,
+  c2 = 2,
+};
+
+enum D {    // Invalid, d1 is not explicitly initialized!
+  d0 = 0,
+  d1,
+  d2 = 2,
+};
+
+enum E {    // Invalid, e1, e3, and e5 are not explicitly initialized.
+  e0 = 0,
+  e1,
+  e2 = 2,
+  e3,       // Dangerous, as the numeric values of e3 and e5 are both 3, and this is not explicitly visible in the code!
+  e4 = 2,
+  e5,
+};</code></pre>
+<p>This check corresponds to the CERT C Coding Standard recommendation <a href="https://wiki.sei.cmu.edu/confluence/display/c/INT09-C.+Ensure+enumeration+constants+map+to+unique+values">INT09-C. Ensure enumeration constants map to unique values</a>.</p>
+<p><span class="title-ref">cert-int09-c</span> redirects here as an alias of this check.</p>
+<h2 id="options">Options</h2>
+<div class="option">
+<p>AllowExplicitZeroFirstInitialValue</p>
+<p>If set to <span class="title-ref">false</span>, the first enumerator must not be explicitly initialized to a literal <code>0</code>. Default is <span class="title-ref">true</span>.</p>
+<pre class="c++"><code>enum F {
+  f0 = 0, // Not allowed if AllowExplicitZeroFirstInitialValue is false.
+  f1,
+  f2,
+};</code></pre>
+</div>
+<div class="option">
+<p>AllowExplicitSequentialInitialValues</p>
+<p>If set to <span class="title-ref">false</span>, explicit initialization to sequential values are not allowed. Default is <span class="title-ref">true</span>.</p>
+<pre class="c++"><code>enum G {
+  g0 = 1, // Not allowed if AllowExplicitSequentialInitialValues is false.
+  g1 = 2,
+  g2 = 3,</code></pre>
+</div>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/enum-initial-value.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -17540,6 +18271,28 @@ public:
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>readability-math-missing-parentheses</key>
+    <name>readability-math-missing-parentheses</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-math-missing-parentheses</p>
+</div>
+<h1 id="readability-math-missing-parentheses">readability-math-missing-parentheses</h1>
+<p>Check for missing parentheses in mathematical expressions that involve operators of different priorities.</p>
+<p>Parentheses in mathematical expressions clarify the order of operations, especially with different-priority operators. Lengthy or multiline expressions can obscure this order, leading to coding errors. IDEs can aid clarity by highlighting parentheses. Explicitly using parentheses also clarifies what the developer had in mind when writing the expression. Ensuring their presence reduces ambiguity and errors, promoting clearer and more maintainable code.</p>
+<p>Before:</p>
+<pre class="c++"><code>int x = 1 + 2 * 3 - 4 / 5;</code></pre>
+<p>After:</p>
+<pre class="c++"><code>int x = 1 + (2 * 3) - (4 / 5);</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/math-missing-parentheses.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>readability-misleading-indentation</key>
     <name>readability-misleading-indentation</name>
     <description>
@@ -18776,6 +19529,34 @@ auto x = 1U; // OK, suffix is uppercase.
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>readability-use-std-min-max</key>
+    <name>readability-use-std-min-max</name>
+    <description>
+      <![CDATA[
+      <div class="title">
+<p>clang-tidy - readability-use-std-min-max</p>
+</div>
+<h1 id="readability-use-std-min-max">readability-use-std-min-max</h1>
+<p>Replaces certain conditional statements with equivalent calls to <code>std::min</code> or <code>std::max</code>. Note: This may impact performance in critical code due to potential additional stores compared to the original if statement.</p>
+<p>Before:</p>
+<pre class="c++"><code>void foo() {
+  int a = 2, b = 3;
+  if (a &lt; b)
+    a = b;
+}</code></pre>
+<p>After:</p>
+<pre class="c++"><code>void foo() {
+  int a = 2, b = 3;
+  a = std::max(a, b);
+}</code></pre>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/use-std-min-max.html" target="_blank">clang.llvm.org</a></p>
+      ]]>
+      <![CDATA[]]>
+      </description>
+    <severity>INFO</severity>
+  </rule>
+  <rule>
     <key>zircon-temporary-objects</key>
     <name>zircon-temporary-objects</name>
     <description>
@@ -18815,787 +19596,6 @@ Derived();             // and so temporary construction is okay</code></pre>
       </description>
     <type>BUG</type>
     </rule>
-  <rule>
-    <key>boost-use-ranges</key>
-    <name>boost-use-ranges</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - boost-use-ranges</p>
-</div>
-<h1 id="boost-use-ranges">boost-use-ranges</h1>
-<p>Detects calls to standard library iterator algorithms that could be replaced with a Boost ranges version instead.</p>
-<h2 id="example">Example</h2>
-<pre class="c++"><code>auto Iter1 = std::find(Items.begin(), Items.end(), 0);
-auto AreSame = std::equal(Items1.cbegin(), Items1.cend(), std::begin(Items2),
-                          std::end(Items2));</code></pre>
-<p>Transforms to:</p>
-<pre class="c++"><code>auto Iter1 = boost::range::find(Items, 0);
-auto AreSame = boost::range::equal(Items1, Items2);</code></pre>
-<h2 id="supported-algorithms">Supported algorithms</h2>
-<p>Calls to the following std library algorithms are checked:</p>
-<p><code>std::accumulate</code>, <code>std::adjacent_difference</code>, <code>std::adjacent_find</code>, <code>std::all_of</code>, <code>std::any_of</code>, <code>std::binary_search</code>, <code>std::copy_backward</code>, <code>std::copy_if</code>, <code>std::copy</code>, <code>std::count_if</code>, <code>std::count</code>, <code>std::equal_range</code>, <code>std::equal</code>, <code>std::fill</code>, <code>std::find_end</code>, <code>std::find_first_of</code>, <code>std::find_if_not</code>, <code>std::find_if</code>, <code>std::find</code>, <code>std::for_each</code>, <code>std::generate</code>, <code>std::includes</code>, <code>std::iota</code>, <code>std::is_partitioned</code>, <code>std::is_permutation</code>, <code>std::is_sorted_until</code>, <code>std::is_sorted</code>, <code>std::lexicographical_compare</code>, <code>std::lower_bound</code>, <code>std::make_heap</code>, <code>std::max_element</code>, <code>std::merge</code>, <code>std::min_element</code>, <code>std::mismatch</code>, <code>std::next_permutation</code>, <code>std::none_of</code>, <code>std::parital_sum</code>, <code>std::partial_sort_copy</code>, <code>std::partition_copy</code>, <code>std::partition_point</code>, <code>std::partition</code>, <code>std::pop_heap</code>, <code>std::prev_permutation</code>, <code>std::push_heap</code>, <code>std::random_shuffle</code>, <code>std::reduce</code>, <code>std::remove_copy_if</code>, <code>std::remove_copy</code>, <code>std::remove_if</code>, <code>std::remove</code>, <code>std::replace_copy_if</code>, <code>std::replace_copy</code>, <code>std::replace_if</code>, <code>std::replace</code>, <code>std::reverse_copy</code>, <code>std::reverse</code>, <code>std::search</code>, <code>std::set_difference</code>, <code>std::set_intersection</code>, <code>std::set_symmetric_difference</code>, <code>std::set_union</code>, <code>std::sort_heap</code>, <code>std::sort</code>, <code>std::stable_partition</code>, <code>std::stable_sort</code>, <code>std::transform</code>, <code>std::unique_copy</code>, <code>std::unique</code>, <code>std::upper_bound</code>.</p>
-<p>The check will also look for the following functions from the <code>boost::algorithm</code> namespace:</p>
-<p><code>all_of_equal</code>, <code>any_of_equal</code>, <code>any_of</code>, <code>apply_permutation</code>, <code>apply_reverse_permutation</code>, <code>clamp_range</code>, <code>copy_if_until</code>, <code>copy_if_while</code>, <code>copy_if</code>, <code>copy_until</code>, <code>copy_while</code>, <code>find_backward</code>, <code>find_if_backward</code>, <code>find_if_not_backward</code>, <code>find_if_not</code>, <code>find_not_backward</code>, <code>hex_lower</code>, <code>hex</code>, <code>iota</code>, <code>all_of</code>, <code>is_decreasing</code>, <code>is_increasing</code>, <code>is_palindrome</code>, <code>is_partitioned_until</code>, <code>is_partitioned</code>, <code>is_permutation</code>, <code>is_sorted_until</code>, <code>is_sorted</code>, <code>is_strictly_decreasing</code>, <code>is_strictly_increasing</code>, <code>none_of_equal</code>, <code>none_of</code>, <code>one_of_equal</code>, <code>one_of</code>, <code>partition_copy</code>, <code>partition_point</code>, <code>reduce</code>, <code>unhex</code>.</p>
-<h2 id="reverse-iteration">Reverse Iteration</h2>
-<p>If calls are made using reverse iterators on containers, The code will be fixed using the <code>boost::adaptors::reverse</code> adaptor.</p>
-<pre class="c++"><code>auto AreSame = std::equal(Items1.rbegin(), Items1.rend(),
-                          std::crbegin(Items2), std::crend(Items2));</code></pre>
-<p>Transforms to:</p>
-<pre class="c++"><code>auto AreSame = boost::range::equal(boost::adaptors::reverse(Items1),
-                                   boost::adaptors::reverse(Items2));</code></pre>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>IncludeStyle</p>
-<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
-</div>
-<div class="option">
-<p>IncludeBoostSystem</p>
-<p>If <span class="title-ref">true</span> (default value) the boost headers are included as system headers with angle brackets (<span class="title-ref">#include &lt;boost.hpp&gt;</span>), otherwise quotes are used (<span class="title-ref">#include "boost.hpp"</span>).</p>
-</div>
-<div class="option">
-<p>UseReversePipe</p>
-<p>When <span class="title-ref">true</span> (default <span class="title-ref">false</span>), fixes which involve reverse ranges will use the pipe adaptor syntax instead of the function syntax.</p>
-<pre class="c++"><code>std::find(Items.rbegin(), Items.rend(), 0);</code></pre>
-<p>Transforms to:</p>
-<pre class="c++"><code>boost::range::find(Items | boost::adaptors::reversed, 0);</code></pre>
-</div>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/boost/use-ranges.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>bugprone-crtp-constructor-accessibility</key>
-    <name>bugprone-crtp-constructor-accessibility</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - bugprone-crtp-constructor-accessibility</p>
-</div>
-<h1 id="bugprone-crtp-constructor-accessibility">bugprone-crtp-constructor-accessibility</h1>
-<p>Detects error-prone Curiously Recurring Template Pattern usage, when the CRTP can be constructed outside itself and the derived class.</p>
-<p>The CRTP is an idiom, in which a class derives from a template class, where itself is the template argument. It should be ensured that if a class is intended to be a base class in this idiom, it can only be instantiated if the derived class is it's template argument.</p>
-<p>Example:</p>
-<pre class="c++"><code>template &lt;typename T&gt; class CRTP {
-private:
-  CRTP() = default;
-  friend T;
-};
-
-class Derived : CRTP&lt;Derived&gt; {};</code></pre>
-<p>Below can be seen some common mistakes that will allow the breaking of the idiom.</p>
-<p>If the constructor of a class intended to be used in a CRTP is public, then it allows users to construct that class on its own.</p>
-<p>Example:</p>
-<pre class="c++"><code>template &lt;typename T&gt; class CRTP {
-public:
-  CRTP() = default;
-};
-
-class Good : CRTP&lt;Good&gt; {};
-Good GoodInstance;
-
-CRTP&lt;int&gt; BadInstance;</code></pre>
-<p>If the constructor is protected, the possibility of an accidental instantiation is prevented, however it can fade an error, when a different class is used as the template parameter instead of the derived one.</p>
-<p>Example:</p>
-<pre class="c++"><code>template &lt;typename T&gt; class CRTP {
-protected:
-  CRTP() = default;
-};
-
-class Good : CRTP&lt;Good&gt; {};
-Good GoodInstance;
-
-class Bad : CRTP&lt;Good&gt; {};
-Bad BadInstance;</code></pre>
-<p>To ensure that no accidental instantiation happens, the best practice is to make the constructor private and declare the derived class as friend. Note that as a tradeoff, this also gives the derived class access to every other private members of the CRTP.</p>
-<p>Example:</p>
-<pre class="c++"><code>template &lt;typename T&gt; class CRTP {
-  CRTP() = default;
-  friend T;
-};
-
-class Good : CRTP&lt;Good&gt; {};
-Good GoodInstance;
-
-class Bad : CRTP&lt;Good&gt; {};
-Bad CompileTimeError;
-
-CRTP&lt;int&gt; AlsoCompileTimeError;</code></pre>
-<p>Limitations:</p>
-<ul>
-<li>The check is not supported below C++11</li>
-<li>The check does not handle when the derived class is passed as a variadic template argument</li>
-<li>Accessible functions that can construct the CRTP, like factory functions are not checked</li>
-</ul>
-<p>The check also suggests a fix-its in some cases.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/crtp-constructor-accessibility.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>bugprone-pointer-arithmetic-on-polymorphic-object</key>
-    <name>bugprone-pointer-arithmetic-on-polymorphic-object</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - bugprone-pointer-arithmetic-on-polymorphic-object</p>
-</div>
-<h1 id="bugprone-pointer-arithmetic-on-polymorphic-object">bugprone-pointer-arithmetic-on-polymorphic-object</h1>
-<p>Finds pointer arithmetic performed on classes that contain a virtual function.</p>
-<p>Pointer arithmetic on polymorphic objects where the pointer's static type is different from its dynamic type is undefined behavior, as the two types could have different sizes, and thus the vtable pointer could point to an invalid address.</p>
-<p>Finding pointers where the static type contains a virtual member function is a good heuristic, as the pointer is likely to point to a different, derived object.</p>
-<p>Example:</p>
-<pre class="c++"><code>struct Base {
-  virtual void ~Base();
-};
-
-struct Derived : public Base {};
-
-void foo() {
-  Base *b = new Derived[10];
-
-  b += 1;
-  // warning: pointer arithmetic on class that declares a virtual function can
-  // result in undefined behavior if the dynamic type differs from the
-  // pointer type
-
-  delete[] static_cast&lt;Derived*&gt;(b);
-}</code></pre>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>IgnoreInheritedVirtualFunctions</p>
-<p>When <span class="title-ref">true</span>, objects that only inherit a virtual function are not checked. Classes that do not declare a new virtual function are excluded by default, as they make up the majority of false positives. Default: <span class="title-ref">false</span>.</p>
-<pre class="c++"><code>void bar() {
-  Base *b = new Base[10];
-  b += 1; // warning, as Base declares a virtual destructor
-
-  delete[] b;
-
-  Derived *d = new Derived[10]; // Derived overrides the destructor, and
-                                // declares no other virtual functions
-  d += 1; // warning only if IgnoreVirtualDeclarationsOnly is set to false
-
-  delete[] d;
-}</code></pre>
-</div>
-<h2 id="references">References</h2>
-<p>This check corresponds to the SEI Cert rule <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/CTR56-CPP.+Do+not+use+pointer+arithmetic+on+polymorphic+objects">CTR56-CPP. Do not use pointer arithmetic on polymorphic objects</a>.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>bugprone-return-const-ref-from-parameter</key>
-    <name>bugprone-return-const-ref-from-parameter</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - bugprone-return-const-ref-from-parameter</p>
-</div>
-<h1 id="bugprone-return-const-ref-from-parameter">bugprone-return-const-ref-from-parameter</h1>
-<p>Detects return statements that return a constant reference parameter as constant reference. This may cause use-after-free errors if the caller uses xvalues as arguments.</p>
-<p>In C++, constant reference parameters can accept xvalues which will be destructed after the call. When the function returns such a parameter also as constant reference, then the returned reference can be used after the object it refers to has been destroyed.</p>
-<h2 id="example">Example</h2>
-<pre class="c++"><code>struct S {
-  int v;
-  S(int);
-  ~S();
-};
-
-const S &amp;fn(const S &amp;a) {
-  return a;
-}
-
-const S&amp; s = fn(S{1});
-s.v; // use after free</code></pre>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/return-const-ref-from-parameter.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>bugprone-suspicious-stringview-data-usage</key>
-    <name>bugprone-suspicious-stringview-data-usage</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - bugprone-suspicious-stringview-data-usage</p>
-</div>
-<h1 id="bugprone-suspicious-stringview-data-usage">bugprone-suspicious-stringview-data-usage</h1>
-<p>Identifies suspicious usages of <code>std::string_view::data()</code> that could lead to reading out-of-bounds data due to inadequate or incorrect string null termination.</p>
-<p>It warns when the result of <code>data()</code> is passed to a constructor or function without also passing the corresponding result of <code>size()</code> or <code>length()</code> member function. Such usage can lead to unintended behavior, particularly when assuming the data pointed to by <code>data()</code> is null-terminated.</p>
-<p>The absence of a <code>c_str()</code> method in <code>std::string_view</code> often leads developers to use <code>data()</code> as a substitute, especially when interfacing with C APIs that expect null-terminated strings. However, since <code>data()</code> does not guarantee null termination, this can result in unintended behavior if the API relies on proper null termination for correct string interpretation.</p>
-<p>In today's programming landscape, this scenario can occur when implicitly converting an <code>std::string_view</code> to an <code>std::string</code>. Since the constructor in <code>std::string</code> designed for string-view-like objects is <code>explicit</code>, attempting to pass an <code>std::string_view</code> to a function expecting an <code>std::string</code> will result in a compilation error. As a workaround, developers may be tempted to utilize the <code>.data()</code> method to achieve compilation, introducing potential risks.</p>
-<p>For instance:</p>
-<pre class="c++"><code>void printString(const std::string&amp; str) {
-  std::cout &lt;&lt; &quot;String: &quot; &lt;&lt; str &lt;&lt; std::endl;
-}
-
-void something(std::string_view sv) {
-  printString(sv.data());
-}</code></pre>
-<p>In this example, directly passing <code>sv</code> to the <code>printString</code> function would lead to a compilation error due to the explicit nature of the <code>std::string</code> constructor. Consequently, developers might opt for <code>sv.data()</code> to resolve the compilation error, albeit introducing potential hazards as discussed.</p>
-<div class="option">
-<p>StringViewTypes</p>
-<p>Option allows users to specify custom string view-like types for analysis. It accepts a semicolon-separated list of type names or regular expressions matching these types. Default value is: <span class="title-ref">::std::basic_string_view;::llvm::StringRef</span>.</p>
-</div>
-<div class="option">
-<p>AllowedCallees</p>
-<p>Specifies methods, functions, or classes where the result of <code>.data()</code> is passed to. Allows to exclude such calls from the analysis. Accepts a semicolon-separated list of names or regular expressions matching these entities. Default value is: empty string.</p>
-</div>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-stringview-data-usage.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>cert-ctr56-cpp</key>
-    <name>cert-ctr56-cpp</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - cert-ctr56-cpp</p>
-</div>
-<div class="meta" data-http-equiv=refresh="5;URL=../bugprone/pointer-arithmetic-on-polymorphic-object.html">
-
-</div>
-<h1 id="cert-ctr56-cpp">cert-ctr56-cpp</h1>
-<p>The <span class="title-ref">cert-ctr56-cpp</span> check is an alias, please see <code class="interpreted-text" role="doc">bugprone-pointer-arithmetic-on-polymorphic-object
-&lt;../bugprone/pointer-arithmetic-on-polymorphic-object&gt;</code> for more information.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/ctr56-cpp.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>cert-int09-c</key>
-    <name>cert-int09-c</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - cert-int09-c</p>
-</div>
-<div class="meta" data-http-equiv=refresh="5;URL=../readability/enum-initial-value.html">
-
-</div>
-<h1 id="cert-int09-c">cert-int09-c</h1>
-<p>The <span class="title-ref">cert-int09-c</span> check is an alias, please see <code class="interpreted-text" role="doc">readability-enum-initial-value &lt;../readability/enum-initial-value&gt;</code> for more information.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/int09-c.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-analyzer-cplusplus.ArrayDelete</key>
-    <name>clang-analyzer-cplusplus.ArrayDelete</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - clang-analyzer-cplusplus.ArrayDelete</p>
-</div>
-<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-arraydelete">
-
-</div>
-<h1 id="clang-analyzer-cplusplus.arraydelete">clang-analyzer-cplusplus.ArrayDelete</h1>
-<p>Reports destructions of arrays of polymorphic objects that are destructed as their base class.</p>
-<p>The <span class="title-ref">clang-analyzer-cplusplus.ArrayDelete</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#cplusplus-arraydelete">Clang Static Analyzer Available Checkers</a> for more information.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/cplusplus.ArrayDelete.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-analyzer-optin.taint.TaintedAlloc</key>
-    <name>clang-analyzer-optin.taint.TaintedAlloc</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - clang-analyzer-optin.taint.TaintedAlloc</p>
-</div>
-<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-taintedalloc">
-
-</div>
-<h1 id="clang-analyzer-optin.taint.taintedalloc">clang-analyzer-optin.taint.TaintedAlloc</h1>
-<p>Check for memory allocations, where the size parameter might be a tainted (attacker controlled) value.</p>
-<p>The <span class="title-ref">clang-analyzer-optin.taint.TaintedAlloc</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#optin-taint-taintedalloc">Clang Static Analyzer Available Checkers</a> for more information.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/optin.taint.TaintedAlloc.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-analyzer-security.PutenvStackArray</key>
-    <name>clang-analyzer-security.PutenvStackArray</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - clang-analyzer-security.PutenvStackArray</p>
-</div>
-<h1 id="clang-analyzer-security.putenvstackarray">clang-analyzer-security.PutenvStackArray</h1>
-<p>Finds calls to the function 'putenv' which pass a pointer to an automatic (stack-allocated) array as the argument.</p>
-<p>The clang-analyzer-security.PutenvStackArray check is an alias of Clang Static Analyzer security.PutenvStackArray.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.PutenvStackArray.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-analyzer-security.SetgidSetuidOrder</key>
-    <name>clang-analyzer-security.SetgidSetuidOrder</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - clang-analyzer-security.SetgidSetuidOrder</p>
-</div>
-<h1 id="clang-analyzer-security.setgidsetuidorder">clang-analyzer-security.SetgidSetuidOrder</h1>
-<p>Warn on possible reversed order of 'setgid(getgid()))' and 'setuid(getuid())' (CERT: POS36-C).</p>
-<p>The clang-analyzer-security.SetgidSetuidOrder check is an alias of Clang Static Analyzer security.SetgidSetuidOrder.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/security.SetgidSetuidOrder.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-analyzer-unix.BlockInCriticalSection</key>
-    <name>clang-analyzer-unix.BlockInCriticalSection</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - clang-analyzer-unix.BlockInCriticalSection</p>
-</div>
-<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-blockincriticalsection">
-
-</div>
-<h1 id="clang-analyzer-unix.blockincriticalsection">clang-analyzer-unix.BlockInCriticalSection</h1>
-<p>Check for calls to blocking functions inside a critical section.</p>
-<p>The <span class="title-ref">clang-analyzer-unix.BlockInCriticalSection</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-blockincriticalsection">Clang Static Analyzer Available Checkers</a> for more information.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.BlockInCriticalSection.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-analyzer-unix.Stream</key>
-    <name>clang-analyzer-unix.Stream</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - clang-analyzer-unix.Stream</p>
-</div>
-<div class="meta" data-http-equiv=refresh="5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#unix-stream">
-
-</div>
-<h1 id="clang-analyzer-unix.stream">clang-analyzer-unix.Stream</h1>
-<p>Check stream handling functions.</p>
-<p>The <span class="title-ref">clang-analyzer-unix.Stream</span> check is an alias, please see <a href="https://clang.llvm.org/docs/analyzer/checkers.html#unix-stream">Clang Static Analyzer Available Checkers</a> for more information.</p>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/unix.Stream.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>linuxkernel-must-check-errs</key>
-    <name>linuxkernel-must-check-errs</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - linuxkernel-must-check-errs</p>
-</div>
-<h1 id="linuxkernel-must-check-errs">linuxkernel-must-check-errs</h1>
-<p>Checks Linux kernel code to see if it uses the results from the functions in <code>linux/err.h</code>. Also checks to see if code uses the results from functions that directly return a value from one of these error functions.</p>
-<p>This is important in the Linux kernel because <code>ERR_PTR</code>, <code>PTR_ERR</code>, <code>IS_ERR</code>, <code>IS_ERR_OR_NULL</code>, <code>ERR_CAST</code>, and <code>PTR_ERR_OR_ZERO</code> return values must be checked, since positive pointers and negative error codes are being used in the same context. These functions are marked with <code>__attribute__((warn_unused_result))</code>, but some kernel versions do not have this warning enabled for clang.</p>
-<p>Examples:</p>
-<pre class="c"><code>/* Trivial unused call to an ERR function */
-PTR_ERR_OR_ZERO(some_function_call());
-
-/* A function that returns ERR_PTR. */
-void *fn() { ERR_PTR(-EINVAL); }
-
-/* An invalid use of fn. */
-fn();</code></pre>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/linuxkernel/must-check-errs.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>misc-use-internal-linkage</key>
-    <name>misc-use-internal-linkage</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - misc-use-internal-linkage</p>
-</div>
-<h1 id="misc-use-internal-linkage">misc-use-internal-linkage</h1>
-<p>Detects variables and functions that can be marked as static or moved into an anonymous namespace to enforce internal linkage.</p>
-<p>Static functions and variables are scoped to a single file. Marking functions and variables as static helps to better remove dead code. In addition, it gives the compiler more information and allows for more aggressive optimizations.</p>
-<p>Example:</p>
-<pre class="c++"><code>int v1; // can be marked as static
-
-void fn1(); // can be marked as static
-
-namespace {
-  // already in anonymous namespace
-  int v2;
-  void fn2();
-}
-// already declared as extern
-extern int v2;</code></pre>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>FixMode</p>
-<p>Selects what kind of a fix the check should provide. The default is <span class="title-ref">UseStatic</span>.</p>
-<dl>
-<dt><code>None</code></dt>
-<dd><p>Don't fix automatically.</p>
-</dd>
-<dt><code>UseStatic</code></dt>
-<dd><p>Add <code>static</code> for internal linkage variable and function.</p>
-</dd>
-</dl>
-</div>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/misc/use-internal-linkage.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>modernize-min-max-use-initializer-list</key>
-    <name>modernize-min-max-use-initializer-list</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - modernize-min-max-use-initializer-list</p>
-</div>
-<h1 id="modernize-min-max-use-initializer-list">modernize-min-max-use-initializer-list</h1>
-<p>Replaces nested <code>std::min</code> and <code>std::max</code> calls with an initializer list where applicable.</p>
-<p>For instance, consider the following code:</p>
-<pre class="cpp"><code>int a = std::max(std::max(i, j), k);</code></pre>
-<p>The check will transform the above code to:</p>
-<pre class="cpp"><code>int a = std::max({i, j, k});</code></pre>
-<h1 id="performance-considerations">Performance Considerations</h1>
-<p>While this check simplifies the code and makes it more readable, it may cause performance degradation for non-trivial types due to the need to copy objects into the initializer list.</p>
-<p>To avoid this, it is recommended to use <span class="title-ref">std::ref</span> or <span class="title-ref">std::cref</span> for non-trivial types:</p>
-<pre class="cpp"><code>std::string b = std::max({std::ref(i), std::ref(j), std::ref(k)});</code></pre>
-<h1 id="options">Options</h1>
-<div class="option">
-<p>IncludeStyle</p>
-<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
-</div>
-<div class="option">
-<p>IgnoreNonTrivialTypes</p>
-<p>A boolean specifying whether to ignore non-trivial types. Default is <span class="title-ref">true</span>.</p>
-</div>
-<div class="option">
-<p>IgnoreTrivialTypesOfSizeAbove</p>
-<p>An integer specifying the size (in bytes) above which trivial types are ignored. Default is <span class="title-ref">32</span>.</p>
-</div>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/min-max-use-initializer-list.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>modernize-use-designated-initializers</key>
-    <name>modernize-use-designated-initializers</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - modernize-use-designated-initializers</p>
-</div>
-<h1 id="modernize-use-designated-initializers">modernize-use-designated-initializers</h1>
-<p>Finds initializer lists for aggregate types which could be written as designated initializers instead.</p>
-<p>With plain initializer lists, it is very easy to introduce bugs when adding new fields in the middle of a struct or class type. The same confusion might arise when changing the order of fields.</p>
-<p>C++20 supports the designated initializer syntax for aggregate types. By applying it, we can always be sure that aggregates are constructed correctly, because every variable being initialized is referenced by its name.</p>
-<p>Example:</p>
-<pre class=""><code>struct S { int i, j; };</code></pre>
-<p>is an aggregate type that should be initialized as</p>
-<pre class=""><code>S s{.i = 1, .j = 2};</code></pre>
-<p>instead of</p>
-<pre class=""><code>S s{1, 2};</code></pre>
-<p>which could easily become an issue when <code>i</code> and <code>j</code> are swapped in the declaration of <code>S</code>.</p>
-<p>Even when compiling in a language version older than C++20, depending on your compiler, designated initializers are potentially supported. Therefore, the check is by default restricted to C99/C++20 and above. Check out the options <code>-Wc99-designator</code> to get support for mixed designators in initializer list in C and <code>-Wc++20-designator</code> for support of designated initializers in older C++ language modes.</p>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>IgnoreMacros</p>
-<p>The value <span class="title-ref">false</span> specifies that components of initializer lists expanded from macros are not checked. The default value is <span class="title-ref">true</span>.</p>
-</div>
-<div class="option">
-<p>IgnoreSingleElementAggregates</p>
-<p>The value <span class="title-ref">false</span> specifies that even initializers for aggregate types with only a single element should be checked. The default value is <span class="title-ref">true</span>.</p>
-</div>
-<div class="option">
-<p>RestrictToPODTypes</p>
-<p>The value <span class="title-ref">true</span> specifies that only Plain Old Data (POD) types shall be checked. This makes the check applicable to even older C++ standards. The default value is <span class="title-ref">false</span>.</p>
-</div>
-<div class="option">
-<p>StrictCStandardCompliance</p>
-<p>When set to <span class="title-ref">false</span>, the check will not restrict itself to C99 and above. The default value is <span class="title-ref">true</span>.</p>
-</div>
-<div class="option">
-<p>StrictCppStandardCompliance</p>
-<p>When set to <span class="title-ref">false</span>, the check will not restrict itself to C++20 and above. The default value is <span class="title-ref">true</span>.</p>
-</div>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-designated-initializers.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>modernize-use-ranges</key>
-    <name>modernize-use-ranges</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - modernize-use-ranges</p>
-</div>
-<h1 id="modernize-use-ranges">modernize-use-ranges</h1>
-<p>Detects calls to standard library iterator algorithms that could be replaced with a ranges version instead.</p>
-<h2 id="example">Example</h2>
-<pre class="c++"><code>auto Iter1 = std::find(Items.begin(), Items.end(), 0);
-auto AreSame = std::equal(Items1.cbegin(), Items1.cend(),
-                          std::begin(Items2), std::end(Items2));</code></pre>
-<p>Transforms to:</p>
-<pre class="c++"><code>auto Iter1 = std::ranges::find(Items, 0);
-auto AreSame = std::ranges::equal(Items1, Items2);</code></pre>
-<h2 id="supported-algorithms">Supported algorithms</h2>
-<p>Calls to the following std library algorithms are checked:</p>
-<p><code>std::adjacent_find</code>, <code>std::all_of</code>, <code>std::any_of</code>, <code>std::binary_search</code>, <code>std::copy_backward</code>, <code>std::copy_if</code>, <code>std::copy</code>, <code>std::destroy</code>, <code>std::equal_range</code>, <code>std::equal</code>, <code>std::fill</code>, <code>std::find_end</code>, <code>std::find_if_not</code>, <code>std::find_if</code>, <code>std::find</code>, <code>std::for_each</code>, <code>std::generate</code>, <code>std::includes</code>, <code>std::inplace_merge</code>, <code>std::iota</code>, <code>std::is_heap_until</code>, <code>std::is_heap</code>, <code>std::is_partitioned</code>, <code>std::is_permutation</code>, <code>std::is_sorted_until</code>, <code>std::is_sorted</code>, <code>std::lexicographical_compare</code>, <code>std::lower_bound</code>, <code>std::make_heap</code>, <code>std::max_element</code>, <code>std::merge</code>, <code>std::min_element</code>, <code>std::minmax_element</code>, <code>std::mismatch</code>, <code>std::move_backward</code>, <code>std::move</code>, <code>std::next_permutation</code>, <code>std::none_of</code>, <code>std::partial_sort_copy</code>, <code>std::partition_copy</code>, <code>std::partition_point</code>, <code>std::partition</code>, <code>std::pop_heap</code>, <code>std::prev_permutation</code>, <code>std::push_heap</code>, <code>std::remove_copy_if</code>, <code>std::remove_copy</code>, <code>std::remove</code>, <code>std::remove_if</code>, <code>std::replace_if</code>, <code>std::replace</code>, <code>std::reverse_copy</code>, <code>std::reverse</code>, <code>std::rotate</code>, <code>std::rotate_copy</code>, <code>std::sample</code>, <code>std::search</code>, <code>std::set_difference</code>, <code>std::set_intersection</code>, <code>std::set_symmetric_difference</code>, <code>std::set_union</code>, <code>std::shift_left</code>, <code>std::shift_right</code>, <code>std::sort_heap</code>, <code>std::sort</code>, <code>std::stable_partition</code>, <code>std::stable_sort</code>, <code>std::transform</code>, <code>std::uninitialized_copy</code>, <code>std::uninitialized_default_construct</code>, <code>std::uninitialized_fill</code>, <code>std::uninitialized_move</code>, <code>std::uninitialized_value_construct</code>, <code>std::unique_copy</code>, <code>std::unique</code>, <code>std::upper_bound</code>.</p>
-<h2 id="reverse-iteration">Reverse Iteration</h2>
-<p>If calls are made using reverse iterators on containers, The code will be fixed using the <code>std::views::reverse</code> adaptor.</p>
-<pre class="c++"><code>auto AreSame = std::equal(Items1.rbegin(), Items1.rend(),
-                          std::crbegin(Items2), std::crend(Items2));</code></pre>
-<p>Transforms to:</p>
-<pre class="c++"><code>auto AreSame = std::ranges::equal(std::ranges::reverse_view(Items1),
-                                  std::ranges::reverse_view(Items2));</code></pre>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>IncludeStyle</p>
-<p>A string specifying which include-style is used, <span class="title-ref">llvm</span> or <span class="title-ref">google</span>. Default is <span class="title-ref">llvm</span>.</p>
-</div>
-<div class="option">
-<p>UseReversePipe</p>
-<p>When <span class="title-ref">true</span> (default <span class="title-ref">false</span>), fixes which involve reverse ranges will use the pipe adaptor syntax instead of the function syntax.</p>
-<pre class="c++"><code>std::find(Items.rbegin(), Items.rend(), 0);</code></pre>
-<p>Transforms to:</p>
-<pre class="c++"><code>std::ranges::find(Items | std::views::reverse, 0);</code></pre>
-</div>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-ranges.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>modernize-use-std-format</key>
-    <name>modernize-use-std-format</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - modernize-use-std-format</p>
-</div>
-<h1 id="modernize-use-std-format">modernize-use-std-format</h1>
-<p>Converts calls to <code>absl::StrFormat</code>, or other functions via configuration options, to C++20's <code>std::format</code>, or another function via a configuration option, modifying the format string appropriately and removing now-unnecessary calls to <code>std::string::c_str()</code> and <code>std::string::data()</code>.</p>
-<p>For example, it turns lines like</p>
-<pre class="c++"><code>return absl::StrFormat(&quot;The %s is %3d&quot;, description.c_str(), value);</code></pre>
-<p>into:</p>
-<pre class="c++"><code>return std::format(&quot;The {} is {:3}&quot;, description, value);</code></pre>
-<p>The check uses the same format-string-conversion algorithm as <a href="../modernize/use-std-print.html">modernize-use-std-print</a> and its shortcomings are described in the documentation for that check.</p>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>StrictMode</p>
-<p>When <span class="title-ref">true</span>, the check will add casts when converting from variadic functions and printing signed or unsigned integer types (including fixed-width integer types from <code>&lt;cstdint&gt;</code>, <code>ptrdiff_t</code>, <code>size_t</code> and <code>ssize_t</code>) as the opposite signedness to ensure that the output would matches that of a simple wrapper for <code>std::sprintf</code> that accepted a C-style variable argument list. For example, with <span class="title-ref">StrictMode</span> enabled,</p>
-<pre class="c++"><code>extern std::string strprintf(const char *format, ...);
-int i = -42;
-unsigned int u = 0xffffffff;
-return strprintf(&quot;%d %u\n&quot;, i, u);</code></pre>
-<p>would be converted to</p>
-<pre class="c++"><code>return std::format(&quot;{} {}\n&quot;, static_cast&lt;unsigned int&gt;(i), static_cast&lt;int&gt;(u));</code></pre>
-<p>to ensure that the output will continue to be the unsigned representation of -42 and the signed representation of 0xffffffff (often 4294967254 and -1 respectively). When <span class="title-ref">false</span> (which is the default), these casts will not be added which may cause a change in the output. Note that this option makes no difference for the default value of <span class="title-ref">StrFormatLikeFunctions</span> since <code>absl::StrFormat</code> takes a function parameter pack and is not a variadic function.</p>
-</div>
-<div class="option">
-<p>StrFormatLikeFunctions</p>
-<p>A semicolon-separated list of (fully qualified) function names to replace, with the requirement that the first parameter contains the printf-style format string and the arguments to be formatted follow immediately afterwards. The default value for this option is <span class="title-ref">absl::StrFormat</span>.</p>
-</div>
-<div class="option">
-<p>ReplacementFormatFunction</p>
-<p>The function that will be used to replace the function set by the <span class="title-ref">StrFormatLikeFunctions</span> option rather than the default <span class="title-ref">std::format</span>. It is expected that the function provides an interface that is compatible with <code>std::format</code>. A suitable candidate would be <span class="title-ref">fmt::format</span>.</p>
-</div>
-<div class="option">
-<p>FormatHeader</p>
-<p>The header that must be included for the declaration of <span class="title-ref">ReplacementFormatFunction</span> so that a <code>#include</code> directive can be added if required. If <span class="title-ref">ReplacementFormatFunction</span> is <span class="title-ref">std::format</span> then this option will default to <code>&lt;format&gt;</code>, otherwise this option will default to nothing and no <code>#include</code> directive will be added.</p>
-</div>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-std-format.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>readability-enum-initial-value</key>
-    <name>readability-enum-initial-value</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - readability-enum-initial-value</p>
-</div>
-<h1 id="readability-enum-initial-value">readability-enum-initial-value</h1>
-<p>Enforces consistent style for enumerators' initialization, covering three styles: none, first only, or all initialized explicitly.</p>
-<p>An inconsistent style and strictness to defining the initializing value of enumerators may cause issues if the enumeration is extended with new enumerators that obtain their integer representation implicitly.</p>
-<p>The following three cases are accepted:</p>
-<ol>
-<li><strong>No</strong> enumerators are explicit initialized.</li>
-<li>Exactly <strong>the first</strong> enumerator is explicit initialized.</li>
-<li><strong>All</strong> enumerators are explicit initialized.</li>
-</ol>
-<pre class="c++"><code>enum A {    // (1) Valid, none of enumerators are initialized.
-  a0,
-  a1,
-  a2,
-};
-
-enum B {    // (2) Valid, the first enumerator is initialized.
-  b0 = 0,
-  b1,
-  b2,
-};
-
-enum C {    // (3) Valid, all of enumerators are initialized.
-  c0 = 0,
-  c1 = 1,
-  c2 = 2,
-};
-
-enum D {    // Invalid, d1 is not explicitly initialized!
-  d0 = 0,
-  d1,
-  d2 = 2,
-};
-
-enum E {    // Invalid, e1, e3, and e5 are not explicitly initialized.
-  e0 = 0,
-  e1,
-  e2 = 2,
-  e3,       // Dangerous, as the numeric values of e3 and e5 are both 3, and this is not explicitly visible in the code!
-  e4 = 2,
-  e5,
-};</code></pre>
-<p>This check corresponds to the CERT C Coding Standard recommendation <a href="https://wiki.sei.cmu.edu/confluence/display/c/INT09-C.+Ensure+enumeration+constants+map+to+unique+values">INT09-C. Ensure enumeration constants map to unique values</a>.</p>
-<p><span class="title-ref">cert-int09-c</span> redirects here as an alias of this check.</p>
-<h2 id="options">Options</h2>
-<div class="option">
-<p>AllowExplicitZeroFirstInitialValue</p>
-<p>If set to <span class="title-ref">false</span>, the first enumerator must not be explicitly initialized to a literal <code>0</code>. Default is <span class="title-ref">true</span>.</p>
-<pre class="c++"><code>enum F {
-  f0 = 0, // Not allowed if AllowExplicitZeroFirstInitialValue is false.
-  f1,
-  f2,
-};</code></pre>
-</div>
-<div class="option">
-<p>AllowExplicitSequentialInitialValues</p>
-<p>If set to <span class="title-ref">false</span>, explicit initialization to sequential values are not allowed. Default is <span class="title-ref">true</span>.</p>
-<pre class="c++"><code>enum G {
-  g0 = 1, // Not allowed if AllowExplicitSequentialInitialValues is false.
-  g1 = 2,
-  g2 = 3,</code></pre>
-</div>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/enum-initial-value.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>readability-math-missing-parentheses</key>
-    <name>readability-math-missing-parentheses</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - readability-math-missing-parentheses</p>
-</div>
-<h1 id="readability-math-missing-parentheses">readability-math-missing-parentheses</h1>
-<p>Check for missing parentheses in mathematical expressions that involve operators of different priorities.</p>
-<p>Parentheses in mathematical expressions clarify the order of operations, especially with different-priority operators. Lengthy or multiline expressions can obscure this order, leading to coding errors. IDEs can aid clarity by highlighting parentheses. Explicitly using parentheses also clarifies what the developer had in mind when writing the expression. Ensuring their presence reduces ambiguity and errors, promoting clearer and more maintainable code.</p>
-<p>Before:</p>
-<pre class="c++"><code>int x = 1 + 2 * 3 - 4 / 5;</code></pre>
-<p>After:</p>
-<pre class="c++"><code>int x = 1 + (2 * 3) - (4 / 5);</code></pre>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/math-missing-parentheses.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>readability-use-std-min-max</key>
-    <name>readability-use-std-min-max</name>
-    <description>
-      <![CDATA[
-      <div class="title">
-<p>clang-tidy - readability-use-std-min-max</p>
-</div>
-<h1 id="readability-use-std-min-max">readability-use-std-min-max</h1>
-<p>Replaces certain conditional statements with equivalent calls to <code>std::min</code> or <code>std::max</code>. Note: This may impact performance in critical code due to potential additional stores compared to the original if statement.</p>
-<p>Before:</p>
-<pre class="c++"><code>void foo() {
-  int a = 2, b = 3;
-  if (a &lt; b)
-    a = b;
-}</code></pre>
-<p>After:</p>
-<pre class="c++"><code>void foo() {
-  int a = 2, b = 3;
-  a = std::max(a, b);
-}</code></pre>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/readability/use-std-min-max.html" target="_blank">clang.llvm.org</a></p>
-      ]]>
-      <![CDATA[]]>
-      </description>
-    <severity>INFO</severity>
-  </rule>
 
   <!-- Clang Diagnostic Rules -->
 

--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -3,7 +3,7 @@
   C and C++ rules from
   * https://clang.llvm.org/extra/clang-tidy/checks/list.html
   * https://clang-analyzer.llvm.org/available_checks.html
-  * last update: llvmorg-19-init (git describe)
+  * last update: llvmorg-19.1.0 (git describe)
 -->
 <rules>
 

--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -3084,7 +3084,7 @@ if (onFire) {
   #define cool__macro // also this
 }
 int _g(); // disallowed in global namespace only</code></pre>
-<p>The check can also be inverted, i.e. it can be configured to flag any identifier that is _<a href="http://clang.llvm.org/extra/clang-tidy/checks/">not</a> a reserved identifier. This mode is for use by e.g. standard library implementors, to ensure they don't infringe on the user namespace.</p>
+<p>The check can also be inverted, i.e. it can be configured to flag any identifier that is <em>not</em> a reserved identifier. This mode is for use by e.g. standard library implementors, to ensure they don't infringe on the user namespace.</p>
 <p>This check does not (yet) check for other reserved names, e.g. macro names identical to language keywords, and names specifically reserved by language standards, e.g. C++ 'zombie names' and C future library directions.</p>
 <p>This check corresponds to CERT C Coding Standard rule <a href="https://wiki.sei.cmu.edu/confluence/display/c/DCL37-C.+Do+not+declare+or+define+a+reserved+identifier">DCL37-C. Do not declare or define a reserved identifier</a> as well as its C++ counterpart, <a href="https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL51-CPP.+Do+not+declare+or+define+a+reserved+identifier">DCL51-CPP. Do not declare or define a reserved identifier</a>.</p>
 <h2 id="options">Options</h2>

--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -12137,7 +12137,7 @@ public:
 +  C(std::string S) : S(std::move(S)) {}
 };</code></pre>
 <div class="seealso">
-<p>For more information about the pass-by-value idiom, read: <a href="http://clang.llvm.org/extra/clang-tidy/checks/">Want Speed? Pass by Value</a>.</p>
+<p>For more information about the pass-by-value idiom, read: <a href="https://web.archive.org/web/20140205194657/http://cpp-next.com/archive/2009/08/want-speed-pass-by-value/">Want Speed? Pass by Value</a>.</p>
 </div>
 <h2 id="options">Options</h2>
 <div class="option">

--- a/cxx-sensors/src/main/resources/clangtidy.xml
+++ b/cxx-sensors/src/main/resources/clangtidy.xml
@@ -20492,6 +20492,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-bit-int-extension</key>
+    <name>clang-diagnostic-bit-int-extension</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '_BitInt' in %select{C17 and earlier|C++}0 is a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbit-int-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-bitwise-conditional-parentheses</key>
     <name>clang-diagnostic-bitwise-conditional-parentheses</name>
     <description>
@@ -32378,19 +32391,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-slash-u-filename</key>
-    <name>clang-diagnostic-slash-u-filename</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '/U%0' treated as the '/U' option</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wslash-u-filename" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-msvc-not-found</key>
     <name>clang-diagnostic-msvc-not-found</name>
     <description>
@@ -32508,19 +32508,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-div-by-zero</key>
-    <name>clang-diagnostic-div-by-zero</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{remainder|division}0 by zero is undefined</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdiv-by-zero" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-module-file-config-mismatch</key>
     <name>clang-diagnostic-module-file-config-mismatch</name>
     <description>
@@ -32532,6 +32519,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmodule-file-config-mismatch" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>CRITICAL</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-div-by-zero</key>
+    <name>clang-diagnostic-div-by-zero</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{remainder|division}0 by zero is undefined</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdiv-by-zero" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-eager-load-cxx-named-modules</key>
@@ -32651,19 +32651,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++1z-compat-mangling</key>
-    <name>clang-diagnostic-c++1z-compat-mangling</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat-mangling" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-mathematical-notation-identifier-extension</key>
     <name>clang-diagnostic-mathematical-notation-identifier-extension</name>
     <description>
@@ -32673,6 +32660,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmathematical-notation-identifier-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++1z-compat-mangling</key>
+    <name>clang-diagnostic-c++1z-compat-mangling</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: mangled name of %0 will change in C++17 due to non-throwing exception specification in function signature</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat-mangling" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -32794,6 +32794,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-disabled-macro-expansion</key>
+    <name>clang-diagnostic-disabled-macro-expansion</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: disabled expansion of recursive macro</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdisabled-macro-expansion" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-pre-c2x-compat</key>
     <name>clang-diagnostic-pre-c2x-compat</name>
     <description>
@@ -32815,19 +32828,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2x-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-disabled-macro-expansion</key>
-    <name>clang-diagnostic-disabled-macro-expansion</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: disabled expansion of recursive macro</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdisabled-macro-expansion" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -32949,6 +32949,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-private-header</key>
+    <name>clang-diagnostic-private-header</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: use of private header from outside its module: '%0'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprivate-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>CRITICAL</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-pre-c2x-compat-pedantic</key>
     <name>clang-diagnostic-pre-c2x-compat-pedantic</name>
     <description>
@@ -32972,19 +32985,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c2x-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-private-header</key>
-    <name>clang-diagnostic-private-header</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: use of private header from outside its module: '%0'</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wprivate-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>CRITICAL</severity>
     </rule>
   <rule>
     <key>clang-diagnostic-include-angled-in-module-purview</key>
@@ -33104,29 +33104,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-c++98-c++11-compat</key>
-    <name>clang-diagnostic-c++98-c++11-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
-<li>warning: digit separators are incompatible with C++ standards before C++14</li>
-<li>warning: generic lambdas are incompatible with C++11</li>
-<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
-<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
-<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
-<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable templates are incompatible with C++ standards before C++14</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-missing-selector-name</key>
     <name>clang-diagnostic-missing-selector-name</name>
     <description>
@@ -33149,6 +33126,29 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wauto-storage-class" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++98-c++11-compat</key>
+    <name>clang-diagnostic-c++98-c++11-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -33257,19 +33257,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-bit-int-extension</key>
-    <name>clang-diagnostic-bit-int-extension</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: '_BitInt' in %select{C17 and earlier|C++}0 is a Clang extension</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wbit-int-extension" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-concepts-ts-compat</key>
     <name>clang-diagnostic-concepts-ts-compat</name>
     <description>
@@ -33292,30 +33279,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wduplicate-enum" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++98-c++11-compat-pedantic</key>
-    <name>clang-diagnostic-c++98-c++11-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
-<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
-<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
-<li>warning: digit separators are incompatible with C++ standards before C++14</li>
-<li>warning: generic lambdas are incompatible with C++11</li>
-<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
-<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
-<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
-<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
-<li>warning: variable templates are incompatible with C++ standards before C++14</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -33355,6 +33318,30 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winterrupt-service-routine" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-c++98-c++11-compat-pedantic</key>
+    <name>clang-diagnostic-c++98-c++11-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'decltype(auto)' type specifier is incompatible with C++ standards before C++14</li>
+<li>warning: binary integer literals are incompatible with C++ standards before C++14</li>
+<li>warning: constexpr function with no return statements is incompatible with C++ standards before C++14</li>
+<li>warning: digit separators are incompatible with C++ standards before C++14</li>
+<li>warning: generic lambdas are incompatible with C++11</li>
+<li>warning: initialized lambda captures are incompatible with C++ standards before C++14</li>
+<li>warning: multiple return statements in constexpr function is incompatible with C++ standards before C++14</li>
+<li>warning: return type deduction is incompatible with C++ standards before C++14</li>
+<li>warning: type definition in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable declaration in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++14</li>
+<li>warning: variable templates are incompatible with C++ standards before C++14</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -33476,6 +33463,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-memsize-comparison</key>
+    <name>clang-diagnostic-memsize-comparison</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: size argument in %0 call is a comparison</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmemsize-comparison" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-c++98-c++11-c++14-compat</key>
     <name>clang-diagnostic-c++98-c++11-c++14-compat</name>
     <description>
@@ -33501,19 +33501,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-memsize-comparison</key>
-    <name>clang-diagnostic-memsize-comparison</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: size argument in %0 call is a comparison</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wmemsize-comparison" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -33635,6 +33622,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-objc-property-matches-cocoa-ownership-rule</key>
+    <name>clang-diagnostic-objc-property-matches-cocoa-ownership-rule</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: property follows Cocoa naming convention for returning 'owned' objects</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-matches-cocoa-ownership-rule" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</key>
     <name>clang-diagnostic-c++98-c++11-c++14-compat-pedantic</name>
     <description>
@@ -33662,19 +33662,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-objc-property-matches-cocoa-ownership-rule</key>
-    <name>clang-diagnostic-objc-property-matches-cocoa-ownership-rule</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: property follows Cocoa naming convention for returning 'owned' objects</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-matches-cocoa-ownership-rule" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -33978,6 +33965,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-undefined-arm-zt0</key>
+    <name>clang-diagnostic-undefined-arm-zt0</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: builtin call is not valid when calling from a function without active ZT0 state</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-zt0" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</key>
     <name>clang-diagnostic-c++98-c++11-c++14-c++17-compat-pedantic</name>
     <description>
@@ -34015,19 +34015,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-98-c-11-c-14-c-17-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-undefined-arm-zt0</key>
-    <name>clang-diagnostic-undefined-arm-zt0</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: builtin call is not valid when calling from a function without active ZT0 state</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-zt0" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -34149,19 +34136,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pre-c++2c-compat</key>
-    <name>clang-diagnostic-pre-c++2c-compat</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2c-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-invalid-initializer-from-system-header</key>
     <name>clang-diagnostic-invalid-initializer-from-system-header</name>
     <description>
@@ -34171,6 +34145,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winvalid-initializer-from-system-header" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++2c-compat</key>
+    <name>clang-diagnostic-pre-c++2c-compat</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2c-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -34292,19 +34279,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pre-c++2c-compat-pedantic</key>
-    <name>clang-diagnostic-pre-c++2c-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2c-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-attribute-packed-for-bitfield</key>
     <name>clang-diagnostic-attribute-packed-for-bitfield</name>
     <description>
@@ -34314,6 +34288,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wattribute-packed-for-bitfield" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pre-c++2c-compat-pedantic</key>
+    <name>clang-diagnostic-pre-c++2c-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: placeholder variables are incompatible with C++ standards before C++2c</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2c-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -34986,19 +34973,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-pointer-integer-compare</key>
-    <name>clang-diagnostic-pointer-integer-compare</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: comparison between pointer and integer (%0 and %1)</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-integer-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-c++1z-compat</key>
     <name>clang-diagnostic-c++1z-compat</name>
     <description>
@@ -35052,6 +35026,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1z-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pointer-integer-compare</key>
+    <name>clang-diagnostic-pointer-integer-compare</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: comparison between pointer and integer (%0 and %1)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-integer-compare" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -35160,45 +35147,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-idiomatic-parentheses</key>
-    <name>clang-diagnostic-idiomatic-parentheses</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: using the result of an assignment as a condition without parentheses</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#widiomatic-parentheses" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-pointer-sign</key>
-    <name>clang-diagnostic-pointer-sign</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2 converts between pointers to integer types %select{with different sign|where one is of the unique plain 'char' type and the other is not}3</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-sign" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-alias-template-in-declaration-name</key>
-    <name>clang-diagnostic-alias-template-in-declaration-name</name>
-    <description><![CDATA[
-        <p>Diagnostic text:</p>
-  <ul>
-  <li>warning: a declarative nested name specifier cannot name an alias template</li>
-  </ul>
-  <h2>References</h2>
-  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walias-template-in-declaration-name" target="_blank">Diagnostic flags in Clang</a></p>
-        ]]></description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-template-in-declaration-name</key>
     <name>clang-diagnostic-template-in-declaration-name</name>
     <description><![CDATA[
@@ -35244,6 +35192,45 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-alias-template-in-declaration-name</key>
+    <name>clang-diagnostic-alias-template-in-declaration-name</name>
+    <description><![CDATA[
+        <p>Diagnostic text:</p>
+  <ul>
+  <li>warning: a declarative nested name specifier cannot name an alias template</li>
+  </ul>
+  <h2>References</h2>
+  <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#walias-template-in-declaration-name" target="_blank">Diagnostic flags in Clang</a></p>
+        ]]></description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-idiomatic-parentheses</key>
+    <name>clang-diagnostic-idiomatic-parentheses</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: using the result of an assignment as a condition without parentheses</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#widiomatic-parentheses" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-pointer-sign</key>
+    <name>clang-diagnostic-pointer-sign</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{%diff{assigning to $ from $|assigning to different types}0,1|%diff{passing $ to parameter of type $|passing to parameter of different type}0,1|%diff{returning $ from a function with result type $|returning from function with different return type}0,1|%diff{converting $ to type $|converting between types}0,1|%diff{initializing $ with an expression of type $|initializing with expression of different type}0,1|%diff{sending $ to parameter of type $|sending to parameter of different type}0,1|%diff{casting $ to type $|casting between types}0,1}2 converts between pointers to integer types %select{with different sign|where one is of the unique plain 'char' type and the other is not}3</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpointer-sign" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -35339,6 +35326,57 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-c++2a-compat-pedantic</key>
+    <name>clang-diagnostic-c++2a-compat-pedantic</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: #warning is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
+<li>warning: '%0' is a keyword in C++20</li>
+<li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
+<li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
+<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: consteval if is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
+<li>warning: taking address of non-addressable standard library function is incompatible with C++20</li>
+<li>warning: this expression will be parsed as explicit(bool) in C++20</li>
+<li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
+<li>warning: use of implicit 'typename' is incompatible with C++ standards before C++20</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-conditional-type-mismatch</key>
     <name>clang-diagnostic-conditional-type-mismatch</name>
     <description>
@@ -35387,57 +35425,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wabstract-vbase-init" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-c++2a-compat-pedantic</key>
-    <name>clang-diagnostic-c++2a-compat-pedantic</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: #warning is incompatible with C++ standards before C++23</li>
-<li>warning: #warning is incompatible with C++ standards before C++23</li>
-<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
-<li>warning: %select{an attribute specifier sequence|%1}0 in this position is incompatible with C++ standards before C++23</li>
-<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
-<li>warning: %select{delimited|named}0 escape sequences are incompatible with C++ standards before C++23</li>
-<li>warning: '%0' is a keyword in C++20</li>
-<li>warning: '&lt;=&gt;' is a single token in C++20; add a space to avoid a change in behavior</li>
-<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
-<li>warning: 'auto' as a functional-style cast is incompatible with C++ standards before C++23</li>
-<li>warning: 'consteval' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'constinit' specifier is incompatible with C++ standards before C++20</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
-<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++23</li>
-<li>warning: aggregate initialization of type %0 with user-declared constructors is incompatible with C++20</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
-<li>warning: alias declaration in this context is incompatible with C++ standards before C++23</li>
-<li>warning: consteval if is incompatible with C++ standards before C++23</li>
-<li>warning: consteval if is incompatible with C++ standards before C++23</li>
-<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: declaring overloaded %0 as 'static' is incompatible with C++ standards before C++23</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
-<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is incompatible with C++ standards before C++23</li>
-<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-<li>warning: definition of a %select{static variable|thread_local variable|variable of non-literal type}1 in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
-<li>warning: label at end of compound statement is incompatible with C++ standards before C++23</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
-<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++23 extension</li>
-<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
-<li>warning: static lambdas are incompatible with C++ standards before C++23</li>
-<li>warning: taking address of non-addressable standard library function is incompatible with C++20</li>
-<li>warning: this expression will be parsed as explicit(bool) in C++20</li>
-<li>warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
-<li>warning: use of a '#%select{&lt;BUG IF SEEN&gt;|elifdef|elifndef}0' directive is incompatible with C++ standards before C++23</li>
-<li>warning: use of implicit 'typename' is incompatible with C++ standards before C++20</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-<li>warning: use of this statement in a constexpr %select{function|constructor}0 is incompatible with C++ standards before C++23</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-2a-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -35533,6 +35520,21 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-return-local-addr</key>
+    <name>clang-diagnostic-return-local-addr</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: %select{address of|reference to}0 stack memory associated with %select{local variable|parameter}2 %1 returned</li>
+<li>warning: returning %select{address of|reference to}0 local temporary object</li>
+<li>warning: returning address of label, which is local</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-local-addr" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-assign-enum</key>
     <name>clang-diagnostic-assign-enum</name>
     <description>
@@ -35568,21 +35570,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wargument-undefined-behaviour" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-return-local-addr</key>
-    <name>clang-diagnostic-return-local-addr</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: %select{address of|reference to}0 stack memory associated with %select{local variable|parameter}2 %1 returned</li>
-<li>warning: returning %select{address of|reference to}0 local temporary object</li>
-<li>warning: returning address of label, which is local</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-local-addr" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -36257,20 +36244,6 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
-    <key>clang-diagnostic-deprecated-copy-dtor</key>
-    <name>clang-diagnostic-deprecated-copy-dtor</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared destructor</li>
-<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided destructor</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-copy-dtor" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
     <key>clang-diagnostic-c++1y-extensions</key>
     <name>clang-diagnostic-c++1y-extensions</name>
     <description>
@@ -36288,6 +36261,20 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-1y-extensions" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-deprecated-copy-dtor</key>
+    <name>clang-diagnostic-deprecated-copy-dtor</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-declared destructor</li>
+<li>warning: definition of implicit copy %select{constructor|assignment operator}1 for %0 is deprecated because it has a user-provided destructor</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-copy-dtor" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -36467,6 +36454,19 @@ Derived();             // and so temporary construction is okay</code></pre>
     <severity>INFO</severity>
     </rule>
   <rule>
+    <key>clang-diagnostic-fixed-point-overflow</key>
+    <name>clang-diagnostic-fixed-point-overflow</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: overflow in expression; result is %0 with type %1</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfixed-point-overflow" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
     <key>clang-diagnostic-partial-availability</key>
     <name>clang-diagnostic-partial-availability</name>
     <description>
@@ -36477,19 +36477,6 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpartial-availability" target="_blank">Diagnostic flags in Clang</a></p>]]>
-      </description>
-    <severity>INFO</severity>
-    </rule>
-  <rule>
-    <key>clang-diagnostic-fixed-point-overflow</key>
-    <name>clang-diagnostic-fixed-point-overflow</name>
-    <description>
-      <![CDATA[<p>Diagnostic text:</p>
-<ul>
-<li>warning: overflow in expression; result is %0 with type %1</li>
-</ul>
-<h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wfixed-point-overflow" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
     </rule>
@@ -36763,6 +36750,19 @@ Derived();             // and so temporary construction is okay</code></pre>
 </ul>
 <h2>References</h2>
 <p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdelayed-template-parsing-in-cxx20" target="_blank">Diagnostic flags in Clang</a></p>]]>
+      </description>
+    <severity>INFO</severity>
+    </rule>
+  <rule>
+    <key>clang-diagnostic-slash-u-filename</key>
+    <name>clang-diagnostic-slash-u-filename</name>
+    <description>
+      <![CDATA[<p>Diagnostic text:</p>
+<ul>
+<li>warning: '/U%0' treated as the '/U' option</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wslash-u-filename" target="_blank">Diagnostic flags in Clang</a></p>]]>
       </description>
     <severity>INFO</severity>
   </rule>

--- a/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
+++ b/cxx-sensors/src/test/java/org/sonar/cxx/sensors/clangtidy/CxxClangTidyRuleRepositoryTest.java
@@ -36,7 +36,7 @@ class CxxClangTidyRuleRepositoryTest {
     def.define(context);
 
     RulesDefinition.Repository repo = context.repository(CxxClangTidyRuleRepository.KEY);
-    assertThat(repo.rules()).hasSize(1573);
+    assertThat(repo.rules()).hasSize(1572);
   }
 
 }

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -608,6 +608,8 @@ def diagnostics_to_rules_xml(json_file):
 
             rules.append(rule)
 
+    rules[:] = sorted(rules, key=lambda rule: rule.find('key').text.lower())
+
     write_rules_xml(rules, sys.stdout)
 
 #

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -564,6 +564,258 @@ def generate_description(diag_group_name, diagnostics):
     return "\n".join(html_lines)
 
 
+def add_old_diagnostics_rules(rules):
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-auto-import'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-auto-import'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: treating #%select{include|import|include_next|__include_macros}0 as an import of module '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wauto-import" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-pre-c++2b-compat'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-pre-c++2b-compat'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2b-compat" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-pre-c++2b-compat-pedantic'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-pre-c++2b-compat-pedantic'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: 'size_t' suffix for literals is incompatible with C++ standards before C++2b</li>
+<li>warning: alias declaration in this context is incompatible with C++ standards before C++2b</li>
+<li>warning: an attribute specifier sequence in this position is incompatible with C++ standards before C++2b</li>
+<li>warning: consteval if is incompatible with C++ standards before C++2b</li>
+<li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2b-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-deprecated-experimental-coroutine'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-deprecated-experimental-coroutine'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: support for std::experimental::%0 will be removed in LLVM 15; use std::%0 instead</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-experimental-coroutine" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-export-unnamed'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-export-unnamed'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++20 does not permit %select{an empty|a static_assert}0 declaration to appear in an export block</li>
+<li>warning: ISO C++20 does not permit a declaration that does not introduce any names to be exported</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexport-unnamed" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-gnu-empty-initializer'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-gnu-empty-initializer'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: use of GNU empty initializer extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-empty-initializer" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-ignored-pragma-optimize'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-ignored-pragma-optimize'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: '#pragma optimize' is not supported</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wignored-pragma-optimize" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-return-std-move'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-return-std-move'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: local variable %0 will be copied despite being %select{returned|thrown}1 by name</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wreturn-std-move" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-requires-expression'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-requires-expression'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: this requires expression will only be checked for syntactic validity; did you intend to place it in a nested requirement? (add another 'requires' before the expression)</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrequires-expression" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-concepts-ts-compat'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-concepts-ts-compat'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++20 does not permit the 'bool' keyword after 'concept'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconcepts-ts-compat" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-interrupt-service-routine'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-interrupt-service-routine'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: interrupt service routine should only call a function with attribute 'no_caller_saved_registers'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winterrupt-service-routine" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-export-using-directive'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-export-using-directive'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: ISO C++20 does not permit using directive to be exported</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexport-using-directive" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-overriding-t-option'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-overriding-t-option'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: overriding '%0' option with '%1'</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverriding-t-option" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-c++23-default-comp-relaxed-constexpr'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-c++23-default-comp-relaxed-constexpr'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is a C++23 extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-default-comp-relaxed-constexpr" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-deprecated-static-analyzer-flag'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-deprecated-static-analyzer-flag'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: analyzer option '%0' is deprecated. This flag will be removed in %1, and passing this option will be an error.</li>
+<li>warning: analyzer option '%0' is deprecated. This flag will be removed in %1, and passing this option will be an error. Use '%2' instead.</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-static-analyzer-flag" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-generic-type-extension'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-generic-type-extension'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: passing a type argument as the first operand to '_Generic' is a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgeneric-type-extension" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-gnu-binary-literal'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-gnu-binary-literal'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: binary integer literals are a GNU extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-binary-literal" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-gnu-offsetof-extensions'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-gnu-offsetof-extensions'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: defining a type within '%select{__builtin_offsetof|offsetof}0' is a Clang extension</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-offsetof-extensions" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-knl-knm-isa-support-removed'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-knl-knm-isa-support-removed'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: KNL, KNM related Intel Xeon Phi CPU's specific ISA's supports will be removed in LLVM 19.</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wknl-knm-isa-support-removed" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-diagnostic-undefined-arm-streaming'
+    et.SubElement(rule, 'name').text = 'clang-diagnostic-undefined-arm-streaming'
+    et.SubElement(rule, 'description').append(CDATA("""<p>Diagnostic text:</p>
+<ul>
+<li>warning: builtin call has undefined behaviour when called from a %0 function</li>
+</ul>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-streaming" target="_blank">Diagnostic flags in Clang</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+
 def diagnostics_to_rules_xml(json_file):
     rules = et.Element('rules')
 
@@ -607,6 +859,8 @@ def diagnostics_to_rules_xml(json_file):
                 et.SubElement(rule, 'type').text = rule_type
 
             rules.append(rule)
+
+    add_old_diagnostics_rules(rules)
 
     rules[:] = sorted(rules, key=lambda rule: rule.find('key').text.lower())
 

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -339,8 +339,10 @@ def rstfile_to_rule(path, fix_urls):
         default_issue_severity = custom_severity["severity"]
         default_issue_type = custom_severity["type"]
 
-    et.SubElement(rule, 'severity').text = default_issue_severity
-    et.SubElement(rule, 'type').text = default_issue_type
+    if default_issue_severity != 'MAJOR': # MAJOR is the default
+        et.SubElement(rule, 'severity').text = default_issue_severity
+    if default_issue_type != 'CODE_SMELL': # CODE_SMELL is the default
+        et.SubElement(rule, 'type').text = default_issue_type
 
     return rule
 

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -303,13 +303,13 @@ def fix_local_urls(html, filename):
 
 def rstfile_to_description(path, filename, fix_urls):
     html = subprocess.check_output(
-        ['pandoc', path, '--no-highlight', '-f', 'rst', '-t', 'html5'])
+        ['pandoc', path, '--no-highlight', '-f', 'rst', '-t', 'html5']).decode('utf-8')
     footer = """<h2>References</h2>
 <p><a href="%s%s.html" target="_blank">clang.llvm.org</a></p>""" % (CLANG_TIDY_DOC_URL_BASE, filename)
     if fix_urls:
         html = fix_local_urls(html, filename)
 
-    html = html.decode('utf-8').replace('\r\n', '\n')
+    html = html.replace('\r\n', '\n')
     return html + footer
 
 

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -303,7 +303,7 @@ def fix_local_urls(html, filename):
 
 def rstfile_to_description(path, filename, fix_urls):
     html = subprocess.check_output(
-        ['pandoc', path, '--no-highlight', '-f', 'rst', '-t', 'html5']).decode('utf-8')
+        ['pandoc', path, '--wrap=none', '--no-highlight', '-f', 'rst', '-t', 'html5']).decode('utf-8')
     footer = """<h2>References</h2>
 <p><a href="%s%s.html" target="_blank">clang.llvm.org</a></p>""" % (CLANG_TIDY_DOC_URL_BASE, filename)
     if fix_urls:

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -294,7 +294,7 @@ CLANG_TIDY_DOC_URL_BASE = "http://clang.llvm.org/extra/clang-tidy/checks/"
 
 def fix_local_urls(html, filename):
     # replace local ancors
-    html = re.sub("href=\"(?!http)#", "href=\"" +
+    html = re.sub("href=\"(?!http)(.*\\.html)??#", "href=\"" +
                   CLANG_TIDY_DOC_URL_BASE + filename + ".html#", html)
     # replace local urls
     html = re.sub("href=\"(?!http)", "href=\"" + CLANG_TIDY_DOC_URL_BASE, html)

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -357,6 +357,9 @@ def rstfiles_to_rules_xml(directory, fix_urls):
             if ext == ".rst" and f != "list.rst":
                 rst_file_path = os.path.join(subdir, f)
                 rules.append(rstfile_to_rule(rst_file_path, fix_urls))
+
+    rules[:] = sorted(rules, key=lambda rule: rule.find('key').text.casefold())
+
     sys.stderr.write("[INFO] write .xml file ...\n")
     write_rules_xml(rules, sys.stdout)
 

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -341,9 +341,6 @@ def rstfile_to_rule(path, fix_urls):
 
     et.SubElement(rule, 'severity').text = default_issue_severity
     et.SubElement(rule, 'type').text = default_issue_type
-    if default_issue_severity != 'INFO':
-        et.SubElement(rule, 'remediationFunction').text = 'CONSTANT_ISSUE'
-        et.SubElement(rule, 'remediationFunctionBaseEffort').text = '5min'
 
     return rule
 
@@ -565,9 +562,6 @@ def diagnostics_to_rules_xml(json_file):
                 et.SubElement(rule, 'severity').text = rule_severity
             if rule_type != 'CODE_SMELL': # CODE_SMELL is the default
                 et.SubElement(rule, 'type').text = rule_type
-            if rule_severity != 'INFO':
-                et.SubElement(rule, 'remediationFunction').text = 'CONSTANT_ISSUE'
-                et.SubElement(rule, 'remediationFunctionBaseEffort').text = '5min'
 
             rules.append(rule)
 

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -373,15 +373,15 @@ def contains_required_fields(entry_value):
 
 def create_template_rules(rules):
     rule_key = "CustomRuleTemplate"
-    rule_name = "Template for custom Custom rules"
+    rule_name = "Rule template for Clang-Tidy custom rules"
     rule_severity = SEVERITY["SEV_Warning"]["sonarqube_severity"]
-    rule_description = """<p>Follow these steps to make your custom Custom rules available in SonarQube:</p>
+    rule_description = """<p>Follow these steps to make your custom rules available in SonarQube:</p>
 <ol>
   <ol>
     <li>Create a new rule in SonarQube by "copying" this rule template and specify the <code>CheckId</code> of your custom rule, a title, a description, and a default severity.</li>
     <li>Enable the newly created rule in your quality profile</li>
   </ol>
-  <li>Relaunch an analysis on your projects, et voila, your custom rules are executed!</li>
+  <li>Relaunch an analysis on your projects, et voilà, your custom rules are executed!</li>
 </ol>"""
 
     rule = et.Element('rule')

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -375,21 +375,22 @@ def create_template_rules(rules):
     rule_key = "CustomRuleTemplate"
     rule_name = "Rule template for Clang-Tidy custom rules"
     rule_severity = SEVERITY["SEV_Warning"]["sonarqube_severity"]
-    rule_description = """<p>Follow these steps to make your custom rules available in SonarQube:</p>
+    rule_description = """
+      <p>Follow these steps to make your custom rules available in SonarQube:</p>
 <ol>
   <ol>
     <li>Create a new rule in SonarQube by "copying" this rule template and specify the <code>CheckId</code> of your custom rule, a title, a description, and a default severity.</li>
     <li>Enable the newly created rule in your quality profile</li>
   </ol>
   <li>Relaunch an analysis on your projects, et voilà, your custom rules are executed!</li>
-</ol>"""
+</ol>
+      """
 
     rule = et.Element('rule')
     et.SubElement(rule, 'key').text = rule_key
     et.SubElement(rule, 'cardinality').text = "MULTIPLE"
     name = et.SubElement(rule, 'name').text=rule_name
     et.SubElement(rule, 'description').append(CDATA(rule_description))
-    et.SubElement(rule, 'severity').text = rule_severity
     rules.append(rule)
 
 def create_clang_default_rules(rules):
@@ -398,7 +399,9 @@ def create_clang_default_rules(rules):
     rule_name = "clang-diagnostic-error"
     rule_type = DIAG_CLASS["CLASS_ERROR"]["sonarqube_type"]
     rule_severity = SEVERITY["SEV_Remark"]["sonarqube_severity"]
-    rule_description = "<p>Default compiler diagnostic for errors without an explicit check name. Compiler error, e.g header file not found.</p>"
+    rule_description = """
+      <p>Default compiler diagnostic for errors without an explicit check name. Compiler error, e.g header file not found.</p>
+      """
 
     rule = et.Element('rule')
     et.SubElement(rule, 'key').text = rule_key
@@ -413,14 +416,14 @@ def create_clang_default_rules(rules):
     rule_name = "clang-diagnostic-warning"
     rule_type = DIAG_CLASS["CLASS_WARNING"]["sonarqube_type"]
     rule_severity = SEVERITY["SEV_Warning"]["sonarqube_severity"]
-    rule_description = "<p>Default compiler diagnostic for warnings without an explicit check name.</p>"
+    rule_description = """
+      <p>Default compiler diagnostic for warnings without an explicit check name.</p>
+      """
 
     rule = et.Element('rule')
     et.SubElement(rule, 'key').text = rule_key
     et.SubElement(rule, 'name').text = rule_name
     et.SubElement(rule, 'description').append(CDATA(rule_description))
-    et.SubElement(rule, 'severity').text = rule_severity
-    et.SubElement(rule, 'type').text = rule_type
     rules.append(rule)
 
     # defaults clang issue (not associated with any activation switch): all other levels
@@ -428,14 +431,15 @@ def create_clang_default_rules(rules):
     rule_name = "clang-diagnostic-unknown"
     rule_type = DIAG_CLASS["CLASS_REMARK"]["sonarqube_type"]
     rule_severity = SEVERITY["SEV_Remark"]["sonarqube_severity"]
-    rule_description = "<p>(Unknown) compiler diagnostic without an explicit check name.</p>"
+    rule_description = """
+      <p>(Unknown) compiler diagnostic without an explicit check name.</p>
+      """
 
     rule = et.Element('rule')
     et.SubElement(rule, 'key').text = rule_key
     et.SubElement(rule, 'name').text = rule_name
     et.SubElement(rule, 'description').append(CDATA(rule_description))
     et.SubElement(rule, 'severity').text = rule_severity
-    et.SubElement(rule, 'type').text = rule_type
     rules.append(rule)
 
 def collect_warnings(data, diag_group_id, warnings_in_group):

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -347,6 +347,41 @@ def rstfile_to_rule(path, fix_urls):
     return rule
 
 
+def add_old_clangtidy_rules(rules):
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'clang-analyzer-core.DynamicTypePropagation'
+    et.SubElement(rule, 'name').text = 'clang-analyzer-core.DynamicTypePropagation'
+    et.SubElement(rule, 'description').append(CDATA("""<div class="title">
+<p>clang-tidy - clang-analyzer-core.DynamicTypePropagation</p>
+</div>
+<h1 id="clang-analyzer-core.dynamictypepropagation">clang-analyzer-core.DynamicTypePropagation</h1>
+<p>Generate dynamic type information</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.DynamicTypePropagation.html" target="_blank">clang.llvm.org</a></p>"""))
+    et.SubElement(rule, 'severity').text = "INFO"
+    rules.append(rule)
+
+    rule = et.Element('rule')
+    et.SubElement(rule, 'key').text = 'cert-dcl21-cpp'
+    et.SubElement(rule, 'name').text = 'cert-dcl21-cpp'
+    et.SubElement(rule, 'description').append(CDATA("""<div class="title">
+<p>clang-tidy - cert-dcl21-cpp</p>
+</div>
+<h1 id="cert-dcl21-cpp">cert-dcl21-cpp</h1>
+<div class="note">
+<div class="title">
+<p>Note</p>
+</div>
+<p>This check is deprecated since it's no longer part of the CERT standard. It will be removed in <code class="interpreted-text" role="program">clang-tidy</code> version 19.</p>
+</div>
+<p>This check flags postfix <code>operator++</code> and <code>operator--</code> declarations if the return type is not a const object. This also warns if the return type is a reference type.</p>
+<p>The object returned by a postfix increment or decrement operator is supposed to be a snapshot of the object's value prior to modification. With such an implementation, any modifications made to the resulting object from calling operator++(int) would be modifying a temporary object. Thus, such an implementation of a postfix increment or decrement operator should instead return a const object, prohibiting accidental mutation of a temporary object. Similarly, it is unexpected for the postfix operator to return a reference to its previous state, and any subsequent modifications would be operating on a stale object.</p>
+<p>This check corresponds to the CERT C++ Coding Standard recommendation DCL21-CPP. Overloaded postfix increment and decrement operators should return a const object. However, all of the CERT recommendations have been removed from public view, and so their justification for the behavior of this check requires an account on their wiki to view.</p>
+<h2>References</h2>
+<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl21-cpp.html" target="_blank">clang.llvm.org</a></p>"""))
+    rules.append(rule)
+
+
 def rstfiles_to_rules_xml(directory, fix_urls):
     sys.stderr.write("[INFO] read .rst files '{}'\n".format(directory))
     rules = et.Element('rules')
@@ -356,6 +391,8 @@ def rstfiles_to_rules_xml(directory, fix_urls):
             if ext == ".rst" and f != "list.rst":
                 rst_file_path = os.path.join(subdir, f)
                 rules.append(rstfile_to_rule(rst_file_path, fix_urls))
+
+    add_old_clangtidy_rules(rules)
 
     rules[:] = sorted(rules, key=lambda rule: rule.find('key').text.casefold())
 

--- a/cxx-sensors/src/tools/clangtidy_createrules.py
+++ b/cxx-sensors/src/tools/clangtidy_createrules.py
@@ -357,7 +357,7 @@ def add_old_clangtidy_rules(rules):
 <h1 id="clang-analyzer-core.dynamictypepropagation">clang-analyzer-core.DynamicTypePropagation</h1>
 <p>Generate dynamic type information</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.DynamicTypePropagation.html" target="_blank">clang.llvm.org</a></p>"""))
+<p><a href="https://releases.llvm.org/17.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/clang-analyzer/core.DynamicTypePropagation.html" target="_blank">clang.llvm.org</a></p>"""))
     et.SubElement(rule, 'severity').text = "INFO"
     rules.append(rule)
 
@@ -378,7 +378,7 @@ def add_old_clangtidy_rules(rules):
 <p>The object returned by a postfix increment or decrement operator is supposed to be a snapshot of the object's value prior to modification. With such an implementation, any modifications made to the resulting object from calling operator++(int) would be modifying a temporary object. Thus, such an implementation of a postfix increment or decrement operator should instead return a const object, prohibiting accidental mutation of a temporary object. Similarly, it is unexpected for the postfix operator to return a reference to its previous state, and any subsequent modifications would be operating on a stale object.</p>
 <p>This check corresponds to the CERT C++ Coding Standard recommendation DCL21-CPP. Overloaded postfix increment and decrement operators should return a const object. However, all of the CERT recommendations have been removed from public view, and so their justification for the behavior of this check requires an account on their wiki to view.</p>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl21-cpp.html" target="_blank">clang.llvm.org</a></p>"""))
+<p><a href="https://releases.llvm.org/18.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/cert/dcl21-cpp.html" target="_blank">clang.llvm.org</a></p>"""))
     rules.append(rule)
 
 
@@ -589,7 +589,7 @@ def add_old_diagnostics_rules(rules):
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2b-compat" target="_blank">Diagnostic flags in Clang</a></p>"""))
+<p><a href="https://releases.llvm.org/16.0.0/tools/clang/docs/DiagnosticsReference.html#wpre-c-2b-compat" target="_blank">Diagnostic flags in Clang</a></p>"""))
     et.SubElement(rule, 'severity').text = "INFO"
     rules.append(rule)
 
@@ -605,7 +605,7 @@ def add_old_diagnostics_rules(rules):
 <li>warning: overloaded %0 with %select{no|a defaulted|more than one}1 parameter is a C++2b extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wpre-c-2b-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>"""))
+<p><a href="https://releases.llvm.org/16.0.0/tools/clang/docs/DiagnosticsReference.html#wpre-c-2b-compat-pedantic" target="_blank">Diagnostic flags in Clang</a></p>"""))
     et.SubElement(rule, 'severity').text = "INFO"
     rules.append(rule)
 
@@ -617,7 +617,7 @@ def add_old_diagnostics_rules(rules):
 <li>warning: support for std::experimental::%0 will be removed in LLVM 15; use std::%0 instead</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-experimental-coroutine" target="_blank">Diagnostic flags in Clang</a></p>"""))
+<p><a href="https://releases.llvm.org/16.0.0/tools/clang/docs/DiagnosticsReference.html#wdeprecated-experimental-coroutine" target="_blank">Diagnostic flags in Clang</a></p>"""))
     et.SubElement(rule, 'severity').text = "INFO"
     rules.append(rule)
 
@@ -678,7 +678,7 @@ def add_old_diagnostics_rules(rules):
 <li>warning: this requires expression will only be checked for syntactic validity; did you intend to place it in a nested requirement? (add another 'requires' before the expression)</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wrequires-expression" target="_blank">Diagnostic flags in Clang</a></p>"""))
+<p><a href="https://releases.llvm.org/13.0.0/tools/clang/docs/DiagnosticsReference.html#wrequires-expression" target="_blank">Diagnostic flags in Clang</a></p>"""))
     et.SubElement(rule, 'severity').text = "INFO"
     rules.append(rule)
 
@@ -690,7 +690,7 @@ def add_old_diagnostics_rules(rules):
 <li>warning: ISO C++20 does not permit the 'bool' keyword after 'concept'</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wconcepts-ts-compat" target="_blank">Diagnostic flags in Clang</a></p>"""))
+<p><a href="https://releases.llvm.org/15.0.0/tools/clang/docs/DiagnosticsReference.html#wconcepts-ts-compat" target="_blank">Diagnostic flags in Clang</a></p>"""))
     et.SubElement(rule, 'severity').text = "INFO"
     rules.append(rule)
 
@@ -702,7 +702,7 @@ def add_old_diagnostics_rules(rules):
 <li>warning: interrupt service routine should only call a function with attribute 'no_caller_saved_registers'</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#winterrupt-service-routine" target="_blank">Diagnostic flags in Clang</a></p>"""))
+<p><a href="https://releases.llvm.org/17.0.1/tools/clang/docs/DiagnosticsReference.html#winterrupt-service-routine" target="_blank">Diagnostic flags in Clang</a></p>"""))
     et.SubElement(rule, 'severity').text = "INFO"
     rules.append(rule)
 
@@ -714,7 +714,7 @@ def add_old_diagnostics_rules(rules):
 <li>warning: ISO C++20 does not permit using directive to be exported</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wexport-using-directive" target="_blank">Diagnostic flags in Clang</a></p>"""))
+<p><a href="https://releases.llvm.org/16.0.0/tools/clang/docs/DiagnosticsReference.html#wexport-using-directive" target="_blank">Diagnostic flags in Clang</a></p>"""))
     et.SubElement(rule, 'severity').text = "INFO"
     rules.append(rule)
 
@@ -726,7 +726,7 @@ def add_old_diagnostics_rules(rules):
 <li>warning: overriding '%0' option with '%1'</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#woverriding-t-option" target="_blank">Diagnostic flags in Clang</a></p>"""))
+<p><a href="https://releases.llvm.org/17.0.1/tools/clang/docs/DiagnosticsReference.html#woverriding-t-option" target="_blank">Diagnostic flags in Clang</a></p>"""))
     et.SubElement(rule, 'severity').text = "INFO"
     rules.append(rule)
 
@@ -738,7 +738,7 @@ def add_old_diagnostics_rules(rules):
 <li>warning: defaulted definition of %select{%sub{select_defaulted_comparison_kind}1|three-way comparison operator}0 that is declared %select{constexpr|consteval}2 but%select{|for which the corresponding implicit 'operator==' }0 invokes a non-constexpr comparison function is a C++23 extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wc-23-default-comp-relaxed-constexpr" target="_blank">Diagnostic flags in Clang</a></p>"""))
+<p><a href="https://releases.llvm.org/18.1.0/tools/clang/docs/DiagnosticsReference.html#wc-23-default-comp-relaxed-constexpr" target="_blank">Diagnostic flags in Clang</a></p>"""))
     et.SubElement(rule, 'severity').text = "INFO"
     rules.append(rule)
 
@@ -751,7 +751,7 @@ def add_old_diagnostics_rules(rules):
 <li>warning: analyzer option '%0' is deprecated. This flag will be removed in %1, and passing this option will be an error. Use '%2' instead.</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-static-analyzer-flag" target="_blank">Diagnostic flags in Clang</a></p>"""))
+<p><a href="https://releases.llvm.org/18.1.0/tools/clang/docs/DiagnosticsReference.html#wdeprecated-static-analyzer-flag" target="_blank">Diagnostic flags in Clang</a></p>"""))
     et.SubElement(rule, 'severity').text = "INFO"
     rules.append(rule)
 
@@ -763,7 +763,7 @@ def add_old_diagnostics_rules(rules):
 <li>warning: passing a type argument as the first operand to '_Generic' is a Clang extension</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wgeneric-type-extension" target="_blank">Diagnostic flags in Clang</a></p>"""))
+<p><a href="https://releases.llvm.org/18.1.0/tools/clang/docs/DiagnosticsReference.html#wgeneric-type-extension" target="_blank">Diagnostic flags in Clang</a></p>"""))
     et.SubElement(rule, 'severity').text = "INFO"
     rules.append(rule)
 
@@ -799,7 +799,7 @@ def add_old_diagnostics_rules(rules):
 <li>warning: KNL, KNM related Intel Xeon Phi CPU's specific ISA's supports will be removed in LLVM 19.</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wknl-knm-isa-support-removed" target="_blank">Diagnostic flags in Clang</a></p>"""))
+<p><a href="https://releases.llvm.org/18.1.0/tools/clang/docs/DiagnosticsReference.html#wknl-knm-isa-support-removed" target="_blank">Diagnostic flags in Clang</a></p>"""))
     et.SubElement(rule, 'severity').text = "INFO"
     rules.append(rule)
 
@@ -811,7 +811,7 @@ def add_old_diagnostics_rules(rules):
 <li>warning: builtin call has undefined behaviour when called from a %0 function</li>
 </ul>
 <h2>References</h2>
-<p><a href="http://clang.llvm.org/docs/DiagnosticsReference.html#wundefined-arm-streaming" target="_blank">Diagnostic flags in Clang</a></p>"""))
+<p><a href="https://releases.llvm.org/18.1.0/tools/clang/docs/DiagnosticsReference.html#wundefined-arm-streaming" target="_blank">Diagnostic flags in Clang</a></p>"""))
     et.SubElement(rule, 'severity').text = "INFO"
     rules.append(rule)
 


### PR DESCRIPTION
I did this before https://github.com/SonarOpenCommunity/sonar-cxx/pull/2782, but it got stuck in my employer's review process. Even if it's not adding any new rule any more, I still think the rest is worth merging.

The main thing is that it makes updating easier. After this,
- The output of `python clangtidy_createrules.py rules_fixurls <src_dir>clang-tools-extra/docs/clang-tidy/checks` (which now works again) can be basically copy&pasted as it is into clangtidy.xml.
- The output of `python clangtidy_createrules.py diagnostics output.json` can be basically copy&pasted as it is into clangtidy.xml.

Doing it this way avoids missing things like the fact the cppcoreguidelines-special-member-functions clang-tidy check gained an "AllowImplicitlyDeletedCopyOrMove" option in llvm 19, which is now included.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2814)
<!-- Reviewable:end -->
