### PR TITLE
add SonarQube 26.7 to CI job

### DIFF
--- a/.github/workflows/cxx-ci.yml
+++ b/.github/workflows/cxx-ci.yml
@@ -226,11 +226,13 @@ jobs:
         os: [ubuntu-latest]
         java: [ '21' ]
         distribution: [ 'temurin' ]
-        sonarqube: [ '25.8.0.112029', '26.1.0.118079' ]
+        sonarqube: [ '25.8.0.112029', '26.1.0.118079', '26.7.0.124771' ]
         include:
           - sonarqube: '25.8.0.112029'
             sonarscanner: '7.2.0.5079'
           - sonarqube: '26.1.0.118079'
+            sonarscanner: '8.0.1.6346'
+          - sonarqube: '26.7.0.124771'
             sonarscanner: '8.0.1.6346'
 
 
@@ -377,11 +379,13 @@ jobs:
         os: [windows-latest]
         java: [ '21' ]
         distribution: [ 'temurin' ]
-        sonarqube: [ '25.8.0.112029', '26.1.0.118079' ]
+        sonarqube: [ '25.8.0.112029', '26.1.0.118079', '26.7.0.124771' ]
         include:
           - sonarqube: '25.8.0.112029'
             sonarscanner: '7.2.0.5079'
           - sonarqube: '26.1.0.118079'
+            sonarscanner: '8.0.1.6346'
+          - sonarqube: '26.7.0.124771'
             sonarscanner: '8.0.1.6346'
 
 


### PR DESCRIPTION
SonarQube community 26.7 got released (see https://github.com/SonarSource/sonarqube/releases/tag/26.7.0.124771). This PR adds it to the CI job run to verify it works.
The relevant CI runs successfully on my fork (see [the run](https://github.com/JuditKnoll/sonar-cxx/actions/runs/29023254800/job/86136357241)), only those (sonarcloud and successfully-finished jobs) failed which require resources only available in upstream.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SonarOpenCommunity/sonar-cxx/3090)
<!-- Reviewable:end -->
