### PR TITLE
update Python version in GitHub actions

### DIFF
--- a/.github/workflows/cxx-ci.yml
+++ b/.github/workflows/cxx-ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.13'
 
     # setup Tidy
     #
@@ -340,7 +340,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.13'
         # cache not working with 2.7?
         #cache: 'pip'
     - run: pip install -r "$GITHUB_WORKSPACE/integration-tests/requirements.txt"
@@ -482,7 +482,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.13'
         # cache not working with 2.7?
         #cache: 'pip'
     - run: pip install -r "$GITHUB_WORKSPACE/integration-tests/requirements.txt"


### PR DESCRIPTION
- Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04
- use Python 3.13 now

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2847)
<!-- Reviewable:end -->
