### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/cxx-sensors/pom.xml
+++ b/cxx-sensors/pom.xml
@@ -49,8 +49,8 @@
     <!-- TODO: this should be provided by sonar... but not in parent pom? -->
     <dependency>
         <groupId>io.github.hakky54</groupId>
-        <artifactId>sslcontext-kickstart</artifactId>
-        <version>9.2.1</version>
+        <artifactId>ayza</artifactId>
+        <version>10.0.4</version>
     </dependency>
 
 


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.4

Sorry for the inconvenience

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/3036)
<!-- Reviewable:end -->
