### PR TITLE
Add new env vars for integration test suite

### DIFF
--- a/integration-tests/Readme.txt
+++ b/integration-tests/Readme.txt
@@ -16,6 +16,11 @@ Make sure the following preconditions are met, before running the test suite:
 
 Usage
 =====
+SonarQube credentials are read from environment variables:
+ - Set SONAR_TOKEN to use token based authentication
+ - To use legacy password based authentication, set sonar.login and sonar.password
+ - if none of the above is set, SonarQube default 'admin/admin' will be used
+
 Either install the plugin, startup SonarQube manually and simply run:
 
 $ behave
@@ -29,6 +34,8 @@ In the latter case, the suite will automatically install and test the
 jar in sonar-python-plugin/target. So make sure the plugin is build
 and the jar is available.
 
+The test suite looks for the existing SonarQube server at http://localhost:9000.
+To change this, set environment variable SONAR_HOST_URL.
 
 Features to test
 ================

--- a/integration-tests/features/webapi.py
+++ b/integration-tests/features/webapi.py
@@ -24,9 +24,15 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 
-SONAR_URL = ('http://localhost:9000')
-SONAR_LOGIN = os.getenv('sonar.login', 'admin')
-SONAR_PASSWORD = os.getenv('sonar.password', 'admin')
+SONAR_URL = os.getenv('SONAR_HOST_URL', 'http://localhost:9000')
+SONAR_TOKEN = os.getenv('SONAR_TOKEN', '')
+
+if SONAR_TOKEN:
+    SONAR_LOGIN = SONAR_TOKEN
+    SONAR_PASSWORD = ''
+else:
+    SONAR_LOGIN = os.getenv('sonar.login', 'admin')
+    SONAR_PASSWORD = os.getenv('sonar.password', 'admin')
 
 
 def web_api_get(url, log=False):


### PR DESCRIPTION
SonarQube recently prefers token based authentication instead of username and password.

This PR adds support for SONAR_TOKEN and SONAR_HOST_URL variables.
Also, the integration test readme is updated as the information for setting the credentials was completely missing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/3001)
<!-- Reviewable:end -->
