### PR TITLE
bugfix - correctly resolve truststore path on filesystem

### DIFF
--- a/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/SSLContextBuilder.java
+++ b/cxx-sensors/src/main/java/org/sonar/cxx/sensors/utils/SSLContextBuilder.java
@@ -101,12 +101,13 @@ public class SSLContextBuilder {
           password -> sslFactoryBuilder.withIdentityMaterial(keyStorePathString, password.toCharArray(), "PKCS12"),
           () -> sslFactoryBuilder.withIdentityMaterial(keyStorePathString, "changeit".toCharArray(), "PKCS12"));
     }
-    var trustStorePathString = config.get("sonar.scanner.truststorePath")
-        .orElse(findSonarHome(config).resolve("ssl/keystore.p12").toString());
-    if (trustStorePathString != null && Files.exists(Path.of(trustStorePathString))) {
+    var trustStorePath = config.get("sonar.scanner.truststorePath")
+        .map(Path::of)
+        .orElse(findSonarHome(config).resolve("ssl/keystore.p12"));
+    if (trustStorePath != null && Files.exists(trustStorePath)) {
       config.get("sonar.scanner.truststorePassword").ifPresentOrElse(
-          password -> sslFactoryBuilder.withTrustMaterial(trustStorePathString, password.toCharArray(), "PKCS12"),
-          () -> sslFactoryBuilder.withTrustMaterial(trustStorePathString, "changeit".toCharArray(), "PKCS12"));
+          password -> sslFactoryBuilder.withTrustMaterial(trustStorePath, password.toCharArray(), "PKCS12"),
+          () -> sslFactoryBuilder.withTrustMaterial(trustStorePath, "changeit".toCharArray(), "PKCS12"));
     }
     return sslFactoryBuilder.build().getSslContext();
   }


### PR DESCRIPTION
Someone on stackoverflow mentioned that there is an issue with the sonar scanner and it crashes. See here for the question on stackoverflow: https://stackoverflow.com/questions/79923615/how-to-disable-ssl-in-sonar-cxx-plugin-when-using-an-http-sonarqube-server

Basically during startup it crashes because it has trouble loading the truststore. The stacktrace is:
```
09:00:49.892 ERROR Error during SonarScanner Engine execution
nl.altindag.ssl.exception.GenericKeyStoreException: java.lang.IllegalArgumentException: Failed to load the keystore from the classpath for the given path: [/usr/lib/jvm/java-21-amazon-corretto.x86_64/lib/security/cacerts]
    at nl.altindag.ssl.util.KeyStoreUtils.loadKeyStore(KeyStoreUtils.java:91)
    at nl.altindag.ssl.SSLFactory$Builder.withTrustMaterial(SSLFactory.java:308)
    at org.sonar.cxx.sensors.utils.SSLContextBuilder.createSSLContext(SSLContextBuilder.java:107)
    at org.sonar.cxx.sensors.utils.SonarServerWebApi.setServerConfig(SonarServerWebApi.java:174)
    at org.sonar.cxx.sensors.utils.CxxIssuesReportSensor.downloadRulesFromServer(CxxIssuesReportSensor.java:95)
    at org.sonar.cxx.sensors.utils.CxxIssuesReportSensor.executeImpl(CxxIssuesReportSensor.java:84)
    at org.sonar.cxx.sensors.utils.CxxReportSensor.execute(CxxReportSensor.java:101)
    ...
Caused by: java.lang.IllegalArgumentException: Failed to load the keystore from the classpath for the given path: [/usr/lib/jvm/java-21-amazon-corretto.x86_64/lib/security/cacerts]
    at nl.altindag.ssl.util.internal.ValidationUtils.requireNotNull(ValidationUtils.java:41)
    at nl.altindag.ssl.util.KeyStoreUtils.loadKeyStore(KeyStoreUtils.java:88)
    ... 26 common frames omitted
```

The user is asking for help to disable ssl, which is not available in sonar actually. however the root cause is clear. The ayza library is loading the truststore from the classpath as the path is defined as a String type. As it tries to find it on the classpath it fails as it does not exist there. By changing the type of the truststorepath from String to Path it will look into the filesystem and it will load correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/3044)
<!-- Reviewable:end -->
