### PR TITLE
fix #2895

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/cobertura/CoberturaParser.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/coverage/cobertura/CoberturaParser.java
@@ -95,10 +95,13 @@ public class CoberturaParser implements CoverageParser {
 
     while (line.getNext() != null) {
       var lineId = Integer.parseInt(line.getAttrValue("number"));
-      var noHits = Long.parseLong(line.getAttrValue("hits"));
-      if (noHits > Integer.MAX_VALUE) {
-        LOG.warn("Truncating the actual number of hits ({}) to the maximum number supported by SonarQube ({})",
-          noHits, Integer.MAX_VALUE);
+      int noHits;
+      try {
+        noHits = Integer.parseInt(line.getAttrValue("hits"));
+      } catch (NumberFormatException e) {
+        LOG.warn(
+          "CoverageParser: Truncating the actual number of hits to the maximum number supported by SonarQube, {}", e
+        );
         noHits = Integer.MAX_VALUE;
       }
       builder.setHits(lineId, (int) noHits);


### PR DESCRIPTION
- handle `NumberFormatException` on Cobertura data
- handle hits > `Integer.MAX_VALUE`
- Clang's code coverage is not thread-safe, `-fprofile-update=atomic` fixes that problem
- close #2895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/2897)
<!-- Reviewable:end -->
