### PR TITLE
Test SQ 25.1.0.102122

### DIFF
--- a/.github/workflows/cxx-ci.yml
+++ b/.github/workflows/cxx-ci.yml
@@ -308,7 +308,7 @@ jobs:
         os: [ubuntu-latest]
         java: [ '17' ]
         distribution: [ 'temurin' ]
-        sonarqube: [ '9.9.7.96285', '24.12.0.100206' ]
+        sonarqube: [ '9.9.8.100196', '25.1.0.102122' ]
         sonarscanner: [ '6.2.1.4610' ]
 
     runs-on: ${{ matrix.os }}
@@ -449,7 +449,7 @@ jobs:
         os: [windows-latest]
         java: [ '17' ]
         distribution: [ 'temurin' ]
-        sonarqube: [ '9.9.7.96285', '24.12.0.100206' ]
+        sonarqube: [ '9.9.8.100196', '25.1.0.102122' ]
         sonarscanner: [ '6.2.1.4610' ]
 
     runs-on: ${{ matrix.os }}

--- a/integration-tests/features/smoketest.feature
+++ b/integration-tests/features/smoketest.feature
@@ -39,7 +39,6 @@ Feature: Smoketests
       | duplicated_files               | 2     |
       | complexity                     | 7     |
       | cognitive_complexity           | 2     |
-      | file_complexity                | 0.9   |
       | violations                     | 12    |
       | lines_to_cover                 | 31    |
       | coverage                       | 53.8  |
@@ -103,7 +102,6 @@ Feature: Smoketests
       | duplicated_files               | 2     |
       | complexity                     | 7     |
       | cognitive_complexity           | 2     |
-      | file_complexity                | 0.9   |
       | violations                     | 12    |
       | lines_to_cover                 | 31    |
       | coverage                       | 53.8  |
@@ -167,7 +165,6 @@ Feature: Smoketests
       | duplicated_files               | 2     |
       | complexity                     | 7     |
       | cognitive_complexity           | 2     |
-      | file_complexity                | 0.9   |
       | violations                     | 12    |
       | lines_to_cover                 | 31    |
       | coverage                       | 53.8  |
@@ -241,7 +238,6 @@ Feature: Smoketests
       | duplicated_blocks        | 0     |
       | duplicated_files         | 0     |
       | complexity               | 4     |
-      | file_complexity          | 2.0   |
       | violations               | 19    |
       | line_coverage            | 100   |
       | branch_coverage          | 50    |

--- a/pom.xml
+++ b/pom.xml
@@ -263,8 +263,8 @@
     <animal.sniffer.skip>true</animal.sniffer.skip>
     <aggregate.report.dir>integration-tests/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
 
-    <!-- we depend on API ${sonar.version} but we keep backward compatibility with LTS -->
-    <sonar.version>24.12.0.100206</sonar.version>
+    <!-- we depend on API ${sonar.plugin.api.version} but we keep backward compatibility -->
+    <sonar.version>25.1.0.102122</sonar.version>
     <sonar.plugin.api.version>10.14.0.2599</sonar.plugin.api.version>
     <pluginApiMinVersion>9.14.0.375</pluginApiMinVersion>
 


### PR DESCRIPTION
complexity metrics has been removed in SQ 25.1.0.102122
https://sonarsource.atlassian.net/browse/SONAR-12647
https://github.com/SonarSource/sonarqube/commit/00aef6b15a70f1a1edee729ce69dbc8799165779

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2845)
<!-- Reviewable:end -->
